### PR TITLE
Don't create a new FileCleaningTracker per upload

### DIFF
--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -92,6 +92,12 @@ public class ImportingUtilities {
         public boolean isCanceled();
     }
     
+    static protected DiskFileItemFactory fileItemFactory = null;
+    static {
+       fileItemFactory = new DiskFileItemFactory();
+       fileItemFactory.setFileCleaningTracker(new FileCleaningTracker());
+    }
+
     static public void loadDataAndPrepareJob(
         HttpServletRequest request,
         HttpServletResponse response,
@@ -185,9 +191,6 @@ public class ImportingUtilities {
                 return progress.isCanceled();
             }
         };
-        
-        DiskFileItemFactory fileItemFactory = new DiskFileItemFactory();
-        fileItemFactory.setFileCleaningTracker(new FileCleaningTracker());
         
         ServletFileUpload upload = new ServletFileUpload(fileItemFactory);
         upload.setProgressListener(new ProgressListener() {


### PR DESCRIPTION
Minor improvement for most cases, but fixes a serious leak in certain corner cases.

In ImportingUtilities.retrieveContentFromPostRequest(), one new FileFactory + 
associated new FileCleaningTracker was being created per each new file upload.

FileCleaningTracker is intended to handle many temporary files and not just one.
For this, it creates a queue and a "File Reaper" thread that watches files.
So now, instead of creating one per upload, we just create a static, global
FileFactory + associated FileCleaningTracker; all uploads will create temporary
files out of this single file factory, which will have just one
FileCleaningTracker.

NOTE: in some situations (ie. when you delete a project before temporary files 
have a chance of being automatically removed), FileCleaningTracker isn't 
properly garbage collected and thus its thread is never shut down, leading to 
leaks.
