### PR TITLE
prevent the multiple sorting

### DIFF
--- a/main/src/com/google/refine/browsing/Engine.java
+++ b/main/src/com/google/refine/browsing/Engine.java
@@ -91,7 +91,7 @@ public class Engine implements Jsonizable {
         _mode = mode;
     }
 
-    public FilteredRows getAllRows() {
+    public synchronized FilteredRows getAllRows() {
         return new FilteredRows() {
             @Override
             public void accept(Project project, RowVisitor visitor) {
@@ -134,7 +134,7 @@ public class Engine implements Jsonizable {
         throw new InternalError("Unknown mode.");
     }
 
-    public FilteredRecords getAllRecords() {
+    public synchronized FilteredRecords getAllRecords() {
         return new FilteredRecords() {
             @Override
             public void accept(Project project, RecordVisitor visitor) {

--- a/main/webapp/modules/core/scripts/util/dialog.js
+++ b/main/webapp/modules/core/scripts/util/dialog.js
@@ -64,13 +64,8 @@ DialogSystem.showDialog = function(elmt, onCancel) {
   return level;
 };
 
-DialogSystem.dismissAll = function() {
-  DialogSystem.dismissUntil(0);
-};
-
-DialogSystem.dismissUntil = function(level) {
-  for (var i = DialogSystem._layers.length - 1; i >= level; i--) {
-    var layer = DialogSystem._layers[i];
+DialogSystem.dismissLevel = function(level) {
+    var layer = DialogSystem._layers[level];
 
     $(document).unbind("keydown", layer.keyHandler);
 
@@ -85,6 +80,15 @@ DialogSystem.dismissUntil = function(level) {
         Refine.reportException(e);
       }
     }
+};
+
+DialogSystem.dismissAll = function() {
+  DialogSystem.dismissUntil(0);
+};
+
+DialogSystem.dismissUntil = function(level) {
+  for (var i = DialogSystem._layers.length - 1; i >= level; i--) {
+	  DialogSystem.dismissLevel(i);
   }
   DialogSystem._layers = DialogSystem._layers.slice(0, level);
 };
@@ -107,3 +111,4 @@ DialogSystem.showBusy = function(message) {
     DialogSystem.dismissUntil(level - 1);
   };
 };
+

--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -327,7 +327,7 @@ DataTableColumnHeaderUI.prototype._showSortingCriterion = function(criterion, ha
   elmts.blankErrorPositions.html(positionsHtml.join("")).sortable().disableSelection();
 
   var level = DialogSystem.showDialog(frame);
-  var dismiss = function() { DialogSystem.dismissUntil(level - 1); };
+  var dismiss = function() { DialogSystem.dismissLevel(level - 1); };
 
   setValueType(criterion.valueType); 
 

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -544,13 +544,21 @@ DataTableView.prototype._addSortingCriterion = function(criterion, alone) {
     for (var i = 0; i < this._sorting.criteria.length; i++) {
       if (this._sorting.criteria[i].column == criterion.column) {
         this._sorting.criteria[i] = criterion;
-        this.update();
+    	var dismissBusy = DialogSystem.showBusy();
+        var onDone = function() {
+          dismissBusy();
+    	}
+        this.update(onDone);
         return;
       }
     }
   }
   this._sorting.criteria.push(criterion);
-  this.update();
+  var dismissBusy = DialogSystem.showBusy();
+  var onDone = function() {
+    dismissBusy();
+  }
+  this.update(onDone);
 };
 
 DataTableView.prototype._createMenuForAllColumns = function(elmt) {


### PR DESCRIPTION
The dialog.js utility provided dismiss function and it's by level(ie if you dismiss the level 2 and the level 3 will be also dismissed). I added one function to allow it dismiss specified level so the "Working" dialog can survive after the main dialog is gone.

For the back end, changed two methods:
public synchronized FilteredRows getAllRows() 
public synchronized FilteredRecords getAllRecords() 
It will handle all the cases which processing the rows and records to prevent the reentry. Hopeful it's not overkill.