### PR TITLE
Add a new range() function to GREL

### DIFF
--- a/main/src/com/google/refine/expr/functions/strings/Range.java
+++ b/main/src/com/google/refine/expr/functions/strings/Range.java
@@ -30,7 +30,7 @@ public class Range implements Function {
     private static final int DEFAULT_START = 0;
     private static final int DEFAULT_STEP = 1;
 
-    private static final String[] EMPTY_STRING_ARRAY = new String[0];
+    private static final Integer[] EMPTY_ARRAY = new Integer[0];
 
     @Override
     public Object call(Properties bindings, Object[] args) {
@@ -280,15 +280,15 @@ public class Range implements Function {
      */
     private static Object createRange(int start, int stop, int step) {        
         if ((start > stop && step > 0) || (start < stop && step < 0) || step == 0) {
-            return EMPTY_STRING_ARRAY;
+            return EMPTY_ARRAY;
         }
 
         int rangeSize = (int) (Math.ceil(((double) Math.abs(start - stop))/ Math.abs(step)));
 
-        String[] generatedRange = new String[rangeSize];
+        Integer[] generatedRange = new Integer[rangeSize];
 
         for (int i = 0; i < rangeSize; i++) {
-           generatedRange[i] = Integer.toString(start + step * i);
+           generatedRange[i] = start + step * i;
         }
 
         return generatedRange;   

--- a/main/src/com/google/refine/expr/functions/strings/Range.java
+++ b/main/src/com/google/refine/expr/functions/strings/Range.java
@@ -1,5 +1,7 @@
 package com.google.refine.expr.functions.strings;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
@@ -13,74 +15,203 @@ import com.google.refine.grel.Function;
 /**
  * Implements the logic behind the range function.
  * 
- * The range function can either take in a single string of the form 'a-b' or
- * two integers, a and b where a represents the first number in the range and
- * b represents the last number in the range.
+ * The range function can take in a single string of the form 'a, b, c' or three
+ * integers a, b, c where a and b represents the first and last numbers in the range respectively.
+ * 
+ * If b is not given, a defaults to the range end and 0 becomes the range start.
+ * c is optional and represents the step (increment) for the generated sequence.
  */
 public class Range implements Function {
     
     private static final int STRING_ARG_LENGTH = 1;
-    private static final String DASH_SEPARATOR = "-";
-    private static final String COMMA_SEPARATOR = ",";
+    private static final String SEPARATOR = ",";
     
-    private static final int INTEGERS_ARG_LENGTH = 2;
+    private static final int INTEGER_ARGS_LENGTH = 2;
+    private static final int INTEGER_ARGS_WITH_STEP = 3;
+    
+    private static final String DEFAULT_RANGE_START = "0";
+    
+    private static final String lastCharacterCommaRegex = ",$";
+    private static final Pattern lastCharacterCommaPattern = Pattern.compile(lastCharacterCommaRegex);
 
     @Override
     public Object call(Properties bindings, Object[] args) {
+
         if (args.length == STRING_ARG_LENGTH) {
-            Object range = args[0];
-            if (range != null && range instanceof String) {
-                String rangeString = (String) range;
-                String[] rangeValues = rangeString.contains(DASH_SEPARATOR)
-                                     ? rangeString.split(DASH_SEPARATOR)
-                                     : rangeString.split(COMMA_SEPARATOR);
+            return createRangeWithOneGivenArgument(args);
+        } else if (args.length == INTEGER_ARGS_LENGTH) {
+            return createRangeWithTwoGivenArguments(args);
+        } else if (args.length == INTEGER_ARGS_WITH_STEP) {
+            return createRangeWithThreeGivenArguments(args);
+        }
 
-                if (rangeValues.length == INTEGERS_ARG_LENGTH) {
-                    String rangeStart = rangeValues[0].trim();
-                    String rangeEnd = rangeValues[1].trim();
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
+                + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
+                + "are the start and the end of the range respectively and c is the step (increment)");
+    }
+    
+    /**
+     * Checks if a given string has a comma as the last character.
+     * 
+     * This is primarily used against abusing the range function like doing range("1,").
+     */
+    private boolean hasCommaAsLastCharacter(String test) {
+        Matcher lastCharacterCommaMatcher = lastCharacterCommaPattern.matcher(test);
+        return lastCharacterCommaMatcher.find();
+    }
+    
+    /**
+     * Processes the single argument given to determine if the argument is a valid string, a 
+     * valid integer, or an invalid argument.
+     * 
+     * If the argument is a valid string, it can either be in the form 'a', or 'a, b' or 'a, b, c' 
+     * where a and b are the start and end of the range respectively, and c is the optional
+     * step argument. In the case where 'a' is the only argument, 'a' becomes the range end and 
+     * 0 becomes the default range start.
+     * 
+     * If the argument is a valid integer, it can will default to become the range end, and 0 defaults
+     * to become the range start.
+     */
+    private Object createRangeWithOneGivenArgument(Object[] args) {
+        Object range = args[0];
 
-                    if (StringUtils.isNumeric(rangeStart) && StringUtils.isNumeric(rangeEnd)) {
-                        return createRange(rangeStart, rangeEnd);
-                    }
+        if (range != null && range instanceof String) {
+            String rangeString = ((String) range).trim();
+            String[] rangeValues = rangeString.split(SEPARATOR);
+            
+            if (rangeValues.length == 1 && StringUtils.isNumeric(rangeValues[0])
+                    && !hasCommaAsLastCharacter(rangeString)) {
+                String rangeEnd = rangeValues[0].trim();
+
+                return createRange(DEFAULT_RANGE_START, rangeEnd);
+            } else if (rangeValues.length == INTEGER_ARGS_LENGTH) {
+                String rangeStart = rangeValues[0].trim();
+                String rangeEnd = rangeValues[1].trim();
+
+                if (StringUtils.isNumeric(rangeStart) && StringUtils.isNumeric(rangeEnd)) {
+                    return createRange(rangeStart, rangeEnd);
+                }
+            } else if (rangeValues.length == INTEGER_ARGS_WITH_STEP) {
+                String rangeStart = rangeValues[0].trim();
+                String rangeEnd = rangeValues[1].trim();
+                String rangeStep = rangeValues[2].trim();
+                
+                if (StringUtils.isNumeric(rangeStart) && StringUtils.isNumeric(rangeEnd) 
+                        && StringUtils.isNumeric(rangeStep)) {
+                    return createRange(rangeStart, rangeEnd, rangeStep);
                 }
             }
         }
         
-        if (args.length == INTEGERS_ARG_LENGTH) {
-            String rangeStart = args[0].toString();
-            String rangeEnd = args[1].toString();
-            
-            if (rangeStart != null && StringUtils.isNumeric(rangeStart) 
-                    && rangeEnd != null && StringUtils.isNumeric(rangeEnd)) {
-                return createRange(rangeStart, rangeEnd);
-            }
+        if (range != null && StringUtils.isNumeric(range.toString())) {
+            String rangeEnd = range.toString();
+
+            return createRange(DEFAULT_RANGE_START, rangeEnd);
         }
         
-        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects a string of the form 'a-b' or 2 integers a, b where a is the start of the range and b is the end of the range");
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
+                + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
+                + "are the start and the end of the range respectively and c is the step (increment)");    
+    }
+    
+    /**
+     * Processes the two arguments given to determine if the arguments are two valid integers or 
+     * a valid string and step or invalid arguments.
+     */
+    private Object createRangeWithTwoGivenArguments(Object[] args) {
+        String rangeStart = args[0].toString().trim();
+        String rangeEnd = args[1].toString().trim();
+
+        String range = rangeStart;
+        String rangeStep = rangeEnd;
+        
+        boolean isTwoValidIntegers = false;
+        boolean isValidStringWithStep = false;
+        
+        String[] rangeValues = range.split(SEPARATOR);
+        
+        if (rangeValues.length == 1) {
+            isTwoValidIntegers = true;
+        } else if (rangeValues.length == 2) {
+            isValidStringWithStep = true;
+        }
+        
+        if (isTwoValidIntegers && StringUtils.isNumeric(rangeStart) &&
+                StringUtils.isNumeric(rangeEnd)) {
+            return createRange(rangeStart, rangeEnd);
+        } else if (isValidStringWithStep) {
+            rangeStart = rangeValues[0].trim();
+            rangeEnd = rangeValues[1].trim();
+            
+            if (StringUtils.isNumeric(rangeStart) && StringUtils.isNumeric(rangeEnd) 
+                    && StringUtils.isNumeric(rangeStep)) {
+                return createRange(rangeStart, rangeEnd, rangeStep);
+            }   
+        }
+        
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
+                + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
+                + "are the start and the end of the range respectively and c is the step (increment)");
+    }
+    
+    /**
+     * Processes the three arguments given to determine if the arguments are three valid integers or 
+     * invalid arguments.
+     */
+    private Object createRangeWithThreeGivenArguments(Object[] args) {
+        String rangeStart = args[0].toString().trim();
+        String rangeEnd = args[1].toString().trim();
+        String rangeStep = args[2].toString().trim();
+        if (StringUtils.isNumeric(rangeStart) && StringUtils.isNumeric(rangeEnd) 
+                && StringUtils.isNumeric(rangeStep)) {
+            return createRange(rangeStart, rangeEnd, rangeStep);
+        }
+        
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
+                + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
+                + "are the start and the end of the range respectively and c is the step (increment)");
     }
     
     /**
      * Creates a range from the given range values.
      * 
-     * The start value must be numerically smaller than the end value, and both values must be whole numbers.
+     * The generated range is either an increasing sequence or a decreasing sequence, and 
+     * each number in the sequence differs from the next number by one.
      */
     private static Object createRange(String rangeStart, String rangeEnd) {
+        return createRange(rangeStart, rangeEnd, "1"); 
+    }
+    
+    /**
+     * Creates a range from the given range values with the given step.
+     * 
+     * The generated range is either an increasing sequence or a decreasing sequence, and 
+     * each number in the sequence differs from the next number by the step value.
+     */
+    private static Object createRange(String rangeStart, String rangeEnd, String rangeStep) {
         int start = Integer.parseInt(rangeStart);
         int end = Integer.parseInt(rangeEnd);
-                
-        StringBuilder generatedRange = new StringBuilder("");
+        int step = Integer.parseInt(rangeStep);
+        int negativeStep = -step;        
+        int rangeSize = 0;
+        
+        if (step != 0) {
+            rangeSize = (int) (Math.ceil((double) (Math.abs(start - end) + 1)/ step));
+        }
+        
+        String[] generatedRange = new String[rangeSize];
         
         if (start < end) {
-            for (int i = start; i < end; i++) {
-                generatedRange.append(i + ", ");
+            for (int i = 0; i < rangeSize; i++) {
+                generatedRange[i] = Integer.toString(start + step * i);
             }
         } else {
-            for (int i = start; i > end; i--) {
-                generatedRange.append(i + ", ");
+            for (int i = 0; i < rangeSize; i++) {
+                generatedRange[i] = Integer.toString(start + negativeStep * i);
             }
         }
         
-        return generatedRange.append(end).toString();    
+        return generatedRange;   
     }
     
     @Override
@@ -89,8 +220,8 @@ public class Range implements Function {
     
         writer.object();
         writer.key("description"); writer.value(
-                "Returns an array of integers [a, a+1, a+2, ..., b] where a is the first (smallest) number in the range and b is the last (largest) number in the range.");
-        writer.key("params"); writer.value("string s, with the form 'a-b' or integers a and b, where a is the first integer in the range and b is the last integer in the range.");
+                "Returns an array where a and b are the start and the end of the range respectively and c is the step (increment).");
+        writer.key("params"); writer.value("A single string 'a', 'a, b' or 'a, b, c' or one, two or three integers a or a, b or a, b, c");
         writer.key("returns"); writer.value("array");
         writer.endObject();
     }

--- a/main/src/com/google/refine/expr/functions/strings/Range.java
+++ b/main/src/com/google/refine/expr/functions/strings/Range.java
@@ -1,0 +1,98 @@
+package com.google.refine.expr.functions.strings;
+
+import java.util.Properties;
+import java.util.stream.IntStream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONException;
+import org.json.JSONWriter;
+
+import com.google.refine.expr.EvalError;
+import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.Function;
+
+/**
+ * Implements the logic behind the range function.
+ * 
+ * The range function can either take in a single string of the form 'a-b' or
+ * two integers, a and b where a represents the first number in the range and
+ * b represents the last number in the range.
+ */
+public class Range implements Function {
+    
+    private static final int STRING_ARG_LENGTH = 1;
+    private static final String DASH_SEPARATOR = "-";
+    private static final String COMMA_SEPARATOR = ",";
+    
+    private static final int INTEGERS_ARG_LENGTH = 2;
+
+    @Override
+    public Object call(Properties bindings, Object[] args) {
+        if (args.length == STRING_ARG_LENGTH) {
+            Object range = args[0];
+            if (range != null && range instanceof String) {
+                String rangeString = (String) range;
+                String[] rangeValues = rangeString.contains(DASH_SEPARATOR)
+                                     ? rangeString.split(DASH_SEPARATOR)
+                                     : rangeString.split(COMMA_SEPARATOR);
+
+                if (rangeValues.length == INTEGERS_ARG_LENGTH) {
+                    String rangeStart = rangeValues[0].trim();
+                    String rangeEnd = rangeValues[1].trim();
+
+                    if (StringUtils.isNumeric(rangeStart) && StringUtils.isNumeric(rangeEnd)) {
+                        return createRange(rangeStart, rangeEnd);
+                    }
+                }
+            }
+        }
+        
+        if (args.length == INTEGERS_ARG_LENGTH) {
+            String rangeStart = args[0].toString();
+            String rangeEnd = args[1].toString();
+            
+            if (rangeStart != null && StringUtils.isNumeric(rangeStart) 
+                    && rangeEnd != null && StringUtils.isNumeric(rangeEnd)) {
+                return createRange(rangeStart, rangeEnd);
+            }
+        }
+        
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects a string of the form 'a-b' or 2 integers a, b where a is the start of the range and b is the end of the range");
+    }
+    
+    /**
+     * Creates a range from the given range values.
+     * 
+     * The start value must be numerically smaller than the end value, and both values must be whole numbers.
+     */
+    private static Object createRange(String rangeStart, String rangeEnd) {
+        int start = Integer.parseInt(rangeStart);
+        int end = Integer.parseInt(rangeEnd);
+                
+        StringBuilder generatedRange = new StringBuilder("");
+        
+        if (start < end) {
+            for (int i = start; i < end; i++) {
+                generatedRange.append(i + ", ");
+            }
+        } else {
+            for (int i = start; i > end; i--) {
+                generatedRange.append(i + ", ");
+            }
+        }
+        
+        return generatedRange.append(end).toString();    
+    }
+    
+    @Override
+    public void write(JSONWriter writer, Properties options)
+        throws JSONException {
+    
+        writer.object();
+        writer.key("description"); writer.value(
+                "Returns an array of integers [a, a+1, a+2, ..., b] where a is the first (smallest) number in the range and b is the last (largest) number in the range.");
+        writer.key("params"); writer.value("string s, with the form 'a-b' or integers a and b, where a is the first integer in the range and b is the last integer in the range.");
+        writer.key("returns"); writer.value("array");
+        writer.endObject();
+    }
+}

--- a/main/src/com/google/refine/expr/functions/strings/Range.java
+++ b/main/src/com/google/refine/expr/functions/strings/Range.java
@@ -4,7 +4,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.Properties;
 
-import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONWriter;
 
@@ -16,32 +15,31 @@ import com.google.refine.grel.Function;
  * Implements the logic behind the range function.
  * 
  * The range function can take in a single string of the form 'a, b, c' or three
- * integers a, b, c where a and b represents the first and last numbers in the range respectively.
- * 
- * If b is not given, a defaults to the range end and 0 becomes the range start.
- * c is optional and represents the step (increment) for the generated sequence.
+ * integers a, b, c where a and b represents the first (inclusive) and last (exclusive)
+ * numbers in the range respectively. If b is not given, a defaults to the range end 
+ * and 0 becomes the range start. c is optional and represents the step (increment) 
+ * for the generated sequence.
  */
 public class Range implements Function {
-    
-    private static final int STRING_ARG_LENGTH = 1;
+
     private static final String SEPARATOR = ",";
-    
-    private static final int INTEGER_ARGS_LENGTH = 2;
-    private static final int INTEGER_ARGS_WITH_STEP = 3;
-    
-    private static final String DEFAULT_RANGE_START = "0";
-    
+
     private static final String lastCharacterCommaRegex = ",$";
     private static final Pattern lastCharacterCommaPattern = Pattern.compile(lastCharacterCommaRegex);
+
+    private static final int DEFAULT_START = 0;
+    private static final int DEFAULT_STEP = 1;
+
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
     @Override
     public Object call(Properties bindings, Object[] args) {
 
-        if (args.length == STRING_ARG_LENGTH) {
+        if (args.length == 1) {
             return createRangeWithOneGivenArgument(args);
-        } else if (args.length == INTEGER_ARGS_LENGTH) {
+        } else if (args.length == 2) {
             return createRangeWithTwoGivenArguments(args);
-        } else if (args.length == INTEGER_ARGS_WITH_STEP) {
+        } else if (args.length == 3) {
             return createRangeWithThreeGivenArguments(args);
         }
 
@@ -49,175 +47,257 @@ public class Range implements Function {
                 + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
                 + "are the start and the end of the range respectively and c is the step (increment)");
     }
-    
+
     /**
      * Checks if a given string has a comma as the last character.
      * 
-     * This is primarily used against abusing the range function like doing range("1,").
+     * This is primarily used to detect edge cases like doing range("1,").
      */
     private boolean hasCommaAsLastCharacter(String test) {
         Matcher lastCharacterCommaMatcher = lastCharacterCommaPattern.matcher(test);
         return lastCharacterCommaMatcher.find();
     }
-    
+
     /**
-     * Processes the single argument given to determine if the argument is a valid string, a 
-     * valid integer, or an invalid argument.
+     * Processes the single argument given to determine if the argument is (i) a valid string, (ii) a 
+     * valid integer, or (iii) an invalid argument.
      * 
      * If the argument is a valid string, it can either be in the form 'a', or 'a, b' or 'a, b, c' 
      * where a and b are the start and end of the range respectively, and c is the optional
-     * step argument. In the case where 'a' is the only argument, 'a' becomes the range end and 
-     * 0 becomes the default range start.
+     * step argument. In the case where 'a' is the only argument, 'a' becomes the range end (exclusive)
+     * and 0 becomes the default range start.
      * 
      * If the argument is a valid integer, it can will default to become the range end, and 0 defaults
      * to become the range start.
+     * 
+     * In all other cases, the argument is considered invalid.
      */
     private Object createRangeWithOneGivenArgument(Object[] args) {
         Object range = args[0];
 
+        int rangeStart = DEFAULT_START;
+        int rangeEnd = 0;
+        int rangeStep = DEFAULT_STEP;
+
+        // Check for valid string argument(s)
         if (range != null && range instanceof String) {
             String rangeString = ((String) range).trim();
             String[] rangeValues = rangeString.split(SEPARATOR);
-            
-            if (rangeValues.length == 1 && StringUtils.isNumeric(rangeValues[0])
-                    && !hasCommaAsLastCharacter(rangeString)) {
-                String rangeEnd = rangeValues[0].trim();
 
-                return createRange(DEFAULT_RANGE_START, rangeEnd);
-            } else if (rangeValues.length == INTEGER_ARGS_LENGTH) {
-                String rangeStart = rangeValues[0].trim();
-                String rangeEnd = rangeValues[1].trim();
+            if (hasCommaAsLastCharacter(rangeString)) {
+                return new EvalError("the last character in the input string should not be a comma");
+            }
 
-                if (StringUtils.isNumeric(rangeStart) && StringUtils.isNumeric(rangeEnd)) {
-                    return createRange(rangeStart, rangeEnd);
-                }
-            } else if (rangeValues.length == INTEGER_ARGS_WITH_STEP) {
-                String rangeStart = rangeValues[0].trim();
-                String rangeEnd = rangeValues[1].trim();
-                String rangeStep = rangeValues[2].trim();
-                
-                if (StringUtils.isNumeric(rangeStart) && StringUtils.isNumeric(rangeEnd) 
-                        && StringUtils.isNumeric(rangeStep)) {
+            try {
+                if (rangeValues.length == 1) {
+                    rangeEnd = Integer.parseInt(rangeValues[0].trim());
+                    return createRange(rangeStart, rangeEnd, rangeStep);
+                } else if (rangeValues.length == 2) {
+                    rangeStart = Integer.parseInt(rangeValues[0].trim());
+                    rangeEnd = Integer.parseInt(rangeValues[1].trim());
+                    return createRange(rangeStart, rangeEnd, rangeStep);
+                } else if (rangeValues.length == 3) {
+                    rangeStart = Integer.parseInt(rangeValues[0].trim());
+                    rangeEnd = Integer.parseInt(rangeValues[1].trim());
+                    rangeStep = Integer.parseInt(rangeValues[2].trim());
                     return createRange(rangeStart, rangeEnd, rangeStep);
                 }
+            } catch (NumberFormatException nfe) {
+                return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
+                        + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
+                        + "are the start and the end of the range respectively and c is the step (increment)");
             }
         }
-        
-        if (range != null && StringUtils.isNumeric(range.toString())) {
-            String rangeEnd = range.toString();
 
-            return createRange(DEFAULT_RANGE_START, rangeEnd);
+        // Check for valid negative integer argument
+        if (range != null && range instanceof Double && (Double) range % 1 == 0) {
+            range = ((Double) range).intValue();
+            return createRange(DEFAULT_START, rangeEnd, DEFAULT_STEP);
         }
-        
+
+        // Check for valid positive integer argument
+        if (range != null) {
+            try {
+                rangeEnd = Integer.parseInt(String.valueOf(range));
+                return createRange(DEFAULT_START, rangeEnd, DEFAULT_STEP);
+            } catch (NumberFormatException nfe) {
+                return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
+                        + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
+                        + "are the start and the end of the range respectively and c is the step (increment)");
+            }
+        }
+
         return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
                 + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
                 + "are the start and the end of the range respectively and c is the step (increment)");    
     }
-    
+
     /**
-     * Processes the two arguments given to determine if the arguments are two valid integers or 
-     * a valid string and step or invalid arguments.
+     * Processes the two arguments given to determine if the arguments are (i) two valid strings, 
+     * (ii) two valid integers or (iii) a valid string and an integer or (iv) invalid arguments.
+     * 
+     * If the arguments are valid strings, the strings can either be such that (i) each string contains 
+     * single arguments (i.e. two arguments in total), or (ii) one string contains one argument and the other 
+     * string contains two argument (i.e. three arguments in total).
+     * 
+     * If the arguments are a valid string and a valid integer, the string can be such that (i) the string
+     * contains a single argument (i.e. two arguments in total) or (ii) the string contains two arguments 
+     * (i.e. three arguments in total).
+     * 
+     * In all other cases, the arguments are considered invalid.
      */
     private Object createRangeWithTwoGivenArguments(Object[] args) {
-        String rangeStart = args[0].toString().trim();
-        String rangeEnd = args[1].toString().trim();
+        Object firstArg = args[0];
+        Object secondArg = args[1];
 
-        String range = rangeStart;
-        String rangeStep = rangeEnd;
-        
-        boolean isTwoValidIntegers = false;
-        boolean isValidStringWithStep = false;
-        
-        String[] rangeValues = range.split(SEPARATOR);
-        
-        if (rangeValues.length == 1) {
-            isTwoValidIntegers = true;
-        } else if (rangeValues.length == 2) {
-            isValidStringWithStep = true;
+        int rangeStart = DEFAULT_START;
+        int rangeEnd = 0;
+        int rangeStep = DEFAULT_STEP;
+
+        if (firstArg == null || secondArg == null) {
+            return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
+                    + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
+                    + "are the start and the end of the range respectively and c is the step (increment)");
         }
-        
-        if (isTwoValidIntegers && StringUtils.isNumeric(rangeStart) &&
-                StringUtils.isNumeric(rangeEnd)) {
-            return createRange(rangeStart, rangeEnd);
-        } else if (isValidStringWithStep) {
-            rangeStart = rangeValues[0].trim();
-            rangeEnd = rangeValues[1].trim();
-            
-            if (StringUtils.isNumeric(rangeStart) && StringUtils.isNumeric(rangeEnd) 
-                    && StringUtils.isNumeric(rangeStep)) {
+
+        boolean hasString = false;
+        boolean hasTwoIntegers = true;
+
+        if (firstArg instanceof String || secondArg instanceof String) {
+            hasString = true;
+            hasTwoIntegers = false;
+        }
+
+        boolean hasTwoArguments = hasTwoIntegers;
+        boolean hasThreeArguments = false;
+
+        // Deal with valid negative integers
+        if (firstArg instanceof Double && (Double) firstArg % 1 == 0) {
+            firstArg = ((Double) firstArg).intValue();
+        }
+
+        if (secondArg instanceof Double && (Double) secondArg % 1 == 0) {
+            secondArg = ((Double) secondArg).intValue();
+        }
+
+        String firstArgStringified = String.valueOf(firstArg).trim();
+        String secondArgStringified = String.valueOf(secondArg).trim();
+        String thirdArgStringified = "";
+
+        if (hasCommaAsLastCharacter(firstArgStringified) || hasCommaAsLastCharacter(secondArgStringified)) {
+            return new EvalError("the last character in the input string should not be a comma");
+        }
+
+        // Check if the strings are valid strings (e.g. range("1, 2", "3, 4") should fail but 
+        // range("1, 2", "1") should pass)
+        if (hasString) {            
+            String[] firstArgArray = firstArgStringified.split(SEPARATOR);
+            String[] secondArgArray = secondArgStringified.split(SEPARATOR);
+
+            int combinedArrayLength = firstArgArray.length + secondArgArray.length;
+
+            if (combinedArrayLength == 3) {
+                hasThreeArguments = true;
+ 
+                if (firstArgArray.length == 1) {
+                    secondArgStringified = secondArgArray[0].trim();
+                    thirdArgStringified = secondArgArray[1].trim();
+                } else {
+                    firstArgStringified = firstArgArray[0].trim();
+                    secondArgStringified = firstArgArray[1].trim();
+                    thirdArgStringified = secondArgArray[0].trim();
+                }
+
+            } else if (combinedArrayLength == 2) {
+                hasTwoArguments = true;
+            }
+        }
+
+        try {
+            if (hasTwoArguments) {
+                rangeStart = Integer.parseInt(firstArgStringified);
+                rangeEnd = Integer.parseInt(secondArgStringified);
                 return createRange(rangeStart, rangeEnd, rangeStep);
-            }   
+            } else if (hasThreeArguments) {
+                rangeStart = Integer.parseInt(firstArgStringified);
+                rangeEnd = Integer.parseInt(secondArgStringified);
+                rangeStep = Integer.parseInt(thirdArgStringified);
+                return createRange(rangeStart, rangeEnd, rangeStep);
+            }
+        } catch (NumberFormatException nfe) {
+            return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
+                    + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
+                    + "are the start and the end of the range respectively and c is the step (increment)");   
         }
-        
+
         return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
                 + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
                 + "are the start and the end of the range respectively and c is the step (increment)");
     }
-    
+
     /**
-     * Processes the three arguments given to determine if the arguments are three valid integers or 
-     * invalid arguments.
+     * Processes the three arguments given to determine if the arguments are (i) three valid strings, 
+     * (ii) three valid integers, (iii) two valid strings and a valid integer, (iv) a valid string and 
+     * two valid integers or (v) invalid arguments.
+     * 
+     * In this case, all valid strings can only contain a single argument.
      */
     private Object createRangeWithThreeGivenArguments(Object[] args) {
-        String rangeStart = args[0].toString().trim();
-        String rangeEnd = args[1].toString().trim();
-        String rangeStep = args[2].toString().trim();
-        if (StringUtils.isNumeric(rangeStart) && StringUtils.isNumeric(rangeEnd) 
-                && StringUtils.isNumeric(rangeStep)) {
-            return createRange(rangeStart, rangeEnd, rangeStep);
+        Object firstArg = args[0];
+        Object secondArg = args[1];
+        Object thirdArg = args[2];
+      
+        // Deal with negative integers first
+        if (firstArg != null && firstArg instanceof Double && (Double) firstArg % 1 == 0) {
+            firstArg = ((Double) firstArg).intValue();
         }
-        
-        return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
-                + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
-                + "are the start and the end of the range respectively and c is the step (increment)");
+
+        if (secondArg != null && secondArg instanceof Double && (Double) secondArg % 1 == 0) {
+            secondArg = ((Double) secondArg).intValue();
+        }
+
+        if (thirdArg != null && thirdArg instanceof Double && (Double) thirdArg % 1 == 0) {
+            thirdArg = ((Double) thirdArg).intValue();
+        }
+
+        try {    
+            int rangeStart = Integer.parseInt(String.valueOf(firstArg).trim());
+            int rangeEnd = Integer.parseInt(String.valueOf(secondArg).trim());
+            int rangeStep = Integer.parseInt(String.valueOf(thirdArg).trim());
+            return createRange(rangeStart, rangeEnd, rangeStep);
+        } catch (NumberFormatException nfe) {
+            return new EvalError(ControlFunctionRegistry.getFunctionName(this) 
+                    + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "
+                    + "are the start and the end of the range respectively and c is the step (increment)");
+        }
     }
-    
-    /**
-     * Creates a range from the given range values.
-     * 
-     * The generated range is either an increasing sequence or a decreasing sequence, and 
-     * each number in the sequence differs from the next number by one.
-     */
-    private static Object createRange(String rangeStart, String rangeEnd) {
-        return createRange(rangeStart, rangeEnd, "1"); 
-    }
-    
+
     /**
      * Creates a range from the given range values with the given step.
      * 
      * The generated range is either an increasing sequence or a decreasing sequence, and 
-     * each number in the sequence differs from the next number by the step value.
+     * each number in the sequence differs from the next number by the step value. 
      */
-    private static Object createRange(String rangeStart, String rangeEnd, String rangeStep) {
-        int start = Integer.parseInt(rangeStart);
-        int end = Integer.parseInt(rangeEnd);
-        int step = Integer.parseInt(rangeStep);
-        int negativeStep = -step;        
-        int rangeSize = 0;
-        
-        if (step != 0) {
-            rangeSize = (int) (Math.ceil((double) (Math.abs(start - end) + 1)/ step));
+    private static Object createRange(int start, int stop, int step) {        
+        if ((start > stop && step > 0) || (start < stop && step < 0) || step == 0) {
+            return EMPTY_STRING_ARRAY;
         }
-        
+
+        int rangeSize = (int) (Math.ceil(((double) Math.abs(start - stop))/ Math.abs(step)));
+
         String[] generatedRange = new String[rangeSize];
-        
-        if (start < end) {
-            for (int i = 0; i < rangeSize; i++) {
-                generatedRange[i] = Integer.toString(start + step * i);
-            }
-        } else {
-            for (int i = 0; i < rangeSize; i++) {
-                generatedRange[i] = Integer.toString(start + negativeStep * i);
-            }
+
+        for (int i = 0; i < rangeSize; i++) {
+           generatedRange[i] = Integer.toString(start + step * i);
         }
-        
+
         return generatedRange;   
     }
-    
+
     @Override
     public void write(JSONWriter writer, Properties options)
         throws JSONException {
-    
+
         writer.object();
         writer.key("description"); writer.value(
                 "Returns an array where a and b are the start and the end of the range respectively and c is the step (increment).");

--- a/main/src/com/google/refine/expr/functions/strings/Range.java
+++ b/main/src/com/google/refine/expr/functions/strings/Range.java
@@ -1,7 +1,6 @@
 package com.google.refine.expr.functions.strings;
 
 import java.util.Properties;
-import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;

--- a/main/src/com/google/refine/grel/ControlFunctionRegistry.java
+++ b/main/src/com/google/refine/grel/ControlFunctionRegistry.java
@@ -115,6 +115,7 @@ import com.google.refine.expr.functions.strings.NGramFingerprint;
 import com.google.refine.expr.functions.strings.ParseJson;
 import com.google.refine.expr.functions.strings.Partition;
 import com.google.refine.expr.functions.strings.Phonetic;
+import com.google.refine.expr.functions.strings.Range;
 import com.google.refine.expr.functions.strings.RPartition;
 import com.google.refine.expr.functions.strings.Reinterpret;
 import com.google.refine.expr.functions.strings.Replace;
@@ -201,6 +202,7 @@ public class ControlFunctionRegistry {
         registerFunction("substring", new Slice());
         registerFunction("replace", new Replace());
         registerFunction("replaceChars", new ReplaceChars());
+        registerFunction("range", new Range());
         registerFunction("split", new Split());
         registerFunction("smartSplit", new SmartSplit());
         registerFunction("splitByCharType", new SplitByCharType());

--- a/main/tests/server/src/com/google/refine/tests/expr/functions/strings/RangeTests.java
+++ b/main/tests/server/src/com/google/refine/tests/expr/functions/strings/RangeTests.java
@@ -14,30 +14,29 @@ import com.google.refine.grel.ControlFunctionRegistry;
 import com.google.refine.grel.Function;
 import com.google.refine.tests.RefineTest;
 
-
 /**
  * Tests for the range function.
  */
 public class RangeTests extends RefineTest {
 
-    static Properties bindings;
+    private static Properties bindings;
 
     @Override
     @BeforeTest
     public void init() {
         logger = LoggerFactory.getLogger(this.getClass());
     }
-    
+
     @BeforeMethod
-    public void SetUp() {
+    public void setUp() {
         bindings = new Properties();
     }
 
     @AfterMethod
-    public void TearDown() {
+    public void tearDown() {
         bindings = null;
     }
-    
+
     /**
      * Lookup a control function by name and invoke it with a variable number of args
      */
@@ -53,13 +52,16 @@ public class RangeTests extends RefineTest {
             return function.call(bindings, args);
         }
     }
-    
+
     @Test
     public void testRangeInvalidParams() {        
         // Test number of arguments
         Assert.assertTrue(invoke("range") instanceof EvalError);
         Assert.assertTrue(invoke("range", "") instanceof EvalError);
-        Assert.assertTrue(invoke("range", "one","two","three") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1, 2, 3, 4") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1, 2, 3", "4") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1", "2, 3, 4") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1, 2", "3", "4") instanceof EvalError);
         Assert.assertTrue(invoke("range", 1, 2, 3, 4) instanceof EvalError);
 
         // Test invalid single string argument types
@@ -67,77 +69,242 @@ public class RangeTests extends RefineTest {
         Assert.assertTrue(invoke("range", "a") instanceof EvalError);
 
         // Test invalid single string numeric arguments
-        Assert.assertTrue(invoke("range", "-1") instanceof EvalError);
         Assert.assertTrue(invoke("range", "1,") instanceof EvalError);
         Assert.assertTrue(invoke("range", ",") instanceof EvalError);
         Assert.assertTrue(invoke("range", ",2") instanceof EvalError);
         Assert.assertTrue(invoke("range", "1.5") instanceof EvalError);
         Assert.assertTrue(invoke("range", ",12.3, 2") instanceof EvalError);
-        
+
+        // Test invalid double string arguments
+        Assert.assertTrue(invoke("range", "1", "") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "", "1") instanceof EvalError);
+
+        Assert.assertTrue(invoke("range", "1,", "2") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1", "2,") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1.5", "3") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1", "3.5") instanceof EvalError);
+
+        // Test invalid triple string arguments
+        Assert.assertTrue(invoke("range", "", "", "") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1", "", "") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "", "1", "") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "", "", "1") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1", "2", "") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "", "1", "2") instanceof EvalError);
+
+        Assert.assertTrue(invoke("range", "1,", "2", "1") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1", "2,", "1") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1", "2", "1,") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1.5", "3", "1") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1", "3.5", "1") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1", "3,", "1.5") instanceof EvalError);
+
         // Test invalid numeric arguments
         Assert.assertTrue(invoke("range", 1.2) instanceof EvalError);
         Assert.assertTrue(invoke("range", 1.2, 4.5) instanceof EvalError);
         Assert.assertTrue(invoke("range", 1.2, 5, 3) instanceof EvalError);
-        Assert.assertTrue(invoke("range", -1) instanceof EvalError);
-        Assert.assertTrue(invoke("range", -1, 2) instanceof EvalError);
-        Assert.assertTrue(invoke("range", -1, 5, 3) instanceof EvalError);
-        
+
         // Test invalid mixed arguments
-        Assert.assertTrue(invoke("range", 1, "2, 3") instanceof EvalError);
         Assert.assertTrue(invoke("range", 1, "") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "", 1) instanceof EvalError);
+        Assert.assertTrue(invoke("range", 1, "a") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "a", 1) instanceof EvalError);
+        Assert.assertTrue(invoke("range", 1, "", "") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "", 1, "") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "", "", 1) instanceof EvalError);
+        Assert.assertTrue(invoke("range", 1.5, "2", 1) instanceof EvalError);
     }
-    
+
     @Test
-    public void testRangeValidStringParams() {
-        // Test valid single string argument
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "3"))), "0, 1, 2, 3");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", " 3  "))), "0, 1, 2, 3");
-        
-        // Test valid double string arguments
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1"))), "1");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5"))), "1, 2, 3, 4, 5");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1"))), "5, 4, 3, 2, 1");
-        
-        // Test valid triple string arguments
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 3, 0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1, 1"))), "1");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, 10"))), "1");
-        
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, 2"))), "1, 3, 5");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1, 2"))), "5, 3, 1");
+    public void testRangeValidSingleStringParams() {
+        // Test valid single string containing one arg
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "3"))), "0, 1, 2");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", " 3  "))), "0, 1, 2");
+
+        // Test valid single string containing two args
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5"))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "   1   ,5"))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1,      5     "))), "1, 2, 3, 4");
+
+        // Test valid single string containing three args
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1, 0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1, 1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, -1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, 0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, 1"))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, 2"))), "1, 3");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1, -2"))), "5, 3");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1, -1"))), "5, 4, 3, 2");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1, 0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1, 1"))), "");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  1  , 5, 1"))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1,  5  ,1"))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5,   1  "))), "1, 2, 3, 4");
     }
