### PR TITLE
Fix zip slip vulnerability

### DIFF
--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -440,7 +440,11 @@ public class ImportingUtilities {
             name = name.substring(0, q);
         }
         
-        File file = new File(dir, name);
+        File file = new File(dir, name);     
+        // For CVE-2018-19859, issue #1840
+        if (!file.toPath().normalize().startsWith(dir.toPath().normalize())) {
+        	throw new IllegalArgumentException("Zip archives with files escaping their root directory are not allowed.");
+        }
         
         int dot = name.indexOf('.');
         String prefix = dot < 0 ? name : name.substring(0, dot);

--- a/main/tests/server/src/com/google/refine/tests/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/tests/importing/ImportingUtilitiesTests.java
@@ -36,6 +36,12 @@ public class ImportingUtilitiesTests extends ImporterTest {
         Assert.assertTrue(pm.getTags().length == 0);
     }
     
+    @Test(expectedExceptions=IllegalArgumentException.class)
+    public void testZipSlip() {
+        // For CVE-2018-19859, issue #1840
+    	ImportingUtilities.allocateFile(workspaceDir, "../../script.sh");
+    }
+    
     private ObjectNode getNestedOptions(ImportingJob job, TreeImportingParserBase parser) {
         ObjectNode options = parser.createParserUIInitializationData(
                 job, new LinkedList<>(), "text/json");

--- a/main/tests/server/src/com/google/refine/tests/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/tests/importing/ImportingUtilitiesTests.java
@@ -1,6 +1,8 @@
 
 package com.google.refine.tests.importing;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.LinkedList;
 
 import org.testng.Assert;
@@ -14,6 +16,7 @@ import com.google.refine.importers.tree.TreeImportingParserBase;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingUtilities;
 import com.google.refine.tests.importers.ImporterTest;
+import com.google.refine.tests.util.TestUtils;
 import com.google.refine.util.JSONUtilities;
 import com.google.refine.util.ParsingUtilities;
 
@@ -37,9 +40,10 @@ public class ImportingUtilitiesTests extends ImporterTest {
     }
     
     @Test(expectedExceptions=IllegalArgumentException.class)
-    public void testZipSlip() {
+    public void testZipSlip() throws IOException {
+    	File tempDir = TestUtils.createTempDirectory("openrefine-zip-slip-test");
         // For CVE-2018-19859, issue #1840
-    	ImportingUtilities.allocateFile(workspaceDir, "../../script.sh");
+    	ImportingUtilities.allocateFile(tempDir, "../../tmp/script.sh");
     }
     
     private ObjectNode getNestedOptions(ImportingJob job, TreeImportingParserBase parser) {


### PR DESCRIPTION
Closes #1840. Also protects other importing sources (such as tar archives) from this sort of vulnerability as the `allocateFile` function is used at various places.