### PR TITLE
Fix date parsing.

### DIFF
--- a/main/src/com/google/refine/util/ParsingUtilities.java
+++ b/main/src/com/google/refine/util/ParsingUtilities.java
@@ -38,7 +38,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
-import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;

--- a/main/tests/server/src/com/google/refine/tests/util/ParsingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/tests/util/ParsingUtilitiesTests.java
@@ -105,7 +105,24 @@ public class ParsingUtilitiesTests extends RefineTest {
         OffsetDateTime zdt = ParsingUtilities.stringToDate(historyEntryDate);
         String zdtString = ParsingUtilities.dateToString(zdt);
         Assert.assertEquals(zdtString, historyEntryDate);
-        
+    }
+    
+    @Test
+    public void stringToDate() {
+        Assert.assertEquals(2017, ParsingUtilities.stringToDate("2017-04-03T08:09:43.123").getYear());
+        Assert.assertEquals(2017, ParsingUtilities.stringToDate("2017-04-03T08:09:43").getYear());
+        Assert.assertEquals(2017, ParsingUtilities.stringToDate("2017-04-03T08:09:43Z").getYear());
+        Assert.assertEquals(2017, ParsingUtilities.stringToDate("2017-04-03T08:09:43.123Z").getYear());
+        Assert.assertEquals(2017, ParsingUtilities.stringToDate("2017-04-03T08:09:43+00:00").getYear());
+    }
+    
+    @Test
+    public void stringToLocalDate() {
+        Assert.assertEquals(2017, ParsingUtilities.stringToLocalDate("2017-04-03T08:09:43.123").getYear());
+        Assert.assertEquals(2017, ParsingUtilities.stringToLocalDate("2017-04-03T08:09:43").getYear());
+        Assert.assertEquals(2017, ParsingUtilities.stringToLocalDate("2017-04-03T08:09:43Z").getYear());
+        Assert.assertEquals(2017, ParsingUtilities.stringToLocalDate("2017-04-03T08:09:43.123Z").getYear());
+        Assert.assertEquals(2017, ParsingUtilities.stringToLocalDate("2017-04-03T08:09:43+00:00").getYear());
     }
     
     @Test


### PR DESCRIPTION
Closes #1564.

This fixes the date parsing utility functions used at various places in the code. Both local times and zoned times are accepted. I have also restored the original behavior of `stringToDate` of returning `null` when parsing failed instead of throwing an exception.