### PR TITLE
translation-en.json: add colon to "custom" label

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -151,7 +151,7 @@
         "col-separated-by": "Columns are separated by",
         "commas": "commas (CSV)",
         "tabs": "tabs (TSV)",
-        "custom": "custom",
+        "custom": "custom:",
         "escape": "Escape special characters with \\",
         "use-quote": "Use character",
         "quote-delimits-cells": "to enclose cells containing column separators",


### PR DESCRIPTION
The styling of the text field that appears after this label makes it easy to miss as an input field.
Having the colon after the label makes it clearer that the user can type into the text box.