### PR TITLE
Fix appveyor

### DIFF
--- a/main/tests/server/src/com/google/refine/tests/model/UrlFetchingTests.java
+++ b/main/tests/server/src/com/google/refine/tests/model/UrlFetchingTests.java
@@ -169,13 +169,13 @@ public class UrlFetchingTests extends RefineTest {
 
         // Inspect rows
         String ref_val = (String)project.rows.get(0).getCellValue(1).toString();
-	if (ref_val.contains("HTTP error 403") || ref_val.contains("HTTP error 503"))
+	if (ref_val.contains("HTTP error 403"))
             return;
         Assert.assertTrue(ref_val != "apple"); // just to make sure I picked the right column
         for (int i = 1; i < 4; i++) {
             System.out.println("value:" + project.rows.get(i).getCellValue(1));
             // all random values should be equal due to caching
-            Assert.assertEquals(project.rows.get(i).getCellValue(1), ref_val);
+            Assert.assertEquals(project.rows.get(i).getCellValue(1).toString(), ref_val);
         }
                Assert.assertFalse(process.isRunning());
     }

--- a/main/tests/server/src/com/google/refine/tests/model/UrlFetchingTests.java
+++ b/main/tests/server/src/com/google/refine/tests/model/UrlFetchingTests.java
@@ -169,7 +169,7 @@ public class UrlFetchingTests extends RefineTest {
 
         // Inspect rows
         String ref_val = (String)project.rows.get(0).getCellValue(1).toString();
-	if (ref_val.startsWith("HTTP error 403") || ref_val.startsWith("HTTP error 503"))
+	if (ref_val.contains("HTTP error 403") || ref_val.contains("HTTP error 503"))
             return;
         Assert.assertTrue(ref_val != "apple"); // just to make sure I picked the right column
         for (int i = 1; i < 4; i++) {

--- a/main/tests/server/src/com/google/refine/tests/model/UrlFetchingTests.java
+++ b/main/tests/server/src/com/google/refine/tests/model/UrlFetchingTests.java
@@ -169,7 +169,7 @@ public class UrlFetchingTests extends RefineTest {
 
         // Inspect rows
         String ref_val = (String)project.rows.get(0).getCellValue(1).toString();
-	if (ref_val.contains("HTTP error 403"))
+	if (ref_val.startsWith("HTTP error"))
             return;
         Assert.assertTrue(ref_val != "apple"); // just to make sure I picked the right column
         for (int i = 1; i < 4; i++) {

--- a/main/tests/server/src/com/google/refine/tests/model/UrlFetchingTests.java
+++ b/main/tests/server/src/com/google/refine/tests/model/UrlFetchingTests.java
@@ -169,7 +169,7 @@ public class UrlFetchingTests extends RefineTest {
 
         // Inspect rows
         String ref_val = (String)project.rows.get(0).getCellValue(1).toString();
-	if (ref_val.startsWith("HTTP error 403"))
+	if (ref_val.startsWith("HTTP error 403") || ref_val.startsWith("HTTP error 503"))
             return;
         Assert.assertTrue(ref_val != "apple"); // just to make sure I picked the right column
         for (int i = 1; i < 4; i++) {


### PR DESCRIPTION
This tweaks the URL caching test so that it passes on Appveyor, where random.org returns 503 errors.