### PR TITLE
bugfix for new option autosave period

### DIFF
--- a/main/src/com/google/refine/RefineServlet.java
+++ b/main/src/com/google/refine/RefineServlet.java
@@ -85,8 +85,6 @@ public class RefineServlet extends Butterfly {
 
     static final Logger logger = LoggerFactory.getLogger("refine");
 
-    static protected long AUTOSAVE_PERIOD = 5; // default: 5 minutes
-    
     static protected class AutoSaveTimerTask implements Runnable {
         @Override
         public void run() {
@@ -131,7 +129,7 @@ public class RefineServlet extends Butterfly {
         FileProjectManager.initialize(s_dataDir);
         ImportingManager.initialize(this);
 
-	AUTOSAVE_PERIOD = Long.parseLong(getInitParameter("refine.autosave"));
+	long AUTOSAVE_PERIOD = Long.parseLong(getInitParameter("refine.autosave"));
 
         service.scheduleWithFixedDelay(new AutoSaveTimerTask(), AUTOSAVE_PERIOD, 
                 AUTOSAVE_PERIOD, TimeUnit.MINUTES);

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -291,7 +291,7 @@ class RefineServer extends Server {
         if (servlet != null) {
             servlet.setInitParameter("refine.data", getDataDir());
             servlet.setInitParameter("butterfly.modules.path", getDataDir() + "/extensions");
-            servlet.setInitParameter("refine.autosave", Configurations.get("refine.autosave"));
+            servlet.setInitParameter("refine.autosave", Configurations.get("refine.autosave", "5")); // default: 5 minutes
             servlet.setInitOrder(1);
             servlet.doStart();
         }


### PR DESCRIPTION
I am very sorry! I have introduced a severe bug with my pull request #1202 recently. This new pull request is a bug fix.

## bug

If REFINE_AUTOSAVE_PERIOD is not set in refine.ini, the application won't start.
```
java.lang.NumberFormatException: null
	at java.lang.Long.parseLong(Long.java:552)
	at java.lang.Long.parseLong(Long.java:631)
	at com.google.refine.RefineServlet.init(RefineServlet.java:134)
	at javax.servlet.GenericServlet.init(GenericServlet.java:241)
	at edu.mit.simile.butterfly.Butterfly.init(Butterfly.java:180)
	at org.mortbay.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:440)
	at org.mortbay.jetty.servlet.ServletHolder.doStart(ServletHolder.java:263)
	at com.google.refine.RefineServer.configure(Refine.java:296)
	at com.google.refine.RefineServer.init(Refine.java:208)
	at com.google.refine.Refine.init(Refine.java:114)
	at com.google.refine.Refine.main(Refine.java:108)
```
## fix

moved default value for autosave period from [main/src/com/google/refine/RefineServlet.java](https://github.com/OpenRefine/OpenRefine/compare/master...felixlohmeier:master#diff-a485437375a9a0725ad9e422aa9ff677) to [server/src/com/google/refine/Refine.java](https://github.com/OpenRefine/OpenRefine/compare/master...felixlohmeier:master#diff-9b5ce7d9db147a619528fee2dd305451)