### PR TITLE
allow more than 2 AND and OR conditions

### DIFF
--- a/main/src/com/google/refine/expr/functions/booleans/And.java
+++ b/main/src/com/google/refine/expr/functions/booleans/And.java
@@ -23,8 +23,8 @@ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -46,7 +46,7 @@ public class And implements Function {
 
     @Override
     public Object call(Properties bindings, Object[] args) {
-        if (args.length == 2 && args[0] instanceof Boolean && args[1] instanceof Boolean) {
+        if (args.length >= 2 && args[0] instanceof Boolean && args[1] instanceof Boolean) {
             for (Object o : args) {
                 if (!Not.objectToBoolean(o)) {
                     return false;
@@ -54,15 +54,15 @@ public class And implements Function {
             }
             return true;
         }
-        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects two booleans");
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects two or more booleans");
     }
-    
+
     @Override
     public void write(JSONWriter writer, Properties options)
             throws JSONException {
-        
+
         writer.object();
-        writer.key("description"); writer.value("ANDs two boolean values");
+        writer.key("description"); writer.value("AND two or more booleans to yield a boolean");
         writer.key("params"); writer.value("boolean a, boolean b");
         writer.key("returns"); writer.value("boolean");
         writer.endObject();

--- a/main/src/com/google/refine/expr/functions/booleans/Or.java
+++ b/main/src/com/google/refine/expr/functions/booleans/Or.java
@@ -23,8 +23,8 @@ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -46,7 +46,7 @@ public class Or implements Function {
 
     @Override
     public Object call(Properties bindings, Object[] args) {
-        if (args.length == 2 && args[0] instanceof Boolean && args[1] instanceof Boolean) {
+        if (args.length >= 2 && args[0] instanceof Boolean && args[1] instanceof Boolean) {
             for (Object o : args) {
                 if (Not.objectToBoolean(o)) {
                     return true;
@@ -54,15 +54,15 @@ public class Or implements Function {
             }
             return false;
         }
-        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects two booleans");
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects two or more booleans");
     }
-    
+
     @Override
     public void write(JSONWriter writer, Properties options)
         throws JSONException {
-    
+
         writer.object();
-        writer.key("description"); writer.value("Returns a OR b");
+        writer.key("description"); writer.value("OR two or more booleans to yield a boolean");
         writer.key("params"); writer.value("boolean a, boolean b");
         writer.key("returns"); writer.value("boolean");
         writer.endObject();

--- a/main/src/com/google/refine/expr/functions/booleans/Xor.java
+++ b/main/src/com/google/refine/expr/functions/booleans/Xor.java
@@ -38,10 +38,10 @@ public class Xor implements Function {
 
     @Override
     public Object call(Properties bindings, Object[] args) {
-        if (args.length == 2 && args[0] instanceof Boolean && args[1] instanceof Boolean) {
+        if (args.length >= 2 && args[0] instanceof Boolean && args[1] instanceof Boolean) {
             return (Boolean) args[0] ^ (Boolean) args[1];
         }
-        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects 2 booleans");
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects 2 or more booleans");
     }
 
     @Override
@@ -50,7 +50,7 @@ public class Xor implements Function {
 
         writer.object();
         writer.key("description");
-        writer.value("XORs two boolean values");
+        writer.value("XORs two or more boolean values");
         writer.key("params");
         writer.value("boolean a, boolean b");
         writer.key("returns");

--- a/main/tests/server/src/com/google/refine/tests/expr/functions/booleans/BooleanTests.java
+++ b/main/tests/server/src/com/google/refine/tests/expr/functions/booleans/BooleanTests.java
@@ -23,14 +23,14 @@ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  */
- 
+
 package com.google.refine.tests.expr.functions.booleans;
 
 import static org.mockito.Mockito.mock;
@@ -70,36 +70,36 @@ public class BooleanTests extends RefineTest {
         {"and","false","false","false"},
         {"and","true","false","false"},
         {"and","false","true","false"},
-        
+
         {"or","true","true","true"},
         {"or","false","false","false"},
         {"or","true","false","true"},
         {"or","false","true","true"},
-        
+
         {"xor","true","true","false"},
         {"xor","false","false","false"},
         {"xor","true","false","true"},
         {"xor","false","true","true"},
     };
 
-    
+
     static Properties bindings;
     Project project;
     Properties options;
     JSONObject engine_config;
     Engine engine;
 
-    
+
     @Override
     @BeforeTest
     public void init() {
         logger = LoggerFactory.getLogger(this.getClass());
     }
-    
+
     @BeforeMethod
     public void SetUp() throws IOException, ModelException {
         bindings = new Properties();
-        
+
         File dir = TestUtils.createTempDirectory("openrefine-test-workspace-dir");
         FileProjectManager.initialize(dir);
         project = new Project();
@@ -110,11 +110,11 @@ public class BooleanTests extends RefineTest {
         int index = project.columnModel.allocateNewCellIndex();
         Column column = new Column(index,"Column A");
         project.columnModel.addColumn(index, column, true);
-        
+
         options = mock(Properties.class);
-      
+
         bindings.put("project", project);
-        
+
         // Five rows of a's and five of 1s
         for (int i = 0; i < 10; i++) {
             Row row = new Row(1);
@@ -128,7 +128,7 @@ public class BooleanTests extends RefineTest {
     public void TearDown() {
         bindings = null;
     }
-    
+
     /**
      * Lookup a control function by name and invoke it with a variable number of args
      */
@@ -144,25 +144,25 @@ public class BooleanTests extends RefineTest {
             return function.call(bindings,args);
         }
     }
-    
+
     @Test
     public void testInvalidParams() {
         for (String op : new String[] {"and","or","xor"}) {
         Assert.assertTrue(invoke(op) instanceof EvalError);
-        Assert.assertTrue(invoke(op, Boolean.TRUE, Boolean.TRUE, Boolean.TRUE) instanceof EvalError);
         Assert.assertTrue(invoke(op, Boolean.TRUE, Integer.valueOf(1)) instanceof EvalError);
         Assert.assertTrue(invoke(op, Integer.valueOf(1), Boolean.TRUE) instanceof EvalError);
         Assert.assertTrue(invoke(op, Boolean.TRUE,"foo") instanceof EvalError);
         Assert.assertTrue(invoke(op, "foo", Boolean.TRUE) instanceof EvalError);
         Assert.assertTrue(invoke(op, Boolean.TRUE) instanceof EvalError);
         }
+        Assert.assertTrue(invoke("xor", Boolean.TRUE, Boolean.TRUE, Boolean.TRUE) instanceof EvalError);
         String op = "not";
         Assert.assertTrue(invoke(op) instanceof EvalError);
-        Assert.assertTrue(invoke(op, Boolean.TRUE,Boolean.TRUE) instanceof EvalError);
+        Assert.assertTrue(invoke(op, Boolean.TRUE, Boolean.TRUE) instanceof EvalError);
         Assert.assertTrue(invoke(op, Integer.valueOf(1)) instanceof EvalError);
         Assert.assertTrue(invoke(op, "foo") instanceof EvalError);
      }
-    
+
     @Test
     public void testBinary() {
         for (String[] test : TRUTH_TABLE) {

--- a/main/tests/server/src/com/google/refine/tests/expr/functions/booleans/BooleanTests.java
+++ b/main/tests/server/src/com/google/refine/tests/expr/functions/booleans/BooleanTests.java
@@ -66,20 +66,20 @@ import com.google.refine.tests.util.TestUtils;
 public class BooleanTests extends RefineTest {
 
     private static String TRUTH_TABLE[][] = {
-        {"and","true","true","true"},
-        {"and","false","false","false"},
-        {"and","true","false","false"},
-        {"and","false","true","false"},
+        {"and","true","true","true","true"},
+        {"and","false","false","false","false"},
+        {"and","true","false","false","false"},
+        {"and","false","true","true","false"},
 
-        {"or","true","true","true"},
-        {"or","false","false","false"},
-        {"or","true","false","true"},
-        {"or","false","true","true"},
+        {"or","true","true","true","true"},
+        {"or","false","false","false","false"},
+        {"or","true","false","false","true"},
+        {"or","false","true","true","true"},
 
-        {"xor","true","true","false"},
-        {"xor","false","false","false"},
-        {"xor","true","false","true"},
-        {"xor","false","true","true"},
+        {"xor","true","true","true","false"},
+        {"xor","false","false","false","false"},
+        {"xor","true","false","false","true"},
+        {"xor","false","true","false","true"},
     };
 
 
@@ -155,7 +155,6 @@ public class BooleanTests extends RefineTest {
         Assert.assertTrue(invoke(op, "foo", Boolean.TRUE) instanceof EvalError);
         Assert.assertTrue(invoke(op, Boolean.TRUE) instanceof EvalError);
         }
-        Assert.assertTrue(invoke("xor", Boolean.TRUE, Boolean.TRUE, Boolean.TRUE) instanceof EvalError);
         String op = "not";
         Assert.assertTrue(invoke(op) instanceof EvalError);
         Assert.assertTrue(invoke(op, Boolean.TRUE, Boolean.TRUE) instanceof EvalError);
@@ -169,8 +168,9 @@ public class BooleanTests extends RefineTest {
             String operator = test[0];
             Boolean op1 = Boolean.valueOf(test[1]);
             Boolean op2 = Boolean.valueOf(test[2]);
-            Boolean result = Boolean.valueOf(test[3]);
-            Assert.assertEquals(invoke(operator, op1, op2),result);
+            Boolean op3 = Boolean.valueOf(test[3]);
+            Boolean result = Boolean.valueOf(test[4]);
+            Assert.assertEquals(invoke(operator, op1, op2, op3),result);
         }
         Assert.assertEquals(invoke("not", Boolean.TRUE),Boolean.FALSE);
         Assert.assertEquals(invoke("not", Boolean.FALSE),Boolean.TRUE);


### PR DESCRIPTION
In reference to my issue #1183 (which was resolved by editing the Wiki to reflect that `AND`/`OR` operators accept *only* two conditions).

I believe it is possible to allow both `AND`/`OR` allow *two or more* conditions, as the changes in my request establish. 

This is an improvement - there is no need to nest `AND`/`OR` functions within each other, and makes testing more than two conditions simpler and more intuitive. It also matches the functionality of the comparable functions in Excel which allow 2+ arguments.
