### PR TITLE
Fixes Cell.toString failing on null value

### DIFF
--- a/main/src/com/google/refine/model/Cell.java
+++ b/main/src/com/google/refine/model/Cell.java
@@ -193,6 +193,10 @@ public class Cell implements HasFields, Jsonizable {
     
     @Override
     public String toString() {
-        return value.toString();
+        if (value != null){
+            return value.toString();
+        } else {
+            return "null";
+        }
     }
 }


### PR DESCRIPTION
Cells can contain null values, but in such case Cell.toString() fails.
