### PR TITLE
Reconciliation panel: spelling of JS property

### DIFF
--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.html
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.html
@@ -15,7 +15,7 @@
     </tr>
     <tr>
       <td><input type="radio" name="type-choice" value="">
-        <span bind="or_proc_againsType"></span> <input size="20" bind="typeInput" /></td>
+        <span bind="or_proc_againstType"></span> <input size="20" bind="typeInput" /></td>
       <td>
       </td>
     </tr>

--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -87,7 +87,7 @@ ReconStandardServicePanel.prototype._constructUI = function() {
   this._elmts.rawServiceLink.html($.i18n._('core-recon')["service-api"]);
   this._elmts.or_proc_cellType.html($.i18n._('core-recon')["cell-type"]+":");
   this._elmts.or_proc_colDetail.html($.i18n._('core-recon')["col-detail"]+":");
-  this._elmts.or_proc_againsType.html($.i18n._('core-recon')["against-type"]+":");
+  this._elmts.or_proc_againstType.html($.i18n._('core-recon')["against-type"]+":");
   this._elmts.or_proc_noType.html($.i18n._('core-recon')["no-type"]);
   this._elmts.or_proc_autoMatch.html($.i18n._('core-recon')["auto-match"]);
   this._elmts.or_proc_max_candidates.html($.i18n._('core-recon')["max-candidates"]);


### PR DESCRIPTION
This PR fixes the spelling of a JS property.

I found this using a global search for common misspellings.