### PR TITLE
Fix #896 - TextSearchFacet refreshes unnecessarily

### DIFF
--- a/main/webapp/modules/core/scripts/facets/text-search-facet.js
+++ b/main/webapp/modules/core/scripts/facets/text-search-facet.js
@@ -128,6 +128,10 @@ TextSearchFacet.prototype._initializeUI = function() {
   }
   
   elmts.input.bind("keyup change input",function(evt) {
+    // Ignore non-character keyup changes
+    if(evt.type === "keyup" && (this.value === self._query || this.value === '' && !self._query)) {
+      return;
+    }
     self._query = this.value;
     self._scheduleUpdate();
   }).focus();


### PR DESCRIPTION
Ignore keystrokes in the TextSearchFacet that do not indicate changes to the search query