### PR TITLE
Add support for references in Wikitable importer.

### DIFF
--- a/main/src/com/google/refine/importers/WikitextImporter.java
+++ b/main/src/com/google/refine/importers/WikitextImporter.java
@@ -332,7 +332,7 @@ public class WikitextImporter extends TabularImportingParserBase {
                 }
 
                 // store the reference for later use
-                if (currentReference != null && currentReferenceName != "") {
+                if (currentReference != null && ! "".equals(currentReferenceName)) {
                     namedReferences.put(currentReferenceName, currentReference);
                 }
             }

--- a/main/tests/server/src/com/google/refine/tests/importers/WikitextImporterTests.java
+++ b/main/tests/server/src/com/google/refine/tests/importers/WikitextImporterTests.java
@@ -196,6 +196,34 @@ public class WikitextImporterTests extends ImporterTest {
         Assert.assertNull(project.rows.get(1).cells.get(3).value);
         Assert.assertEquals(project.rows.get(1).cells.get(4).value, "Butter");
     }
+    
+    @Test
+    public void readTableWithReferences() {
+        // inspired from https://www.mediawiki.org/wiki/Help:Tables
+        String input = "{|\n"
+        +"! price\n"
+        +"! fruit\n"
+        +"! merchant\n"
+        +"|-\n"
+        +"| a || b <ref name=\"myref\"> See [http://gnu.org here]</ref>  || c <ref name=\"ms\"> or http://microsoft.com/ </ref>\n"
+        +"|-\n"
+        +"| d || e <ref name=\"ms\"/>|| f <ref name=\"myref\" />\n"
+        +"|-\n"
+        +"|}\n";
+        
+        try {
+            prepareOptions(-1, true, true, null);
+            parse(input);
+        } catch (Exception e) {
+                Assert.fail("Parsing failed", e);
+        }
+        Assert.assertEquals(project.columnModel.columns.size(), 5);
+        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "b");
+        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "http://gnu.org");
+        Assert.assertEquals(project.rows.get(0).cells.get(4).value, "http://microsoft.com/");
+        Assert.assertEquals(project.rows.get(1).cells.get(4).value, "http://gnu.org");
+        Assert.assertEquals(project.rows.get(1).cells.get(2).value, "http://microsoft.com/");
+    }
     //--helpers--
     
     private void parse(String wikitext) {
@@ -210,6 +238,7 @@ public class WikitextImporterTests extends ImporterTest {
         whenGetBooleanOption("guessCellValueTypes", options, guessValueType);
         whenGetBooleanOption("blankSpanningCells", options, blankSpanningCells);
         whenGetBooleanOption("storeBlankCellsAsNulls", options, true);
+        whenGetBooleanOption("parseReferences", options, true);
         whenGetStringOption("wikiUrl", options, wikiUrl);
         whenGetIntegerOption("headerLines", options, 1);
         whenGetStringOption("reconService", options, "https://tools.wmflabs.org/openrefine-wikidata/en/api");

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -115,6 +115,7 @@
         "store-nulls": "Store blank cells as nulls",
         "blank-spanning-cells": "Pad cells spanning over multiple rows or columns with nulls",
         "include-raw-templates": "Include templates as raw wikicode",
+        "parse-references": "Extract references in additional columns",
         "wiki-base-url": "Reconcile to wiki with base URL:",
         "invalid-wikitext": "No table could be parsed. Are you sure this is a valid wiki table?",
         "store-source": "Store file source <br/>(file names, URLs)<br/>in each row",

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.html
@@ -15,6 +15,8 @@
         <td colspan="2"><label for="$store-blank-rows" id="or-import-blank"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="includeRawTemplatesCheckbox" id="$include-raw-templates" /></td>
         <td colspan="2"><label for="$include-raw-templates" id="or-import-includeRawTemplates"></label></td></tr>
+      <tr><td width="1%"><input type="checkbox" bind="parseReferencesCheckbox" id="$parse-references" /></td>
+        <td colspan="2"><label for="$parse-references" id="or-import-parseReferences"></label></td></tr>
 
       <tr><td width="1%"><input type="checkbox" bind="storeBlankCellsAsNullsCheckbox" id="$store-blank-cells" /></td>
         <td colspan="2"><label for="$store-blank-cells" id="or-import-null"></label></td></tr>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.js
@@ -88,6 +88,7 @@ Refine.WikitextParserUI.prototype.getOptions = function() {
   options.storeBlankRows = this._optionContainerElmts.storeBlankRowsCheckbox[0].checked;
   options.blankSpanningCells = this._optionContainerElmts.blankSpanningCellsCheckbox[0].checked;
   options.includeRawTemplates = this._optionContainerElmts.includeRawTemplatesCheckbox[0].checked;
+  options.parseReferences = this._optionContainerElmts.parseReferencesCheckbox[0].checked;
 
   options.guessCellValueTypes = this._optionContainerElmts.guessCellValueTypesCheckbox[0].checked;
 
@@ -115,6 +116,7 @@ Refine.WikitextParserUI.prototype._initialize = function() {
   $('#or-import-parseCell').html($.i18n._('core-index-parser')["parse-cell"]);
   $('#or-import-blankSpanningCells').text($.i18n._('core-index-parser')["blank-spanning-cells"]);
   $('#or-import-includeRawTemplates').text($.i18n._('core-index-parser')["include-raw-templates"]);
+  $('#or-import-parseReferences').text($.i18n._('core-index-parser')["parse-references"]);
   $('#or-import-blank').text($.i18n._('core-index-parser')["store-blank"]);
   $('#or-import-null').text($.i18n._('core-index-parser')["store-nulls"]);
   $('#or-import-source').html($.i18n._('core-index-parser')["store-source"]);
@@ -146,6 +148,10 @@ Refine.WikitextParserUI.prototype._initialize = function() {
 
   if (this._config.includeRawTemplates) {
     this._optionContainerElmts.includeRawTemplatesCheckbox.prop("checked", true);
+  }
+
+  if (this._config.parseReferences) {
+    this._optionContainerElmts.parseReferencesCheckbox.prop("checked", true);
   }
 
   if (this._config.storeBlankRows) {


### PR DESCRIPTION
This lets users import the individual references of each cell. As OpenRefine does not support adding arbitrary metadata to cells yet (see #499), references are added alongside the values they support, in their own column.

Closes #1243.