### PR TITLE
Create issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+When reporting a bug please provide the following information to help reproduce the bug:
+
+Version of OpenRefine used (Google Refine 2.6, OpenRefine2.7, an other distribution?):
+
+Operating Systems and version:
+
+Browser + version used - Please note that OpenRefine doesn't support Internet Explorer:
+
+Steps followed to create the issue:
+
+If you are allowed, it is awesome if you can include the data generating the issue:
+
+Current Results:
+
+Expected Results:


### PR DESCRIPTION
I was submitting a new issue today when I noticed that the contribution guidelines have been updated - there is now a preferred format for bug reports.

As such, I have put together a simple template that will show up as a comment when contributors attempt to open a new request. It will look like this:

![image](https://user-images.githubusercontent.com/24493463/36111181-3360765a-1060-11e8-876a-93284b69f917.png)

albeit with the corresponding message (as taken from the [updated documentation](https://github.com/OpenRefine/OpenRefine/blob/master/CONTRIBUTING.md#guidelines-for-reporting-a-bug)) and corresponding repository name.

This can possibly help to keep the format of bug reports more consistent since some people just don't want to open an extra page of documentation to read.