### PR TITLE
Running Refine from Linux kit did not load extensions 

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -224,7 +224,7 @@
         </replace>
 
         <replace file="${built.webapp.dir}/WEB-INF/butterfly.properties">
-            <replacefilter token="../../extensions/" value="extensions"/>
+            <replacefilter token="../../extensions" value="extensions"/>
         </replace>
 
     </target>


### PR DESCRIPTION
In main/webapp/WEB_INF/butterfly.properties extensions path is set to ../../extensions (no trailing slash).
After removing extra slash in replacefilter extensions, I re-built linux dist version and now Refine loads the extensions. Freebase is visible in the extensions bar.