-    
+
+    @Test
+    public void testRangeValidDoubleStringParams() {
+        // Test valid double string containing two args
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "2", "1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "1"))), "-1, 0");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "5"))), "1, 2, 3, 4");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  -1   ", "1"))), "-1, 0");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", " 5  "))), "1, 2, 3, 4");
+
+        // Test valid double string containing three args
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5, 0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5, 0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5, -1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5, 1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5, 1"))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5, -1"))), "1, 0, -1, -2, -3, -4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5, 2"))), "-1, 1, 3");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5, -2"))), "1, -1, -3");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5, 10"))), "-1");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5, -10"))), "1");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, -5", "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", "-1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, -5", "1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", "1"))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, -5", "-1"))), "1, 0, -1, -2, -3, -4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", "2"))), "-1, 1, 3");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, -5", "-2"))), "1, -1, -3");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", "10"))), "-1");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, -5", "-10"))), "1");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  -1  , 5", "1"))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1,   5"  , "1"))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", " 1   "))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  -1  ", "5, 1"))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "  5  , 1"))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  -1  ", "5,    1   "))), "-1, 0, 1, 2, 3, 4");
+    }
+
+    @Test public void testRangeValidTripleStringParams() {
+        // Test valid triple string containing three arguments
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5", "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5", "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5", "-1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5", "1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5", "1"))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5", "-1"))), "1, 0, -1, -2, -3, -4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5", "2"))), "-1, 1, 3");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5", "-2"))), "1, -1, -3");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5", "10"))), "-1");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5", "-10"))), "1");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  -1  , 5, 1"))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1,   5  , 1"))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5,   1   "))), "-1, 0, 1, 2, 3, 4");
+    }
+
     @Test
     public void testRangeValidIntegerParams() {
         // Test valid single integer argument
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 0))), "0");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5))), "0, 1, 2, 3, 4, 5");
-        
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 0))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5))), "0, 1, 2, 3, 4");
+
         // Test valid double integer arguments
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5))), "1, 2, 3, 4, 5");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1))), "5, 4, 3, 2, 1");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", -1, 5))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1))), "");
 
         // Test valid triple integer arguments
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, -1))), "");
         Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, 2))), "1, 3, 5");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, 2))), "5, 3, 1");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, 1))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, 1))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, 2))), "1, 3");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, -2))), "5, 3");
     }
