### PR TITLE
Fix Recon features computation for empty recons

### DIFF
--- a/main/src/com/google/refine/model/recon/StandardReconConfig.java
+++ b/main/src/com/google/refine/model/recon/StandardReconConfig.java
@@ -566,8 +566,8 @@ public class StandardReconConfig extends ReconConfig {
      * @param text
      * 	    the cell value to compare the reconciliation data to
      */
-	public void computeFeatures(Recon recon, String text) {
-        if (!recon.candidates.isEmpty()) {
+    public void computeFeatures(Recon recon, String text) {
+        if (recon.candidates != null && !recon.candidates.isEmpty()) {
             ReconCandidate candidate = recon.candidates.get(0);
             
             recon.setFeature(Recon.Feature_nameMatch, text.equalsIgnoreCase(candidate.name));
@@ -587,7 +587,7 @@ public class StandardReconConfig extends ReconConfig {
         } else {
         	recon.features = new Object[Recon.Feature_max];
         }
-	}
+    }
     
     static protected double wordDistance(String s1, String s2) {
         Set<String> words1 = breakWords(s1);

--- a/main/tests/server/src/com/google/refine/tests/model/recon/StandardReconConfigTests.java
+++ b/main/tests/server/src/com/google/refine/tests/model/recon/StandardReconConfigTests.java
@@ -27,6 +27,7 @@
 package com.google.refine.tests.model.recon;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -332,5 +333,16 @@ public class StandardReconConfigTests extends RefineTest {
     	Recon recon = stub.createReconServiceResults("Kamila", node, 1234L);
     	assertEquals(recon.candidates.get(0).score, 0.3);
     	assertEquals(recon.candidates.get(0).id, "18951129");
+    }
+    
+    /**
+     * computing the features on an empty recon should not fail
+     */
+    @Test
+    public void testComputeFeatures() {
+    	StandardReconConfigStub stub = new StandardReconConfigStub();
+    	Recon recon = stub.createNewRecon(2384738L);
+    	stub.computeFeatures(recon, "my string");
+    	assertNotNull(recon.features);
     }
 }


### PR DESCRIPTION
A null pointer exception could be thrown when computing the features of a recon with no candidates.