### PR TITLE
Total number of operations for Undo / Redo

### DIFF
--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -69,7 +69,7 @@ HistoryPanel.prototype.update = function(onDone) {
 HistoryPanel.prototype._render = function() {
   var self = this;
 
-  this._tabHeader.html($.i18n._('core-project')["undo-redo"]+' <span class="count">' + this._data.past.length + '</span>');
+  this._tabHeader.html($.i18n._('core-project')["undo-redo"]+' <span class="count">' + this._data.past.length + ' / ' + ( this._data.future.length + this._data.past.length ) + '</span>');
 
   this._div.empty().unbind().html(DOM.loadHTML("core", "scripts/project/history-panel.html"));
 


### PR DESCRIPTION
Currently, if you open a project that, when it was last closed, was "undone" up to the first operation, you will see : 
![capture du 2018-05-18 08-54-52](https://user-images.githubusercontent.com/300907/40220374-3494d602-5a79-11e8-8dc9-0a9d67eca7cd.png)

Opening an old project this morning I was confused and thought it was a recently created one because of this, but in fact I already had many operations on this project, it was just that before closing it I had viewed the file at first operation.

This PR proposes to change the display to the following : 
![capture du 2018-05-18 08-55-41](https://user-images.githubusercontent.com/300907/40220399-47e76346-5a79-11e8-80d4-ecce98c99575.png)

With 10 in this screenshot being the total number of available operations in the current project. It makes more sense to me, hope I'm not alone!