### PR TITLE
Added system property refine.max_form_content_size

### DIFF
--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -182,10 +182,11 @@ class RefineServer extends Server {
         }
 
         final String contextPath = Configurations.get("refine.context_path","/");
+        final int maxFormContentSize = Configurations.getInteger("refine.max_form_content_size", 1048576);
         
         logger.info("Initializing context: '" + contextPath + "' from '" + webapp.getAbsolutePath() + "'");
         WebAppContext context = new WebAppContext(webapp.getAbsolutePath(), contextPath);
-        context.setMaxFormContentSize(1048576);
+        context.setMaxFormContentSize(maxFormContentSize);
 
         this.setHandler(context);
         this.setStopAtShutdown(true);


### PR DESCRIPTION
To allow configuring the maximum allowed form content size in Jetty. We recieved

```
java.lang.IllegalStateException: Form too large
```

when uploading over 1MB of operation data to apply-operations. We wanted to be able to increase the hardcoded limit.

Being able to configure the allowed form content size can be useful in several cases, see https://github.com/OpenRefine/OpenRefine/issues/638 and https://github.com/OpenRefine/OpenRefine/issues/863.
