### PR TITLE
Added Start and Stop Script For Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ broker/core/test-output/
 tmp/
 /test-output
 /bin
+open-refine.log

--- a/open-refine.log
+++ b/open-refine.log
@@ -1,0 +1,7 @@
+Starting OpenRefine at 'http://192.168.2.219:3333/'
+
+17:28:11.505 [            refine_server] Starting Server bound to '192.168.2.219:3333' (0ms)
+17:28:11.507 [            refine_server] refine.memory size: 1400M JVM Max heap: 1407188992 (2ms)
+17:28:11.517 [            refine_server] Initializing context: '/' from '/home/knodus/Documents/OpenRefine/main/webapp' (10ms)
+17:28:11.579 [            refine_server] Starting autoreloading scanner...  (62ms)
+17:28:11.975 [                   refine] Starting OpenRefine 2.7 [TRUNK]... (396ms)

--- a/open-refine.log
+++ b/open-refine.log
@@ -1,7 +1,0 @@
-Starting OpenRefine at 'http://192.168.2.219:3333/'
-
-17:28:11.505 [            refine_server] Starting Server bound to '192.168.2.219:3333' (0ms)
-17:28:11.507 [            refine_server] refine.memory size: 1400M JVM Max heap: 1407188992 (2ms)
-17:28:11.517 [            refine_server] Initializing context: '/' from '/home/knodus/Documents/OpenRefine/main/webapp' (10ms)
-17:28:11.579 [            refine_server] Starting autoreloading scanner...  (62ms)
-17:28:11.975 [                   refine] Starting OpenRefine 2.7 [TRUNK]... (396ms)

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,6 @@
 echo 'Starting open refine'
-nohup ./refine -i 192.168.2.121 > open-refine.log 2>&1 &
-echo "open refine started, check log through - tail -f open-refine.log"
+read -p "Enter IP Address [Default 127.0.0.1]: " ip
+ip=${ip:-127.0.0.1}
+nohup ./refine -i $ip > open-refine.log 2>&1 &
+echo "Started Open-Refine on" $ip
+echo "open refine started, check log through -> tail -f open-refine.log"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+echo 'Starting open refine'
+nohup ./refine -i 192.168.2.121 > open-refine.log 2>&1 &
+echo "open refine started, check log through - tail -f open-refine.log"

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,2 @@
+ps -ef | grep refine | awk '{print $2}' | awk 'NR==1' | xargs kill
+echo 'successfully stopped open-refine'


### PR DESCRIPTION
The script to start OpenRefine is "start.sh". It starts OpenRefine as a background process and logs are created respectively in "open-refine.log" file.
The script to stop OpenRefine is "stop.sh". It kills the OpenRefine process and displays a message like "successfully stopped open-refine".