### PR TITLE
Fixed history and header update in IE

### DIFF
--- a/main/src/com/google/refine/commands/Command.java
+++ b/main/src/com/google/refine/commands/Command.java
@@ -303,6 +303,7 @@ public abstract class Command {
 
         response.setCharacterEncoding("UTF-8");
         response.setHeader("Content-Type", "application/json");
+        response.setHeader("Cache-Control", "no-cache");
 
         Writer w = response.getWriter();
         JSONWriter writer = new JSONWriter(w);

--- a/main/src/com/google/refine/commands/project/GetModelsCommand.java
+++ b/main/src/com/google/refine/commands/project/GetModelsCommand.java
@@ -85,6 +85,7 @@ public class GetModelsCommand extends Command {
         try {
             response.setCharacterEncoding("UTF-8");
             response.setHeader("Content-Type", "application/json");
+            response.setHeader("Cache-Control", "no-cache");
             
             Properties options = new Properties();
             JSONWriter writer = new JSONWriter(response.getWriter());


### PR DESCRIPTION
Due to Internet Explorer caching GET requests the Undo/Redo list and
column headers were not updated, leaving essential parts of the user
interface crippled even if Google Frame is installed. Adding
Cache-Control headers to the responses fixes this.
