### PR TITLE
Added CSV quote options

### DIFF
--- a/main/src/com/google/refine/exporters/CsvExporter.java
+++ b/main/src/com/google/refine/exporters/CsvExporter.java
@@ -81,6 +81,7 @@ public class CsvExporter implements WriterExporter{
             JSONUtilities.getString(options, "separator", Character.toString(this.separator));
         final String lineSeparator = options == null ? CSVWriter.DEFAULT_LINE_END :
             JSONUtilities.getString(options, "lineSeparator", CSVWriter.DEFAULT_LINE_END);
+        final boolean quoteAll = options == null ? false : JSONUtilities.getBoolean(options, "quoteAll", false);
         
         final boolean printColumnHeader =
             (params != null && params.getProperty("printColumnHeader") != null) ?
@@ -110,7 +111,7 @@ public class CsvExporter implements WriterExporter{
                             cellData.text :
                             "";
                     }
-                    csvWriter.writeNext(strings, false);
+                    csvWriter.writeNext(strings, quoteAll);
                 }
             }
         };

--- a/main/src/com/google/refine/importers/SeparatorBasedImporter.java
+++ b/main/src/com/google/refine/importers/SeparatorBasedImporter.java
@@ -95,12 +95,13 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
         }
         sep = StringEscapeUtils.unescapeJava(sep);
         boolean processQuotes = JSONUtilities.getBoolean(options, "processQuotes", true);
+        boolean strictQuotes = JSONUtilities.getBoolean(options, "strictQuotes", false);
         
         final CSVParser parser = new CSVParser(
             sep.toCharArray()[0],//HACK changing string to char - won't work for multi-char separators.
             CSVParser.DEFAULT_QUOTE_CHARACTER,
             (char) 0, // escape character
-            CSVParser.DEFAULT_STRICT_QUOTES,
+            strictQuotes,
             CSVParser.DEFAULT_IGNORE_LEADING_WHITESPACE,
             !processQuotes);
         


### PR DESCRIPTION
Added two additional CSV options, one for parsing and one for export.

Specifying strict quotes when parsing will ignore all data not quoted.
Specifying quote all when exporting will enclose all values in quotes.

No front-end changes made, just added the support for the options in the
requests.
