### PR TITLE
Allow longer expressions by sendig them as POST

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
@@ -158,8 +158,8 @@ ExpressionPreviewDialog.Widget.prototype.getExpression = function(commit) {
     s = this._getLanguage() + ":" + s;
     if (commit) {
         $.post(
-            "command/core/log-expression?" + $.param({ project: theProject.id, expression: s }),
-            null,
+            "command/core/log-expression?" + $.param({ project: theProject.id }),
+            { expression: s },
             function(data) {
             },
             "json"
@@ -390,7 +390,6 @@ ExpressionPreviewDialog.Widget.prototype.update = function() {
     var expression = this.expression = $.trim(this._elmts.expressionPreviewTextarea[0].value);
     var params = {
         project: theProject.id,
-        expression: this._getLanguage() + ":" + expression,
         cellIndex: this._cellIndex
     };
     this._prepareUpdate(params);
@@ -398,6 +397,7 @@ ExpressionPreviewDialog.Widget.prototype.update = function() {
     $.post(
         "command/core/preview-expression?" + $.param(params), 
         {
+        	expression: this._getLanguage() + ":" + expression,
             rowIndices: JSON.stringify(this._rowIndices) 
         },
         function(data) {
@@ -421,10 +421,12 @@ ExpressionPreviewDialog.Widget.prototype._renderPreview = function(expression, d
     var table = $('<table></table>').appendTo(
         $('<div>').addClass("expression-preview-table-wrapper").appendTo(container))[0];
     
+    var truncExpression = expression.length > 30 ? expression.substring(0, 30) + ' ...' : expression; 
+    
     var tr = table.insertRow(0);
     $(tr.insertCell(0)).addClass("expression-preview-heading").text("row");
     $(tr.insertCell(1)).addClass("expression-preview-heading").text("value");
-    $(tr.insertCell(2)).addClass("expression-preview-heading").text(expression);
+    $(tr.insertCell(2)).addClass("expression-preview-heading").text(truncExpression);
     
     var renderValue = function(td, v) {
         if (v !== null && v !== undefined) {

--- a/main/webapp/modules/core/scripts/project/process-panel.js
+++ b/main/webapp/modules/core/scripts/project/process-panel.js
@@ -96,10 +96,13 @@ ProcessPanel.prototype.showUndo = function(historyEntry) {
 
   this._latestHistoryEntry = historyEntry;
 
+  truncDescription = historyEntry.description.length > 250 ?
+  	historyEntry.description.substring(0, 250) + " ..." : historyEntry.description  
+
   this._div.stop(true, false);
   this._elmts.progressDiv.hide();
   this._elmts.undoDiv.show();
-  this._elmts.undoDescription.text(historyEntry.description);
+  this._elmts.undoDescription.text( truncDescription );
   this._elmts.undoLink.unbind().click(function() { self.undo(); });
   
   this._div

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
@@ -36,13 +36,12 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     Refine.postCoreProcess(
       "text-transform",
       {
-        columnName: column.name, 
-        expression: expression, 
+        columnName: column.name,  
         onError: onError,
         repeat: repeat,
         repeatCount: repeatCount
       },
-      null,
+      { expression: expression },
       { cellsChanged: true }
     );
   };

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
@@ -72,13 +72,12 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       Refine.postCoreProcess(
         "add-column", 
         {
-          baseColumnName: column.name, 
-          expression: previewWidget.getExpression(true), 
+          baseColumnName: column.name,  
           newColumnName: columnName, 
           columnInsertIndex: columnIndex + 1,
           onError: $('input[name="create-column-dialog-onerror-choice"]:checked')[0].value
         },
-        null,
+        { expression: previewWidget.getExpression(true) },
         { modelsChanged: true },
         {
           onDone: function(o) {


### PR DESCRIPTION
Expressions from expression-preview are send to server via HTTP GET. Because of this users aren't able to send expressions longer than a few hundreds chars (limit by url length). This fix sends expressions via POST and that solves the problem for longer scripts.
