### PR TITLE
Update WeLoveOurBackers.md

### DIFF
--- a/WeLoveOurBackers.md
+++ b/WeLoveOurBackers.md
@@ -1,8 +1,7 @@
 An evergrowing list of our forever immortalized OpenRefine Backers that we LOVE because they help support further development !
 
-Want to help also?  Visit https://salt.bountysource.com/teams/openrefine
-
 1. Owen Stephens - Wiki contributor, extension author, and supporting you in our mailing list.
 2. PaulZH -
 3. Jens Willmer -
 4. mroswell -
+5. Google Inc. News Lab


### PR DESCRIPTION
Removing Bountysource, since we unanimously decided to go away from this support model.
Adding Google Inc. News Lab.