### PR TITLE
Javascript error on project page from database extension

### DIFF
--- a/extensions/database/module/MOD-INF/controller.js
+++ b/extensions/database/module/MOD-INF/controller.js
@@ -120,8 +120,6 @@ function init() {
     "project/scripts",
     module,
     [
-      "scripts/index/jquery.contextMenu.min.js",
-      "scripts/index/jquery.ui.position.min.js",
       "scripts/database-extension.js",
       "scripts/project/database-exporters.js"
     ]

--- a/extensions/database/module/MOD-INF/controller.js
+++ b/extensions/database/module/MOD-INF/controller.js
@@ -120,6 +120,8 @@ function init() {
     "project/scripts",
     module,
     [
+      "scripts/index/jquery.contextMenu.min.js",
+      "scripts/index/jquery.ui.position.min.js",
       "scripts/database-extension.js",
       "scripts/project/database-exporters.js"
     ]

--- a/extensions/database/module/scripts/database-extension.js
+++ b/extensions/database/module/scripts/database-extension.js
@@ -27,32 +27,6 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-$(function(){
-    $.contextMenu({
-        selector: '.context-menu-one', 
-        trigger: 'left',
-        build: function($trigger, e) {
-   
-            return {
-                callback: function(key, options) {
-                    var m = "clicked: " + key;
-                    DatabaseExtension.handleSavedConnectionClicked(key,  $(this).text());
-                    
-                },
-
-                items: {
-                    "edit": 	   {name: " Edit "},
-                    "sep0": "",
-                    "delete":   {name: " Delete "},
-                    "sep1": "---------",
-                    "connect": {name: " Connect "},
-                    "dummy":  {name: "", icon: ""}
-                }
-            };
-        }
-    });
-});
-
 var DatabaseExtension = {};
 
 DatabaseExtension.currentConnection = {};

--- a/extensions/database/module/scripts/index/database-source-ui.js
+++ b/extensions/database/module/scripts/index/database-source-ui.js
@@ -27,6 +27,32 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+$(function(){
+    $.contextMenu({
+        selector: '.context-menu-one',
+        trigger: 'left',
+        build: function($trigger, e) {
+
+            return {
+                callback: function(key, options) {
+                    var m = "clicked: " + key;
+                    DatabaseExtension.handleSavedConnectionClicked(key,  $(this).text());
+
+                },
+
+                items: {
+                    "edit":        {name: " Edit "},
+                    "sep0": "",
+                    "delete":   {name: " Delete "},
+                    "sep1": "---------",
+                    "connect": {name: " Connect "},
+                    "dummy":  {name: "", icon: ""}
+                }
+            };
+        }
+    });
+});
+
 Refine.DatabaseSourceUI = function(controller) {
   this._controller = controller;
 };


### PR DESCRIPTION
The following javascript error occurs on the project page caused by the script extension/database/scripts/database-extension.js.

```
project-bundle.js:41312 Uncaught TypeError: $.contextMenu is not a function
    at HTMLDocument.<anonymous> (project-bundle.js:41312)
    at fire (project-bundle.js:3121)
    at Object.fireWith [as resolveWith] (project-bundle.js:3233)
    at Function.ready (project-bundle.js:3445)
    at HTMLDocument.completed (project-bundle.js:3476)

```