### PR TITLE
Added option to toggle show/hide null values in cells in data-table

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -600,6 +600,7 @@
         "view": "View",
         "collapse-all": "Collapse all columns",
         "expand-all": "Expand all columns",
+        "display-null": "Show/Hide 'null' values in cells",
         "reorder-perma": "Reorder rows permanently",
         "by": "By",
         "custom-text-trans": "Custom text transform on column",

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -39,6 +39,7 @@ function DataTableView(div) {
   this._collapsedColumnNames = {};
   this._sorting = { criteria: [] };
   this._columnHeaderUIs = [];
+  this._shownulls = false;
 
   this._showRows(0);
 }
@@ -134,7 +135,10 @@ DataTableView.prototype.render = function() {
 
   this._renderDataTables(elmts.table[0], elmts.headerTable[0]);
   this._div.empty().append(html);
-  
+
+  // show/hide null values in cells
+  $(".data-table-null").toggle(self._shownulls);
+
   this.resize();
   
   elmts.dataTableContainer[0].scrollLeft = scrollLeft;
@@ -741,6 +745,13 @@ DataTableView.prototype._createMenuForAllColumns = function(elmt) {
             self._collapsedColumnNames = [];
             self.render();
           }
+        },
+        {
+          label: $.i18n._('core-views')["display-null"],
+          id: "core/display-null",
+          click: function() {
+            $(".data-table-null").toggle();
+            self._shownulls = !(self._shownulls);
         }
       ]
     }

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -752,6 +752,7 @@ DataTableView.prototype._createMenuForAllColumns = function(elmt) {
           click: function() {
             $(".data-table-null").toggle();
             self._shownulls = !(self._shownulls);
+          }
         }
       ]
     }

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -203,6 +203,7 @@ div.data-table-cell-content-numeric > a.data-table-cell-edit {
 
 .data-table-null {
   color: #aaa;
+  display: none;
   }
 
 .data-table-error {


### PR DESCRIPTION
As discussed in #1544 this PR adds a toggle option for displaying 'null' in cells containing a null value (as opposed to an empty string). Adds option under the All->View menu. Option is persistent while viewing a project (unless the user forces a refresh of the screen via the browser).

Default is to not display the null values to keep the screen from becoming too busy