### PR TITLE
Make dialog containers start from 10% from top

### DIFF
--- a/main/webapp/modules/core/scripts/util/dialog.js
+++ b/main/webapp/modules/core/scripts/util/dialog.js
@@ -47,7 +47,8 @@ DialogSystem.showDialog = function(elmt, onCancel) {
   .appendTo(document.body);
 
   elmt.css("visibility", "hidden").appendTo(container);
-  container.css("top", Math.round((overlay.height() - elmt.height()) / 2) + "px");
+  container.css("top", "10%");
+//  container.css("top", Math.round((overlay.height() - elmt.height()) / 2) + "px");
   elmt.css("visibility", "visible");
 
   container.draggable({ handle: '.dialog-header', cursor: 'move' });


### PR DESCRIPTION
...instead of our current vertical centering approach, which sometimes cuts off longer dialogs like "Select Encoding" on users with smaller screen sizes that sometimes occur during projecting for training.

Fixes issue #1812 