### PR TITLE
Mass edit fix for blanks, numbers and booleans

### DIFF
--- a/main/src/com/google/refine/operations/cell/MassEditOperation.java
+++ b/main/src/com/google/refine/operations/cell/MassEditOperation.java
@@ -121,13 +121,13 @@ public class MassEditOperation extends EngineDependentMassCellOperation {
                 
                 from = new ArrayList<String>(fromCount);
                 for (int j = 0; j < fromCount; j++) {
-                    from.add(fromA.getString(j));
+                    from.add(fromA.get(j).toString());
                 }
             } else {
                 from = new ArrayList<String>();
             }
             
-            boolean fromBlank = editO.has("fromBlank") && editO.getBoolean("fromBlank");
+            boolean fromBlank = (editO.has("fromBlank") && editO.getBoolean("fromBlank") || from.get(0).length() == 0 && from.size() == 1);
             boolean fromError = editO.has("fromError") && editO.getBoolean("fromError");
             
             Serializable to = (Serializable) editO.get("to");

--- a/main/tests/server/src/com/google/refine/tests/operations/cell/MassOperationTests.java
+++ b/main/tests/server/src/com/google/refine/tests/operations/cell/MassOperationTests.java
@@ -1,0 +1,110 @@
+package com.google.refine.tests.operations.cell;
+
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.refine.operations.cell.MassEditOperation;
+import com.google.refine.operations.cell.MassEditOperation.Edit;
+import com.google.refine.tests.RefineTest;
+import com.google.refine.util.ParsingUtilities;
+
+public class MassOperationTests extends RefineTest {
+
+    List<Edit> editList;
+    String editsString = null;
+
+    @BeforeMethod
+    public void setUp() {
+    }
+
+    @AfterMethod
+    public void tearDown() {
+    }
+
+    @Test
+    public void testReconstructEditString() throws Exception {
+        editsString = "[{\"from\":[\"String\"],\"to\":\"newString\",\"type\":\"text\"}]";
+
+        editList = MassEditOperation.reconstructEdits(ParsingUtilities.evaluateJsonStringToArray(editsString));
+
+        Assert.assertEquals(editList.get(0).from.size(), 1);
+        Assert.assertEquals(editList.get(0).from.get(0), "String");
+        Assert.assertEquals(editList.get(0).to,"newString" );
+        Assert.assertFalse(editList.get(0).fromBlank);
+        Assert.assertFalse(editList.get(0).fromError);
+    }
+
+    @Test
+    public void testReconstructEditMultiString() throws Exception {
+        editsString = "[{\"from\":[\"String1\",\"String2\"],\"to\":\"newString\",\"type\":\"text\"}]";
+
+        editList = MassEditOperation.reconstructEdits(ParsingUtilities.evaluateJsonStringToArray(editsString));
+
+        Assert.assertEquals(editList.get(0).from.size(), 2);
+        Assert.assertEquals(editList.get(0).from.get(0), "String1");
+        Assert.assertEquals(editList.get(0).from.get(1), "String2");
+        Assert.assertEquals(editList.get(0).to,"newString" );
+        Assert.assertFalse(editList.get(0).fromBlank);
+        Assert.assertFalse(editList.get(0).fromError);
+    }
+
+    @Test
+    public void testReconstructEditBoolean() throws Exception {
+      editsString = "[{\"from\":[true],\"to\":\"newString\",\"type\":\"text\"}]";
+
+      editList = MassEditOperation.reconstructEdits(ParsingUtilities.evaluateJsonStringToArray(editsString));
+
+      Assert.assertEquals(editList.get(0).from.size(), 1);
+      Assert.assertEquals(editList.get(0).from.get(0), "true");
+      Assert.assertEquals(editList.get(0).to,"newString" );
+      Assert.assertFalse(editList.get(0).fromBlank);
+      Assert.assertFalse(editList.get(0).fromError);
+    }
+
+    @Test
+    public void testReconstructEditNumber() throws Exception {
+      editsString = "[{\"from\":[1],\"to\":\"newString\",\"type\":\"text\"}]";
+
+      editList = MassEditOperation.reconstructEdits(ParsingUtilities.evaluateJsonStringToArray(editsString));
+
+      Assert.assertEquals(editList.get(0).from.size(), 1);
+      Assert.assertEquals(editList.get(0).from.get(0), "1");
+      Assert.assertEquals(editList.get(0).to,"newString" );
+      Assert.assertFalse(editList.get(0).fromBlank);
+      Assert.assertFalse(editList.get(0).fromError);
+    }
+
+    @Test
+    public void testReconstructEditDate() throws Exception {
+      editsString = "[{\"from\":[\"2018-10-04T00:00:00Z\"],\"to\":\"newString\",\"type\":\"text\"}]";
+
+      editList = MassEditOperation.reconstructEdits(ParsingUtilities.evaluateJsonStringToArray(editsString));
+
+      Assert.assertEquals(editList.get(0).from.size(), 1);
+      Assert.assertEquals(editList.get(0).from.get(0), "2018-10-04T00:00Z");
+      Assert.assertEquals(editList.get(0).to,"newString" );
+      Assert.assertFalse(editList.get(0).fromBlank);
+      Assert.assertFalse(editList.get(0).fromError);
+    }
+
+    @Test
+    public void testReconstructEditEmpty() throws Exception {
+      editsString = "[{\"from\":[\"\"],\"to\":\"newString\",\"type\":\"text\"}]";
+
+      editList = MassEditOperation.reconstructEdits(ParsingUtilities.evaluateJsonStringToArray(editsString));
+
+      Assert.assertEquals(editList.get(0).from.size(), 1);
+      Assert.assertEquals(editList.get(0).from.get(0), "");
+      Assert.assertEquals(editList.get(0).to,"newString" );
+      Assert.assertTrue(editList.get(0).fromBlank);
+      Assert.assertFalse(editList.get(0).fromError);
+
+    }
+
+    //Not yet testing for editing a cell containing an OR error
+
+}