-    
+
     @Test
     public void testRangeValidMixedParams() {
-        // Test when each argument is of type integer/ string
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5))), "1, 2, 3, 4, 5");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1))), "5, 4, 3, 2, 1");
-        
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5"))), "1, 2, 3, 4, 5");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1"))), "5, 4, 3, 2, 1");
-        
-        // Test when step is an integer (e.g. range(value, 1))
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 3", 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1", 1))), "1");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", 10))), "1");
-        
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", 2))), "1, 3, 5");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1", 2))), "5, 3, 1");   
+        // Test two valid arguments, with a single string arg (containing one arg) and a single int arg
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5"))), "1, 2, 3, 4");
+
+        // Test two valid arguments, with a single string arg (containing two args) and a single int arg
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", -1))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", 0))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", 1))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", 2))), "1, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5, -1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5, 0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5, 1"))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5, 2"))), "1, 3");
+
+        // Test three valid arguments, with a single string arg (containing one arg) and two int args
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, -1))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, 0))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, 1))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, 2))), "1, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, 1))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, 0))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, -1))), "5, 4, 3, 2");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, -2))), "5, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", -1))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", 0))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", 1))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", 2))), "1, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", 1))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", 0))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", -1))), "5, 4, 3, 2");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", -2))), "5, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, "-1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, "1"))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, "2"))), "1, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, "1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, "-1"))), "5, 4, 3, 2");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, "-2"))), "5, 3");
+
+        // Test three valid arguments, with two string args and one int arg
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "5", -1))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "5", 0))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "5", 1))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "5", 2))), "1, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", "1", 1))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", "1", 0))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", "1", -1))), "5, 4, 3, 2");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", "1", -2))), "5, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, "-1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, "1"))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, "2"))), "1, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, "1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, "-1"))), "5, 4, 3, 2");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, "-2"))), "5, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", "-1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", "1"))), "1, 2, 3, 4");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", "2"))), "1, 3");
+
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", "1"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", "0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", "-1"))), "5, 4, 3, 2");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", "-2"))), "5, 3");
     }
 }

