### PR TITLE
Null to string

### DIFF
--- a/main/src/com/google/refine/util/StringUtils.java
+++ b/main/src/com/google/refine/util/StringUtils.java
@@ -17,7 +17,7 @@ public class StringUtils {
             OffsetDateTime odt = (OffsetDateTime)o;
             return odt.format(DateTimeFormatter.ofPattern(DEFAULT_PATTERN));
         } else if (o == null) {
-            return "null";
+            return "";
         } else {
             return o.toString();
         }

--- a/main/tests/server/src/com/google/refine/tests/expr/functions/strings/ToFromConversionTests.java
+++ b/main/tests/server/src/com/google/refine/tests/expr/functions/strings/ToFromConversionTests.java
@@ -112,7 +112,7 @@ public class ToFromConversionTests extends RefineTest {
     @Test
     public void testToString() throws CalendarParserException {
       Assert.assertTrue(invoke("toString") instanceof EvalError);
-      Assert.assertEquals(invoke("toString", (Object) null), "null");
+      Assert.assertEquals(invoke("toString", (Object) null), "");
       Assert.assertEquals(invoke("toString", Long.valueOf(100)),"100");
       Assert.assertEquals(invoke("toString", Double.valueOf(100.0)),"100.0");
       Assert.assertEquals(invoke("toString", Double.valueOf(100.0),"%.0f"),"100");


### PR DESCRIPTION
Changed behaviour of using null.toString() as per #1635
This makes the behaviour constistent with using "string" + null and more intuitive/safer for users