### PR TITLE
Options metadata

### DIFF
--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -1008,6 +1008,8 @@ public class ImportingUtilities {
         ProjectMetadata pm = new ProjectMetadata();
         pm.setName(JSONUtilities.getString(optionObj, "projectName", "Untitled"));
         pm.setTags(JSONUtilities.getStringArray(optionObj, "projectTags"));
+        pm.appendImportOptionMetadata(optionObj);
+
         String encoding = JSONUtilities.getString(optionObj, "encoding", "UTF-8");
         if ("".equals(encoding)) {
             // encoding can be present, but empty, which won't trigger JSONUtilities default processing

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -1005,18 +1005,7 @@ public class ImportingUtilities {
         final Format record,
         final Project project
     ) {
-        ProjectMetadata pm = new ProjectMetadata();
-        pm.setName(JSONUtilities.getString(optionObj, "projectName", "Untitled"));
-        pm.setTags(JSONUtilities.getStringArray(optionObj, "projectTags"));
-        pm.appendImportOptionMetadata(optionObj);
-
-        String encoding = JSONUtilities.getString(optionObj, "encoding", "UTF-8");
-        if ("".equals(encoding)) {
-            // encoding can be present, but empty, which won't trigger JSONUtilities default processing
-            encoding = "UTF-8";
-        }
-        pm.setEncoding(encoding);
-        
+        ProjectMetadata pm = createProjectMetadata(optionObj);
         record.parser.parse(
             project,
             pm,
@@ -1043,6 +1032,19 @@ public class ImportingUtilities {
             job.updating = false;
         }
     }
-    
 
+    static public ProjectMetadata createProjectMetadata(JSONObject optionObj) {
+        ProjectMetadata pm = new ProjectMetadata();
+        pm.setName(JSONUtilities.getString(optionObj, "projectName", "Untitled"));
+        pm.setTags(JSONUtilities.getStringArray(optionObj, "projectTags"));
+        pm.appendImportOptionMetadata(optionObj);
+
+        String encoding = JSONUtilities.getString(optionObj, "encoding", "UTF-8");
+        if ("".equals(encoding)) {
+            // encoding can be present, but empty, which won't trigger JSONUtilities default processing
+            encoding = "UTF-8";
+        }
+        pm.setEncoding(encoding);
+        return pm;
+    }
 }

--- a/main/tests/server/src/com/google/refine/tests/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/tests/importing/ImportingUtilitiesTests.java
@@ -1,0 +1,22 @@
+package com.google.refine.tests.importing;
+
+import org.json.JSONObject;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.refine.ProjectMetadata;
+import com.google.refine.importing.ImportingUtilities;
+import com.google.refine.tests.RefineTest;
+
+public class ImportingUtilitiesTests extends RefineTest {
+
+	@Test
+    public void createProjectMetadataTest() throws Exception {
+		JSONObject optionObj = new JSONObject("{\"projectName\":\"acme\",\"projectTags\":[],\"created\":\"2017-12-18T13:28:40.659\",\"modified\":\"2017-12-20T09:28:06.654\",\"creator\":\"\",\"contributors\":\"\",\"subject\":\"\",\"description\":\"\",\"rowCount\":50,\"customMetadata\":{},\"importOptionMetadata\":[{\"guessCellValueTypes\":false,\"projectTags\":[\"\"],\"ignoreLines\":-1,\"processQuotes\":true,\"fileSource\":\"acme.txt\",\"encoding\":\"\",\"separator\":\"|\",\"storeBlankCellsAsNulls\":true,\"storeBlankRows\":true,\"skipDataLines\":0,\"includeFileSources\":false,\"headerLines\":1,\"limit\":-1,\"projectName\":\"acme\"},{\"guessCellValueTypes\":false,\"projectTags\":[\"\"],\"ignoreLines\":-1,\"processQuotes\":true,\"fileSource\":\"acme.txt\",\"encoding\":\"\",\"separator\":\"|\",\"storeBlankCellsAsNulls\":true,\"storeBlankRows\":true,\"skipDataLines\":0,\"includeFileSources\":false,\"headerLines\":1,\"limit\":-1,\"projectName\":\"acme\"}]}");
+		ProjectMetadata pm = ImportingUtilities.createProjectMetadata(optionObj);
+        Assert.assertEquals(pm.getName(), "acme");
+        Assert.assertEquals(pm.getEncoding(), "UTF-8");
+        Assert.assertTrue(pm.getTags().length == 0);
+        Assert.assertTrue(pm.getImportOptionMetadata().length() > 0);
+    }
+}


### PR DESCRIPTION
In order to apply the same operations while manipulating projects via scheduled jobs using a Python client, the `importOptionMetadata` is needed, e.g.:

```json
{
    "name":"acme",
    "tags":[

    ],
    "created":"2017-12-18T13:28:40.659",
    "modified":"2017-12-18T15:38:05.44",
    "creator":"",
    "contributors":"",
    "subject":"",
    "description":"",
    "rowCount":50,
    "customMetadata":{
    },
    "importOptionMetadata":[
        {
            "guessCellValueTypes":false,
            "projectTags":[
                ""
            ],
            "ignoreLines":-1,
            "processQuotes":true,
            "fileSource":"acme.txt",
            "encoding":"",
            "separator":"|",
            "storeBlankCellsAsNulls":true,
            "storeBlankRows":true,
            "skipDataLines":0,
            "includeFileSources":false,
            "headerLines":1,
            "limit":-1,
            "projectName":"acme"
        },
        {
            "guessCellValueTypes":false,
            "projectTags":[
                ""
            ],
            "ignoreLines":-1,
            "processQuotes":true,
            "fileSource":"acme.txt",
            "encoding":"",
            "separator":"|",
            "storeBlankCellsAsNulls":true,
            "storeBlankRows":true,
            "skipDataLines":0,
            "includeFileSources":false,
            "headerLines":1,
            "limit":-1,
            "projectName":"acme"
        }
    ]
}
```

If there is another way to make this section available in the endpoint `/command/core/get-project-metadata?project=<id>` let me know, otherwise please consider this patch.

Thanks!