### PR TITLE
Fix overflow of history items outside the window.

### DIFF
--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -153,12 +153,8 @@ function initializeUI(uiState) {
   ui.historyPanel = new HistoryPanel(ui.historyPanelDiv, ui.historyTabHeader);
   ui.dataTableView = new DataTableView(ui.viewPanelDiv);
 
-  ui.leftPanelTabs.bind('tabsshow', function(event, tabs) {
-    if (tabs.index === 0) {
-      ui.browsingEngine.resize();
-    } else if (tabs.index === 1) {
-      ui.historyPanel.resize();
-    }
+  ui.leftPanelTabs.bind('tabsactivate', function(event, tabs) {
+    tabs.newPanel.resize();
   });
 
   $(window).bind("resize", resizeAll);


### PR DESCRIPTION
This fixes the auto-resize code which ensures that history items don't overflow beyond the end of the window. The order of the history items is still preserved (oldest first). According to @Opennat in #1106 it used to be in the reverse order, but I can't find the commit that changed that. I think the current order is less of a problem now that this bug is fixed.