### PR TITLE
Add exception handling for "refine" command

### DIFF
--- a/refine.bat
+++ b/refine.bat
@@ -184,7 +184,8 @@ set REFINE_LIB_DIR=server\target\lib
 rem ----- Respond to the action ----------------------------------------------------------
 
 set ACTION=%1
-
+setlocal
+%@Try%
 if ""%ACTION%"" == ""build"" goto doMvn
 if ""%ACTION%"" == ""server_test"" goto doMvn
 if ""%ACTION%"" == ""extensions_test"" goto doMvn
@@ -192,6 +193,11 @@ if ""%ACTION%"" == ""test"" goto doMvn
 if ""%ACTION%"" == ""clean"" goto doMvn
 if ""%ACTION%"" == ""distclean"" goto doMvn
 if ""%ACTION%"" == ""run"" goto doRun
+%@EndTry%
+:@Catch
+  echo Unknown Refine command called "%1", type "refine /?" for proper usage.
+  exit /B 1
+:@EndCatch
 
 :doRun
 rem --- Log for troubleshooting ------------------------------------------


### PR DESCRIPTION
We should be more graceful for those that mistype a refine command.  As I sometimes do and inadvertently start OpenRefine, since :doRun is the default.
(someone else can do the PR for the same thing in the bash script)

Tested Output is:

```console
C:\Users\THAD\OpenRefine>set ACTION=reset
C:\Users\THAD\OpenRefine>setlocal
C:\Users\THAD\OpenRefine>if ""reset"" == ""build"" goto doMvn
C:\Users\THAD\OpenRefine>if ""reset"" == ""server_test"" goto doMvn
C:\Users\THAD\OpenRefine>if ""reset"" == ""extensions_test"" goto doMvn
C:\Users\THAD\OpenRefine>if ""reset"" == ""test"" goto doMvn
C:\Users\THAD\OpenRefine>if ""reset"" == ""clean"" goto doMvn
C:\Users\THAD\OpenRefine>if ""reset"" == ""distclean"" goto doMvn
C:\Users\THAD\OpenRefine>if ""reset"" == ""run"" goto doRun
C:\Users\THAD\OpenRefine>if ""reset"" == """" goto doRun
C:\Users\THAD\OpenRefine>echo Unknown Refine command called "reset" , type "refine /?" for proper usage
Unknown Refine command called "reset" , type "refine /?" for proper usage
C:\Users\THAD\OpenRefine>exit /B 1
C:\Users\THAD\OpenRefine>
```