--- a/main/tests/server/src/com/google/refine/tests/expr/functions/strings/RangeTests.java
+++ b/main/tests/server/src/com/google/refine/tests/expr/functions/strings/RangeTests.java
@@ -20,6 +20,18 @@ import com.google.refine.tests.RefineTest;
 public class RangeTests extends RefineTest {
 
     private static Properties bindings;
+    
+    private static final Integer[] EMPTY_ARRAY = new Integer[0];
+
+    private static final Integer[] ONE_AND_THREE = new Integer[] {1, 3};
+    private static final Integer[] FIVE_AND_THREE = new Integer[] {5, 3};
+
+    private static final Integer[] ZERO_TO_TWO = new Integer[] {0, 1, 2};
+    private static final Integer[] ONE_TO_FOUR = new Integer[] {1, 2, 3, 4};
+    private static final Integer[] FIVE_TO_TWO = new Integer[] {5, 4, 3, 2};
+
+    private static final Integer[] NEGATIVE_ONE_TO_FOUR = new Integer[] {-1, 0, 1, 2, 3, 4};
+    private static final Integer[] ONE_TO_NEGATIVE_FOUR = new Integer[] {1, 0, -1, -2, -3, -4};
 
     @Override
     @BeforeTest
@@ -118,193 +130,193 @@ public class RangeTests extends RefineTest {
     @Test
     public void testRangeValidSingleStringParams() {
         // Test valid single string containing one arg
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "3"))), "0, 1, 2");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", " 3  "))), "0, 1, 2");
+        Assert.assertEquals(((Integer[]) invoke("range", "3")), ZERO_TO_TWO);
+        Assert.assertEquals(((Integer[]) (invoke("range", " 3  "))), ZERO_TO_TWO);
 
         // Test valid single string containing two args
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5"))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "   1   ,5"))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1,      5     "))), "1, 2, 3, 4");
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5, 1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 5"))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "   1   ,5"))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1,      5     "))), ONE_TO_FOUR);
 
         // Test valid single string containing three args
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1, 0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1, 1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, -1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, 0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, 1"))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, 2"))), "1, 3");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1, -2"))), "5, 3");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1, -1"))), "5, 4, 3, 2");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1, 0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1, 1"))), "");
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 1, 0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 1, 1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 5, -1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 5, 0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 5, 1"))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 5, 2"))), ONE_AND_THREE);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5, 1, -2"))), FIVE_AND_THREE);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5, 1, -1"))), FIVE_TO_TWO);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5, 1, 0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5, 1, 1"))), EMPTY_ARRAY);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  1  , 5, 1"))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1,  5  ,1"))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5,   1  "))), "1, 2, 3, 4");
+        Assert.assertEquals(((Integer[]) (invoke("range", "  1  , 5, 1"))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1,  5  ,1"))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 5,   1  "))), ONE_TO_FOUR);
     }
 
     @Test
     public void testRangeValidDoubleStringParams() {
         // Test valid double string containing two args
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "2", "1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "1"))), "-1, 0");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "5"))), "1, 2, 3, 4");
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "2", "1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "1"))), new Integer[] {-1, 0});
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "5"))), ONE_TO_FOUR);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  -1   ", "1"))), "-1, 0");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", " 5  "))), "1, 2, 3, 4");
+        Assert.assertEquals(((Integer[]) (invoke("range", "  -1   ", "1"))), new Integer[] {-1, 0});
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", " 5  "))), ONE_TO_FOUR);
 
         // Test valid double string containing three args
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5, 0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5, 0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5, -1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5, 1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5, 1"))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5, -1"))), "1, 0, -1, -2, -3, -4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5, 2"))), "-1, 1, 3");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5, -2"))), "1, -1, -3");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5, 10"))), "-1");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5, -10"))), "1");
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "5, 0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-5, 0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "5, -1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-5, 1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "5, 1"))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-5, -1"))), ONE_TO_NEGATIVE_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "5, 2"))), new Integer[] {-1, 1, 3});
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-5, -2"))), new Integer[] {1, -1, -3});
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "5, 10"))), new Integer[] {-1});
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-5, -10"))), new Integer[] {1});
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, -5", "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", "-1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, -5", "1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", "1"))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, -5", "-1"))), "1, 0, -1, -2, -3, -4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", "2"))), "-1, 1, 3");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, -5", "-2"))), "1, -1, -3");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", "10"))), "-1");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, -5", "-10"))), "1");
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1, 5", "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, -5", "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1, 5", "-1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, -5", "1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1, 5", "1"))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, -5", "-1"))), ONE_TO_NEGATIVE_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1, 5", "2"))), new Integer[] {-1, 1, 3});
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, -5", "-2"))), new Integer[] {1, -1, -3});
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1, 5", "10"))), new Integer[] {-1});
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, -5", "-10"))), new Integer[] {1});
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  -1  , 5", "1"))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1,   5"  , "1"))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5", " 1   "))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  -1  ", "5, 1"))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "  5  , 1"))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  -1  ", "5,    1   "))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(((Integer[]) (invoke("range", "  -1  , 5", "1"))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1,   5"  , "1"))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1, 5", " 1   "))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "  -1  ", "5, 1"))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "  5  , 1"))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "  -1  ", "5,    1   "))), NEGATIVE_ONE_TO_FOUR);
     }
 
     @Test public void testRangeValidTripleStringParams() {
         // Test valid triple string containing three arguments
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5", "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5", "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5", "-1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5", "1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5", "1"))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5", "-1"))), "1, 0, -1, -2, -3, -4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5", "2"))), "-1, 1, 3");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5", "-2"))), "1, -1, -3");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1", "5", "10"))), "-1");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "-5", "-10"))), "1");
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "5", "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-5", "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "5", "-1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-5", "1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "5", "1"))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-5", "-1"))), ONE_TO_NEGATIVE_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "5", "2"))), new Integer[] {-1, 1, 3});
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-5", "-2"))), new Integer[] {1, -1, -3});
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1", "5", "10"))), new Integer[] {-1});
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "-5", "-10"))), new Integer[] {1});
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "  -1  , 5, 1"))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1,   5  , 1"))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "-1, 5,   1   "))), "-1, 0, 1, 2, 3, 4");
+        Assert.assertEquals(((Integer[]) (invoke("range", "  -1  , 5, 1"))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1,   5  , 1"))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "-1, 5,   1   "))), NEGATIVE_ONE_TO_FOUR);
     }
 
     @Test
     public void testRangeValidIntegerParams() {
         // Test valid single integer argument
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5))), "0, 1, 2, 3, 4");
+        Assert.assertEquals(((Integer[]) (invoke("range", 0))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5))), new Integer[] {0, 1, 2, 3, 4});
 
         // Test valid double integer arguments
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", -1, 5))), "-1, 0, 1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1))), "");
+        Assert.assertEquals(((Integer[]) (invoke("range", -1, 5))), NEGATIVE_ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, 1))), EMPTY_ARRAY);
 
         // Test valid triple integer arguments
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, -1))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, 1))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, 1))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, 2))), "1, 3");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, -2))), "5, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, 5, -1))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, 5, 0))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, 1, 1))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, 5, 1))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, 5, 2))), ONE_AND_THREE);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, 1, -2))), FIVE_AND_THREE);
     }
 
     @Test
     public void testRangeValidMixedParams() {
-        // Test two valid arguments, with a single string arg (containing one arg) and a single int arg
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5"))), "1, 2, 3, 4");
+        // Test two valid arguments, with a single string arg (containing one arg) and a single Integer arg
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", 1))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", 5))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, "1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5"))), ONE_TO_FOUR);
 
