### PR TITLE
Ignore deprecated constraints. 

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/WikidataConstraintFetcher.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/WikidataConstraintFetcher.java
@@ -39,6 +39,7 @@ import org.wikidata.wdtk.datamodel.interfaces.Snak;
 import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
+import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 import org.wikidata.wdtk.datamodel.interfaces.StringValue;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 
@@ -290,7 +291,8 @@ public class WikidataConstraintFetcher implements ConstraintFetcher {
      */
     protected Stream<Statement> getConstraintsByType(PropertyIdValue pid, String qid) {
         Stream<Statement> allConstraints = getConstraintStatements(pid).stream()
-                .filter(s -> ((EntityIdValue) s.getValue()).getId().equals(qid));
+                .filter(s -> s.getValue() != null && ((EntityIdValue) s.getValue()).getId().equals(qid))
+                .filter(s -> !StatementRank.DEPRECATED.equals(s.getRank()));
         return allConstraints;
     }
 


### PR DESCRIPTION
Closes #1772.
No tests for this one because we don't have a good way to test constraint fetching by mocking HTTP calls at the moment.