### PR TITLE
Custom column names for separator based importer

### DIFF
--- a/main/src/com/google/refine/importers/SeparatorBasedImporter.java
+++ b/main/src/com/google/refine/importers/SeparatorBasedImporter.java
@@ -114,7 +114,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
               }
             }
 
-            if (retrievedColumnNames.size() > 0) {
+            if (!retrievedColumnNames.isEmpty()) {
               JSONUtilities.safePut(options, "headerLines", 1);
             } else {
               retrievedColumnNames = null;

--- a/main/tests/server/src/com/google/refine/tests/importers/TsvCsvImporterTests.java
+++ b/main/tests/server/src/com/google/refine/tests/importers/TsvCsvImporterTests.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.StringReader;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -521,7 +522,7 @@ public class TsvCsvImporterTests extends ImporterTest {
         String input = "data1" + inputSeparator + "data2" + inputSeparator + "data3\n";
         
         try {
-            prepareOptions(sep, -1, 0, 0, 0, false, false,"\"","col1,col2,col3");
+            prepareOptions(sep, -1, 0, 0, 1, false, false,"\"","[col1,col2,col3]");
             parseOneFile(SUT, new StringReader(input));
         } catch (Exception e) {
             Assert.fail("Exception during file parse",e);
@@ -600,7 +601,8 @@ public class TsvCsvImporterTests extends ImporterTest {
     protected void prepareOptions(
         String sep, int limit, int skip, int ignoreLines,
         int headerLines, boolean guessValueType, boolean ignoreQuotes, String quoteCharacter) {
-        prepareOptions(sep, limit, skip, ignoreLines, headerLines, guessValueType, ignoreQuotes, "\"","");
+        
+        prepareOptions(sep, limit, skip, ignoreLines, headerLines, guessValueType, ignoreQuotes, quoteCharacter,"[]");      
     }
     
     protected void prepareOptions(
@@ -616,7 +618,7 @@ public class TsvCsvImporterTests extends ImporterTest {
             whenGetBooleanOption("guessCellValueTypes", options, guessValueType);
             whenGetBooleanOption("processQuotes", options, !ignoreQuotes);
             whenGetBooleanOption("storeBlankCellsAsNulls", options, true);
-            whenGetStringOption("columnNames", options, columnNames);
+            whenGetArrayOption("columnNames", options, new JSONArray(columnNames));
         }
 
     private void verifyOptions() {
@@ -629,7 +631,7 @@ public class TsvCsvImporterTests extends ImporterTest {
             verify(options, times(1)).getBoolean("guessCellValueTypes");
             verify(options, times(1)).getBoolean("processQuotes");
             verify(options, times(1)).getBoolean("storeBlankCellsAsNulls");
-            verify(options, times(1)).getBoolean("columnNames");
+            verify(options, times(1)).getJSONArray("columnNames");
         } catch (JSONException e) {
             Assert.fail("JSON exception",e);
         }

--- a/main/tests/server/src/com/google/refine/tests/importers/TsvCsvImporterTests.java
+++ b/main/tests/server/src/com/google/refine/tests/importers/TsvCsvImporterTests.java
@@ -514,6 +514,27 @@ public class TsvCsvImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
     }
     
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
+    public void readCustomColumnNames(String sep){
+        //create input
+        String inputSeparator =  sep == null ? "\t" : sep;
+        String input = "data1" + inputSeparator + "data2" + inputSeparator + "data3\n";
+        
+        try {
+            prepareOptions(sep, -1, 0, 0, 0, false, false,"\"","col1,col2,col3");
+            parseOneFile(SUT, new StringReader(input));
+        } catch (Exception e) {
+            Assert.fail("Exception during file parse",e);
+        }
+        Assert.assertEquals(project.columnModel.columns.size(), 3);
+        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
+        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
+        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
+        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
+        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
+        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+    }
+    
     //---------------------read tests------------------------
     @Test
     public void readCsvWithProperties() {
@@ -579,17 +600,24 @@ public class TsvCsvImporterTests extends ImporterTest {
     protected void prepareOptions(
         String sep, int limit, int skip, int ignoreLines,
         int headerLines, boolean guessValueType, boolean ignoreQuotes, String quoteCharacter) {
-        
-        whenGetStringOption("separator", options, sep);
-        whenGetStringOption("quoteCharacter", options, quoteCharacter);
-        whenGetIntegerOption("limit", options, limit);
-        whenGetIntegerOption("skipDataLines", options, skip);
-        whenGetIntegerOption("ignoreLines", options, ignoreLines);
-        whenGetIntegerOption("headerLines", options, headerLines);
-        whenGetBooleanOption("guessCellValueTypes", options, guessValueType);
-        whenGetBooleanOption("processQuotes", options, !ignoreQuotes);
-        whenGetBooleanOption("storeBlankCellsAsNulls", options, true);
+        prepareOptions(sep, limit, skip, ignoreLines, headerLines, guessValueType, ignoreQuotes, "\"","");
     }
+    
+    protected void prepareOptions(
+            String sep, int limit, int skip, int ignoreLines,
+            int headerLines, boolean guessValueType, boolean ignoreQuotes, String quoteCharacter, String columnNames) {
+            
+            whenGetStringOption("separator", options, sep);
+            whenGetStringOption("quoteCharacter", options, quoteCharacter);
+            whenGetIntegerOption("limit", options, limit);
+            whenGetIntegerOption("skipDataLines", options, skip);
+            whenGetIntegerOption("ignoreLines", options, ignoreLines);
+            whenGetIntegerOption("headerLines", options, headerLines);
+            whenGetBooleanOption("guessCellValueTypes", options, guessValueType);
+            whenGetBooleanOption("processQuotes", options, !ignoreQuotes);
+            whenGetBooleanOption("storeBlankCellsAsNulls", options, true);
+            whenGetStringOption("columnNames", options, columnNames);
+        }
 
     private void verifyOptions() {
         try {
@@ -601,6 +629,7 @@ public class TsvCsvImporterTests extends ImporterTest {
             verify(options, times(1)).getBoolean("guessCellValueTypes");
             verify(options, times(1)).getBoolean("processQuotes");
             verify(options, times(1)).getBoolean("storeBlankCellsAsNulls");
+            verify(options, times(1)).getBoolean("columnNames");
         } catch (JSONException e) {
             Assert.fail("JSON exception",e);
         }

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -156,7 +156,7 @@
         "use-quote": "Use character",
         "quote-delimits-cells": "to enclose cells containing column separators",
         "click-xml": "Click on the first XML element corresponding to the first record to load.",
-        "column-names-label": "Column names",
+        "column-names-label": "Column names (comma separated)",
 		"column-names-optional":"comma separated"
     },
     "core-dialogs": {

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -155,7 +155,9 @@
         "escape": "Escape special characters with \\",
         "use-quote": "Use character",
         "quote-delimits-cells": "to enclose cells containing column separators",
-        "click-xml": "Click on the first XML element corresponding to the first record to load."
+        "click-xml": "Click on the first XML element corresponding to the first record to load.",
+        "column-names-label": "Column names",
+		"column-names-optional":"comma separated"
     },
     "core-dialogs": {
         "cluster-edit": "Cluster & Edit column",

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
@@ -24,6 +24,8 @@
         <td><label for="$column-separator-custom" id="or-import-custom"></label>
           <input bind="columnSeparatorInput" type="text" class="lightweight" size="5" /></td></tr>
       <tr><td colspan="2" id="or-import-escape"></td></tr>
+      <tr><td colspan="2" id="or-import-columnNames"></td></tr>
+	  <tr><td><input style="width: 33em;" bind="columnNamesInput" /></td><td id="or-import-optional"></td></tr>
     </table></div></td>
     
     <td colspan="2"><div class="grid-layout layout-tightest"><table>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
@@ -59,7 +59,6 @@
       <tr><td width="1%"><input type="checkbox" bind="columnNamesCheckbox" id="$check-column-names" /></td>
       <td id="or-import-columnNames"></td>    
 	  <td><input style="width: 18em;" bind="columnNamesInput" /></td>
-	  <td id="or-import-optional"></td>
     </tr></table></div></td>
     
     <td colspan="1"><div class="grid-layout layout-tightest"><table>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
@@ -56,9 +56,10 @@
   </tr>
   <tr>
     <td><div class="grid-layout layout-tightest" style="width:fit-content;"><table>
-      <tr><td width="1%"><input type="checkbox" bind="columnNamesCheckbox" id="$check-column-names" /></td>
-      <td id="or-import-columnNames"></td>    
-	  <td><input style="width: 18em;" bind="columnNamesInput" /></td>
+      <tr><td width="1%"><input type="checkbox" bind="columnNamesCheckbox" id="$check-column-names" />
+      <label id="or-import-columnNames"></label></td></tr>
+      <tr>
+	  <td><input style="width: 25em;" bind="columnNamesInput" /></td>
     </tr></table></div></td>
     
     <td colspan="1"><div class="grid-layout layout-tightest"><table>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
@@ -1,4 +1,4 @@
-<div class="grid-layout layout-loose layout-full"><table>
+<div class="grid-layout layout-loose  layout-full"><table>
   <tr>
     <td><div class="grid-layout layout-tighter"><table>
       <tr>
@@ -24,12 +24,7 @@
         <td><label for="$column-separator-custom" id="or-import-custom"></label>
           <input bind="columnSeparatorInput" type="text" class="lightweight" size="5" /></td></tr>
       <tr><td colspan="2" id="or-import-escape"></td></tr>
-      </table>
-	  <br>
-	  <table>
-	  <tr><td colspan="2" id="or-import-columnNames"></td></tr> 
-	  <tr><td><input style="width: 33em;" bind="columnNamesInput" /></td><td id="or-import-optional"></td></tr>
-    </table></div></td>
+      </table></div></td>
     
     <td colspan="2"><div class="grid-layout layout-tightest"><table>
       <tr><td width="1%"><input type="checkbox" bind="ignoreCheckbox" id="$ignore" /></td>
@@ -60,9 +55,14 @@
     </table></div></td>
   </tr>
   <tr>
-    <td>&nbsp;</td>
+    <td><div class="grid-layout layout-tightest" style="width:fit-content;"><table>
+      <tr><td width="1%"><input type="checkbox" bind="columnNamesCheckbox" id="$check-column-names" /></td>
+      <td id="or-import-columnNames"></td>    
+	  <td><input style="width: 18em;" bind="columnNamesInput" /></td>
+	  <td id="or-import-optional"></td>
+    </tr></table></div></td>
     
-    <td><div class="grid-layout layout-tightest"><table>
+    <td colspan="1"><div class="grid-layout layout-tightest"><table>
       <tr><td width="1%"><input type="checkbox" bind="guessCellValueTypesCheckbox" id="$guess" /></td>
         <td><label for="$guess" id="or-import-parseCell"></label></td></tr>
          </table></div></td>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
@@ -24,7 +24,10 @@
         <td><label for="$column-separator-custom" id="or-import-custom"></label>
           <input bind="columnSeparatorInput" type="text" class="lightweight" size="5" /></td></tr>
       <tr><td colspan="2" id="or-import-escape"></td></tr>
-      <tr><td colspan="2" id="or-import-columnNames"></td></tr>
+      </table>
+	  <br>
+	  <table>
+	  <tr><td colspan="2" id="or-import-columnNames"></td></tr> 
 	  <tr><td><input style="width: 33em;" bind="columnNamesInput" /></td><td id="or-import-optional"></td></tr>
     </table></div></td>
     

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
@@ -118,9 +118,11 @@ Refine.SeparatorBasedParserUI.prototype.getOptions = function() {
   options.storeBlankCellsAsNulls = this._optionContainerElmts.storeBlankCellsAsNullsCheckbox[0].checked;
   options.includeFileSources = this._optionContainerElmts.includeFileSourcesCheckbox[0].checked;
   
-  var columnNames = this._optionContainerElmts.columnNamesInput.val();
-  if (columnNames != undefined && columnNames != null && columnNames != '') {
-      options.columnNames = columnNames.split(",");
+  if (this._optionContainerElmts.columnNamesCheckbox[0].checked) {
+      var columnNames = this._optionContainerElmts.columnNamesInput.val();
+      if (columnNames != undefined && columnNames != null && columnNames != '') {
+          options.columnNames = columnNames.split(",");
+      }
   }
 
   return options;
@@ -174,10 +176,23 @@ Refine.SeparatorBasedParserUI.prototype._initialize = function() {
           var isDisabled = $('textbox').prop('disabled');
           if (!isDisabled) {
               self._optionContainerElmts.columnNamesInput.prop('disabled', true);
+              self._optionContainerElmts.columnNamesCheckbox.prop("checked", false);
               self._optionContainerElmts.columnNamesInput.val('');
           }
       } else {
           self._optionContainerElmts.columnNamesInput.prop('disabled', false);
+          self._optionContainerElmts.columnNamesCheckbox.prop("checked", true);
+      }
+  });
+  
+  this._optionContainerElmts.columnNamesCheckbox.on("click", function() {
+      if ($(this).is(':checked')) {
+          self._optionContainerElmts.headerLinesCheckbox.prop("checked", false);
+          self._optionContainerElmts.columnNamesInput.prop('disabled', false);
+      } else {
+          self._optionContainerElmts.headerLinesCheckbox.prop("checked", true);
+          self._optionContainerElmts.columnNamesInput.val('');
+          self._optionContainerElmts.columnNamesInput.prop('disabled', true);
       }
   });
   

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
@@ -227,6 +227,7 @@ Refine.SeparatorBasedParserUI.prototype._initialize = function() {
   };
   this._optionContainer.find("input").bind("change", onChange);
   this._optionContainer.find("select").bind("change", onChange);
+  this._optionContainerElmts.columnNamesInput.bind("keyup",onChange);
 };
 
 Refine.SeparatorBasedParserUI.prototype._scheduleUpdatePreview = function() {

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
@@ -117,6 +117,11 @@ Refine.SeparatorBasedParserUI.prototype.getOptions = function() {
 
   options.storeBlankCellsAsNulls = this._optionContainerElmts.storeBlankCellsAsNullsCheckbox[0].checked;
   options.includeFileSources = this._optionContainerElmts.includeFileSourcesCheckbox[0].checked;
+  
+  var columnNames = this._optionContainerElmts.columnNamesInput.val();
+  if (columnNames != undefined && columnNames != null && columnNames != '') {
+      options.columnNames = columnNames.split(",");
+  }
 
   return options;
 };
@@ -136,6 +141,10 @@ Refine.SeparatorBasedParserUI.prototype._initialize = function() {
   $('#or-import-tabs').html($.i18n._('core-index-parser')["tabs"]);
   $('#or-import-custom').html($.i18n._('core-index-parser')["custom"]);
   $('#or-import-escape').html($.i18n._('core-index-parser')["escape"]);
+  $('#or-import-columnNames').html($.i18n._('core-index-parser')["column-names-label"] + ':');
+  $('#or-import-optional').html($.i18n._('core-index-parser')["column-names-optional"]);
+  
+  self._optionContainerElmts.columnNamesInput.prop('disabled', true);
   
   $('#or-import-ignore').text($.i18n._('core-index-parser')["ignore-first"]);
   $('#or-import-lines').text($.i18n._('core-index-parser')["lines-beg"]);
@@ -159,6 +168,18 @@ Refine.SeparatorBasedParserUI.prototype._initialize = function() {
         self._updatePreview();
       });
     });
+  
+  this._optionContainerElmts.headerLinesCheckbox.on("click", function() {
+      if ($(this).is(':checked')) {
+          var isDisabled = $('textbox').prop('disabled');
+          if (!isDisabled) {
+              self._optionContainerElmts.columnNamesInput.prop('disabled', true);
+              self._optionContainerElmts.columnNamesInput.val('');
+          }
+      } else {
+          self._optionContainerElmts.columnNamesInput.prop('disabled', false);
+      }
+  });
   
   var columnSeparatorValue = (this._config.separator == ",") ? 'comma' :
     ((this._config.separator == "\\t") ? 'tab' : 'custom');


### PR DESCRIPTION
Sometimes there is the need to change the column names of an importing separator based file or to add them because they are missing (without renaming individually once the file have been imported).

This option allows to define a comma separated string that will be parsed as the column names for the project. The option is only available when the "Parse next" checkbox is not selected. Selecting the "Parse next" checkbox will disable and clear the column names input box:

[demo](https://ibb.co/gxk1aU)