### PR TITLE
Reorder reconciliation results by decreasing score

### DIFF
--- a/main/src/com/google/refine/model/recon/StandardReconConfig.java
+++ b/main/src/com/google/refine/model/recon/StandardReconConfig.java
@@ -41,6 +41,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -524,6 +525,14 @@ public class StandardReconConfig extends ReconConfig {
     protected Recon createReconServiceResults(String text, ArrayNode resultsList, long historyEntryID) throws IOException {
         Recon recon = new Recon(historyEntryID, identifierSpace, schemaSpace);
         List<ReconResult> results = ParsingUtilities.mapper.convertValue(resultsList, new TypeReference<List<ReconResult>>() {});
+        
+        // Sort results by decreasing score
+        results.sort(new Comparator<ReconResult>() {
+        	@Override
+        	public int compare(ReconResult a, ReconResult b) {
+        		return Double.compare(b.score, a.score);
+        	}
+        });
         
         int length = results.size();
         int count = 0;

--- a/main/tests/server/src/com/google/refine/tests/model/recon/StandardReconConfigTests.java
+++ b/main/tests/server/src/com/google/refine/tests/model/recon/StandardReconConfigTests.java
@@ -270,4 +270,54 @@ public class StandardReconConfigTests extends RefineTest {
     	assertTrue(recon.candidates.get(0).score > 0.2);
     	assertEquals(recon.candidates.get(0).id, "102271932");
     }
+    
+    @Test
+    public void reorderReconciliationResultsStableSort() throws JsonParseException, JsonMappingException, IOException {
+    	String viafJson = " [\n" + 
+    			"\n" + 
+    			"    {\n" + 
+    			"        \"id\": \"18951129\",\n" + 
+    			"        \"name\": \"Varano, Camilla Battista da 1458-1524\",\n" + 
+    			"        \"type\": [\n" + 
+    			"            {\n" + 
+    			"                \"id\": \"/people/person\",\n" + 
+    			"                \"name\": \"Person\"\n" + 
+    			"            }\n" + 
+    			"        ],\n" + 
+    			"        \"score\": 0.3,\n" + 
+    			"        \"match\": false\n" + 
+    			"    },\n" + 
+    			"    {\n" + 
+    			"        \"id\": \"102271932\",\n" + 
+    			"        \"name\": \"Shamsie, Kamila, 1973-....\",\n" + 
+    			"        \"type\": [\n" + 
+    			"            {\n" + 
+    			"                \"id\": \"/people/person\",\n" + 
+    			"                \"name\": \"Person\"\n" + 
+    			"            }\n" + 
+    			"        ],\n" + 
+    			"        \"score\": 0.23076923076923078,\n" + 
+    			"        \"match\": false\n" + 
+    			"    },\n" + 
+    			"    {\n" + 
+    			"        \"id\": \"63233597\",\n" + 
+    			"        \"name\": \"Camilla, Duchess of Cornwall, 1947-\",\n" + 
+    			"        \"type\": [\n" + 
+    			"            {\n" + 
+    			"                \"id\": \"/people/person\",\n" + 
+    			"                \"name\": \"Person\"\n" + 
+    			"            }\n" + 
+    			"        ],\n" + 
+    			"        \"score\": 0.3,\n" + 
+    			"        \"match\": false\n" + 
+    			"    }\n" + 
+    			"\n" + 
+    			"]";
+    	
+    	StandardReconConfigStub stub = new StandardReconConfigStub();
+    	ArrayNode node = ParsingUtilities.mapper.readValue(viafJson, ArrayNode.class);
+    	Recon recon = stub.createReconServiceResults("Kamila", node, 1234L);
+    	assertEquals(recon.candidates.get(0).score, 0.3);
+    	assertEquals(recon.candidates.get(0).id, "18951129");
+    }
 }


### PR DESCRIPTION
Fixes #1913.

Reconciliation services should still return results ordered by decreasing score for compatibility with OpenRefine <= 3.1, I have updated the wiki about that:
https://github.com/OpenRefine/OpenRefine/wiki/Reconciliation-Service-API