-        // Test two valid arguments, with a single string arg (containing two args) and a single int arg
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", -1))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", 1))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", 2))), "1, 3");
+        // Test two valid arguments, with a single string arg (containing two args) and a single Integer arg
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 5", -1))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 5", 0))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 5", 1))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1, 5", 2))), ONE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5, -1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5, 0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5, 1"))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5, 2"))), "1, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5, -1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5, 0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5, 1"))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5, 2"))), ONE_AND_THREE);
 
-        // Test three valid arguments, with a single string arg (containing one arg) and two int args
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, -1))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, 1))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, 2))), "1, 3");
+        // Test three valid arguments, with a single string arg (containing one arg) and two Integer args
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", 5, -1))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", 5, 0))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", 5, 1))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", 5, 2))), ONE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, 1))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, -1))), "5, 4, 3, 2");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, -2))), "5, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", 1, 1))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", 1, 0))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", 1, -1))), FIVE_TO_TWO);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", 1, -2))), FIVE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", -1))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", 1))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", 2))), "1, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5", -1))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5", 0))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5", 1))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5", 2))), ONE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", 1))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", -1))), "5, 4, 3, 2");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", -2))), "5, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, "1", 1))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, "1", 0))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, "1", -1))), FIVE_TO_TWO);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, "1", -2))), FIVE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, "-1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, "1"))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, "2"))), "1, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, 5, "-1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, 5, "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, 5, "1"))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, 5, "2"))), ONE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, "1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, "-1"))), "5, 4, 3, 2");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, "-2"))), "5, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, 1, "1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, 1, "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, 1, "-1"))), FIVE_TO_TWO);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, 1, "-2"))), FIVE_AND_THREE);
 
