### PR TITLE
Update README.txt for Emeritus contributors

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -52,7 +52,8 @@ This is the full list of contributors (in chronological order):
  - pxb <pxb1988@gmail.com>
  - Qi <jackyq2015@gmail.com>
  - Antonin Delpeuch <antonin@delpeuch.eu>
- 
+ - Owen Stephens <owen@ostephens.com>
+  
  We welcome additional contributors if you'd like to help out.
                                 - o -
 

--- a/README.txt
+++ b/README.txt
@@ -50,6 +50,7 @@ CURRENT CONTRIBUTORS
  - Iain Sproat <iainsproat@gmail.com>
  - Tom Morris <tfmorris@gmail.com>
  - Thad Guidry <thadguidry@gmail.com>
+ - Martin Magdinier <martin.magdinier@gmail.com>
  - Paul Makepeace <paulm@paulm.com>
  - Tomaž Šolc <tomaz.solc@zemanta.com>
  - Gabriel Sjoberg <GabrielSjoberg@gmail.com>

--- a/README.txt
+++ b/README.txt
@@ -33,17 +33,22 @@ was acquired by Google, Inc. in July 2010 and the product was renamed Google Ref
 In October 2012, it was renamed OpenRefine as it transitioned to a 
 community-supported product.
 
-This is the full list of contributors (in chronological order):
+EMERITUS CONTRIBUTORS (no longer current but honored here for their previous contributions)
+---------------------
 
- - David Huynh <dfhuynh@google.com> (EMERITUS)
- - Stefano Mazzocchi <stefanom@google.com> (EMERITUS)
+ - David Huynh <dfhuynh@google.com>
+ - Stefano Mazzocchi <stefanom@google.com>
  - Vishal Talwar <vtalwar@google.com> 
  - Jeff Fry <jfry@google.com>
  - Will Moffat <wdm@google.com>
  - James Home <jameshome@google.com>
+ - Heather Campbell <campbellh@google.com>
+
+CURRENT CONTRIBUTORS
+--------------------
+
  - Iain Sproat <iainsproat@gmail.com>
  - Tom Morris <tfmorris@gmail.com>
- - Heather Campbell <campbellh@google.com>
  - Thad Guidry <thadguidry@gmail.com>
  - Paul Makepeace <paulm@paulm.com>
  - Tomaž Šolc <tomaz.solc@zemanta.com>

--- a/README.txt
+++ b/README.txt
@@ -35,8 +35,8 @@ community-supported product.
 
 This is the full list of contributors (in chronological order):
 
- - David Huynh <dfhuynh@google.com>
- - Stefano Mazzocchi <stefanom@google.com>
+ - David Huynh <dfhuynh@google.com> (EMERITUS)
+ - Stefano Mazzocchi <stefanom@google.com> (EMERITUS)
  - Vishal Talwar <vtalwar@google.com> 
  - Jeff Fry <jfry@google.com>
  - Will Moffat <wdm@google.com>

--- a/README.txt
+++ b/README.txt
@@ -33,18 +33,22 @@ was acquired by Google, Inc. in July 2010 and the product was renamed Google Ref
 In October 2012, it was renamed OpenRefine as it transitioned to a 
 community-supported product.
 
-EMERITUS CONTRIBUTORS (no longer current but honored here for their previous contributions)
+EMERITUS CREATORS (no longer active but honored for bringing OpenRefine to life)
 ---------------------
 
  - David Huynh <dfhuynh@google.com>
  - Stefano Mazzocchi <stefanom@google.com>
+ 
+EMERITUS CONTRIBUTORS (no longer active but honored here for their previous contributions)
+---------------------
+
  - Vishal Talwar <vtalwar@google.com> 
  - Jeff Fry <jfry@google.com>
  - Will Moffat <wdm@google.com>
  - James Home <jameshome@google.com>
  - Heather Campbell <campbellh@google.com>
-
-CURRENT CONTRIBUTORS
+ 
+CURRENT CONTRIBUTORS 
 --------------------
 
  - Iain Sproat <iainsproat@gmail.com>
@@ -59,6 +63,48 @@ CURRENT CONTRIBUTORS
  - Qi <jackyq2015@gmail.com>
  - Antonin Delpeuch <antonin@delpeuch.eu>
  - Owen Stephens <owen@ostephens.com>
+ - Ettore Rizza <ettorerizza@gmail.com>
+ - Fabio Tacchelli <fabio.tacchelli@gmail.com>
+ - noamoss
+ - ROMitat
+ - Jesus M. Castagnetto
+ - Pablo Moyano <ultraklon@gmail.com>
+ - David Leoni
+ - Cora Johnson-Roberson
+ - Pei Long Hui
+ - Rudy Alvarez <rudygt@gmail.com>
+ - Mateja Verlic Bruncic
+ - nestorjal <nbeltran@humboldt.org.co>
+ - Alexey Medvetsky <am@opendata.by>
+ - Remi Rampin <remirampin@gmail.com>
+ - lispc <mycinbrin@gmail.com>
+ - Bob Harper
+ - Felix Lohmeier <mail@felixlohmeier.de>
+ - Shixiong Zhu
+ - Ankit Sardesai
+ - Scott Wiedemann
+ - Ryo Yamazaki
+ - Ralf Claussnitzer
+ - Charles Pritchard
+ - Maxim Galushka
+ - Evelyn Mitchell
+ - Andreas Kohn
+ - Honza
+ - Ram Ezrach <ram.ezrach@gmail.com>
+ - Daniel Berthereau <daniel.on.github-no-spam@berthereau.net>
+ - Gideon Thomas <gideon@mozillafoundation.org>
+ - José Vitor Hisse
+ - Vitor Baptista <vitor@vitorbaptista.com>
+ - Joe Wicentowski <joewiz@gmail.com>
+ - mpc9000
+ - Dan Michael O. <d.m.heggo@ub.uio.no>
+ - Adi Eyal
+ - Shrubhra Sharma
+ - Fadi Maali <fadi.maali@zalando.ie>
+ - Aubrey Mcfato <aubreymcfato@gmail.com>
+ - Matthias Findeisen
+ - Mathieu Saby
+ - Allan Nordhøy <epost@anotheragency.no>
   
  We welcome additional contributors if you'd like to help out.
                                 - o -


### PR DESCRIPTION
Stefano Mazzocchi and David Huynh have expressed that they no longer will contribute directly to OpenRefine but would like to be regarded as "Emeritus" status (having retired but allowed to retain their title as an honor)