### PR TITLE
Change default precision of Wikibase dates to match the UI's defaults.

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
@@ -119,7 +119,7 @@ public class WbDateConstant implements WbExpression<TimeValue> {
             calendar.setTime(date);
             return Datamodel.makeTimeValue(calendar.get(Calendar.YEAR), (byte) (calendar.get(Calendar.MONTH) + 1), 
                     (byte) calendar.get(Calendar.DAY_OF_MONTH), (byte) calendar.get(Calendar.HOUR_OF_DAY),
-                    (byte) calendar.get(Calendar.MINUTE), (byte) calendar.get(Calendar.SECOND), (byte) precision, 0, 1,
+                    (byte) calendar.get(Calendar.MINUTE), (byte) calendar.get(Calendar.SECOND), (byte) precision, 0, 0,
                     0, TimeValue.CM_GREGORIAN_PRO);
         }
     }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
@@ -46,15 +46,17 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
 
     @Test
     public void testEvaluate() {
-        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 1, 0,
+        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), year);
-        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 1, 0,
+        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), month);
-        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, TimeValue.CM_GREGORIAN_PRO), day);
-        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, (byte) 13, (byte) 0, (byte) 0, (byte) 12, 0, 1,
+        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), day);
+        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, (byte) 13, (byte) 0, (byte) 0, (byte) 12, 0, 0,
                 0, TimeValue.CM_GREGORIAN_PRO), hour);
 
-        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, TimeValue.CM_GREGORIAN_PRO), whitespace);
+        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), whitespace);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateVariableTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateVariableTest.java
@@ -33,9 +33,10 @@ import com.google.refine.model.Cell;
 public class WbDateVariableTest extends WbVariableTest<TimeValue> {
 
     private TimeValue year = Datamodel.makeTimeValue(2018, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9,
-            0, 1, 0, TimeValue.CM_GREGORIAN_PRO);
-    private TimeValue day = Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, TimeValue.CM_GREGORIAN_PRO);
-    private TimeValue minute = Datamodel.makeTimeValue(2001, (byte) 2, (byte) 3, (byte)4, (byte)5, (byte)0, (byte)13, (byte)0, (byte)1, (byte)0, TimeValue.CM_GREGORIAN_PRO);
+            0, 0, 0, TimeValue.CM_GREGORIAN_PRO);
+    private TimeValue day = Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11,
+            0, 0, 0,  TimeValue.CM_GREGORIAN_PRO);
+    private TimeValue minute = Datamodel.makeTimeValue(2001, (byte) 2, (byte) 3, (byte)4, (byte)5, (byte)0, (byte)13, (byte)0, (byte)0, (byte)0, TimeValue.CM_GREGORIAN_PRO);
 
     
     @Override

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbReferenceExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbReferenceExprTest.java
@@ -42,7 +42,7 @@ public class WbReferenceExprTest extends WbExpressionTest<Reference> {
             new WbSnakExpr(new WbPropConstant("P347", "reference URL", "url"), new WbStringVariable("column B"))));
 
     private Snak snak1 = Datamodel.makeValueSnak(Datamodel.makeWikidataPropertyIdValue("P87"),
-            Datamodel.makeTimeValue(2018, (byte) 3, (byte) 28, TimeValue.CM_GREGORIAN_PRO));
+            Datamodel.makeTimeValue(2018, (byte) 3, (byte) 28, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0, TimeValue.CM_GREGORIAN_PRO));
     private Snak snak2 = Datamodel.makeValueSnak(Datamodel.makeWikidataPropertyIdValue("P347"),
             Datamodel.makeStringValue("http://gnu.org/"));
 

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStatementExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStatementExprTest.java
@@ -62,7 +62,7 @@ public class WbStatementExprTest extends WbExpressionTest<Statement> {
             Collections.singletonList(Datamodel.makeValueSnak(Datamodel.makeWikidataPropertyIdValue("P43"),
                     Datamodel.makeWikidataItemIdValue("Q3434"))))));
     private Snak qualifier = Datamodel.makeValueSnak(Datamodel.makeWikidataPropertyIdValue("P897"),
-            Datamodel.makeTimeValue(2010, (byte) 7, (byte) 23, TimeValue.CM_GREGORIAN_PRO));
+            Datamodel.makeTimeValue(2010, (byte) 7, (byte) 23, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0, TimeValue.CM_GREGORIAN_PRO));
     private Snak mainsnak = Datamodel.makeValueSnak(property, Datamodel.makeGlobeCoordinatesValue(3.898, 4.389,
             WbLocationConstant.defaultPrecision, GlobeCoordinatesValue.GLOBE_EARTH));
     private Claim fullClaim = Datamodel.makeClaim(subject, mainsnak,

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WikibaseSchemaTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WikibaseSchemaTest.java
@@ -64,16 +64,17 @@ public class WikibaseSchemaTest extends RefineTest {
     private ItemIdValue qid1 = Datamodel.makeWikidataItemIdValue("Q1377");
     private ItemIdValue qid2 = Datamodel.makeWikidataItemIdValue("Q865528");
     private TimeValue date1 = Datamodel.makeTimeValue(1919, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9,
-            (byte) 0, (byte) 1, (byte) 0, TimeValue.CM_GREGORIAN_PRO);
+            (byte) 0, (byte) 0, (byte) 0, TimeValue.CM_GREGORIAN_PRO);
     private TimeValue date2 = Datamodel.makeTimeValue(1965, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9,
-            (byte) 0, (byte) 1, (byte) 0, TimeValue.CM_GREGORIAN_PRO);
+            (byte) 0, (byte) 0, (byte) 0, TimeValue.CM_GREGORIAN_PRO);
     private StringValue url = Datamodel.makeStringValue("http://www.ljubljana-slovenia.com/university-ljubljana");
     private PropertyIdValue inceptionPid = Datamodel.makeWikidataPropertyIdValue("P571");
     private PropertyIdValue refPid = Datamodel.makeWikidataPropertyIdValue("P854");
     private PropertyIdValue retrievedPid = Datamodel.makeWikidataPropertyIdValue("P813");
     private Snak refSnak = Datamodel.makeValueSnak(refPid, url);
     private Snak retrievedSnak = Datamodel.makeValueSnak(retrievedPid,
-            Datamodel.makeTimeValue(2018, (byte) 2, (byte) 28, TimeValue.CM_GREGORIAN_PRO));
+            Datamodel.makeTimeValue(2018, (byte) 2, (byte) 28, (byte) 0, (byte) 0, (byte) 0, (byte) 11,
+                    (byte) 0, (byte) 0, (byte) 0, TimeValue.CM_GREGORIAN_PRO));
     private Snak mainSnak1 = Datamodel.makeValueSnak(inceptionPid, date1);
     private Snak mainSnak2 = Datamodel.makeValueSnak(inceptionPid, date2);
     private Claim claim1 = Datamodel.makeClaim(qid1, mainSnak1, Collections.emptyList());


### PR DESCRIPTION
The wikibase data model lets users store dates with precisions. The Wikidata-Toolkit library and the Wikibase implementation disagreed on the default values for these precisions. This leads to conflicting values being added to the items (see https://www.wikidata.org/w/index.php?title=Q391056&action=history for instance).

This was fixed in Wikidata-Toolkit (https://github.com/Wikidata/Wikidata-Toolkit/pull/375) and this PR brings the fix to OpenRefine.