### PR TITLE
Tweak: previewCandidate window width

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -450,7 +450,7 @@ DataTableCellUI.prototype._previewCandidateTopic = function(candidate, elmt, pre
   var id = candidate.id;
   var fakeMenu = MenuSystem.createMenu();
   fakeMenu
-  .width(414)
+  .width(preview.width?preview.width:414)
   .addClass('data-table-topic-popup')
   .html(DOM.loadHTML("core", "scripts/views/data-table/cell-recon-preview-popup-header.html"));
 


### PR DESCRIPTION
I was playing with a custom reconciliation service and noticed that the preview window had a fixed width. This small fix adapts the width to the one declared in the reconciliation service.
