### PR TITLE
make OpenRefine more robust to misconfigured charset strings,

### DIFF
--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -365,6 +365,7 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
                                 }
                             }
                         }
+                        encoding = encoding.replaceAll("(^[\" ]*|[ \";]*$)", "");
                         return ParsingUtilities.inputStreamToString(
                                                 is, (encoding == null) || ( encoding.equalsIgnoreCase("\"UTF-8\"")) ? "UTF-8" : encoding);
 


### PR DESCRIPTION
there are a lot of services out there that are not programmed/configured correctly and that deliver character encoding strings with additional spaces or an semicolon at the end. Regular browsers are robust and don't care, but OpenRefine fails in those cases. This change removes additional spaces, quotation marks and semicolon at the beginning/end of the charset string from the Content-Type HTTP header. Calls to external services that are wrongly configured now return the desired content instead of "HTTP error 200 : OK | ".