### PR TITLE
Make sure toDate always returns Calendar instances. Closes #1588

### DIFF
--- a/main/src/com/google/refine/commands/recon/PreviewExtendDataCommand.java
+++ b/main/src/com/google/refine/commands/recon/PreviewExtendDataCommand.java
@@ -35,6 +35,7 @@ package com.google.refine.commands.recon;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -168,6 +169,8 @@ public class PreviewExtendDataCommand extends Command {
                                         writer.key("id"); writer.value(rc.id);
                                         writer.key("name"); writer.value(rc.name);
                                         writer.endObject();
+                                    } else if (cell instanceof Calendar){
+                                        writer.value(((Calendar)cell).toInstant().toString());
                                     } else {
                                         writer.value(cell);
                                     }

--- a/main/src/com/google/refine/expr/functions/ToDate.java
+++ b/main/src/com/google/refine/expr/functions/ToDate.java
@@ -36,6 +36,7 @@ package com.google.refine.expr.functions;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -87,7 +88,7 @@ public class ToDate implements Function {
             } catch (CalendarParserException e) {
                 OffsetDateTime d = ParsingUtilities.stringToDate(o1);
                 if (d != null) {
-                    return d;
+                    return GregorianCalendar.from(d.atZoneSameInstant(ZoneId.of("Z")));
                 } else {
                     try {
                         return javax.xml.bind.DatatypeConverter.parseDateTime(o1).getTime();


### PR DESCRIPTION
This is a fix for the issue reported, but the root issue is the partial migration to JDK8 date classes which is likely to cause more trouble in the future, I think.