### PR TITLE
fix issue #1517, limit is written as int and should have been read as int

### DIFF
--- a/main/src/com/google/refine/model/recon/StandardReconConfig.java
+++ b/main/src/com/google/refine/model/recon/StandardReconConfig.java
@@ -112,8 +112,7 @@ public class StandardReconConfig extends ReconConfig {
         
         JSONObject t = obj.has("type") && !obj.isNull("type") ? obj.getJSONObject("type") : null;
         
-        String limitString = obj.has("limit") && !obj.isNull("limit") ? obj.getString("limit") : "";
-        int limit = "".equals(limitString) ? 0 : Integer.parseInt(limitString); 
+        int limit = obj.has("limit") && !obj.isNull("limit") ? obj.getInt("limit") : 0;
         
         return new StandardReconConfig(
             obj.getString("service"),

--- a/main/tests/server/src/com/google/refine/tests/model/ReconTests.java
+++ b/main/tests/server/src/com/google/refine/tests/model/ReconTests.java
@@ -2,11 +2,13 @@ package com.google.refine.tests.model;
 
 import java.util.ArrayList;
 
+import org.json.JSONObject;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import com.google.refine.model.recon.ReconConfig;
 import com.google.refine.model.recon.StandardReconConfig;
 import com.google.refine.tests.RefineTest;
 
@@ -43,5 +45,33 @@ public class ReconTests extends RefineTest {
 
         Assert.assertTrue(!Double.isInfinite(r));
         Assert.assertTrue(!Double.isNaN(r));
+    }
+    
+    /**
+     * Regression for issue #1517:
+     * JSON deserialization exception due to the upgrade of org.json library in data package PR
+     * @throws Exception
+     */
+    @Test
+    public void limitJSONKeyTest() throws Exception {
+        JSONObject obj = new JSONObject(
+                " {\n" + 
+                "        \"mode\": \"standard-service\",\n" + 
+                "        \"service\": \"https://tools.wmflabs.org/openrefine-wikidata/en/api\",\n" + 
+                "        \"identifierSpace\": \"http://www.wikidata.org/entity/\",\n" + 
+                "        \"schemaSpace\": \"http://www.wikidata.org/prop/direct/\",\n" + 
+                "        \"type\": {\n" + 
+                "                \"id\": \"Q13442814\",\n" + 
+                "                \"name\": \"scientific article\"\n" + 
+                "        },\n" + 
+                "        \"autoMatch\": true,\n" + 
+                "        \"columnDetails\": [],\n" + 
+                "        \"limit\": 0\n" + 
+                " }");
+        
+        ReconConfig config = StandardReconConfig.reconstruct(obj);
+        
+        // Assert the object is created
+        Assert.assertTrue(config != null);
     }
 }


### PR DESCRIPTION
Some background: new version json.lib is required as data package dependency. but the new version of json lib has more strict check when try to convert a string to int