### PR TITLE
Fix inconsistency in serialization of ReconMatchSpecificTopicOperation

### DIFF
--- a/main/src/com/google/refine/operations/recon/ReconMatchSpecificTopicOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconMatchSpecificTopicOperation.java
@@ -68,7 +68,7 @@ public class ReconMatchSpecificTopicOperation extends EngineDependentMassCellOpe
         
         JSONObject match = obj.getJSONObject("match");
         
-        JSONArray types = obj.getJSONArray("types");
+        JSONArray types = match.getJSONArray("types");
         String[] typeIDs = new String[types.length()];
         for (int i = 0; i < typeIDs.length; i++) {
             typeIDs[i] = types.getString(i);


### PR DESCRIPTION
Closes #1708.
Testing for this (and the serialization of a lot of other classes) will come in a different PR.