### PR TITLE
Simplify parsing of HTTP headers in fetch-url operation

### DIFF
--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -338,16 +338,12 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
             try {
                 URLConnection urlConnection = url.openConnection();
                 if (_httpHeadersJson != null) {
-                    Map<String, String> httpHeaders = new HashMap<>();
-                    for (int i = 0; i < _httpHeadersJson.length(); i++) {            
+                    for (int i = 0; i < _httpHeadersJson.length(); i++) {
                         String headerLabel = _httpHeadersJson.getJSONObject(i).getString("name");
                         String headerValue = _httpHeadersJson.getJSONObject(i).getString("value");
-                        httpHeaders.put(headerLabel, headerValue);
-                    }
-                    for (String headerLabel : HttpHeadersSupport.getHttpHeaderLabels()) {
-                        HttpHeaderInfo info = HttpHeadersSupport.getHttpHeaderInfo(headerLabel);
-
-                        urlConnection.setRequestProperty(info.header, httpHeaders.get(headerLabel));
+                        if (headerValue != null && !headerValue.isEmpty()) {
+                            urlConnection.setRequestProperty(headerLabel, headerValue);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Closes #1669 and makes it possible to specify other headers via the JSON representation of the operation.

@michaelavoigt could you try this and confirm that it solves the issue on your side? Let me know if you need help to run the development version on this branch.

@ostephens what do you think of this simpler version? It lets users specify arbitrary HTTP headers in the JSON representation of the operation - I guess that could be useful for some APIs using some non-standard headers.