### PR TITLE
Improve thread safety for importing jobs

### DIFF
--- a/extensions/gdata/src/com/google/refine/extension/gdata/GDataImporter.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GDataImporter.java
@@ -172,13 +172,15 @@ public class GDataImporter {
     }
     
     static private void setProgress(ImportingJob job, String fileSource, int percent) {
-        JSONObject progress = JSONUtilities.getObject(job.config, "progress");
-        if (progress == null) {
+        JSONObject progress = job.copyConfigObject("progress");
+        
+        if (progress == null)
             progress = new JSONObject();
-            JSONUtilities.safePut(job.config, "progress", progress);
-        }
+        
         JSONUtilities.safePut(progress, "message", "Reading " + fileSource);
         JSONUtilities.safePut(progress, "percent", percent);
+        
+        job.safePutConfig("progress", progress);
     }
     
     static private class WorksheetBatchRowReader implements TableDataReader {

--- a/extensions/gdata/src/com/google/refine/extension/gdata/GDataImportingController.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GDataImportingController.java
@@ -371,7 +371,7 @@ public class GDataImportingController implements ImportingController {
             
             final List<Exception> exceptions = new LinkedList<Exception>();
             
-            JSONUtilities.safePut(job.config, "state", "creating-project");
+            job.safePutConfig("state", "creating-project");
             
             final Project project = new Project();
             new Thread() {
@@ -393,16 +393,16 @@ public class GDataImportingController implements ImportingController {
                     
                     if (!job.canceled) {
                         if (exceptions.size() > 0) {
-                            JSONUtilities.safePut(job.config, "errors",
+                            job.safePutConfig("errors",
                                 DefaultImportingController.convertErrorsToJsonArray(exceptions));
-                            JSONUtilities.safePut(job.config, "state", "error");
+                            job.safePutConfig("state", "error");
                         } else {
                             project.update(); // update all internal models, indexes, caches, etc.
                             
                             ProjectManager.singleton.registerProject(project, pm);
                             
-                            JSONUtilities.safePut(job.config, "state", "created-project");
-                            JSONUtilities.safePut(job.config, "projectID", project.id);
+                            job.safePutConfig("state", "created-project");
+                            job.safePutConfig("projectID", project.id);
                         }
                         
                         job.touch();

--- a/main/src/com/google/refine/importing/ImportingJob.java
+++ b/main/src/com/google/refine/importing/ImportingJob.java
@@ -36,16 +36,19 @@ package com.google.refine.importing;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.Collection;
 
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.JSONWriter;
+import org.json.JSONArray;
 
 import com.google.refine.Jsonizable;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.model.Project;
 import com.google.refine.util.JSONUtilities;
+import java.util.Map;
 
 
 public class ImportingJob implements Jsonizable {
@@ -61,6 +64,8 @@ public class ImportingJob implements Jsonizable {
     public boolean updating;
     public boolean canceled;
     
+    final private Object lock = new Object();
+    
     public ImportingJob(long id, File dir) {
         this.id = id;
         this.dir = dir;
@@ -68,12 +73,104 @@ public class ImportingJob implements Jsonizable {
         dir.mkdirs();
     }
     
-    public JSONObject getOrCreateDefaultConfig() {
-        if (config == null) {
-            config = new JSONObject();
-            JSONUtilities.safePut(config, "state", "new");
-            JSONUtilities.safePut(config, "hasData", false);
+    public void safePutConfig(String key, int value)
+    {
+        synchronized(lock) {
+            JSONUtilities.safePut(config, key, value);
         }
+    }
+    
+    public void safePutConfig(String key, long value)
+    {
+        synchronized(lock) {
+            JSONUtilities.safePut(config, key, value);
+        }
+    }
+    
+    public void safePutConfig(String key, double value)
+    {
+        synchronized(lock) {
+            JSONUtilities.safePut(config, key, value);
+        }
+    }
+    
+    public void safePutConfig(String key, boolean value)
+    {
+        synchronized(lock) {
+            JSONUtilities.safePut(config, key, value);
+        }
+    }
+    
+    public void safePutConfig(String key, String value)
+    {
+        synchronized(lock) {
+            JSONUtilities.safePut(config, key, value);
+        }
+    }
+    
+    public void safePutConfig(String key, Collection<?> value)
+    {
+        synchronized(lock) {
+            JSONUtilities.safePut(config, key, value);
+        }
+    }
+    
+    public void safePutConfig(String key, Map<?, ?> value)
+    {
+        synchronized(lock) {
+            JSONUtilities.safePut(config, key, value);
+        }
+    }
+    
+    public void safePutConfig(String key, Object value)
+    {
+        synchronized(lock) {
+            JSONUtilities.safePut(config, key, value);
+        }
+    }
+    
+    public JSONObject getConfigObject(String key)
+    {
+        JSONObject jsonObject;
+        
+        synchronized(lock) {
+            jsonObject = JSONUtilities.getObject(config, key);
+        }
+        
+        return jsonObject;
+    }
+    
+    public JSONObject copyConfigObject(String key)
+    {
+        JSONObject jsonObject;
+        
+        synchronized(lock) {
+            jsonObject = new JSONObject(config, new String[] {key});
+        }
+        
+        return jsonObject;
+    }
+    
+    public JSONArray getConfigArray(String key)
+    {
+        JSONArray jsonArray;
+        
+        synchronized(lock) {
+            jsonArray = JSONUtilities.getArray(config, key);
+        }
+        
+        return jsonArray;
+    }
+    
+    public JSONObject getOrCreateDefaultConfig() {
+        synchronized(lock) {
+            if (config == null) {
+                config = new JSONObject();
+                JSONUtilities.safePut(config, "state", "new");
+                JSONUtilities.safePut(config, "hasData", false);
+            }
+        }
+        
         return config;
     }
     
@@ -111,8 +208,11 @@ public class ImportingJob implements Jsonizable {
     @Override
     public void write(JSONWriter writer, Properties options)
             throws JSONException {
-        writer.object();
-        writer.key("config"); writer.value(config);
-        writer.endObject();
+        
+        synchronized(lock) {
+            writer.object();
+            writer.key("config"); writer.value(config);
+            writer.endObject();
+        }
     }
 }

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -148,13 +148,13 @@ public class ImportingUtilities {
     }
     
     static public void updateJobWithNewFileSelection(ImportingJob job, JSONArray fileSelectionArray) {
-        JSONUtilities.safePut(job.config, "fileSelection", fileSelectionArray);
+        job.safePutConfig("fileSelection", fileSelectionArray);
         
         String bestFormat = ImportingUtilities.getCommonFormatForSelectedFiles(job, fileSelectionArray);
         bestFormat = ImportingUtilities.guessBetterFormat(job, bestFormat);
         
         JSONArray rankedFormats = new JSONArray();
-        JSONUtilities.safePut(job.config, "rankedFormats", rankedFormats);
+        job.safePutConfig("rankedFormats", rankedFormats);
         ImportingUtilities.rankFormats(job, bestFormat, rankedFormats);
     }
     
@@ -740,7 +740,7 @@ public class ImportingUtilities {
     }
     
     static public String getCommonFormatForSelectedFiles(ImportingJob job, JSONArray fileSelectionIndexes) {
-        JSONObject retrievalRecord = JSONUtilities.getObject(job.config, "retrievalRecord");
+        JSONObject retrievalRecord = job.getConfigObject("retrievalRecord");
         
         final Map<String, Integer> formatToCount = new HashMap<String, Integer>();
         List<String> formats = new ArrayList<String>();
@@ -773,7 +773,7 @@ public class ImportingUtilities {
     }
     
     static String guessBetterFormat(ImportingJob job, String bestFormat) {
-        JSONObject retrievalRecord = JSONUtilities.getObject(job.config, "retrievalRecord");
+        JSONObject retrievalRecord = job.getConfigObject("retrievalRecord");
         return retrievalRecord != null ? guessBetterFormat(job, retrievalRecord, bestFormat) : bestFormat;
     }
     
@@ -876,11 +876,11 @@ public class ImportingUtilities {
     static public List<JSONObject> getSelectedFileRecords(ImportingJob job) {
         List<JSONObject> results = new ArrayList<JSONObject>();
         
-        JSONObject retrievalRecord = JSONUtilities.getObject(job.config, "retrievalRecord");
+        JSONObject retrievalRecord = job.getConfigObject("retrievalRecord");
         if (retrievalRecord != null) {
             JSONArray fileRecordArray = JSONUtilities.getArray(retrievalRecord, "files");
             if (fileRecordArray != null) {
-                JSONArray fileSelectionArray = JSONUtilities.getArray(job.config, "fileSelection");
+                JSONArray fileSelectionArray = job.getConfigArray("fileSelection");
                 if (fileSelectionArray != null) {
                     for (int i = 0; i < fileSelectionArray.length(); i++) {
                         int index = JSONUtilities.getIntElement(fileSelectionArray, i, -1);
@@ -929,7 +929,7 @@ public class ImportingUtilities {
             return -1;
         }
         
-        JSONUtilities.safePut(job.config, "state", "creating-project");
+        job.safePutConfig("state", "creating-project");
         
         final Project project = new Project();
         if (synchronous) {
@@ -981,11 +981,11 @@ public class ImportingUtilities {
                 
                 ProjectManager.singleton.registerProject(project, pm);
                 
-                JSONUtilities.safePut(job.config, "projectID", project.id);
-                JSONUtilities.safePut(job.config, "state", "created-project");
+                job.safePutConfig("projectID", project.id);
+                job.safePutConfig("state", "created-project");
             } else {
-                JSONUtilities.safePut(job.config, "state", "error");
-                JSONUtilities.safePut(job.config, "errors",
+                job.safePutConfig("state", "error");
+                job.safePutConfig("errors",
                     DefaultImportingController.convertErrorsToJsonArray(exceptions));
             }
             job.touch();
@@ -994,14 +994,16 @@ public class ImportingUtilities {
     }
     
     static public void setCreatingProjectProgress(ImportingJob job, String message, int percent) {
-        JSONObject progress = JSONUtilities.getObject(job.config, "progress");
-        if (progress == null) {
+        JSONObject progress = job.copyConfigObject("progress");
+        
+        if (progress == null)
             progress = new JSONObject();
-            JSONUtilities.safePut(job.config, "progress", progress);
-        }
+        
         JSONUtilities.safePut(progress, "message", message);
         JSONUtilities.safePut(progress, "percent", percent);
         JSONUtilities.safePut(progress, "memory", Runtime.getRuntime().totalMemory() / 1000000);
         JSONUtilities.safePut(progress, "maxmemory", Runtime.getRuntime().maxMemory() / 1000000);
+        
+        job.safePutConfig("progress", progress);
     }
 }


### PR DESCRIPTION
Added locks to improve thread safety when accessing the ImportingJob
config object or the ImportingManager job collection.
