### PR TITLE
Fix typo on encodeURIComponent JS call

### DIFF
--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -229,7 +229,7 @@ Refine.OpenProjectUI.prototype._onClickUploadFileButton = function(evt) {
   } else {
     $("#file-upload-form").attr("action",
         "command/core/create-project-from-upload?" + [
-          "url=" +                encodeURICompnent(dataURL),
+          "url=" +                encodeURIComponent(dataURL),
           "split-into-columns=" + $("#split-into-columns-input")[0].checked,
           "separator=" +          $("#separator-input")[0].value,
           "ignore=" +             $("#ignore-input")[0].value,


### PR DESCRIPTION
I found this while reading the code. I haven't tested it, but as this is the only instance of the `encodeURICompnent` string in the codebase, I suppose it's a typo.