-        // Test three valid arguments, with two string args and one int arg
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "5", -1))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "5", 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "5", 1))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", "5", 2))), "1, 3");
+        // Test three valid arguments, with two string args and one Integer arg
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "5", -1))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "5", 0))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "5", 1))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", "5", 2))), ONE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", "1", 1))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", "1", 0))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", "1", -1))), "5, 4, 3, 2");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", "1", -2))), "5, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", "1", 1))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", "1", 0))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", "1", -1))), FIVE_TO_TWO);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", "1", -2))), FIVE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, "-1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, "1"))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5, "2"))), "1, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", 5, "-1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", 5, "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", 5, "1"))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", "1", 5, "2"))), ONE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, "1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, "-1"))), "5, 4, 3, 2");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1, "-2"))), "5, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", 1, "1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", 1, "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", 1, "-1"))), FIVE_TO_TWO);
+        Assert.assertEquals(((Integer[]) (invoke("range", "5", 1, "-2"))), FIVE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", "-1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", "1"))), "1, 2, 3, 4");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5", "2"))), "1, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5", "-1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5", "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5", "1"))), ONE_TO_FOUR);
+        Assert.assertEquals(((Integer[]) (invoke("range", 1, "5", "2"))), ONE_AND_THREE);
 
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", "1"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", "0"))), "");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", "-1"))), "5, 4, 3, 2");
-        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1", "-2"))), "5, 3");
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, "1", "1"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, "1", "0"))), EMPTY_ARRAY);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, "1", "-1"))), FIVE_TO_TWO);
+        Assert.assertEquals(((Integer[]) (invoke("range", 5, "1", "-2"))), FIVE_AND_THREE);
     }
 }

