### PR TITLE
Add labels for checkboxes in text facet, making them clickable

### DIFF
--- a/main/webapp/modules/core/scripts/facets/text-search-facet.js
+++ b/main/webapp/modules/core/scripts/facets/text-search-facet.js
@@ -93,8 +93,8 @@ TextSearchFacet.prototype._initializeUI = function() {
       '<div class="facet-text-body"><div class="grid-layout layout-tightest layout-full"><table>' +
       '<tr><td colspan="4"><div class="input-container"><input bind="input" /></div></td></tr>' +
       '<tr>' +
-      '<td width="1%"><input type="checkbox" bind="caseSensitiveCheckbox" /></td><td>'+$.i18n._('core-facets')["case-sensitive"]+'</td>' +
-      '<td width="1%"><input type="checkbox" bind="regexCheckbox" /></td><td>'+$.i18n._('core-facets')["regular-exp"]+'</td>' +
+      '<td width="1%"><input type="checkbox" bind="caseSensitiveCheckbox" id="caseSensitiveCheckbox" /></td><td><label for="caseSensitiveCheckbox">'+$.i18n._('core-facets')["case-sensitive"]+'</label></td>' +
+      '<td width="1%"><input type="checkbox" bind="regexCheckbox" id="regexCheckbox" /></td><td><label for="regexCheckbox">'+$.i18n._('core-facets')["regular-exp"]+'</label></td>' +
       '</tr>' +
       '</table></div></div>'
   );


### PR DESCRIPTION
Checkboxes are small targets. Making the labels clickable for toggling checkboxes improves usability.