### PR TITLE
Quotes should not be removed from values

### DIFF
--- a/main/src/com/google/refine/importers/ImporterUtilities.java
+++ b/main/src/com/google/refine/importers/ImporterUtilities.java
@@ -57,10 +57,6 @@ public class ImporterUtilities {
 
     static public Serializable parseCellValue(String text) {
         if (text.length() > 0) {
-            if (text.length() > 1 && text.startsWith("\"") && text.endsWith("\"")) {
-                return text.substring(1, text.length() - 1);
-            }
-
             String text2 = text.trim();
             if (text2.length() > 0) {
                 try {


### PR DESCRIPTION
Leading quotation marks should not be removed from values. If they have
been left by the importing parser they should be considered part of the
value.
