### PR TITLE
Correcting typo that was breaking one UI test

### DIFF
--- a/main/tests/client/src/facets.js
+++ b/main/tests/client/src/facets.js
@@ -14,7 +14,7 @@ var test_facets = new function() {
     test = newTest();
     action (test, "click",        { link:    "Food" });
     wait   (test, "forPageLoad",  { timeout: "20000" });
-    assert (test, "assertTest", {xpath: "//div[@id='summary-bar']/span",validator: "7413 rows"});
+    assert (test, "assertText", {xpath: "//div[@id='summary-bar']/span",validator: "7413 rows"});
     this.test_open_project = test;
 
     // create text facet from 1st word of Short Description column


### PR DESCRIPTION
The UI tests are failing when making

```
./refine ui_test
```

With this modification, 1 of the tests gets fixed (still 5 to go)
