### PR TITLE
Fix issue with add column from freebase

### DIFF
--- a/extensions/freebase/module/scripts/dialogs/extend-data-preview-dialog.js
+++ b/extensions/freebase/module/scripts/dialogs/extend-data-preview-dialog.js
@@ -146,13 +146,12 @@ ExtendDataPreviewDialog.prototype._show = function(properties) {
   }
 
   this._elmts.addPropertyInput.suggestP(suggestConfig).bind("fb-select", function(evt, data) {
-    var expected = data.expected_type;
     self._addProperty({
       id : data.id,
       name: data.name,
       expected: {
-        id: expected.id,
-        name: expected.name
+        id: "/type/object",
+        name: "Object"
       }
     });
   });


### PR DESCRIPTION
When the suggest widget was update in Refine, it broke the add column from freebase functionality if the property was picked from the suggest widget. This change fixes the issue.
