### PR TITLE
Ensure _max is never less than _min for numeric range facet

### DIFF
--- a/main/src/com/google/refine/browsing/util/NumericBinIndex.java
+++ b/main/src/com/google/refine/browsing/util/NumericBinIndex.java
@@ -87,7 +87,7 @@ abstract public class NumericBinIndex {
         if (_min >= _max) {
             _step = 1;
             _min = Math.min(_min, _max);
-            _max = _step;
+            _max = _min+_step;
             _bins = new int[1];
             
             return;


### PR DESCRIPTION
If there is only a single numeric value for a numeric range facet, the 'max' value for the facet is set to '1' ( actually _step, but _step is hard coded to be '1'). This leads to the behaviour reported in #1247 (for any situation where all numeric values are equal, not just in the "Best candidate's score" scenario described)

This change ensures that the max value is min+step in this scenario - i.e. one more than 'min' in the case where 'step' is hard coded to '1'