### PR TITLE
Index terms by language code in ItemUpdate.

### DIFF
--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/updates/ItemUpdateTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/updates/ItemUpdateTest.java
@@ -156,4 +156,14 @@ public class ItemUpdateTest {
                 .addLabel(aliasFr).build();
         assertEquals(expectedUpdate, normalized);
     }
+    
+    @Test
+    public void testMergeLabels() {
+    	MonolingualTextValue label1 = Datamodel.makeMonolingualTextValue("first label", "en");
+        MonolingualTextValue label2 = Datamodel.makeMonolingualTextValue("second label", "en");
+        ItemUpdate update1 = new ItemUpdateBuilder(existingSubject).addLabel(label1).build();
+        ItemUpdate update2 = new ItemUpdateBuilder(existingSubject).addLabel(label2).build();
+        ItemUpdate merged = update1.merge(update2);
+        assertEquals(Collections.singleton(label2), merged.getLabels());
+    }
 }


### PR DESCRIPTION
Fixes #1917. This makes it possible to override labels, descriptions and add aliases multiple times in the same batch.