### PR TITLE
Make suggest items clickable with the middle button.

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/schema-alignment-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/schema-alignment-dialog.js
@@ -802,6 +802,10 @@ SchemaAlignmentDialog._initField = function(inputContainer, mode, initialValue, 
     var suggestConfig = $.extend({}, endpoint);
     suggestConfig.key = null;
     suggestConfig.query_param_name = "prefix";
+    if ('view' in this._reconService && 'url' in this._reconService.view && !('view_url' in endpoint)) {
+       suggestOptions.view_url = this._reconService.view.url;
+    }
+
 
     input.suggestP(suggestConfig).bind("fb-select", function(evt, data) {
         inputContainer.data("jsonValue", {
@@ -820,6 +824,9 @@ SchemaAlignmentDialog._initField = function(inputContainer, mode, initialValue, 
     var suggestConfig = $.extend({}, endpoint);
     suggestConfig.key = null;
     suggestConfig.query_param_name = "prefix";
+    if ('view' in this._reconService && 'url' in this._reconService.view && !('view_url' in endpoint)) {
+       suggestOptions.view_url = this._reconService.view.url;
+    }
 
     input.suggestP(suggestConfig).bind("fb-select", function(evt, data) {
         inputContainer.data("jsonValue", {

--- a/extensions/wikidata/module/scripts/dialogs/schema-alignment-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/schema-alignment-dialog.js
@@ -803,11 +803,11 @@ SchemaAlignmentDialog._initField = function(inputContainer, mode, initialValue, 
     suggestConfig.key = null;
     suggestConfig.query_param_name = "prefix";
     if ('view' in this._reconService && 'url' in this._reconService.view && !('view_url' in endpoint)) {
-       suggestOptions.view_url = this._reconService.view.url;
+       suggestConfig.view_url = this._reconService.view.url;
     }
 
 
-    input.suggestP(suggestConfig).bind("fb-select", function(evt, data) {
+    input.suggest(suggestConfig).bind("fb-select", function(evt, data) {
         inputContainer.data("jsonValue", {
             type : "wbitemconstant",
             qid : data.id,
@@ -824,9 +824,6 @@ SchemaAlignmentDialog._initField = function(inputContainer, mode, initialValue, 
     var suggestConfig = $.extend({}, endpoint);
     suggestConfig.key = null;
     suggestConfig.query_param_name = "prefix";
-    if ('view' in this._reconService && 'url' in this._reconService.view && !('view_url' in endpoint)) {
-       suggestOptions.view_url = this._reconService.view.url;
-    }
 
     input.suggestP(suggestConfig).bind("fb-select", function(evt, data) {
         inputContainer.data("jsonValue", {

--- a/main/webapp/modules/core/externals/suggest/suggest-4_3.js
+++ b/main/webapp/modules/core/externals/suggest/suggest-4_3.js
@@ -1303,7 +1303,7 @@
       // clicking with the middle button sends the user to
       // the view page.
       if('view_url' in this.options && data.id) {
-        var view_url = this.options.view_url.replace('{{id}}', data.id);
+        var view_url = this.options.view_url.replace('{{id}}', data.id).replace('${id}', data.id);
         li.on('mousedown', function(e) {
            if (e.which == 2) {
               var win = window.open(view_url, '_blank');

--- a/main/webapp/modules/core/externals/suggest/suggest-4_3.js
+++ b/main/webapp/modules/core/externals/suggest/suggest-4_3.js
@@ -1299,6 +1299,20 @@
           name.append($("<span></span>").text(data.description));
       }
 
+      // If we know of a view URL for this suggest service,
+      // clicking with the middle button sends the user to
+      // the view page.
+      if('view_url' in this.options && data.id) {
+        var view_url = this.options.view_url.replace('{{id}}', data.id);
+        li.on('mousedown', function(e) {
+           if (e.which == 2) {
+              var win = window.open(view_url, '_blank');
+              win.focus();
+              e.preventDefault();
+           }
+        });
+      }
+
       //console.log("create_item", li);
       return li;
     },

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -200,6 +200,9 @@ DataTableCellUI.prototype._render = function() {
         var addSuggest = false;
         if ((service) && (service.suggest) && (service.suggest.entity)) {
           suggestOptions = service.suggest.entity;
+          if ('view' in service && 'url' in service.view && !('view_url' in suggestOptions)) {
+            suggestOptions.view_url = service.view.url;
+          }
           addSuggest = true;
         }
 

--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -85,6 +85,9 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     if (service && service.suggest && service.suggest.entity) {
        suggestOptions = $.extend({}, service.suggest.entity);
        suggestOptions.query_param_name = "prefix";
+       if ('view' in service && 'url' in service.view && !('view_url' in suggestOptions)) {
+          suggestOptions.formatter_url = service.view.url;
+       }
     }
 
     var frame = DialogSystem.createDialog();


### PR DESCRIPTION
Clicking on an item with the middle button leads the user to the page
for this item. This lets users inspect items without selecting them.

By default this is only enabled on suggest widgets for entities (not for types or properties) because reconciliation services do not declare view URLs for types or properties so far. The view URL for entities is derived from the main view URL for reconciliation results.

Reconciliation services can now declare view URLs for all three sorts of suggested things (entities, properties and types) by adding a `view_url` field in the definition of their suggest widgets as follows:

```
entity: {
"service_url": "https://tools.wmflabs.org/openrefine-wikidata",
"service_path": "/en/suggest/entity",
"flyout_service_path": "/en/flyout/entity?id=${id}",
"view_url": "https://www.wikidata.org/wiki/${id}",
}
```

I will update the docs about that once this is merged.

Closes #1934.