### PR TITLE
Codified [date].toString() behaviour from 2.8 in tests

### DIFF
--- a/main/tests/server/src/com/google/refine/tests/expr/functions/strings/ToFromConversionTests.java
+++ b/main/tests/server/src/com/google/refine/tests/expr/functions/strings/ToFromConversionTests.java
@@ -117,12 +117,32 @@ public class ToFromConversionTests extends RefineTest {
       Assert.assertEquals(invoke("toString", Double.valueOf(100.0)),"100.0");
       Assert.assertEquals(invoke("toString", Double.valueOf(100.0),"%.0f"),"100");
       
-      String intputDate = "2013-06-01";
-      String expectedDate = "2013-06-01";
-      Assert.assertEquals(invoke("toString", CalenderParser.parseAsOffsetDateTime(intputDate)), 
-              expectedDate);
-      Assert.assertEquals(invoke("toString", CalenderParser.parseAsOffsetDateTime(intputDate), "yyyy-MM-dd"),
-              expectedDate);
+      String inputDate = "2013-06-01";
+      String inputDateTime = "2013-06-01 13:12:11";
+      Assert.assertEquals(invoke("toString", CalenderParser.parseAsOffsetDateTime(inputDate)
+              ), 
+              "01-Jun-2013");
+      Assert.assertEquals(invoke("toString", CalenderParser.parseAsOffsetDateTime(inputDate), 
+              "yyyy-MM-dd"),
+              "2013-06-01");
+      Assert.assertEquals(invoke("toString", CalenderParser.parseAsOffsetDateTime(inputDate), 
+              "yyyy/dd/MM"),
+              "2013/01/06");
+      Assert.assertEquals(invoke("toString", CalenderParser.parseAsOffsetDateTime(inputDate), 
+              "yyyy-MMM"),
+              "2013-Jun");
+      Assert.assertEquals(invoke("toString", CalenderParser.parseAsOffsetDateTime(inputDate), 
+              "yyyy-MM-dd hh:mm:ss"),
+              "2013-06-01 12:00:00");
+      Assert.assertEquals(invoke("toString", CalenderParser.parseAsOffsetDateTime(inputDateTime)
+              ),
+              "01-Jun-2013");
+      Assert.assertEquals(invoke("toString", CalenderParser.parseAsOffsetDateTime(inputDateTime), 
+              "yyyy-MM-dd"),
+              "2013-06-01");
+      Assert.assertEquals(invoke("toString", CalenderParser.parseAsOffsetDateTime(inputDateTime),
+               "yyyy-MM-dd hh:mm:ss"),
+              "2013-06-01 01:12:11");
     }
     
     @Test


### PR DESCRIPTION
This is my attempt to add tests for the 2.8 [date].toString() behaviour so we can replicate with the new DateTime API.

The equivalent tests in 2.8 would be written as follows, and these all pass in 2.8:

```
      String inputDate = "2013-06-01";
      String inputDateTime = "2013-06-01 13:12:11";
      Assert.assertEquals(invoke("toString", CalendarParser.parse(inputDate)), "01-Jun-2013");
      Assert.assertEquals(invoke("toString", CalendarParser.parse(inputDate), "yyyy-MM-dd"), "2013-06-01");
      Assert.assertEquals(invoke("toString", CalendarParser.parse(inputDate), "yyyy/dd/MM"), "2013/01/06");
      Assert.assertEquals(invoke("toString", CalendarParser.parse(inputDate), "yyyy-MMM"), "2013-Jun");
      Assert.assertEquals(invoke("toString", CalendarParser.parse(inputDate), "yyyy-MM-dd hh:mm:ss"), "2013-06-01 12:00:00");
      Assert.assertEquals(invoke("toString", CalendarParser.parse(inputDateTime)), "01-Jun-2013");
      Assert.assertEquals(invoke("toString", CalendarParser.parse(inputDateTime), "yyyy-MM-dd"), "2013-06-01");
      Assert.assertEquals(invoke("toString", CalendarParser.parse(inputDateTime), "yyyy-MM-dd hh:mm:ss"),"2013-06-01 01:12:11");
```

There is definitely some slightly odd behaviour here (specifically the rendering of the time which I believe to be incorrect) and I'm happy to update the tests to reflect what we think the behaviour *should* be. However, this PR is to give us a starting point for compatibility with 2.8
