### PR TITLE
Made expression preview tabs initially hidden

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
@@ -118,9 +118,6 @@ ExpressionPreviewDialog.Widget = function(
     this._timerID = null;
     
     $("#expression-preview-tabs").tabs();
-    $("#expression-preview-tabs-history").css("display", "");
-    $("#expression-preview-tabs-starred").css("display", "");
-    $("#expression-preview-tabs-help").css("display", "");
     
     this._elmts.expressionPreviewLanguageSelect[0].value = language;
     this._elmts.expressionPreviewLanguageSelect.bind("change", function() {


### PR DESCRIPTION
The display:none style was removed from the tab content elements. This was needed earlier since the tab contents would otherwise not show. Recent changes seems to have fixed the original issue and the previous fix now makes the contents of all tabs show when opening the dialog, potentially making the dialog too large to fit in the UI and the buttons to save or cancel positioned outside the screen.

This was reproduced in Chrome 32.0.1700.102 m and IE10.

Removing the lines which removed the display:none style fixes this issue.
