### PR TITLE
Concurrent access issue to jython evaluables.

### DIFF
--- a/extensions/jython/src/com/google/refine/jython/JythonEvaluable.java
+++ b/extensions/jython/src/com/google/refine/jython/JythonEvaluable.java
@@ -33,28 +33,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.jython;
 
+import com.google.refine.expr.*;
+import org.python.core.*;
+import org.python.util.PythonInterpreter;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
-
-import org.python.core.Py;
-import org.python.core.PyException;
-import org.python.core.PyFloat;
-import org.python.core.PyFunction;
-import org.python.core.PyInteger;
-import org.python.core.PyLong;
-import org.python.core.PyNone;
-import org.python.core.PyObject;
-import org.python.core.PyString;
-import org.python.util.PythonInterpreter;
-
-import com.google.refine.expr.EvalError;
-import com.google.refine.expr.Evaluable;
-import com.google.refine.expr.HasFields;
-import com.google.refine.expr.LanguageSpecificParser;
-import com.google.refine.expr.ParsingException;
 
 public class JythonEvaluable implements Evaluable {
     
@@ -68,7 +55,7 @@ public class JythonEvaluable implements Evaluable {
         };
     }
     
-    private static final String s_functionName = "___temp___";
+    private final String s_functionName;
     
     private static PythonInterpreter _engine; 
     
@@ -97,6 +84,8 @@ public class JythonEvaluable implements Evaluable {
     }
 
     public JythonEvaluable(String s) {
+        this.s_functionName = String.format("__temp_%d__", Math.abs(s.hashCode()));
+
         // indent and create a function out of the code
         String[] lines = s.split("\r\n|\r|\n");
         

--- a/extensions/jython/tests/com/google/refine/jython/JythonEvaluableTest.java
+++ b/extensions/jython/tests/com/google/refine/jython/JythonEvaluableTest.java
@@ -1,0 +1,47 @@
+package com.google.refine.jython;
+
+import com.google.refine.expr.CellTuple;
+import com.google.refine.expr.Evaluable;
+import com.google.refine.model.Cell;
+import com.google.refine.model.Project;
+import com.google.refine.model.Row;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Properties;
+
+/**
+ * @author Maxim Galushka
+ */
+public class JythonEvaluableTest {
+
+  @Test
+  public void testJythonConcurrent(){
+    Properties props = new Properties();
+    Project project = new Project();
+
+    Row row = new Row(2);
+    row.setCell(0, new Cell("one", null));
+    row.setCell(0, new Cell("1", null));
+
+    props.put("columnName", "number");
+    props.put("true", "true");
+    props.put("false", "false");
+    props.put("rowIndex", "0");
+    props.put("value", 1);
+    props.put("project", project);
+    props.put("call", "number");
+    props.put("PI", "3.141592654");
+    props.put("cells", new CellTuple(project, row));
+
+    Evaluable eval1 = new JythonEvaluable("a = value\nreturn a * 2");
+    Long value1 = (Long) eval1.evaluate(props);
+
+    // create some unrelated evaluable
+    new JythonEvaluable("a = value\nreturn a * 10");
+
+    // repeat same previous test
+    Long value2 = (Long) eval1.evaluate(props);
+    Assert.assertEquals(value1, value2);
+  }
+}


### PR DESCRIPTION
Description: any jython function used in the project has implicit name __\__temp\____ which creates issues when there are multiple projects which transforms are applied concurrently.

Fix replaces default name to include hashcode of function code itself and making this safer in concurrent environments.

Created corresponding test which was failing before and now passes.

We are using openrefine on production to apply transformations to datasets and found that during concurrent access sometimes we are getting corrupted data.

Patch will also help to all forks which are trying to make batch processing transformations engine based on openrefine (what we actually did for internal usage)