### PR TITLE
Temporary fix for HTTP 500 errors from Wikibase. Closes #1746

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/editing/EditBatchProcessor.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/editing/EditBatchProcessor.java
@@ -192,7 +192,8 @@ public class EditBatchProcessor {
         logger.info("Requesting documents");
         currentDocs = null;
         int retries = 3;
-        while (currentDocs == null && retries > 0) {
+        // TODO: remove currentDocs.isEmpty() once https://github.com/Wikidata/Wikidata-Toolkit/issues/402 is solved
+        while ((currentDocs == null || currentDocs.isEmpty()) && retries > 0) {
             try {
                 currentDocs = fetcher.getEntityDocuments(qidsToFetch);
             } catch (MediaWikiApiErrorException e) {


### PR DESCRIPTION
This is a temporary fix until the bug is fixed upstream, in Wikidata-Toolkit.