### PR TITLE
Accept 1.9 as a valid Java VM version

### DIFF
--- a/refine
+++ b/refine
@@ -872,7 +872,7 @@ if [ ! -x "$JAVA" ] ; then
     error "Could not find the 'java' executable at '$JAVA', are you sure your JAVA_HOME environment variable is pointing to a proper java installation?"
 fi
 
-JAVA_VERSION=`$JAVA -version 2>&1 | grep version | cut -d ' ' -f 3 | egrep '^\"1\.(6|7|8)'`
+JAVA_VERSION=`$JAVA -version 2>&1 | grep version | cut -d ' ' -f 3 | egrep '^\"1\.(6|7|8|9)'`
 if [ -z "$JAVA_VERSION" ] ; then
     error "OpenRefine requires Java version 6 or later. If you have multiple versions of Java installed, please set the environment variable JAVA_HOME to the correct version."
 fi


### PR DESCRIPTION
This makes openrefine start up with a 1.9 VM (ea snapshot)
