### PR TITLE
Fix duplicate item in Reconcile > Actions menu. Closes #1272.

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -385,11 +385,10 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
             doReconMarkNewTopics(false);
           }
         },
-        {},
         {
           id: "core/match-similar-to-new-topic",
-          label: $.i18n._('core-views')["new-topic"],
-          tooltip: $.i18n._('core-views')["new-topic2"],
+          label: $.i18n._('core-views')["one-topic"],
+          tooltip: $.i18n._('core-views')["one-topic2"],
           click: function() {
             doReconMarkNewTopics(true);
           }


### PR DESCRIPTION
So the two buttons of #1272 had same label and tooltip but had indeed different meanings, this fixes it.