### PR TITLE
Add Common transform which replaces smart quotes with ascii equivalent

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -604,6 +604,7 @@
     "core-views/trim-all": "Trim leading and trailing whitespace",
     "core-views/collapse-white": "Collapse consecutive whitespace",
     "core-views/unescape-html": "Unescape HTML entities",
+    "core-views/replace-smartquotes": "Replace Smart quotes with ascii",
     "core-views/titlecase": "To titlecase",
     "core-views/uppercase": "To uppercase",
     "core-views/lowercase": "To lowercase",

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
@@ -384,6 +384,11 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           label: $.i18n('core-views/unescape-html'),
           click: function() { doTextTransform("value.unescape('html')", "keep-original", true, 10); }
         },
+        {
+          id: "core/replace-smartquotes",
+          label: $.i18n('core-views/replace-smartquotes'),
+          click: function() { doTextTransform("value.replace(/[\u2018\u2019\u201A\u201B\u2039\u203A\u201A]/,\"\\\'\").replace(/[\u201C\u201D\u00AB\u00BB\u201E]/,\"\\\"\")", "keep-original", false, ""); }
+        },
         {},
         {
           id: "core/to-titlecase",


### PR DESCRIPTION
Adding new 'Common transform' in response to #1676. This is a trivial change, my only concern is that the list of "common transforms" that people might want to have from this menu is essentially endless. I feel that adding this one is fine, but feel there is some need here to have something easily extensible that doesn't require adding code to add things to this list (maybe hooked into 'starred' transforms?)

@thadguidry @ettorerizza comments welcome