### PR TITLE
Fix regex filter error

### DIFF
--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -220,7 +220,7 @@ Refine._renameProject = function() {
     data: { "project" : theProject.id, "name" : name },
     dataType: "json",
     success: function (data) {
-      if (data && typeof data.code != 'undefined' && data.code == "ok") {
+      if (data && typeof data.code != "undefined" && data.code == "ok") {
         theProject.metadata.name = name;
         Refine.setTitle();
       } else {
@@ -428,7 +428,7 @@ Refine.fetchRows = function(start, limit, onDone, sorting) {
     "command/core/get-rows?" + $.param({ project: theProject.id, start: start, limit: limit }),
     body,
     function(data) {
-      if(data.code === 'error') {
+      if(data.code === "error") {
         data = theProject.rowModel;
       }
       theProject.rowModel = data;

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -178,7 +178,7 @@ Refine.reinitializeProjectData = function(f, fError) {
   $.getJSON(
     "command/core/get-project-metadata?" + $.param({ project: theProject.id }), null,
     function(data) {
-      if (data.status == 'error') {
+      if (data.status == "error") {
         alert(data.message);
         if (fError) {
           fError();

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -425,9 +425,15 @@ Refine.fetchRows = function(start, limit, onDone, sorting) {
   }
 
   $.post(
-    "command/core/get-rows?" + $.param({ project: theProject.id, start: start, limit: limit }) + "&callback=?",
+    "command/core/get-rows?" + $.param({ project: theProject.id, start: start, limit: limit }),
     body,
     function(data) {
+      if(data.code === 'error') {
+        data = theProject.rowModel;
+        //maybe change the data to zero?
+        data.rows = [];
+        data.filtered = 0;
+      }
       theProject.rowModel = data;
 
       // Un-pool objects
@@ -445,7 +451,7 @@ Refine.fetchRows = function(start, limit, onDone, sorting) {
         onDone();
       }
     },
-    "jsonp"
+    "json"
   );
 };
 

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -430,9 +430,6 @@ Refine.fetchRows = function(start, limit, onDone, sorting) {
     function(data) {
       if(data.code === 'error') {
         data = theProject.rowModel;
-        //maybe change the data to zero?
-        data.rows = [];
-        data.filtered = 0;
       }
       theProject.rowModel = data;
 

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -33,7 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 function BrowsingEngine(div, facetConfigs) {
   this._div = div;
-  this._mode = theProject.recordModel.hasRecords ? 'record-based' : 'row-based';
+  this._mode = theProject.recordModel.hasRecords ? "record-based" : "row-based";
 
   this._facets = [];
   this._initializeUI();

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -101,6 +101,7 @@ BrowsingEngine.prototype._initializeUI = function() {
     '<p>'+$.i18n._('core-project')["not-sure"]+'<br /><a href="https://github.com/OpenRefine/OpenRefine/wiki/Screencasts" target="_blank"><b>'+$.i18n._('core-project')["watch-cast"]+'</b></a></p>' +
     '</div>' +
     '<div class="browsing-panel-header" bind="header">' +
+    '<div class="browsing-panel-errors" bind="errors"></div>' +
     '<div class="browsing-panel-indicator" bind="indicator">' +
     '<img src="images/small-spinner.gif" /> '+$.i18n._('core-project')["refreshing-facet"]+'' +
     '</div>' +
@@ -240,19 +241,31 @@ BrowsingEngine.prototype.update = function(onDone) {
 
   this._elmts.header.show();
   this._elmts.controls.css("visibility", "hidden");
-  this._elmts.indicator.css("visibility", "visible");
+  this._elmts.indicator.css("display", "block");
 
   $.post(
     "command/core/compute-facets?" + $.param({ project: theProject.id }),
     { engine: JSON.stringify(this.getJSON(true)) },
     function(data) {
+      if(data.code === 'error') {
+        var clearErr = $('#err-text').remove();
+        var err = $('<div id="err-text">')
+                  .text(data.message)
+                  .appendTo(self._elmts.errors);
+         self._elmts.errors.css("display", "block");
+        if (onDone) {
+          onDone();
+        }
+        return;
+      }
       var facetData = data.facets;
 
       for (var i = 0; i < facetData.length; i++) {
         self._facets[i].facet.updateState(facetData[i]);
       }
 
-      self._elmts.indicator.css("visibility", "hidden");
+      self._elmts.indicator.css("display", "none");
+      self._elmts.errors.css("display", "none");
       if (self._facets.length > 0) {
         self._elmts.header.show();
         self._elmts.controls.css("visibility", "visible");

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -247,7 +247,7 @@ BrowsingEngine.prototype.update = function(onDone) {
     "command/core/compute-facets?" + $.param({ project: theProject.id }),
     { engine: JSON.stringify(this.getJSON(true)) },
     function(data) {
-      if(data.code === 'error') {
+      if(data.code === "error") {
         var clearErr = $('#err-text').remove();
         var err = $('<div id="err-text">')
                   .text(data.message)

--- a/main/webapp/modules/core/styles/project/sidebar.less
+++ b/main/webapp/modules/core/styles/project/sidebar.less
@@ -38,9 +38,23 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   display: none;
   }
 
+.browsing-panel-errors {
+  display: none;
+  position: relative;
+  height: auto;
+  margin: 5px;
+  text-align: center;
+  background: #fff0f4; 
+  color: #c51244;
+  padding: 4px 4px;
+  -moz-border-radius: 4px;
+  -webkit-border-radius: 4px;
+  border: 1px solid #ccc;
+  }
+
 .browsing-panel-indicator {
-  visibility: hidden;
-  position: absolute;
+  display: none;
+  position: relative;
   width: 50%;
   margin: 5px;
   top: 0em;


### PR DESCRIPTION
To fix #1203 
- Changes get-rows call to request JSON rather than JSONP
- Catches situations where JSON returned for get-rows or compute-facets includes an 'error' element
  - Where there is an error with get-rows, the existing row set is used for the data-table
  - Where there is an error with compute-facets, the error message from the JSON is displayed at the top of the facets/filter sidebar (some minor modifications to css and DOM manipulation were needed to achieve this alongside the 'refreshing facets' notification)

Comments welcome

