### PR TITLE
ImportingJob.config thread-safety

### DIFF
--- a/extensions/gdata/src/com/google/refine/extension/gdata/FusionTableImporter.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/FusionTableImporter.java
@@ -77,7 +77,7 @@ public class FusionTableImporter {
     }
     
     static void setProgress(ImportingJob job, String fileSource, int percent) {
-        job.setProgress(percent, "Reading " + fileSource);
+        job.setProgressAndMemUsage(percent, "Reading " + fileSource);
     }
     
     

--- a/extensions/gdata/src/com/google/refine/extension/gdata/GDataImporter.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GDataImporter.java
@@ -169,7 +169,7 @@ public class GDataImporter {
     }
     
     static private void setProgress(ImportingJob job, String fileSource, int percent) {
-        job.setProgress(percent, "Reading " + fileSource);
+        job.setProgressAndMemUsage(percent, "Reading " + fileSource);
     }
     
     static private class WorksheetBatchRowReader implements TableDataReader {

--- a/main/src/com/google/refine/commands/project/CreateProjectCommand.java
+++ b/main/src/com/google/refine/commands/project/CreateProjectCommand.java
@@ -42,7 +42,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,9 +68,8 @@ public class CreateProjectCommand extends Command {
         try {
             Properties parameters = ParsingUtilities.parseUrlParameters(request);
             ImportingJob job = ImportingManager.createJob();
-            JSONObject config = job.getOrCreateDefaultConfig();
             ImportingUtilities.loadDataAndPrepareJob(
-                    request, response, parameters, job, config);
+                    request, response, parameters, job);
             
             String format = parameters.getProperty("format");
             
@@ -93,9 +91,9 @@ public class CreateProjectCommand extends Command {
                            "\\t".equals(parameters.getProperty("separator"))) {
                     format = "text/line-based/*sv";
                 } else {
-                    JSONArray rankedFormats = JSONUtilities.getArray(config, "rankedFormats");
-                    if (rankedFormats != null && rankedFormats.length() > 0) {
-                        format = rankedFormats.getString(0);
+                    List<String> rankedFormats = job.getRankedFormats();
+                    if (rankedFormats.size() > 0) {
+                        format = rankedFormats.get(0);
                     }
                 }
                 

--- a/main/src/com/google/refine/importers/ImporterUtilities.java
+++ b/main/src/com/google/refine/importers/ImporterUtilities.java
@@ -209,7 +209,7 @@ public class ImporterUtilities {
             long totalBytesRead = 0;
             
             void setProgress(String fileSource, long bytesRead) {
-                job.setProgress(totalSize2 == 0 ? -1 : (int) (100 * (totalBytesRead + bytesRead) / totalSize2),
+                job.setProgressAndMemUsage(totalSize2 == 0 ? -1 : (int) (100 * (totalBytesRead + bytesRead) / totalSize2),
                     "Reading " + fileSource);
             }
             

--- a/main/src/com/google/refine/importing/DefaultImportingController.java
+++ b/main/src/com/google/refine/importing/DefaultImportingController.java
@@ -110,16 +110,13 @@ public class DefaultImportingController implements ImportingController {
         
         job.updating = true;
         try {
-            JSONObject config = job.getOrCreateDefaultConfig();
-            if (!("new".equals(config.getString("state")))) {
+            if (!("new".equals(job.getState()))) {
                 HttpUtilities.respond(response, "error", "Job already started; cannot load more data");
                 return;
             }
             
             ImportingUtilities.loadDataAndPrepareJob(
-                request, response, parameters, job, config);
-        } catch (JSONException e) {
-            throw new ServletException(e);
+                request, response, parameters, job);
         } finally {
             job.touch();
             job.updating = false;
@@ -138,8 +135,7 @@ public class DefaultImportingController implements ImportingController {
         
         job.updating = true;
         try {
-            JSONObject config = job.getOrCreateDefaultConfig();
-            if (!("ready".equals(config.getString("state")))) {
+            if (!("ready".equals(job.getState()))) {
                 HttpUtilities.respond(response, "error", "Job not ready");
                 return;
             }
@@ -147,7 +143,9 @@ public class DefaultImportingController implements ImportingController {
             JSONArray fileSelectionArray = ParsingUtilities.evaluateJsonStringToArray(
                     request.getParameter("fileSelection"));
             
-            ImportingUtilities.updateJobWithNewFileSelection(job, fileSelectionArray);
+            List<Integer> fileSelectionList = JSONUtilities.toIntList(fileSelectionArray); 
+            
+            ImportingUtilities.updateJobWithNewFileSelection(job, fileSelectionList);
             
             replyWithJobData(request, response, job);
         } catch (JSONException e) {
@@ -170,8 +168,7 @@ public class DefaultImportingController implements ImportingController {
         
         job.updating = true;
         try {
-            JSONObject config = job.getOrCreateDefaultConfig();
-            if (!("ready".equals(config.getString("state")))) {
+            if (!("ready".equals(job.getState()))) {
                 HttpUtilities.respond(response, "error", "Job not ready");
                 return;
             }
@@ -252,8 +249,7 @@ public class DefaultImportingController implements ImportingController {
         job.updating = true;
         job.touch();
         try {
-            JSONObject config = job.getOrCreateDefaultConfig();
-            if (!("ready".equals(config.getString("state")))) {
+            if (!("ready".equals(job.getState()))) {
                 HttpUtilities.respond(response, "error", "Job not ready");
                 return;
             }

--- a/main/src/com/google/refine/util/JSONUtilities.java
+++ b/main/src/com/google/refine/util/JSONUtilities.java
@@ -330,6 +330,17 @@ public class JSONUtilities {
         return a2;
     }
     
+    static public List<Integer> toIntList(JSONArray a) throws JSONException {
+        int l = a.length();
+        
+        List<Integer> list = new ArrayList<Integer>();
+        for (int i = 0; i < l; i++) {
+            list.add(a.getInt(i));
+        }
+        
+        return list;
+    }
+    
     static public List<String> toStringList(JSONArray a) throws JSONException {
         int l = a.length();
         
@@ -339,5 +350,19 @@ public class JSONUtilities {
         }
         
         return list;
+    }
+    
+    static public JSONObject cloneObject(JSONObject obj) {
+        JSONObject objClone = null;
+        
+        try {
+            objClone = new JSONObject(obj.toString());
+        }
+        catch (JSONException ex) {
+            // This shouldn't happen unless JSONObject.toString() returns incorrect syntax.
+            throw new RuntimeException(ex);
+        }
+        
+        return objClone;
     }
 }


### PR DESCRIPTION
Made the remaining changes to ImportingJob and user classes to make the access to the config JSONObject thread-safe. Initial work for this was made in 1e5f89e84cb7c88cc157ae246c0bf7b9da3dc501.

Our reason for completing this was that we saw numerous Null pointer JSONExceptions thrown when calling the GetImportingJobStatusCommand during heavy load.

This is a large commit. We decided not to divide it since all changes are made to fix the same problem. Thread-safety can only be assured if all access to the config object is made in a thread safe manner.
