### PR TITLE
Add Java 9 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk9
   - openjdk7
+  - openjdk8
 
 env:
   # encrypted Codacy key, see https://docs.travis-ci.com/user/encryption-keys/

--- a/main/tests/server/src/com/google/refine/tests/model/UrlFetchingTests.java
+++ b/main/tests/server/src/com/google/refine/tests/model/UrlFetchingTests.java
@@ -147,7 +147,7 @@ public class UrlFetchingTests extends RefineTest {
 	    // results. Just to make sure the test passes with plenty of
 	    // net latency we sleep for longer (but still less than
 	    // 50,000ms).
-	    Thread.sleep(5000);
+	    Thread.sleep(8000);
         } catch (InterruptedException e) {
 	    Assert.fail("Test interrupted");
         }


### PR DESCRIPTION
Following the changes made by @jackyq2015 to adapt the script for Java 9 I have tried to enable Java 9 in Travis. It looks like one tests fails with this Java version, due to a different behavior in date parsing. I'm just submitting this PR so that people are aware of the issue. It should of course only be merged once we find a fix for that, and we should not claim that OR runs with Java 9 before that.