### PR TITLE
fix PR #1092 to work with Firefox

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
@@ -397,7 +397,9 @@ ClusteringDialog.prototype._export = function() {
     var link = document.createElement('a');
     link.href = 'data:' + data;
     link.download = "clusters_" + projectName + "_" + columnName + "_" + timeStamp + ".json";
+    document.body.appendChild(link);
     link.click();
+    document.body.removeChild(link);
 };
 
 ClusteringDialog.prototype._dismiss = function() {


### PR DESCRIPTION
@thadguidry Thanks for the merge! Unfortunately just afterward I noticed a problem with the cluster export functionality in Firefox. The generated link has to be added to the document body in order for the download to work -- now it works on both Firefox and Chrome.