--- a/main/tests/server/src/com/google/refine/tests/operations/cell/MassOperationTests.java
+++ b/main/tests/server/src/com/google/refine/tests/operations/cell/MassOperationTests.java
@@ -14,16 +14,8 @@ import com.google.refine.util.ParsingUtilities;
 
 public class MassOperationTests extends RefineTest {
 
-    List<Edit> editList;
-    String editsString = null;
-
-    @BeforeMethod
-    public void setUp() {
-    }
-
-    @AfterMethod
-    public void tearDown() {
-    }
+    private List<Edit> editList;
+    private String editsString = null;
 
     @Test
     public void testReconstructEditString() throws Exception {

--- a/main/tests/server/src/com/google/refine/tests/operations/cell/MassOperationTests.java
+++ b/main/tests/server/src/com/google/refine/tests/operations/cell/MassOperationTests.java
@@ -3,8 +3,6 @@ package com.google.refine.tests.operations.cell;
 import java.util.List;
 
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.refine.operations.cell.MassEditOperation;
@@ -15,7 +13,7 @@ import com.google.refine.util.ParsingUtilities;
 public class MassOperationTests extends RefineTest {
 
     private List<Edit> editList;
-    private String editsString = null;
+    private String editsString;
 
     @Test
     public void testReconstructEditString() throws Exception {

--- a/main/tests/server/src/com/google/refine/tests/operations/cell/MassOperationTests.java
+++ b/main/tests/server/src/com/google/refine/tests/operations/cell/MassOperationTests.java
@@ -79,19 +79,6 @@ public class MassOperationTests extends RefineTest {
     }
 
     @Test
-    public void testReconstructEditDate() throws Exception {
-      editsString = "[{\"from\":[\"2018-10-04T00:00:00Z\"],\"to\":\"newString\",\"type\":\"text\"}]";
-
-      editList = MassEditOperation.reconstructEdits(ParsingUtilities.evaluateJsonStringToArray(editsString));
-
-      Assert.assertEquals(editList.get(0).from.size(), 1);
-      Assert.assertEquals(editList.get(0).from.get(0), "2018-10-04T00:00Z");
-      Assert.assertEquals(editList.get(0).to,"newString" );
-      Assert.assertFalse(editList.get(0).fromBlank);
-      Assert.assertFalse(editList.get(0).fromError);
-    }
-
-    @Test
     public void testReconstructEditEmpty() throws Exception {
       editsString = "[{\"from\":[\"\"],\"to\":\"newString\",\"type\":\"text\"}]";
 
@@ -105,6 +92,7 @@ public class MassOperationTests extends RefineTest {
 
     }
 
-    //Not yet testing for editing a cell containing an OR error
+    //Not yet testing for mass edit from OR Error
+    //Not yet testing for mass edit from OR Date
 
 }


### PR DESCRIPTION
This fix is for #1631 and #180
(clean version of previous PR #1641)