### PR TITLE
Migrate to new scope constraint format

### DIFF
--- a/extensions/wikidata/module/langs/translation-en.json
+++ b/extensions/wikidata/module/langs/translation-en.json
@@ -121,29 +121,17 @@
                         "title": "Statements without references.",
                         "body": "Most statements should have references. You can add them easily in the schema."
                 },
-                "property-restricted-to-reference-found-in-mainsnak": {
+                "property-found-in-mainsnak": {
                         "title": "{property_entity} used as statement.",
-                        "body": "You are using {property_entity} in a statement but it is designed to be used in references only."
+                        "body": "You are using {property_entity} as a main statement but it is not designed for that."
                 },
-                "property-restricted-to-reference-found-in-qualifier": {
+                "property-found-in-qualifier": {
                         "title": "{property_entity} used as qualifier.",
-                        "body": "You are using in {property_entity} in a qualifier but it is designed to be used in references only."
+                        "body": "You are using in {property_entity} as a qualifier but it is not designed for that ."
                 },
-                "property-restricted-to-qualifier-found-in-mainsnak": {
-                        "title": "{property_entity} used as statement.",
-                        "body": "You are using {property_entity} in a statement but it is designed to be used in qualifiers only."
-                },
-                "property-restricted-to-qualifier-found-in-reference": {
+                "property-found-in-reference": {
                         "title": "{property_entity} used as reference.",
-                        "body": "You are using {property_entity} in a reference but it is designed to be used in qualifiers only."
-                },
-                "property-restricted-to-mainsnak-found-in-qualifier": {
-                        "title": "{property_entity} used as qualifier.",
-                        "body": "You are using {property_entity} in a qualifier but it is designed to be used as a statement only."
-                },
-                "property-restricted-to-mainsnak-found-in-reference": {
-                        "title": "{property_entity} used as reference.",
-                        "body": "You are using {property_entity} in a reference but it is designed to be used as a statement only."
+                        "body": "You are using {property_entity} in a reference but it is not designed for that."
                 },
                 "missing-mandatory-qualifiers": {
                         "title": "{statement_property_entity} is missing a {missing_property_entity} qualifier.",

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/ConstraintFetcher.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/ConstraintFetcher.java
@@ -55,19 +55,19 @@ public interface ConstraintFetcher {
     PropertyIdValue getInversePid(PropertyIdValue pid);
 
     /**
-     * Is this property for values only?
+     * Can this property be used as values?
      */
-    boolean isForValuesOnly(PropertyIdValue pid);
+    boolean allowedAsValue(PropertyIdValue pid);
 
     /**
-     * Is this property for qualifiers only?
+     * Can this property be used as qualifiers?
      */
-    boolean isForQualifiersOnly(PropertyIdValue pid);
+    boolean allowedAsQualifier(PropertyIdValue pid);
 
     /**
-     * Is this property for references only?
+     * Can this property be used in a reference?
      */
-    boolean isForReferencesOnly(PropertyIdValue pid);
+    boolean allowedAsReference(PropertyIdValue pid);
 
     /**
      * Get the list of allowed qualifiers (as property ids) for this property (null

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/WikidataConstraintFetcher.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/WikidataConstraintFetcher.java
@@ -30,7 +30,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.openrefine.wikidata.utils.EntityCache;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
@@ -57,7 +59,11 @@ public class WikidataConstraintFetcher implements ConstraintFetcher {
     public static String INVERSE_CONSTRAINT_QID = "Q21510855";
     public static String INVERSE_PROPERTY_PID = "P2306";
 
-    public static String USED_ONLY_AS_VALUES_CONSTRAINT_QID = "Q21528958";
+    public static String SCOPE_CONSTRAINT_QID = "Q53869507";
+    public static String SCOPE_CONSTRAINT_PID = "P5314";
+    public static String SCOPE_CONSTRAINT_VALUE_QID = "Q54828448";
+    public static String SCOPE_CONSTRAINT_QUALIFIER_QID = "Q54828449";
+    public static String SCOPE_CONSTRAINT_REFERENCE_QID = "Q54828450";
 
     public static String USED_ONLY_AS_QUALIFIER_CONSTRAINT_QID = "Q21510863";
 
@@ -102,18 +108,36 @@ public class WikidataConstraintFetcher implements ConstraintFetcher {
     }
 
     @Override
-    public boolean isForValuesOnly(PropertyIdValue pid) {
-        return getSingleConstraint(pid, USED_ONLY_AS_VALUES_CONSTRAINT_QID) != null;
+    public boolean allowedAsValue(PropertyIdValue pid) {
+        List<SnakGroup> specs = getSingleConstraint(pid, SCOPE_CONSTRAINT_QID);
+        
+        if (specs != null) {
+            ItemIdValue target = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_VALUE_QID);
+            return findValues(specs, SCOPE_CONSTRAINT_PID).contains(target);
+        }
+        return true;
     }
 
     @Override
-    public boolean isForQualifiersOnly(PropertyIdValue pid) {
-        return getSingleConstraint(pid, USED_ONLY_AS_QUALIFIER_CONSTRAINT_QID) != null;
+    public boolean allowedAsQualifier(PropertyIdValue pid) {
+        List<SnakGroup> specs = getSingleConstraint(pid, SCOPE_CONSTRAINT_QID);
+        
+        if (specs != null) {
+            ItemIdValue target = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_QUALIFIER_QID);
+            return findValues(specs, SCOPE_CONSTRAINT_PID).contains(target);
+        }
+        return true;
     }
 
     @Override
-    public boolean isForReferencesOnly(PropertyIdValue pid) {
-        return getSingleConstraint(pid, USED_ONLY_AS_REFERENCE_CONSTRAINT_QID) != null;
+    public boolean allowedAsReference(PropertyIdValue pid) {
+        List<SnakGroup> specs = getSingleConstraint(pid, SCOPE_CONSTRAINT_QID);
+        
+        if (specs != null) {
+            ItemIdValue target = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_REFERENCE_QID);
+            return findValues(specs, SCOPE_CONSTRAINT_PID).contains(target);
+        }
+        return true;
     }
 
     @Override

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/MockConstraintFetcher.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/MockConstraintFetcher.java
@@ -60,18 +60,18 @@ public class MockConstraintFetcher implements ConstraintFetcher {
     }
 
     @Override
-    public boolean isForValuesOnly(PropertyIdValue pid) {
-        return mainSnakPid.equals(pid);
+    public boolean allowedAsValue(PropertyIdValue pid) {
+        return (!qualifierPid.equals(pid) && !referencePid.equals(pid));
     }
 
     @Override
-    public boolean isForQualifiersOnly(PropertyIdValue pid) {
-        return qualifierPid.equals(pid);
+    public boolean allowedAsQualifier(PropertyIdValue pid) {
+        return (!mainSnakPid.equals(pid) && !referencePid.equals(pid));
     }
 
     @Override
-    public boolean isForReferencesOnly(PropertyIdValue pid) {
-        return referencePid.equals(pid);
+    public boolean allowedAsReference(PropertyIdValue pid) {
+        return (!mainSnakPid.equals(pid) && !qualifierPid.equals(pid));
     }
 
     @Override

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/WikidataConstraintFetcherTests.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/WikidataConstraintFetcherTests.java
@@ -39,10 +39,7 @@ public class WikidataConstraintFetcherTests {
     private PropertyIdValue endTime;
     private PropertyIdValue instanceOf;
     private PropertyIdValue gridId;
-    private PropertyIdValue hasPart;
     private PropertyIdValue partOf;
-    private PropertyIdValue referenceURL;
-    private PropertyIdValue reasonForDeprecation;
     private PropertyIdValue mother;
     private PropertyIdValue child;
 
@@ -53,10 +50,7 @@ public class WikidataConstraintFetcherTests {
         endTime = Datamodel.makeWikidataPropertyIdValue("P582");
         instanceOf = Datamodel.makeWikidataPropertyIdValue("P31");
         gridId = Datamodel.makeWikidataPropertyIdValue("P2427");
-        hasPart = Datamodel.makeWikidataPropertyIdValue("P527");
         partOf = Datamodel.makeWikidataPropertyIdValue("P361");
-        referenceURL = Datamodel.makeWikidataPropertyIdValue("P854");
-        reasonForDeprecation = Datamodel.makeWikidataPropertyIdValue("P2241");
         mother = Datamodel.makeWikidataPropertyIdValue("P25");
         child = Datamodel.makeWikidataPropertyIdValue("P40");
     }
@@ -75,24 +69,6 @@ public class WikidataConstraintFetcherTests {
     @Test
     public void testGetInverseConstraint() {
         Assert.assertEquals(fetcher.getInversePid(mother), child);
-    }
-
-    @Test
-    public void testOnlyReferences() {
-        Assert.assertTrue(fetcher.isForReferencesOnly(referenceURL));
-        Assert.assertFalse(fetcher.isForReferencesOnly(reasonForDeprecation));
-    }
-
-    @Test
-    public void testOnlyQualifiers() {
-        Assert.assertTrue(fetcher.isForQualifiersOnly(reasonForDeprecation));
-        Assert.assertFalse(fetcher.isForQualifiersOnly(headOfGovernment));
-    }
-
-    @Test
-    public void testOnlyValues() {
-        Assert.assertTrue(fetcher.isForValuesOnly(headOfGovernment));
-        Assert.assertFalse(fetcher.isForValuesOnly(referenceURL));
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedPositionScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedPositionScrutinizerTest.java
@@ -48,7 +48,7 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
     @Test
     public void testTriggerMainSnak() {
         scrutinize(TestingData.generateStatement(qid, MockConstraintFetcher.qualifierPid, qid));
-        assertWarningsRaised("property-restricted-to-qualifier-found-in-mainsnak");
+        assertWarningsRaised("property-found-in-mainsnak");
     }
 
     @Test
@@ -72,7 +72,7 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
                 TestingData.generateStatement(qid, MockConstraintFetcher.mainSnakPid, qid).getClaim(),
                 Collections.singletonList(Datamodel.makeReference(snakGroups)), StatementRank.NORMAL, "");
         scrutinize(statement);
-        assertWarningsRaised("property-restricted-to-mainsnak-found-in-reference");
+        assertWarningsRaised("property-found-in-reference");
     }
 
 }


### PR DESCRIPTION
Wikidata is changing the way they are representing scope constraints. This PR adapts the code to the new format.
Discussion: https://www.wikidata.org/wiki/Wikidata:Property_proposal/property_scope