### PR TITLE
#1604 upgrade java version check to accept all versions greater than 6

### DIFF
--- a/refine
+++ b/refine
@@ -839,10 +839,8 @@ checkJavaMajorVersion() {
     # Java 9+ starts with x using semver versioning
     major=`echo ${java_ver} | sed -E 's/([0-9]+)(-ea|(\.[0-9]+)*)/\1/g'`
   fi
-  
-  JAVA_VERSION=$(echo ${major} | egrep '^(6|7|8|9)')
-  if [ -z "$JAVA_VERSION" ] ; then
-    error "OpenRefine requires Java version 6 or later. If you have multiple versions of Java installed, please set the environment variable JAVA_HOME to the correct version."
+  if (( ${major} < 7 )); then
+    error "OpenRefine requires Java version 7 or later. If you have multiple versions of Java installed, please set the environment variable JAVA_HOME to the correct version."
   fi
 }
 

--- a/refine
+++ b/refine
@@ -842,6 +842,9 @@ checkJavaMajorVersion() {
   if (( ${major} < 7 )); then
     error "OpenRefine requires Java version 7 or later. If you have multiple versions of Java installed, please set the environment variable JAVA_HOME to the correct version."
   fi
+  if (( ${major} > 9 )); then
+    echo "WARNING: OpenRefine is not tested and not recommended for use with Java versions greater than 9."
+  fi
 }
 
 # -------------------------- script -----------------------------


### PR DESCRIPTION
I've removed support for version 6, and allowed all java versions greater than or equal to 7. Is this the range of java version supported by OpenRefine?