### PR TITLE
force the encoding to UTF8

### DIFF
--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -585,7 +585,7 @@ function process(path, request, response) {
             var urlConnection = url.openConnection();
 
             input = new Packages.java.io.BufferedReader(
-                new Packages.java.io.InputStreamReader(urlConnection.getInputStream()));
+                new Packages.java.io.InputStreamReader(urlConnection.getInputStream(), "UTF8"));
 
             output.write("/* ===== "); 
             output.write(qualifiedPath.fullPath); 


### PR DESCRIPTION
Fix issue #1717. Solution is to always read the file in UTF8. Otherwise it will cause problem on windows 10 and updated chrome.