### PR TITLE
Streamline Eclipse setup with Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you have cloned this repository to your computer, you can run OpenRefine with
 * `./refine` on Mac OS and Linux
 * `refine.bat` on Windows
 
-This requires JDK 8 and Apache Ant.
+This requires JDK 8 and Apache Maven.
 
 Documentation and Videos
 -------------------------

--- a/extensions/database/pom.xml
+++ b/extensions/database/pom.xml
@@ -2,10 +2,8 @@
 	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.openrefine</groupId>
   <artifactId>database</artifactId>
   <packaging>jar</packaging>
-  <version>3.1-SNAPSHOT</version>
 
   <name>OpenRefine - Database extension</name>
   <description>Connections to SQL databases for import and export</description>

--- a/extensions/gdata/pom.xml
+++ b/extensions/gdata/pom.xml
@@ -2,10 +2,8 @@
 	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.openrefine</groupId>
   <artifactId>gdata</artifactId>
   <packaging>jar</packaging>
-  <version>3.1-SNAPSHOT</version>
 
   <name>OpenRefine - Gdata extension</name>
   <description>Connects with Google services for data import and export</description>

--- a/extensions/pc-axis/pom.xml
+++ b/extensions/pc-axis/pom.xml
@@ -2,10 +2,8 @@
 	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.openrefine</groupId>
   <artifactId>pc-axis</artifactId>
   <packaging>jar</packaging>
-  <version>3.1-SNAPSHOT</version>
 
   <name>OpenRefine - PC-axis extension</name>
   <description>OpenRefine integration of PC-axis</description>

--- a/extensions/wikidata/pom.xml
+++ b/extensions/wikidata/pom.xml
@@ -2,10 +2,8 @@
 	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.openrefine</groupId>
   <artifactId>wikidata</artifactId>
   <packaging>jar</packaging>
-  <version>3.1-SNAPSHOT</version>
 
   <name>OpenRefine - Wikidata extension</name>
   <description>Schema alignment and data upload for Wikidata</description>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -2,10 +2,8 @@
 	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.openrefine</groupId>
   <artifactId>main</artifactId>
   <packaging>jar</packaging>
-  <version>3.1-SNAPSHOT</version>
 
   <name>OpenRefine - main</name>
   <description>OpenRefine is a free, open source power tool for working with messy data and improving it</description>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -1,10 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.openrefine</groupId>
   <artifactId>packaging</artifactId>
-  <version>3.1-SNAPSHOT</version>
-
   <name>OpenRefine - packaging</name>
   <description>Creates packages for all supported operating systems</description>
   <url>http://openrefine.org/</url>
@@ -218,6 +215,39 @@
       </plugin>
 
     </plugins>
+    <pluginManagement>
+    	<plugins>
+    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+    		<plugin>
+    			<groupId>org.eclipse.m2e</groupId>
+    			<artifactId>lifecycle-mapping</artifactId>
+    			<version>1.0.0</version>
+    			<configuration>
+    				<lifecycleMappingMetadata>
+    					<pluginExecutions>
+    						<pluginExecution>
+    							<pluginExecutionFilter>
+    								<groupId>
+    									org.apache.maven.plugins
+    								</groupId>
+    								<artifactId>
+    									maven-antrun-plugin
+    								</artifactId>
+    								<versionRange>[1.4,)</versionRange>
+    								<goals>
+    									<goal>run</goal>
+    								</goals>
+    							</pluginExecutionFilter>
+    							<action>
+    								<ignore></ignore>
+    							</action>
+    						</pluginExecution>
+    					</pluginExecutions>
+    				</lifecycleMappingMetadata>
+    			</configuration>
+    		</plugin>
+    	</plugins>
+    </pluginManagement>
   </build>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -150,9 +150,68 @@
                 </configuration>
 
       </plugin>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+        	<groupId>org.eclipse.m2e</groupId>
+        	<artifactId>lifecycle-mapping</artifactId>
+        	<version>1.0.0</version>
+        	<configuration>
+        		<lifecycleMappingMetadata>
+        			<pluginExecutions>
+        				<pluginExecution>
+        					<pluginExecutionFilter>
+        						<groupId>
+        							org.apache.maven.plugins
+        						</groupId>
+        						<artifactId>
+        							maven-install-plugin
+        						</artifactId>
+        						<versionRange>[2.5.2,)</versionRange>
+        						<goals>
+        							<goal>install-file</goal>
+        						</goals>
+        					</pluginExecutionFilter>
+        					<action>
+        						<ignore></ignore>
+        					</action>
+        				</pluginExecution>
+        			</pluginExecutions>
+        		</lifecycleMappingMetadata>
+        	</configuration>
+        </plugin>
+
     </plugins>
     <pluginManagement>
       <plugins>
+      <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+      	<plugin>
+      	<groupId>org.eclipse.m2e</groupId>
+      	<artifactId>lifecycle-mapping</artifactId>
+      	<version>1.0.0</version>
+      	<configuration>
+      		<lifecycleMappingMetadata>
+      			<pluginExecutions>
+      				<pluginExecution>
+      					<pluginExecutionFilter>
+      						<groupId>
+      							org.apache.maven.plugins
+      						</groupId>
+      						<artifactId>
+      							maven-install-plugin
+      						</artifactId>
+      						<versionRange>[2.5.2,)</versionRange>
+      						<goals>
+      							<goal>install-file</goal>
+      						</goals>
+      					</pluginExecutionFilter>
+      					<action>
+      						<ignore></ignore>
+      					</action>
+      				</pluginExecution>
+      			</pluginExecutions>
+      		</lifecycleMappingMetadata>
+      	</configuration>
+      	</plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -72,6 +72,16 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.3</version>
+        <configuration>
+          <mainClass>com.google.refine.Refine</mainClass>
+          <commandlineArgs>-Drefine.headless=true -Drefine.autoreload=true -Dbutterfly.autoreload=true -Drefine.memory=1400M -Drefine.port=3333 -Drefine.host=127.0.0.1</commandlineArgs>
+          <skip>false</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.0</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -2,10 +2,8 @@
 	 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.openrefine</groupId>
   <artifactId>server</artifactId>
   <packaging>jar</packaging>
-  <version>3.1-SNAPSHOT</version>
 
   <name>OpenRefine - server</name>
   <description>OpenRefine is a free, open source power tool for working with messy data and improving it</description>
@@ -125,6 +123,35 @@
                 </configuration>
                 </execution>
             </executions>
+        </plugin>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+        	<groupId>org.eclipse.m2e</groupId>
+        	<artifactId>lifecycle-mapping</artifactId>
+        	<version>1.0.0</version>
+        	<configuration>
+        		<lifecycleMappingMetadata>
+        			<pluginExecutions>
+        				<pluginExecution>
+        					<pluginExecutionFilter>
+        						<groupId>
+        							org.apache.maven.plugins
+        						</groupId>
+        						<artifactId>
+        							maven-install-plugin
+        						</artifactId>
+        						<versionRange>[2.5.2,)</versionRange>
+        						<goals>
+        							<goal>install-file</goal>
+        						</goals>
+        					</pluginExecutionFilter>
+        					<action>
+        						<ignore></ignore>
+        					</action>
+        				</pluginExecution>
+        			</pluginExecutions>
+        		</lifecycleMappingMetadata>
+        	</configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This tweaks the Maven configuration files so that they are better accepted by Eclipse.
To run OpenRefine from Eclipse, add a new maven execution goal profile with "exec:java" as goal.
It is also possible to run OpenRefine from command line with `mvn compile test-compile exec:java`.

This closes #1805.