--- a/main/tests/server/src/com/google/refine/tests/expr/functions/strings/RangeTests.java
+++ b/main/tests/server/src/com/google/refine/tests/expr/functions/strings/RangeTests.java
@@ -1,0 +1,127 @@
+package com.google.refine.tests.expr.functions.strings;
+
+import java.util.Properties;
+
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.EvalError;
+import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.Function;
+import com.google.refine.tests.RefineTest;
+
+
+/**
+ * Tests for the range function.
+ */
+public class RangeTests extends RefineTest {
+
+    static Properties bindings;
+
+    @Override
+    @BeforeTest
+    public void init() {
+        logger = LoggerFactory.getLogger(this.getClass());
+    }
+    
+    @BeforeMethod
+    public void SetUp() {
+        bindings = new Properties();
+    }
+
+    @AfterMethod
+    public void TearDown() {
+        bindings = null;
+    }
+    
+    /**
+     * Lookup a control function by name and invoke it with a variable number of args
+     */
+    private static Object invoke(String name,Object... args) {
+        // registry uses static initializer, so no need to set it up
+        Function function = ControlFunctionRegistry.getFunction(name);
+        if (function == null) {
+            throw new IllegalArgumentException("Unknown function "+name);
+        }
+        if (args == null) {
+            return function.call(bindings,new Object[0]);
+        } else {
+            return function.call(bindings,args);
+        }
+    }
+    
+    @Test
+    public void testRangeInvalidParams() {        
+        // Test number of arguments
+        Assert.assertTrue(invoke("range") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "one","two","three") instanceof EvalError);
+        Assert.assertTrue(invoke("range", 1) instanceof EvalError);
+        Assert.assertTrue(invoke("range", 1, 2, 3) instanceof EvalError);
+        
+        // Test invalid single string arguments with dash separator
+        Assert.assertTrue(invoke("range", "a") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "-") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "a-") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "-b") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "a-b") instanceof EvalError);
+        
+        Assert.assertTrue(invoke("range", "1") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "-") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1-") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "-3") instanceof EvalError);
+        
+        // Test invalid single string arguments with comma separator
+        Assert.assertTrue(invoke("range", ",") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "a,") instanceof EvalError);
+        Assert.assertTrue(invoke("range", ",b") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "a,b") instanceof EvalError);
+        
+        Assert.assertTrue(invoke("range", "1") instanceof EvalError);
+        Assert.assertTrue(invoke("range", ",") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1,") instanceof EvalError);
+        Assert.assertTrue(invoke("range", ",3") instanceof EvalError);
+        
+        // Test invalid numeric arguments
+        Assert.assertTrue(invoke("range", 1.2, 4.5) instanceof EvalError);
+        Assert.assertTrue(invoke("range", -5, 1) instanceof EvalError);
+        Assert.assertTrue(invoke("range", -1, 5) instanceof EvalError);
+    }
+    
+    @Test
+    public void testRangeValidStringParams() {
+        // Test valid string arguments with dash separator
+        Assert.assertEquals((String)(invoke("range", "1-1")),"1");
+        Assert.assertEquals((String)(invoke("range", "1-5")), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", "5-1")), "5, 4, 3, 2, 1");
+        
+        Assert.assertEquals((String)(invoke("range", " 1-5")), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", "1 -5")), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", "1- 5")), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", "1-5 ")), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", "1 - 5")), "1, 2, 3, 4, 5");
+        
+        // Test valid string arguments with comma separator
+        Assert.assertEquals((String)(invoke("range", "1,1")), "1");
+        Assert.assertEquals((String)(invoke("range", "1,5")), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", "5,1")), "5, 4, 3, 2, 1");
+        
+        Assert.assertEquals((String)(invoke("range", " 1,5")), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", "1 -5")), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", "1- 5")), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", "1-5 ")), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", "1 - 5")), "1, 2, 3, 4, 5");
+    }
+    
+    @Test
+    public void testRangeValidIntegerParams() {
+        Assert.assertEquals((String)(invoke("range", 1, 1)), "1");
+        Assert.assertEquals((String)(invoke("range", 1, 5)), "1, 2, 3, 4, 5");
+        Assert.assertEquals((String)(invoke("range", 5, 1)), "5, 4, 3, 2, 1");
+    }
+    
+}

--- a/main/tests/server/src/com/google/refine/tests/expr/functions/strings/RangeTests.java
+++ b/main/tests/server/src/com/google/refine/tests/expr/functions/strings/RangeTests.java
@@ -45,12 +45,12 @@ public class RangeTests extends RefineTest {
         // registry uses static initializer, so no need to set it up
         Function function = ControlFunctionRegistry.getFunction(name);
         if (function == null) {
-            throw new IllegalArgumentException("Unknown function "+name);
+            throw new IllegalArgumentException("Unknown function " + name);
         }
         if (args == null) {
-            return function.call(bindings,new Object[0]);
+            return function.call(bindings, new Object[0]);
         } else {
-            return function.call(bindings,args);
+            return function.call(bindings, args);
         }
     }
     
