### PR TITLE
Enable autocomplete for Wikidata upload form

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.html
@@ -6,12 +6,15 @@
     <div class="perform-edits-warnings-area" bind="warningsArea">
     </div>
     <div class="wikibase-perform-edits-area">
-        <p><span bind="loggedInAs"></span> <a bind="loggedInUsername" target="_blank"></a>.</p>
-        <p><span bind="editSummaryLabel"></span> <input type="text" name="editSummary" bind="editSummary" class="edit-summary" value="" /></p>
-        <div class="wikibase-login-buttons">
-            <button class="button cancel-button" bind="cancelButton"></button>
-            <button class="button button-primary" bind="performEditsButton"></button>
-        </div>
+        <form id="wikibase-perform-edits-form" onsubmit="return false;" bind="performEditsForm" autocomplete="on">
+            <p><span bind="loggedInAs"></span> <a bind="loggedInUsername" target="_blank"></a>.</p>
+            <p><span bind="editSummaryLabel"></span> <input type="text" name="editSummary" bind="editSummary" class="edit-summary" value="" /></p>
+            <div class="wikibase-login-buttons">
+                <button class="button cancel-button" bind="cancelButton"></button>
+                <button class="button button-primary" bind="performEditsButton"></button>
+            </div>
+        </form>
+        <iframe id="hiddeniframe" src="javascript:false" class="hidden" bind="hiddenIframe"></iframe>
     </div>
   </div>
 </div>

--- a/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
@@ -30,10 +30,17 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
      dismiss();
   });
 
+  var hiddenIframe = $('#hiddenIframe').contents();
+
   if (max_severity === 'CRITICAL') {
       elmts.performEditsButton.prop("disabled",true).addClass("button-disabled");
   } else {
     elmts.performEditsButton.click(function() {
+        hiddenIframe.find('body').append(
+                elmts.performEditsForm.clone());
+        var formCopy = hiddenIframe.find("#wikibase-perform-edits-form");
+        formCopy.submit();
+
         if(elmts.editSummary.val().length == 0) {
             elmts.editSummary.focus();
         } else {
@@ -51,6 +58,7 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
                 }
             });
         }
+        event.preventDefault();
     });
   }
 };


### PR DESCRIPTION
Summaries are remembered and proposed natively to the user in the summary field.
Closes #1778.