### PR TITLE
Improve range facets in the cases in which all candidates have the same score

### DIFF
--- a/main/src/com/google/refine/browsing/facets/RangeFacet.java
+++ b/main/src/com/google/refine/browsing/facets/RangeFacet.java
@@ -205,7 +205,7 @@ public class RangeFacet implements Facet {
 
                 @Override
                 protected boolean checkValue(double d) {
-                    return d >= _from && d < _to;
+                    return d >= _from && d <= _to;
                 };
             };
         } else {


### PR DESCRIPTION
When all the reconciliated candidates have the same score _x_, and we apply a facet based on "Best candidate's score" the filter range is set to, according to the formula in RangeFacet.java class, **d >= _x_ && d < _x_**, because in this special case the value of _from is equals to the value of _to, that is equals to _x_. In this situation it is obvious that the filtered set of candidates that match that condition is always empty and no rows are visualized. To avoid this it we can consider to include also the upper limit to the range filter so that, even if all candidates has the same score, they are visualized when faceting by candidate's score. (d >= _from && d <**=** _to).