@@ -60,68 +60,84 @@ public class RangeTests extends RefineTest {
         Assert.assertTrue(invoke("range") instanceof EvalError);
         Assert.assertTrue(invoke("range", "") instanceof EvalError);
         Assert.assertTrue(invoke("range", "one","two","three") instanceof EvalError);
-        Assert.assertTrue(invoke("range", 1) instanceof EvalError);
-        Assert.assertTrue(invoke("range", 1, 2, 3) instanceof EvalError);
-        
-        // Test invalid single string arguments with dash separator
+        Assert.assertTrue(invoke("range", 1, 2, 3, 4) instanceof EvalError);
+
+        // Test invalid single string argument types
+        Assert.assertTrue(invoke("range", "null") instanceof EvalError);
         Assert.assertTrue(invoke("range", "a") instanceof EvalError);
-        Assert.assertTrue(invoke("range", "-") instanceof EvalError);
-        Assert.assertTrue(invoke("range", "a-") instanceof EvalError);
-        Assert.assertTrue(invoke("range", "-b") instanceof EvalError);
-        Assert.assertTrue(invoke("range", "a-b") instanceof EvalError);
-        
-        Assert.assertTrue(invoke("range", "1") instanceof EvalError);
-        Assert.assertTrue(invoke("range", "-") instanceof EvalError);
-        Assert.assertTrue(invoke("range", "1-") instanceof EvalError);
-        Assert.assertTrue(invoke("range", "-3") instanceof EvalError);
-        
-        // Test invalid single string arguments with comma separator
-        Assert.assertTrue(invoke("range", ",") instanceof EvalError);
-        Assert.assertTrue(invoke("range", "a,") instanceof EvalError);
-        Assert.assertTrue(invoke("range", ",b") instanceof EvalError);
-        Assert.assertTrue(invoke("range", "a,b") instanceof EvalError);
-        
-        Assert.assertTrue(invoke("range", "1") instanceof EvalError);
-        Assert.assertTrue(invoke("range", ",") instanceof EvalError);
+
+        // Test invalid single string numeric arguments
+        Assert.assertTrue(invoke("range", "-1") instanceof EvalError);
         Assert.assertTrue(invoke("range", "1,") instanceof EvalError);
-        Assert.assertTrue(invoke("range", ",3") instanceof EvalError);
+        Assert.assertTrue(invoke("range", ",") instanceof EvalError);
+        Assert.assertTrue(invoke("range", ",2") instanceof EvalError);
+        Assert.assertTrue(invoke("range", "1.5") instanceof EvalError);
+        Assert.assertTrue(invoke("range", ",12.3, 2") instanceof EvalError);
         
         // Test invalid numeric arguments
+        Assert.assertTrue(invoke("range", 1.2) instanceof EvalError);
         Assert.assertTrue(invoke("range", 1.2, 4.5) instanceof EvalError);
-        Assert.assertTrue(invoke("range", -5, 1) instanceof EvalError);
-        Assert.assertTrue(invoke("range", -1, 5) instanceof EvalError);
+        Assert.assertTrue(invoke("range", 1.2, 5, 3) instanceof EvalError);
+        Assert.assertTrue(invoke("range", -1) instanceof EvalError);
+        Assert.assertTrue(invoke("range", -1, 2) instanceof EvalError);
+        Assert.assertTrue(invoke("range", -1, 5, 3) instanceof EvalError);
+        
+        // Test invalid mixed arguments
+        Assert.assertTrue(invoke("range", 1, "2, 3") instanceof EvalError);
+        Assert.assertTrue(invoke("range", 1, "") instanceof EvalError);
     }
     
     @Test
     public void testRangeValidStringParams() {
-        // Test valid string arguments with dash separator
-        Assert.assertEquals((String)(invoke("range", "1-1")),"1");
-        Assert.assertEquals((String)(invoke("range", "1-5")), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", "5-1")), "5, 4, 3, 2, 1");
+        // Test valid single string argument
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "3"))), "0, 1, 2, 3");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", " 3  "))), "0, 1, 2, 3");
         
-        Assert.assertEquals((String)(invoke("range", " 1-5")), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", "1 -5")), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", "1- 5")), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", "1-5 ")), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", "1 - 5")), "1, 2, 3, 4, 5");
+        // Test valid double string arguments
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1"))), "1");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5"))), "1, 2, 3, 4, 5");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1"))), "5, 4, 3, 2, 1");
         
-        // Test valid string arguments with comma separator
-        Assert.assertEquals((String)(invoke("range", "1,1")), "1");
-        Assert.assertEquals((String)(invoke("range", "1,5")), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", "5,1")), "5, 4, 3, 2, 1");
+        // Test valid triple string arguments
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 3, 0"))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1, 1"))), "1");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, 10"))), "1");
         
-        Assert.assertEquals((String)(invoke("range", " 1,5")), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", "1 -5")), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", "1- 5")), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", "1-5 ")), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", "1 - 5")), "1, 2, 3, 4, 5");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5, 2"))), "1, 3, 5");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1, 2"))), "5, 3, 1");
     }
     
     @Test
     public void testRangeValidIntegerParams() {
-        Assert.assertEquals((String)(invoke("range", 1, 1)), "1");
-        Assert.assertEquals((String)(invoke("range", 1, 5)), "1, 2, 3, 4, 5");
-        Assert.assertEquals((String)(invoke("range", 5, 1)), "5, 4, 3, 2, 1");
+        // Test valid single integer argument
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 0))), "0");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5))), "0, 1, 2, 3, 4, 5");
+        
+        // Test valid double integer arguments
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5))), "1, 2, 3, 4, 5");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1))), "5, 4, 3, 2, 1");
+
+        // Test valid triple integer arguments
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, 0))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, 5, 2))), "1, 3, 5");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, 1, 2))), "5, 3, 1");
     }
     
+    @Test
+    public void testRangeValidMixedParams() {
+        // Test when each argument is of type integer/ string
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1", 5))), "1, 2, 3, 4, 5");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5", 1))), "5, 4, 3, 2, 1");
+        
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 1, "5"))), "1, 2, 3, 4, 5");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", 5, "1"))), "5, 4, 3, 2, 1");
+        
+        // Test when step is an integer (e.g. range(value, 1))
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 3", 0))), "");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 1", 1))), "1");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", 10))), "1");
+        
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "1, 5", 2))), "1, 3, 5");
+        Assert.assertEquals(String.join(", ", (String[]) (invoke("range", "5, 1", 2))), "5, 3, 1");   
+    }
 }


### PR DESCRIPTION
Fixes #1319 

The original specification that @thadguidry suggested for the `range` function was:

> It will work like this...
>
>can take accept a String form:
>range("2-4") --> [2,3,4]
>
>or a String form in a value
>range(value) --> [2,3,4]
>
>or 2 numbers
>range(2, 4) --> [2,3,4]
>
>and doing join(",") will convert the Array to a String
>range(2,4).join(","). --> 2,3,4

However, because of issues such as [cells being unable to display arrays](https://github.com/OpenRefine/OpenRefine/issues/1088) and the [potential confusion it can cause](https://github.com/OpenRefine/OpenRefine/issues/1475), I have taken the liberty to display the results of `range` as a string with comma-separated values instead.

Hence, my implementation works like this:

**(a) String arguments**
1. `range("2-4") --> 2, 3, 4`
2. `range("4-2") --> 4, 3, 2` 
3. `range("2, 4") --> 2, 3, 4` 
4. `range("4, 2") --> 4, 3, 2`
5. `range(value) --> 2, 3, 4 //given that value is written as 2-4 (text) or 2, 4 (text) in the cell`

**(b) Integer arguments**
1. `range(2, 4) --> 2, 3, 4`
2. `range(4, 2) --> 4, 3, 2`

*`range(value)` does not apply to integer arguments since `2, 4` is stored as text in a cell.

**Additional notes**
1. Given valid arguments, either an increasing sequence or a decreasing sequence is returned depending on whether the `rangeStart` value is larger than the `rangeEnd` value.
2. Integer arguments cannot be negative; otherwise, an `EvalError` is returned.
3. Numeric arguments can only be integers, and decimal values will cause an `EvalError` to be returned.
4. It is okay to have whitespace(s) within the string (e.g. `range("2   -   4  ")` will work as well).
 
**Questions to discuss**
1. Should the implementation use integers? What about `long` or `BigInteger`? Should we worry about when users try to input very large values (e.g. 2980572305402385707520357208) to the `range` function?
2. Should the result returned be an array as @thadguidry has suggested? In this case, the result will directly be displayed in the cells after the transformation without having to use `join`, but is this consistent with other functions already provided by OpenRefine?
3. Should negative integers, or even decimal numbers be supported by this function?

Lastly, I have also added some basic tests for the new function (although more comprehensive testing can be done with real examples). I am willing to help to update the documentation on GitHub pages for this function after it is approved :)

Thanks for reading this lengthy pull request message, and I look forward to any incoming feedback :)