### PR TITLE
Translations aren't loaded with server context different from "/"

### DIFF
--- a/extensions/freebase/module/scripts/extension.js
+++ b/extensions/freebase/module/scripts/extension.js
@@ -39,7 +39,7 @@ var lang = navigator.language.split("-")[0]
 		|| navigator.userLanguage.split("-")[0];
 var dictionary = "";
 $.ajax({
-	url : "/command/core/load-language?",
+	url : "command/core/load-language?",
 	type : "POST",
 	async : false,
 	data : {

--- a/extensions/gdata/module/scripts/index/importing-controller.js
+++ b/extensions/gdata/module/scripts/index/importing-controller.js
@@ -36,7 +36,7 @@ var lang = navigator.language.split("-")[0]
 		|| navigator.userLanguage.split("-")[0];
 var dictionary = "";
 $.ajax({
-	url : "/command/core/load-language?",
+	url : "command/core/load-language?",
 	type : "POST",
 	async : false,
 	data : {

--- a/extensions/gdata/module/scripts/project/exporters.js
+++ b/extensions/gdata/module/scripts/project/exporters.js
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 var dictionary = "";
 $.ajax({
-	url : "/command/core/load-language?",
+	url : "command/core/load-language?",
 	type : "POST",
 	async : false,
 	data : {

--- a/main/webapp/modules/core/scripts/index.js
+++ b/main/webapp/modules/core/scripts/index.js
@@ -40,7 +40,7 @@ var Refine = {
 var lang = (navigator.language|| navigator.userLanguage).split("-")[0];
 var dictionary = "";
 $.ajax({
-	url : "/command/core/load-language?",
+	url : "command/core/load-language?",
 	type : "POST",
 	async : false,
 	data : {

--- a/main/webapp/modules/core/scripts/index/lang-settings-ui.js
+++ b/main/webapp/modules/core/scripts/index/lang-settings-ui.js
@@ -11,7 +11,7 @@ Refine.SetLanguageUI = function(elmt) {
 	
 
   $.ajax({
-    url : "/command/core/get-languages?",
+    url : "command/core/get-languages?",
     type : "GET",
     async : false,
     data : {
@@ -29,7 +29,7 @@ Refine.SetLanguageUI = function(elmt) {
 
 	this._elmts.set_lan_btn.bind('click', function(e) {		
 		$.ajax({
-			url : "/command/core/set-preference?",
+			url : "command/core/set-preference?",
 			type : "POST",
 			async : false,
 			data : {

--- a/main/webapp/modules/core/scripts/preferences.js
+++ b/main/webapp/modules/core/scripts/preferences.js
@@ -36,7 +36,7 @@ var preferenceUIs = [];
 var lang = (navigator.language|| navigator.userLanguage).split("-")[0];
 var dictionary = "";
 $.ajax({
-url : "/command/core/load-language?",
+url : "command/core/load-language?",
 type : "POST",
 async : false,
 data : {

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -37,7 +37,7 @@ var ui = {};
 var lang = (navigator.language|| navigator.userLanguage).split("-")[0];
 var dictionary = "";
 $.ajax({
-	url : "/command/core/load-language?",
+	url : "command/core/load-language?",
 	type : "POST",
 	async : false,
 	data : {


### PR DESCRIPTION
Translations aren't loaded in the browser when refine is run from a server context different than "/".
The problem cause is the same as in #576
