### PR TITLE
about page: closing LI tags

### DIFF
--- a/main/webapp/modules/core/about.html
+++ b/main/webapp/modules/core/about.html
@@ -101,9 +101,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             <li>Tomaž Šolc tomaz.solc@zemanta.com</li>
             <li>Gabriel Sjoberg GabrielSjoberg@gmail.com</li>
             <li>Rod Salazar rodrod.salazar@gmail.com</li>
-            <li>pxb pxb1988@gmail.com<li>
-            <li>Qi jackyq2015@gmail.com<li>
-            <li>Antonin Delpeuch antonin@delpeuch.eu<li>
+            <li>pxb pxb1988@gmail.com</li>
+            <li>Qi jackyq2015@gmail.com</li>
+            <li>Antonin Delpeuch antonin@delpeuch.eu</li>
           </ul>
         </td>
         <td>


### PR DESCRIPTION
This PR fixes the list of contributors' LI elements, so that the HTML renders correctly.