### PR TITLE
Added config item to refine.ini for system property refine.max_form_content_size

### DIFF
--- a/refine
+++ b/refine
@@ -917,6 +917,11 @@ if [ -z "$REFINE_MEMORY" ] ; then
 fi
 add_option "-Xms256M -Xmx$REFINE_MEMORY -Drefine.memory=$REFINE_MEMORY"
 
+if [ -z "$REFINE_MAX_FORM_CONTENT_SIZE" ] ; then
+    REFINE_MAX_FORM_CONTENT_SIZE="1048576"
+fi
+add_option "-Drefine.max_form_content_size=$REFINE_MAX_FORM_CONTENT_SIZE"
+
 if [ -z "$REFINE_PORT" ] ; then
     REFINE_PORT="3333"
 fi

--- a/refine.ini
+++ b/refine.ini
@@ -5,6 +5,9 @@ no_proxy="localhost,127.0.0.1"
 #REFINE_PORT=3334
 #REFINE_HOST=127.0.0.1
 #REFINE_WEBAPP=main\webapp
+
+# Memory and max form size allocations
+#REFINE_MAX_FORM_CONTENT_SIZE=1048576
 REFINE_MEMORY=1400M
 
 # Some sample configurations. These have no defaults.


### PR DESCRIPTION
When using OpenRefine with super large data sets and using the fingerprint clustering algorithm, I usually get an error (the same error as https://github.com/OpenRefine/OpenRefine/issues/638) when trying to merge and re-cluster a massive data set. I noticed that the max form content size has been added to the system properties in https://github.com/OpenRefine/OpenRefine/pull/876. This PR would make it a lot easier to modify the property by adding an entry into refine.ini, and it is commented out by default. 
