### PR TITLE
Expose fields as attributes in Jython

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="main/src"/>
+	<classpathentry kind="src" path="extensions/jython/tests/src"/>
 	<classpathentry kind="src" path="server/src"/>
 	<classpathentry kind="src" path="extensions/gdata/src"/>
 	<classpathentry kind="src" path="extensions/jython/src"/>

--- a/extensions/jython/src/com/google/refine/jython/JythonHasFieldsWrapper.java
+++ b/extensions/jython/src/com/google/refine/jython/JythonHasFieldsWrapper.java
@@ -55,7 +55,12 @@ public class JythonHasFieldsWrapper extends PyObject {
     @Override
     public PyObject __finditem__(PyObject key) {
         String k = (String) key.__tojava__(String.class);
-        Object v = _obj.getField(k, _bindings);
+        return __findattr_ex__(k);
+    }
+
+    @Override
+    public PyObject __findattr_ex__(String name) {
+        Object v = _obj.getField(name, _bindings);
         if (v != null) {
             if (v instanceof PyObject) {
                 return (PyObject) v;
@@ -70,5 +75,4 @@ public class JythonHasFieldsWrapper extends PyObject {
             return null;
         }
     }
-
 }

--- a/extensions/jython/tests/src/com/google/refine/jython/JythonAttributeTest.java
+++ b/extensions/jython/tests/src/com/google/refine/jython/JythonAttributeTest.java
@@ -5,11 +5,9 @@ import java.util.Properties;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.expr.CellTuple;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.HasFields;
 import com.google.refine.model.Cell;
-import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 
 public class JythonAttributeTest {
@@ -18,7 +16,7 @@ public class JythonAttributeTest {
 
         @Override
         public Object getField(String name, Properties bindings) {
-            if (name.equals("sunshine")) {
+            if ("sunshine".equals(name)) {
                 return "hammock";
             }
             return null;
@@ -33,8 +31,6 @@ public class JythonAttributeTest {
     
     @Test
     public void testWrappedObjectsHaveAttributes() {
-        Project project = new Project();
-
         Row row = new Row(2);
         row.setCell(0, new Cell("sunshine", null));
         row.setCell(1, new Cell("hammock", null));

--- a/extensions/jython/tests/src/com/google/refine/jython/JythonAttributeTest.java
+++ b/extensions/jython/tests/src/com/google/refine/jython/JythonAttributeTest.java
@@ -1,0 +1,54 @@
+package com.google.refine.jython;
+
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.CellTuple;
+import com.google.refine.expr.Evaluable;
+import com.google.refine.expr.HasFields;
+import com.google.refine.model.Cell;
+import com.google.refine.model.Project;
+import com.google.refine.model.Row;
+
+public class JythonAttributeTest {
+    
+    class MyFieldObject implements HasFields {
+
+        @Override
+        public Object getField(String name, Properties bindings) {
+            if (name.equals("sunshine")) {
+                return "hammock";
+            }
+            return null;
+        }
+
+        @Override
+        public boolean fieldAlsoHasFields(String name) {
+            return true;
+        }
+        
+    }
+    
+    @Test
+    public void testWrappedObjectsHaveAttributes() {
+        Project project = new Project();
+
+        Row row = new Row(2);
+        row.setCell(0, new Cell("sunshine", null));
+        row.setCell(1, new Cell("hammock", null));
+        
+        Properties props = new Properties();
+        
+        MyFieldObject obj = new MyFieldObject();
+        JythonHasFieldsWrapper wrapper = new JythonHasFieldsWrapper(obj, props);
+        Assert.assertEquals(wrapper.__findattr__("sunshine").toString(), "hammock");
+        
+        props.put("cell", obj);
+
+        Evaluable eval = new JythonEvaluable("return cell.sunshine");
+        String result = (String)eval.evaluate(props).toString();
+        Assert.assertEquals(result, "hammock");
+    }
+}


### PR DESCRIPTION
This implements #1377 : fields in Jython are available both as items and as attributes, just like GREL.
In other words, both `return cell.recon.match.id` and `return cell['recon']['match']['id']` are possible in Jython.