### PR TITLE
Initialized ImportingJob.lastTouched

### DIFF
--- a/main/src/com/google/refine/importing/ImportingJob.java
+++ b/main/src/com/google/refine/importing/ImportingJob.java
@@ -76,6 +76,8 @@ public class ImportingJob implements Jsonizable {
         JSONUtilities.safePut(cfg, "hasData", false);
         this.config = cfg;
         
+        lastTouched = System.currentTimeMillis();
+        
         dir.mkdirs();
     }
     


### PR DESCRIPTION
Prevents the CleaningTimerTask from disposing newly created
ImportingJobs which have not yet been touched.
