### PR TITLE
Fix cell index computation in filldown/blankdown

### DIFF
--- a/main/src/com/google/refine/operations/cell/BlankDownOperation.java
+++ b/main/src/com/google/refine/operations/cell/BlankDownOperation.java
@@ -103,6 +103,7 @@ public class BlankDownOperation extends EngineDependentMassCellOperation {
         
         return new RowVisitor() {
             int                 cellIndex;
+            int 			    keyCellIndex;
             List<CellChange>    cellChanges;
             Cell                previousCell;
             Mode                engineMode;
@@ -116,7 +117,8 @@ public class BlankDownOperation extends EngineDependentMassCellOperation {
 
             @Override
             public void start(Project project) {
-                // nothing to do
+            	keyCellIndex = project.columnModel.columns.get(
+                		project.columnModel.getKeyColumnIndex()).getCellIndex();
             }
 
             @Override
@@ -126,7 +128,7 @@ public class BlankDownOperation extends EngineDependentMassCellOperation {
             
             @Override
             public boolean visit(Project project, int rowIndex, Row row) {
-                if (engineMode.equals(Mode.RecordBased) && ExpressionUtils.isNonBlankData(row.getCellValue(0))) {
+                if (engineMode.equals(Mode.RecordBased) && ExpressionUtils.isNonBlankData(row.getCellValue(keyCellIndex))) {
                     previousCell = null;
                 }
                 Object value = row.getCellValue(cellIndex);

--- a/main/src/com/google/refine/operations/cell/FillDownOperation.java
+++ b/main/src/com/google/refine/operations/cell/FillDownOperation.java
@@ -105,6 +105,7 @@ public class FillDownOperation extends EngineDependentMassCellOperation {
         
         return new RowVisitor() {
             int                 cellIndex;
+            int 			    keyCellIndex;
             List<CellChange>    cellChanges;
             Cell                previousCell;
             Mode                engineMode;
@@ -118,7 +119,8 @@ public class FillDownOperation extends EngineDependentMassCellOperation {
             
             @Override
             public void start(Project project) {
-                // nothing to do
+                keyCellIndex = project.columnModel.columns.get(
+                		project.columnModel.getKeyColumnIndex()).getCellIndex();
             }
 
             @Override
@@ -129,7 +131,7 @@ public class FillDownOperation extends EngineDependentMassCellOperation {
             @Override
             public boolean visit(Project project, int rowIndex, Row row) {
                 Object value = row.getCellValue(cellIndex);
-                if (engineMode.equals(Mode.RecordBased) && ExpressionUtils.isNonBlankData(row.getCellValue(0))) {
+                if (engineMode.equals(Mode.RecordBased) && ExpressionUtils.isNonBlankData(row.getCellValue(keyCellIndex))) {
                     previousCell = null;
                 }
                 if (ExpressionUtils.isNonBlankData(value)) {

--- a/main/tests/server/src/com/google/refine/tests/operations/cell/BlankDownTests.java
+++ b/main/tests/server/src/com/google/refine/tests/operations/cell/BlankDownTests.java
@@ -1,5 +1,7 @@
 package com.google.refine.tests.operations.cell;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import org.json.JSONException;
@@ -13,12 +15,16 @@ import org.testng.annotations.Test;
 import com.google.refine.ProjectManager;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.Column;
 import com.google.refine.model.Project;
+import com.google.refine.model.Row;
 import com.google.refine.operations.OperationRegistry;
 import com.google.refine.operations.cell.BlankDownOperation;
+import com.google.refine.operations.cell.FillDownOperation;
 import com.google.refine.process.Process;
 import com.google.refine.tests.RefineTest;
 import com.google.refine.tests.util.TestUtils;
+import com.google.refine.util.Pool;
 
 public class BlankDownTests extends RefineTest {
     
@@ -80,5 +86,32 @@ public class BlankDownTests extends RefineTest {
         Assert.assertNull(project.rows.get(1).cells.get(2));
         Assert.assertNull(project.rows.get(2).cells.get(2));
         Assert.assertNull(project.rows.get(3).cells.get(2));
+    }
+    
+    @Test
+    public void testKeyColumnIndex() throws Exception {
+    	// Shift all column indices
+    	for(Row r : project.rows) {
+    		r.cells.add(0, null);
+    	}
+    	List<Column> newColumns = new ArrayList<>();
+    	for(Column c : project.columnModel.columns) {
+    		newColumns.add(new Column(c.getCellIndex()+1, c.getName()));
+    	}
+    	project.columnModel.columns.clear();
+    	project.columnModel.columns.addAll(newColumns);
+    	project.columnModel.update();
+    	
+    	AbstractOperation op = new BlankDownOperation(
+                EngineConfig.reconstruct(new JSONObject("{\"mode\":\"record-based\",\"facets\":[]}")),
+                "second");
+        Process process = op.createProcess(project, new Properties());
+        process.performImmediate();
+        //project.saveToOutputStream(System.out, new Pool());
+        
+        Assert.assertEquals("c", project.rows.get(0).cells.get(3).value);
+        Assert.assertNull(project.rows.get(1).cells.get(3));
+        Assert.assertEquals("c", project.rows.get(2).cells.get(3).value);
+        Assert.assertNull(project.rows.get(3).cells.get(3));
     }
 }


### PR DESCRIPTION
So the fill down and blank down incorrectly assumed that the first column had cell index 0, which gave the weird bugs observed in #1573. This should fix it.

@msaby can you confirm this fixes the issue on your side?