### PR TITLE
Mass edit dates

### DIFF
--- a/main/src/com/google/refine/browsing/DecoratedValue.java
+++ b/main/src/com/google/refine/browsing/DecoratedValue.java
@@ -33,12 +33,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.browsing;
 
+import java.time.OffsetDateTime;
 import java.util.Properties;
 
 import org.json.JSONException;
 import org.json.JSONWriter;
 
 import com.google.refine.Jsonizable;
+import com.google.refine.util.StringUtils;
 
 /**
  * Store a value and its text label, in case the value is not a string itself.
@@ -52,8 +54,12 @@ public class DecoratedValue implements Jsonizable {
     final public String label;
     
     public DecoratedValue(Object value, String label) {
-        this.value = value;
-        this.label = label;
+      if (value instanceof OffsetDateTime) {
+          this.value = StringUtils.toString(value);
+      } else {
+          this.value = value;
+      }
+      this.label = label;
     }
     
     @Override

--- a/main/src/com/google/refine/operations/cell/MassEditOperation.java
+++ b/main/src/com/google/refine/operations/cell/MassEditOperation.java
@@ -59,6 +59,7 @@ import com.google.refine.model.changes.CellChange;
 import com.google.refine.operations.EngineDependentMassCellOperation;
 import com.google.refine.operations.OperationRegistry;
 import com.google.refine.util.ParsingUtilities;
+import com.google.refine.util.StringUtils;
 
 public class MassEditOperation extends EngineDependentMassCellOperation {
     final protected String         _expression;
@@ -259,7 +260,7 @@ public class MassEditOperation extends EngineDependentMassCellOperation {
                         newCell = new Cell(fromErrorTo, (cell != null) ? cell.recon : null);
                     }
                 } else if (ExpressionUtils.isNonBlankData(v)) {
-                    String from = v.toString();
+                    String from = StringUtils.toString(v);
                     Serializable to = fromTo.get(from);
                     if (to != null) {
                         newCell = new Cell(to, (cell != null) ? cell.recon : null);

--- a/main/src/com/google/refine/util/StringUtils.java
+++ b/main/src/com/google/refine/util/StringUtils.java
@@ -1,7 +1,6 @@
 package com.google.refine.util;
 
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 
 public class StringUtils {
     /**

--- a/main/src/com/google/refine/util/StringUtils.java
+++ b/main/src/com/google/refine/util/StringUtils.java
@@ -4,8 +4,6 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 
 public class StringUtils {
-    private static String DEFAULT_PATTERN = "dd-MMM-yyyy";
-    
     /**
      * String formatting method that knows how to format dates (using the default locale's date formatter)
      * @param o object to be converted to a string
@@ -15,7 +13,7 @@ public class StringUtils {
         // to replace the DateFormat with java.time.format.DateTimeFormatter 
         if (o instanceof OffsetDateTime) {
             OffsetDateTime odt = (OffsetDateTime)o;
-            return odt.format(DateTimeFormatter.ofPattern(DEFAULT_PATTERN));
+            return ParsingUtilities.dateToString((OffsetDateTime) odt);
         } else if (o == null) {
             return "";
         } else {
@@ -23,4 +21,3 @@ public class StringUtils {
         }
     }
 }
-

--- a/main/tests/server/src/com/google/refine/tests/browsing/util/ExpressionNominalValueGrouperTests.java
+++ b/main/tests/server/src/com/google/refine/tests/browsing/util/ExpressionNominalValueGrouperTests.java
@@ -53,7 +53,6 @@ import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.tests.RefineTest;
-import com.google.refine.util.StringUtils;
 
 
 public class ExpressionNominalValueGrouperTests extends RefineTest {
@@ -61,8 +60,6 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
     //Variables
     private static Project project;
     private static Properties bindings;
-    private static final String ENGINE_JSON_LISTFACET = "{\"facets\":[{\"type\":\"list\",\"name\":\"facet A\",\"columnName\":\"Column\",\"expression\":\"value\",\"omitBlank\":false,\"omitError\":false,\"selection\":[],\"selectBlank\":false,\"selectError\":false,\"invert\":false}],\"mode\":\"row-based\"}}";
-    private static String projectid;
     
     private static OffsetDateTime dateTimeValue = OffsetDateTime.parse("2017-05-12T05:45:00+00:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
     private static String dateTimeStringValue = "2017-05-12T05:45:00Z";
@@ -92,12 +89,12 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
     }
     
     @AfterMethod
-    public void TearDown() {
+    public void tearDown() {
         project = null;
     }
 
     @Test
-    public void ExpressionNominalValueGrouperStrings() throws Exception {
+    public void expressionNominalValueGrouperStrings() throws Exception {
       //populate project
       // Five rows of a's
       for (int i = 0; i < numberOfRows; i++) {
@@ -126,7 +123,7 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
     }
     
     @Test
-    public void ExpressionNominalValueGrouperInts() throws Exception {
+    public void expressionNominalValueGrouperInts() throws Exception {
       //populate project
       for (int i = 0; i < numberOfRows; i++) {
           Row row = new Row(1);
@@ -154,7 +151,7 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
     }
     
     @Test
-    public void ExpressionNominalValueGrouperDates() throws Exception {
+    public void expressionNominalValueGrouperDates() throws Exception {
       //populate project
       for (int i = 0; i < numberOfRows; i++) {
           Row row = new Row(1);

--- a/main/tests/server/src/com/google/refine/tests/browsing/util/ExpressionNominalValueGrouperTests.java
+++ b/main/tests/server/src/com/google/refine/tests/browsing/util/ExpressionNominalValueGrouperTests.java
@@ -1,0 +1,183 @@
+/*
+
+Copyright 2018, Owen Stephens
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+package com.google.refine.tests.browsing.util;
+
+import com.google.refine.expr.MetaParser;
+import org.testng.annotations.AfterMethod;
+import org.testng.Assert;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Properties;
+
+
+import org.json.JSONException;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.google.refine.browsing.util.ExpressionNominalValueGrouper;
+import com.google.refine.expr.Evaluable;
+import com.google.refine.model.Cell;
+import com.google.refine.model.ModelException;
+import com.google.refine.model.Project;
+import com.google.refine.model.Row;
+import com.google.refine.tests.RefineTest;
+import com.google.refine.util.StringUtils;
+
+
+public class ExpressionNominalValueGrouperTests extends RefineTest {
+    // dependencies    
+    //Variables
+    private static Project project;
+    private static Properties bindings;
+    private static final String ENGINE_JSON_LISTFACET = "{\"facets\":[{\"type\":\"list\",\"name\":\"facet A\",\"columnName\":\"Column\",\"expression\":\"value\",\"omitBlank\":false,\"omitError\":false,\"selection\":[],\"selectBlank\":false,\"selectError\":false,\"invert\":false}],\"mode\":\"row-based\"}}";
+    private static String projectid;
+    
+    private static OffsetDateTime dateTimeValue = OffsetDateTime.parse("2017-05-12T05:45:00+00:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    private static String dateTimeStringValue = "2017-05-12T05:45:00Z";
+    private static int integerValue = 1;
+    private static String integerStringValue = "1";
+    private static String stringStringValue = "a";
+    
+    private static ExpressionNominalValueGrouper grouper;
+    private static Evaluable eval;
+    private static final int cellIndex = 0;
+    private static final String columnName = "Col1";
+    private static final int numberOfRows = 5;
+    private static final String projectName = "ExpressionNominalValueGrouper";
+    
+
+    @Override
+    @BeforeTest
+    public void init() {
+        logger = LoggerFactory.getLogger(this.getClass());
+    }
+
+    @BeforeMethod
+    public void setUp() throws JSONException, IOException, ModelException {
+      project = createProjectWithColumns(projectName, columnName);
+      bindings = new Properties();
+      bindings.put("project", project);
+    }
+    
+    @AfterMethod
+    public void TearDown() {
+        project = null;
+    }
+
+    @Test
+    public void ExpressionNominalValueGrouperStrings() throws Exception {
+      //populate project
+      // Five rows of a's
+      for (int i = 0; i < numberOfRows; i++) {
+          Row row = new Row(1);
+          row.setCell(0, new Cell(stringStringValue, null));
+          project.rows.add(row);
+      }
+      //create grouper
+      eval = MetaParser.parse("value");
+      grouper = new ExpressionNominalValueGrouper(eval, columnName, cellIndex);
+      try {
+          grouper.start(project);
+          for (int rowIndex = 0; rowIndex < numberOfRows; rowIndex++) {
+              Row row = project.rows.get(rowIndex);
+              grouper.visit(project, rowIndex, row);
+          }
+      } finally {
+          grouper.end(project);
+      }
+      
+      Assert.assertEquals(grouper.choices.size(),1);
+      
+      Assert.assertTrue(grouper.choices.containsKey(stringStringValue));
+      Assert.assertEquals(grouper.choices.get(stringStringValue).decoratedValue.label,stringStringValue);
+      Assert.assertEquals(grouper.choices.get(stringStringValue).decoratedValue.value.toString(),stringStringValue);
+    }
+    
+    @Test
+    public void ExpressionNominalValueGrouperInts() throws Exception {
+      //populate project
+      for (int i = 0; i < numberOfRows; i++) {
+          Row row = new Row(1);
+          row.setCell(0, new Cell(integerValue, null));
+          project.rows.add(row);
+      }
+      //create grouper
+      eval = MetaParser.parse("value");
+      grouper = new ExpressionNominalValueGrouper(eval, columnName, cellIndex);
+      try {
+          grouper.start(project);
+          for (int rowIndex = 0; rowIndex < numberOfRows; rowIndex++) {
+              Row row = project.rows.get(rowIndex);
+              grouper.visit(project, rowIndex, row);
+          }
+      } finally {
+          grouper.end(project);
+      }
+      
+      Assert.assertEquals(grouper.choices.size(),1);
+      
+      Assert.assertTrue(grouper.choices.containsKey(integerStringValue));
+      Assert.assertEquals(grouper.choices.get(integerStringValue).decoratedValue.label,integerStringValue);
+      Assert.assertEquals(grouper.choices.get(integerStringValue).decoratedValue.value.toString(),integerStringValue);
+    }
+    
+    @Test
+    public void ExpressionNominalValueGrouperDates() throws Exception {
+      //populate project
+      for (int i = 0; i < numberOfRows; i++) {
+          Row row = new Row(1);
+          row.setCell(0, new Cell(dateTimeValue, null));
+          project.rows.add(row);
+      }
+      //create grouper
+      eval = MetaParser.parse("value");
+      grouper = new ExpressionNominalValueGrouper(eval, columnName, cellIndex);
+      try {
+          grouper.start(project);
+          for (int rowIndex = 0; rowIndex < numberOfRows; rowIndex++) {
+              Row row = project.rows.get(rowIndex);
+              grouper.visit(project, rowIndex, row);
+          }
+      } finally {
+          grouper.end(project);
+      }
+      
+      Assert.assertEquals(grouper.choices.size(),1);
+      
+      Assert.assertTrue(grouper.choices.containsKey(dateTimeStringValue));
+      Assert.assertEquals(grouper.choices.get(dateTimeStringValue).decoratedValue.label,dateTimeStringValue);
+      Assert.assertEquals(grouper.choices.get(dateTimeStringValue).decoratedValue.value.toString(),dateTimeStringValue);
+    }
+}

--- a/main/tests/server/src/com/google/refine/tests/expr/functions/strings/ToFromConversionTests.java
+++ b/main/tests/server/src/com/google/refine/tests/expr/functions/strings/ToFromConversionTests.java
@@ -119,7 +119,7 @@ public class ToFromConversionTests extends RefineTest {
       
       String inputDate = "2013-06-01";
       Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDate)), 
-              "01-Jun-2013");
+              "2013-06-01T00:00:00Z");
       Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDate), "yyyy-MM-dd"),
               "2013-06-01");
       Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDate), "yyyy/dd/MM"), "2013/01/06");
@@ -127,7 +127,7 @@ public class ToFromConversionTests extends RefineTest {
       Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDate), "yyyy-MM-dd hh:mm:ss"), "2013-06-01 12:00:00");
       
       String inputDateTime = "2013-06-01 13:12:11";
-      Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime)), "01-Jun-2013");
+      Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime)), "2013-06-01T13:12:11Z");
       Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime), "yyyy-MM-dd"), "2013-06-01");
       Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime), "yyyy-MM-dd hh:mm:ss"),"2013-06-01 01:12:11");
       Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime), "yyyy-MM-dd HH:mm:ss"),"2013-06-01 13:12:11");

--- a/main/tests/server/src/com/google/refine/tests/operations/cell/MassOperationTests.java
+++ b/main/tests/server/src/com/google/refine/tests/operations/cell/MassOperationTests.java
@@ -69,6 +69,18 @@ public class MassOperationTests extends RefineTest {
     }
 
     @Test
+    public void testReconstructEditDate() throws Exception {
+      editsString = "[{\"from\":[\"2018-10-04T00:00:00Z\"],\"to\":\"newString\",\"type\":\"text\"}]";
+
+      editList = MassEditOperation.reconstructEdits(ParsingUtilities.evaluateJsonStringToArray(editsString));
+
+      Assert.assertEquals(editList.get(0).from.get(0), "2018-10-04T00:00:00Z");
+      Assert.assertEquals(editList.get(0).to,"newString" );
+      Assert.assertFalse(editList.get(0).fromBlank);
+      Assert.assertFalse(editList.get(0).fromError);
+    }
+
+    @Test
     public void testReconstructEditEmpty() throws Exception {
       editsString = "[{\"from\":[\"\"],\"to\":\"newString\",\"type\":\"text\"}]";
 
@@ -83,6 +95,5 @@ public class MassOperationTests extends RefineTest {
     }
 
     //Not yet testing for mass edit from OR Error
-    //Not yet testing for mass edit from OR Date
 
 }


### PR DESCRIPTION
This PR fixes #1632.
This is a surprisingly complex area, as it relates to how dates are transformed to strings. This can happen in different ways in different places in OR. When converting a date to a string results in a different value to the required one, it can result in unexpected behaviour.

This PR:

- Adds tests for how Mass Edits are reconstructed for dates to ensure OR does this correctly. This test fails in OR 3.0 beta
- Changes the behaviour of StringUtils.toString() to convert OffsetDateTime to a string using ParsingUtilities.dateToString -  this helps to standardise behaviour in converting dates to strings in OpenRefine, including for Mass Edits. This makes the test introduced a passing test
- Changes the expected behaviour being tested for in ToFromConversionTests.java to expect new format when using StringUtils.toString()

These changes had a knock on impact on the behaviour of using 'Edit' from a List facet. The representation of non-string objects in a List/Text facet has been broken for some time, but the mass edit function had worked for dates, so this PR restores that working functionality by:

- Adding tests for the facet grouper to make sure that for date values the facet 'value' converted to a string and facet 'label' are the same
- Changes the behaviour of DecoratedValue to pass the test (by always converting dates to Strings before populating the facet value)

The behaviour of text or list facets in relation to non-string values needs much more thought and work,  but the existing behaviour (2.8 and earlier) is also incorrect, and there is no attempt to fix further than ensure mass edit works.

Finally the implication of changing the behaviour of StringUtils.toString() is that the default format obtained when using 'toString()' in GREL is to convert to a string with the format:
`yyyy-MM-ddThh:mm:ddZ`
instead of
`dd MMM yyyy`

which was the previous default.
This change in behaviour seems relatively minor and ensures that using 'toString' results in the same value in the cell visually whether the cell is left as a Date type or converted to a String type
