### PR TITLE
Fixed too frequent job cleanups

### DIFF
--- a/main/src/com/google/refine/importing/ImportingManager.java
+++ b/main/src/com/google/refine/importing/ImportingManager.java
@@ -110,7 +110,7 @@ public class ImportingManager {
     static private ScheduledExecutorService service;
 
     final static private long TIMER_PERIOD = 10; // 10 minutes
-    final static private long STALE_PERIOD = 60; // 60 minutes
+    final static private long STALE_PERIOD = 60 * 60 * 1000; // 60 minutes in milliseconds
     
     static private class CleaningTimerTask implements Runnable {
         @Override


### PR DESCRIPTION
The ImportingManager cleans up jobs that has not been touched in 60ms.
According to comment this should be 60 minutes but was changed in
4529310237f9f862a0ad86d3b466b380bd9cb80c.
