### PR TITLE
Increment size of Wikidata edit batch ids

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/operations/PerformWikibaseEditsOperation.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/operations/PerformWikibaseEditsOperation.java
@@ -194,7 +194,7 @@ public class PerformWikibaseEditsOperation extends EngineDependentOperation {
             // Generate batch token
             long token = (new Random()).nextLong();
             String summary = _summary + String.format(" ([[:toollabs:editgroups/b/OR/%s|details]])",
-                    (Long.toHexString(token).substring(0, 7)));
+                    (Long.toHexString(token).substring(0, 8)));
 
             // Evaluate the schema
             List<ItemUpdate> itemDocuments = _schema.evaluate(_project, _engine);


### PR DESCRIPTION
This adds one hex digit to each edit group id on Wikidata. My intention is to do this for the next few major versions, so that we can easily tell which OpenRefine was used to upload a given batch.