### PR TITLE
 Show reconciliation previews on hover of reconciliation candidates 

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -108,7 +108,7 @@ DataTableCellUI.prototype._render = function() {
         a.attr("href", encodeURI(service.view.url.replace("{{id}}", match.id)));
       }
 
-      self._previewOnHover(service, match, a, false);
+      self._previewOnHover(service, match, a, a, false);
 
       $('<span> </span>').appendTo(divContent);
       $('<a href="javascript:{}"></a>')
@@ -153,7 +153,7 @@ DataTableCellUI.prototype._render = function() {
               a.attr("href", encodeURI(service.view.url.replace("{{id}}", candidate.id)));
             }
 
-            self._previewOnHover(service, candidate, liSpan, true);
+            self._previewOnHover(service, candidate, liSpan.parent(), liSpan, true);
 
             var score;
             if (candidate.score < 1) {
@@ -475,7 +475,7 @@ DataTableCellUI.prototype._previewCandidateTopic = function(candidate, elmt, pre
 /**
  * Sets up a preview widget to appear when hovering the given DOM element.
  */
-DataTableCellUI.prototype._previewOnHover = function(service, candidate, element, showActions) {
+DataTableCellUI.prototype._previewOnHover = function(service, candidate, hoverElement, coreElement, showActions) {
     var self = this;
     var preview = null;
     if ((service) && (service.preview)) {
@@ -484,9 +484,9 @@ DataTableCellUI.prototype._previewOnHover = function(service, candidate, element
 
     if (preview) {
         var dismissCallback = null;
-        element.hover(function(evt) {
+        hoverElement.hover(function(evt) {
         if (!evt.metaKey && !evt.ctrlKey) {
-            dismissCallback = self._previewCandidateTopic(candidate, this, preview, showActions);
+            dismissCallback = self._previewCandidateTopic(candidate, coreElement, preview, showActions);
             evt.preventDefault();
         }
         }, function(evt) {

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -41,6 +41,23 @@ function DataTableCellUI(dataTableView, cell, rowIndex, cellIndex, td) {
   this._render();
 }
 
+DataTableCellUI.previewMatchedCells = true;
+
+(function() {
+   
+   $.ajax({
+     url: "command/core/get-preference?" + $.param({
+        name: "cell-ui.previewMatchedCells"
+     }),
+    success: function(data) {
+      if (data.value && data.value == "false") {
+        DataTableCellUI.previewMatchedCells = false;
+     }
+   },
+   dataType: "json",
+  });
+})();
+
 DataTableCellUI.prototype._render = function() {
   var self = this;
   var cell = this._cell;
@@ -108,7 +125,9 @@ DataTableCellUI.prototype._render = function() {
         a.attr("href", encodeURI(service.view.url.replace("{{id}}", match.id)));
       }
 
-      self._previewOnHover(service, match, a, a, false);
+      if (DataTableCellUI.previewMatchedCells) {
+        self._previewOnHover(service, match, a, a, false);
+      }
 
       $('<span> </span>').appendTo(divContent);
       $('<a href="javascript:{}"></a>')

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -108,7 +108,7 @@ DataTableCellUI.prototype._render = function() {
         a.attr("href", encodeURI(service.view.url.replace("{{id}}", match.id)));
       }
 
-      self._previewOnHover(service, match, a);
+      self._previewOnHover(service, match, a, false);
 
       $('<span> </span>').appendTo(divContent);
       $('<a href="javascript:{}"></a>')
@@ -153,7 +153,7 @@ DataTableCellUI.prototype._render = function() {
               a.attr("href", encodeURI(service.view.url.replace("{{id}}", candidate.id)));
             }
 
-            self._previewOnHover(service, candidate, liSpan);
+            self._previewOnHover(service, candidate, liSpan, true);
 
             var score;
             if (candidate.score < 1) {
@@ -418,15 +418,18 @@ DataTableCellUI.prototype._postProcessSeveralCells = function(command, params, b
   );
 };
 
-DataTableCellUI.prototype._previewCandidateTopic = function(candidate, elmt, preview) {
+DataTableCellUI.prototype._previewCandidateTopic = function(candidate, elmt, preview, showActions) {
   var self = this;
   var id = candidate.id;
   var fakeMenu = $('<div></div>')
         .addClass("menu-container");
   fakeMenu
   .width(preview.width?preview.width:414)
-  .addClass('data-table-topic-popup')
-  .html(DOM.loadHTML("core", "scripts/views/data-table/cell-recon-preview-popup-header.html"));
+  .addClass('data-table-topic-popup');
+  if (showActions) {
+    fakeMenu
+      .html(DOM.loadHTML("core", "scripts/views/data-table/cell-recon-preview-popup-header.html"));
+  }
 
   if (preview && preview.url) { // Service has a preview URL associated with it
     var url = encodeURI(preview.url.replace("{{id}}", id));
@@ -447,30 +450,32 @@ DataTableCellUI.prototype._previewCandidateTopic = function(candidate, elmt, pre
      fakeMenu.unbind();  
   };
 
-  var elmts = DOM.bind(fakeMenu);
-  
-  elmts.matchButton.html($.i18n('core-views/match-cell'));
-  elmts.matchSimilarButton.html($.i18n('core-views/match-identical'));
-  elmts.cancelButton.html($.i18n('core-buttons/cancel'));
-  
-  elmts.matchButton.click(function() {
-    self._doMatchTopicToOneCell(candidate);
-    dismissMenu();
-  });
-  elmts.matchSimilarButton.click(function() {
-    self._doMatchTopicToSimilarCells(candidate);
-    dismissMenu();
-  });
-  elmts.cancelButton.click(function() {
-    dismissMenu();
-  });
+  if (showActions) {
+    var elmts = DOM.bind(fakeMenu);
+    
+    elmts.matchButton.html($.i18n('core-views/match-cell'));
+    elmts.matchSimilarButton.html($.i18n('core-views/match-identical'));
+    elmts.cancelButton.html($.i18n('core-buttons/cancel'));
+    
+    elmts.matchButton.click(function() {
+        self._doMatchTopicToOneCell(candidate);
+        dismissMenu();
+    });
+    elmts.matchSimilarButton.click(function() {
+        self._doMatchTopicToSimilarCells(candidate);
+        dismissMenu();
+    });
+    elmts.cancelButton.click(function() {
+        dismissMenu();
+    });
+  }
   return dismissMenu;
 };
 
 /**
  * Sets up a preview widget to appear when hovering the given DOM element.
  */
-DataTableCellUI.prototype._previewOnHover = function(service, candidate, element) {
+DataTableCellUI.prototype._previewOnHover = function(service, candidate, element, showActions) {
     var self = this;
     var preview = null;
     if ((service) && (service.preview)) {
@@ -481,7 +486,7 @@ DataTableCellUI.prototype._previewOnHover = function(service, candidate, element
         var dismissCallback = null;
         element.hover(function(evt) {
         if (!evt.metaKey && !evt.ctrlKey) {
-            dismissCallback = self._previewCandidateTopic(candidate, this, preview);
+            dismissCallback = self._previewCandidateTopic(candidate, this, preview, showActions);
             evt.preventDefault();
         }
         }, function(evt) {

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -298,6 +298,13 @@ a.data-table-flag-off {
   padding: @padding_tight;
   .rounded_corners();
   }
+
+.data-table-topic-popup {
+  z-index: 1010;
+  position: fixed;
+  line-height: 1;
+  white-space: initial;
+  }
  
 .data-table-topic-popup-header {
   padding: 0 0 5px;


### PR DESCRIPTION
When hovering unmatched reconciliation candidates and matched cells, the reconciliation preview from the service shows up (if provided).

Clicking on unmatched reconciliation candidates now has the same behaviour as clicking on matched cells: it opens the page of the entity in a new tab.

As argued in #1943 I think this is a much more natural behaviour and I have heard of multiple users who were confused about this. I think it should not be too hard for experienced users to adapt.

Tested in Firefox and Chromium: please test extensively on as many environments as possible and report if anything does not feel natural.

One possible downside of this is that people could feel like the previews pop up too often, when the user inadvertently hovers a reconciliation link without any intent to inspect it. If you think this is a big issue, maybe it's worth removing the hover on matched cells, but my gut feeling is that it is nice to preview matched cells too (especially when using the auto-match feature in the reconciliation operation, which is enabled by default).

Closes #1943.