### PR TITLE
Add charset=UTF-8 to HTTP Content-Type for reconciliation queries.

### DIFF
--- a/main/src/com/google/refine/commands/recon/GuessTypesOfColumnCommand.java
+++ b/main/src/com/google/refine/commands/recon/GuessTypesOfColumnCommand.java
@@ -167,7 +167,7 @@ public class GuessTypesOfColumnCommand extends Command {
             URL url = new URL(serviceUrl);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             {
-                connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+                connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
                 connection.setConnectTimeout(30000);
                 connection.setDoOutput(true);
                 

--- a/main/src/com/google/refine/model/recon/StandardReconConfig.java
+++ b/main/src/com/google/refine/model/recon/StandardReconConfig.java
@@ -335,7 +335,7 @@ public class StandardReconConfig extends ReconConfig {
             URL url = new URL(service);
             HttpURLConnection connection = (HttpURLConnection) url.openConnection();
             {
-                connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+                connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
                 connection.setConnectTimeout(30000);
                 connection.setDoOutput(true);
                 


### PR DESCRIPTION
Fixes #917 where non-ASCII characters would be URL encoded as UTF-8, but interpreted according to the whims of the server.
