### PR TITLE
Fix when exporting to excel files

### DIFF
--- a/main/src/com/google/refine/exporters/XlsExporter.java
+++ b/main/src/com/google/refine/exporters/XlsExporter.java
@@ -102,6 +102,7 @@ public class XlsExporter implements StreamExporter {
                     Cell c = r.createCell(i);
                     if (i == 255 && cells.size() > 256) {
                         c.setCellValue("ERROR: TOO MANY COLUMNS");
+                        break;
                     } else {
                         CellData cellData = cells.get(i);
                         


### PR DESCRIPTION
When exporting to excel, there cannot be more than 255 columns.
If there are more columns than that, we write "ERROR: TOO MANY
COLUMNS" to the 255th column. Formerly, OpenRefine reported
a 500 Server error. Addresses issue #834.
