### PR TITLE
Change 'Add columns from Freebase' to allow using custom MQL sources.

### DIFF
--- a/extensions/freebase/module/MOD-INF/controller.js
+++ b/extensions/freebase/module/MOD-INF/controller.js
@@ -91,6 +91,8 @@ function init() {
     [
       "scripts/extension.js",
 
+      "scripts/dialogs/extend-data-manager.js",
+
       "scripts/util/freebase.js",
 
       "scripts/dialogs/freebase-loading-dialog.js",

--- a/extensions/freebase/module/langs/translation-default.json
+++ b/extensions/freebase/module/langs/translation-default.json
@@ -88,9 +88,9 @@
 		"ok-button": "Yes, QA Data Load"
 	},
 	"fb-extend": {
-		"add-column": "Add Columns from Freebase Based on Column",
+		"add-column": "Add Columns using MQL Based on Column",
 		"warning-add-properties": "Please add some properties first.",
-		"querying-freebase": "Querying Freebase ...",
+		"querying-freebase": "Querying MQL service...",
 		"remove-column": "Remove this column",
 		"add-constraints": "Add constraints to this column",
 		"mql-constraints": "Enter MQL query constraints as JSON",
@@ -98,7 +98,12 @@
 		"warning-json-obj": "The JSON you enter must be an object, that is, it is of this form { ... }.",
 		"add-property": "Add Property",
 		"suggested-properties": "Suggested Properties",
-		"constraint": "Constraint"		
+		"constraint": "Constraint",
+		"add-mql-srv": "Add MQL (Metaweb Query Language) Service",
+		"pick-service": "Pick a service on the left",
+		"service-title": "Services",
+		"enter-name": "Enter the service's name",
+		"preview": "Preview"
 	},
 	"fb-menu": {
 		"freebase": "Freebase",
@@ -107,7 +112,7 @@
 		"load": "Load into Freebase...",
 		"browse-data-load": "Browse data load details...",
 		"import-qa": "Import QA data",
-		"add-columns": "Add columns from Freebase ...",
+		"add-columns": "Add columns using MQL ...",
 		"warning-load": "You have not tried to load the data in this project into Freebase yet."
 	},
     "fb-buttons": {

--- a/extensions/freebase/module/langs/translation-en.json
+++ b/extensions/freebase/module/langs/translation-en.json
@@ -88,9 +88,9 @@
 		"ok-button": "Yes, QA Data Load"
 	},
 	"fb-extend": {
-		"add-column": "Add Columns from Freebase Based on Column",
+		"add-column": "Add Columns using MQL Based on Column",
 		"warning-add-properties": "Please add some properties first.",
-		"querying-freebase": "Querying Freebase ...",
+		"querying-freebase": "Querying MQL service...",
 		"remove-column": "Remove this column",
 		"add-constraints": "Add constraints to this column",
 		"mql-constraints": "Enter MQL query constraints as JSON",
@@ -98,7 +98,12 @@
 		"warning-json-obj": "The JSON you enter must be an object, that is, it is of this form { ... }.",
 		"add-property": "Add Property",
 		"suggested-properties": "Suggested Properties",
-		"constraint": "Constraint"		
+		"constraint": "Constraint",
+		"add-mql-srv": "Add MQL (Metaweb Query Language) Service",
+		"pick-service": "Pick a service on the left",
+		"service-title": "Services",
+		"enter-name": "Enter the service's name",
+		"preview": "Preview"
 	},
 	"fb-menu": {
 		"freebase": "Freebase",
@@ -107,7 +112,7 @@
 		"load": "Load into Freebase...",
 		"browse-data-load": "Browse data load details...",
 		"import-qa": "Import QA data",
-		"add-columns": "Add columns from Freebase ...",
+		"add-columns": "Add columns using MQL ...",
 		"warning-load": "You have not tried to load the data in this project into Freebase yet."
 	},
     "fb-buttons": {

--- a/extensions/freebase/module/langs/translation-it.json
+++ b/extensions/freebase/module/langs/translation-it.json
@@ -88,9 +88,9 @@
 		"ok-button": "Si, Caricamento dati con analisi qualitativa"
 	},
 	"fb-extend": {
-		"add-column": "Aggiungi colonne da Freebase basandoti sulla colonna",
+		"add-column": "Aggiungi colonne da Freebase basandoti sulla colonna", // New translation required
 		"warning-add-properties": "Prima aggiungi delle proprietà.",
-		"querying-freebase": "Interrogando Freebase ...",
+		"querying-freebase": "Interrogando Freebase ...", // New translation required
 		"remove-column": "Rimuovi questa colonna",
 		"add-constraints": "Aggiungi vincoli a questa colonna",
 		"mql-constraints": "Inserisci i vincoli per la query MQL come JSON",
@@ -98,7 +98,12 @@
 		"warning-json-obj": "Il JSON che inserisci deve essere un oggetto, cioè in questa forma: { ... }.",
 		"add-property": "Aggiungi Proprietà",
 		"suggested-properties": "Proprietà suggerite",
-		"constraint": "Vincoli"		
+		"constraint": "Vincoli",
+		"add-mql-srv": "Add MQL (Metaweb Query Language) Service", // Translation required
+		"pick-service": "Pick a service on the left", // Translation required
+		"service-title": "Services", // Translation required
+		"enter-name": "Enter the service's name", // Translation required
+		"preview": "Preview" // New translation required
 	},
 	"fb-menu": {
 		"freebase": "Freebase",
@@ -107,7 +112,7 @@
 		"load": "Carica in Freebase...",
 		"browse-data-load": "Vedi i dettagli per il caricamento dati...",
 		"import-qa": "Importa dati con controllo qualità",
-		"add-columns": "Aggiungi colonne da Freebase ...",
+		"add-columns": "Aggiungi colonne da Freebase ...", // New translation required
 		"warning-load": "Non hai ancora provato a caricare i dati di questo progetto in Freebase."
 	},
     "fb-buttons": {

--- a/extensions/freebase/module/scripts/dialogs/add-service-dialog.html
+++ b/extensions/freebase/module/scripts/dialogs/add-service-dialog.html
@@ -1,0 +1,13 @@
+<div class="dialog-frame" style="width: 500px;">
+  <div class="dialog-header" bind="dialogHeader"></div>
+  <div class="dialog-body" bind="dialogBody">
+    <p><span bind="or_recon_enterName"></span></p>
+    <div class="input-container"><input placeholder="Service name" bind="inputName" /></div>
+    <p><span bind="or_recon_enterUrl"></span></p>
+    <div class="input-container"><input placeholder="http://" bind="inputUrl" /></div>
+  </div>
+  <div class="dialog-footer" bind="dialogFooter">
+    <button class="button" bind="addButton"></button>
+    <button class="button" bind="cancelButton"></button>
+  </div>
+</div>

--- a/extensions/freebase/module/scripts/dialogs/extend-data-manager.js
+++ b/extensions/freebase/module/scripts/dialogs/extend-data-manager.js
@@ -1,0 +1,143 @@
+/*
+
+Copyright 2010, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+ * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+var ExtendDataManager = {
+		customServices : [],     // services registered by core and extensions
+		standardServices : [],   // services registered by user
+		_urlMap : {}
+};
+
+ExtendDataManager._rebuildMap = function() {
+	var map = {};
+	$.each(ExtendDataManager.getAllServices(), function(i, service) {
+		if ("url" in service) {
+			map[service.url] = service;
+		}
+	});
+	ExtendDataManager._urlMap = map;
+};
+
+ExtendDataManager.getServiceFromUrl = function(url) {
+	return ExtendDataManager._urlMap[url];
+};
+
+ExtendDataManager.getAllServices = function() {
+	return ExtendDataManager.customServices.concat(ExtendDataManager.standardServices);
+};
+
+ExtendDataManager.registerService = function(service) {
+	ExtendDataManager.customServices.push(service);
+	ExtendDataManager._rebuildMap();
+
+	return ExtendDataManager.customServices.length - 1;
+};
+
+ExtendDataManager.registerStandardService = function(url, name, f) {
+	var data = {};
+
+	// I don't see an API call to find the schema space or identifier space,
+	// but here would be an appropriate place to find it.
+	data.url = url;
+	data.name = name ? name : url;
+	if (url.indexOf("https://www.googleapis.com/freebase/v1") > -1) {
+		data.identifierSpace = "http://rdf.freebase.com/ns/type.object.mid";
+		data.schemaSpace = "http://rdf.freebase.com/ns/type.object.id";
+		data.viewUrl = "http://www.freebase.com/view{{id}}";
+	} else {
+		data.identifierSpace = "";
+		data.schemaSpace = "";
+		data.viewUrl = "{{id}}";
+	}
+
+	index = ExtendDataManager.customServices.length + ExtendDataManager.standardServices.length;
+
+	ExtendDataManager.standardServices.push(data);
+	ExtendDataManager._rebuildMap();
+
+	ExtendDataManager.save();
+
+	if (f) {
+		f(index);
+	}
+};
+
+ExtendDataManager.unregisterService = function(service, f) {
+	for (var i = 0; i < ExtendDataManager.customServices.length; i++) {
+		if (ExtendDataManager.customServices[i] === service) {
+			ExtendDataManager.customServices.splice(i, 1);
+			break;
+		}
+	}
+	for (var i = 0; i < ExtendDataManager.standardServices.length; i++) {
+		if (ExtendDataManager.standardServices[i] === service) {
+			ExtendDataManager.standardServices.splice(i, 1);
+			break;
+		}
+	}
+	ExtendDataManager._rebuildMap();
+	ExtendDataManager.save(f);
+};
+
+ExtendDataManager.save = function(f) {
+	$.ajax({
+		async: false,
+		type: "POST",
+		url: "command/core/set-preference?" + $.param({
+			name: "freebase.mqlServices"
+		}),
+		data: { "value" : JSON.stringify(ExtendDataManager.standardServices) },
+		success: function(data) {
+			if (f) { f(); }
+		},
+		dataType: "json"
+	});
+};
+
+(function() {
+	$.ajax({
+		async: false,
+		url: "command/core/get-preference?" + $.param({
+			name: "freebase.mqlServices"
+		}),
+		success: function(data) {
+			if (data.value && data.value != "null") {
+				ExtendDataManager.standardServices = JSON.parse(data.value);
+				ExtendDataManager._rebuildMap();
+			}
+			else {
+				ExtendDataManager.registerStandardService("https://www.googleapis.com/freebase/v1/mqlread", "Freebase (v1)");
+			}
+		},
+		dataType: "json"
+	});
+})();

--- a/extensions/freebase/module/scripts/dialogs/extend-data-preview-dialog.html
+++ b/extensions/freebase/module/scripts/dialogs/extend-data-preview-dialog.html
@@ -1,26 +1,54 @@
-<div class="dialog-frame extend-data-preview-dialog" style="width: 800px;">
+<div class="dialog-frame extend-data-preview-dialog" style="width: 900px;">
   <div class="dialog-header" bind="dialogHeader"></div>
   <div class="dialog-body" bind="dialogBody">
-    <div class="grid-layout layout-normal layout-full"><table rows="4">
-      <tr>
-        <td width="300" height="1" ><span bind="fb_add_property"></span></td>
-        <td height="1">Preview</td>
-        <td height="1" width="1%"><button class="button" bind="resetButton"></button></td>
-      </tr>
-      <tr>
-        <td style="vertical-align: top;" height="1"><div class="input-container"><input bind="addPropertyInput" /></div></td>
-        <td style="vertical-align: top;" rowspan="3" colspan="2"><div class="preview-container" bind="previewContainer"></div></td>
-      </tr>
-      <tr>
-        <td height="1" bind="suggested_properties"></td>
-      </tr>
-      <tr>
-        <td><div class="suggested-property-container" bind="suggestedPropertyContainer"></div></td>
-      </tr>
-    </table></div>
+    <div class="grid-layout layout-normal layout-full grid-layout-for-ui">
+      <div class="recon-dialog-service">
+        <div class="recon-dialog-service-list-container">
+          <div class="recon-dialog-service-opener">
+            <div class="recon-dialog-service-opener-title" bind="serviceListTitle"></div>
+            <img class="recon-dialog-service-opener-img" src="images/menu-opener.png" />
+          </div>
+          <div class="recon-dialog-service-list" bind="serviceList"></div>
+        </div>
+        <div class="recon-dialog-service-panel-container" bind="servicePanelContainer">
+          <div class="recon-dialog-service-panel-message" bind="servicePanelMessage"></div>
+          <div class="recon-dialog-service-panel recon-dialog-mql-service-panel" bind="servicePanel">
+            <div class="grid-layout layout-normal layout-full grid-layout-for-ui">
+              <table>
+                <tr>
+                  <td width="300" height="1"><span bind="addProperty"></span></td>
+                  <td height="1"><span bind="preview"></span></td>
+                  <td height="1" width="1%"><button class="button" bind="resetButton"></button></td>
+                </tr>
+                <tr>
+                  <td style="vertical-align: top;" height="1"><div class="input-container"><input bind="addPropertyInput" /></div></td>
+                  <td style="vertical-align: top;" rowspan="3" colspan="2"><div class="preview-container" bind="previewContainer"></div></td>
+                </tr>
+                <tr>
+                  <td height="1" bind="suggestedProperties"></td>
+                </tr>
+                <tr>
+                  <td><div class="suggested-property-container" bind="suggestedPropertyContainer"></div></td>
+                </tr>
+                </tr>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
   <div class="dialog-footer" bind="dialogFooter">
-    <button class="button" bind="okButton"></button>
-    <button class="button" bind="cancelButton"></button>
+    <table width="100%">
+      <tr>
+        <td align="left">
+          <button class="button" bind="addServiceButton"></button>
+        </td>
+        <td align="right">
+          <button class="button" bind="okButton"></button>
+          <button class="button" bind="cancelButton"></button>
+        </td>
+      </tr>
+    </table>
   </div>
 </div>

--- a/extensions/freebase/module/scripts/dialogs/extend-data-preview-dialog.js
+++ b/extensions/freebase/module/scripts/dialogs/extend-data-preview-dialog.js
@@ -499,7 +499,7 @@ ExtendDataPreviewDialog.prototype._renderPreview = function(data) {
       var cell = row[c];
       if (cell !== null) {
         if ($.isPlainObject(cell)) {
-          $('<a>').attr("href", self._extension.service.viewUrl.replace("{{id}}", cell.id)).text(cell.name).appendTo(td);
+          $('<a>').attr("href", (self._extension.service.viewUrl != null) ? self._extension.service.viewUrl.replace("{{id}}", cell.id) : cell.id).text(cell.name).appendTo(td);
         } else {
           $('<span>').text(cell).appendTo(td);
         }

--- a/extensions/freebase/src/com/google/refine/freebase/operations/ExtendDataOperation.java
+++ b/extensions/freebase/src/com/google/refine/freebase/operations/ExtendDataOperation.java
@@ -304,6 +304,9 @@ public class ExtendDataOperation extends EngineDependentOperation {
                         columnTypes,
                         rowIndices,
                         dataExtensions,
+                        _job.reconServiceUrl,
+                        _job.identifierSpace,
+                        _job.schemaSpace,
                         _historyEntryID)
                 );
                 

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -51,9 +51,7 @@ $.ajax({
 $.i18n.setDictionary(dictionary);
 // End internationalization
 
-var Refine = {
-  refineHelperService: "http://openrefine-helper.freebaseapps.com"
-};
+var Refine = {};
 
 Refine.reportException = function(e) {
   if (window.console) {

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -108,6 +108,8 @@ DataTableCellUI.prototype._render = function() {
         a.attr("href", encodeURI(service.view.url.replace("{{id}}", match.id)));
       } else if (ReconciliationManager.isFreebaseIdOrMid(r.identifierSpace)) {
         a.attr("href", "http://www.freebase.com/view" + match.id);
+      } else if (URL.looksLikeUrl(r.identifierSpace + match.id)) {
+        a.attr("href", r.identifierSpace + match.id);
       }
 
       $('<span> </span>').appendTo(divContent);
@@ -152,6 +154,8 @@ DataTableCellUI.prototype._render = function() {
               a.attr("href", encodeURI(service.view.url.replace("{{id}}", candidate.id)));
             } else if (ReconciliationManager.isFreebaseIdOrMid(r.identifierSpace)) {
               a.attr("href", "http://www.freebase.com/view" + candidate.id);
+            } else if (URL.looksLikeUrl(r.identifierSpace + candidate.id)) {
+                a.attr("href", r.identifierSpace + candidate.id);
             }
 
             var preview = null;


### PR DESCRIPTION
As discussed on the [mailing list](https://groups.google.com/forum/#!topic/openrefine-dev/lRU-tleLYfM), I'd been working on an extension (based on the Freebase one) to allow OpenRefine to _read_ from MQL services other than Freebase.

This commit transfers that functionality to the Freebase extension, including a dialogue to add a new MQL service, and changes to record and display non-Freebase cells generated by the extension.

An Italian translation for a few new phrases is still needed.

It's probably not ideal that this is all one commit, but I did 90% of the work in my [extension](https://github.com/RBGKew/OpenRefine-Kew-Extension/commits/move-to-freebase-extension) before moving it across.
