### PR TITLE
Fix for #780 - removed exclude

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -259,7 +259,6 @@
 	<copy todir="${mac.dir}/OpenRefine.app/Contents/Resource">
           <fileset dir="${build.dir}" id="librarypathset" >
             <include name="${built.webapp.name}/**/**" />
-            <exclude name="**/*.class" />
           </fileset>
 	</copy>
 


### PR DESCRIPTION
Exclude prevented extensions' .class files to be included in the OpenRefine.app. 
After removing exclude I built mac_dist, installed OpenRefine from .dmg and was able to see the extensions.
