### PR TITLE
added options for initial java heap space and autosave period

### DIFF
--- a/main/src/com/google/refine/RefineServlet.java
+++ b/main/src/com/google/refine/RefineServlet.java
@@ -85,7 +85,7 @@ public class RefineServlet extends Butterfly {
 
     static final Logger logger = LoggerFactory.getLogger("refine");
 
-    static final protected long AUTOSAVE_PERIOD = 5; // 5 minutes
+    static protected long AUTOSAVE_PERIOD = 5; // default: 5 minutes
     
     static protected class AutoSaveTimerTask implements Runnable {
         @Override
@@ -130,6 +130,8 @@ public class RefineServlet extends Butterfly {
         s_dataDir = new File(data);
         FileProjectManager.initialize(s_dataDir);
         ImportingManager.initialize(this);
+
+	AUTOSAVE_PERIOD = Long.parseLong(getInitParameter("refine.autosave"));
 
         service.scheduleWithFixedDelay(new AutoSaveTimerTask(), AUTOSAVE_PERIOD, 
                 AUTOSAVE_PERIOD, TimeUnit.MINUTES);

--- a/refine
+++ b/refine
@@ -679,6 +679,10 @@ run() {
         add_option "-Drefine.google_api_key=$REFINE_GOOGLE_API_KEY"
     fi
 
+    if [ "$REFINE_AUTOSAVE_PERIOD" ] ; then
+        add_option "-Drefine.autosave=$REFINE_AUTOSAVE_PERIOD"
+    fi
+
     CLASSPATH="$REFINE_CLASSES_DIR${SEP}$REFINE_LIB_DIR/*"
 
     RUN_CMD="$JAVA -cp $CLASSPATH $OPTS com.google.refine.Refine"
@@ -912,7 +916,10 @@ add_option "$JAVA_OPTIONS"
 if [ -z "$REFINE_MEMORY" ] ; then
     REFINE_MEMORY="1024M"
 fi
-add_option "-Xms256M -Xmx$REFINE_MEMORY -Drefine.memory=$REFINE_MEMORY"
+if [ -z "$REFINE_MIN_MEMORY" ] ; then
+    REFINE_MIN_MEMORY="256M"
+fi
+add_option "-Xms$REFINE_MIN_MEMORY -Xmx$REFINE_MEMORY -Drefine.memory=$REFINE_MEMORY"
 
 if [ -z "$REFINE_MAX_FORM_CONTENT_SIZE" ] ; then
     REFINE_MAX_FORM_CONTENT_SIZE="1048576"

--- a/refine.bat
+++ b/refine.bat
@@ -135,8 +135,10 @@ set OPTS=%OPTS% %JAVA_OPTIONS%
 
 if not "%REFINE_MEMORY%" == "" goto gotMemory
 set REFINE_MEMORY=1024M
+if not "%REFINE_MIN_MEMORY%" == "" goto gotMemory
+set REFINE_MIN_MEMORY=256M
 :gotMemory
-set OPTS=%OPTS% -Xms256M -Xmx%REFINE_MEMORY% -Drefine.memory=%REFINE_MEMORY%
+set OPTS=%OPTS% -Xms%REFINE_MIN_MEMORY% -Xmx%REFINE_MEMORY% -Drefine.memory=%REFINE_MEMORY%
 
 if not "%REFINE_MAX_FORM_CONTENT_SIZE%" == "" goto gotMaxFormContentSize
 set REFINE_MAX_FORM_CONTENT_SIZE=1048576

--- a/refine.ini
+++ b/refine.ini
@@ -15,3 +15,9 @@ REFINE_MEMORY=1400M
 #JAVA_HOME=C:\Program Files\Java\jdk1.6.0_25
 #JAVA_OPTIONS=-XX:+UseParallelGC -verbose:gc -Drefine.headless=true
 #JAVA_OPTIONS=-Drefine.data_dir=C:\Users\user\AppData\Roaming\OpenRefine
+
+# Set initial java heap space (default: 256M) for better performance with large datasets
+#REFINE_MIN_MEMORY=1400M
+
+# Increase autosave period (default: 5 minutes) for better performance of long-lasting transformations
+#REFINE_AUTOSAVE_PERIOD=1

--- a/refine.ini
+++ b/refine.ini
@@ -20,4 +20,4 @@ REFINE_MEMORY=1400M
 #REFINE_MIN_MEMORY=1400M
 
 # Increase autosave period (default: 5 minutes) for better performance of long-lasting transformations
-#REFINE_AUTOSAVE_PERIOD=1
+#REFINE_AUTOSAVE_PERIOD=60

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -285,11 +285,13 @@ class RefineServer extends Server {
     // inject configuration parameters in the servlets
     // NOTE: this is done *after* starting the server because jetty might override the init
     // parameters if we set them in the webapp context upon reading the web.xml file    
+
     static private void configure(WebAppContext context) throws Exception {
         ServletHolder servlet = context.getServletHandler().getServlet("refine");
         if (servlet != null) {
             servlet.setInitParameter("refine.data", getDataDir());
             servlet.setInitParameter("butterfly.modules.path", getDataDir() + "/extensions");
+            servlet.setInitParameter("refine.autosave", Configurations.get("refine.autosave"));
             servlet.setInitOrder(1);
             servlet.doStart();
         }


### PR DESCRIPTION
Changes:
* added option for initial java heap space (-Xms) in refine.ini.
* added option for autosave period in refine.ini

Reasons:
* setting -Xms = -Xmx prevents the JVM from wasteful upsizing steps. -Xms was "hardcoded" to 256M in refine shell script
* autosave period defaults to 5 minutes which is a significant performance issue for longlasting transformations. This setting was "hardcoded" in RefineServlet.java
* cf. discussion "[Performance Improvements (initial heap space, autosave, row operations)](https://groups.google.com/forum/#!topic/openrefine/zglQEePk_b4)" in google group