### PR TITLE
change in format guesser to enable a difference of more than 0,1

### DIFF
--- a/main/src/com/google/refine/importers/SeparatorBasedImporter.java
+++ b/main/src/com/google/refine/importers/SeparatorBasedImporter.java
@@ -242,9 +242,9 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
                     });
                     
                     Separator separator = separators.get(0);
-                    if (separator.stddev / separator.averagePerLine < 0.1) {
+                    //if (separator.stddev / separator.averagePerLine < 0.1) {
                         return separator;
-                    }
+                    //}
                    
                 }
             } finally {


### PR DESCRIPTION
Hi, 

i'm working with the attached CSV, which is ; separated. But the SeparatorBasedImporter returns *null* because of the test in line 245.

*separator.stddev / separator.averagePerLine* for  this file results in 0.10101010, which is more than the 0.1 in the if clause. What is the reason for this test and also for this 0.1? If i remove the if statement its working great.

Regards
   Steffen...

