### PR TITLE
Remove test assertion that can fail depending on the locale

### DIFF
--- a/main/tests/server/src/com/google/refine/tests/expr/functions/strings/ToFromConversionTests.java
+++ b/main/tests/server/src/com/google/refine/tests/expr/functions/strings/ToFromConversionTests.java
@@ -123,7 +123,6 @@ public class ToFromConversionTests extends RefineTest {
       Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDate), "yyyy-MM-dd"),
               "2013-06-01");
       Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDate), "yyyy/dd/MM"), "2013/01/06");
-      Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDate), "yyyy-MMM"), "2013-Jun");
       Assert.assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDate), "yyyy-MM-dd hh:mm:ss"), "2013-06-01 12:00:00");
       
       String inputDateTime = "2013-06-01 13:12:11";


### PR DESCRIPTION
This assertion fails if the locale is not English, so I am removing it so that the test suite runs independently.