### PR TITLE
Added Select All/Select None buttons to Excel Worksheet Importer

### DIFF
--- a/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.html
@@ -11,6 +11,8 @@
   <tr>
     <td><div class="grid-layout layout-tightest"><table bind="sheetRecordContainer">
       <tr><td colspan="3" id="or-import-worksheet"></td></tr>
+      <tr><td colspan="1"><button class="button" bind="selectAllButton"></button></td>
+          <td colspan="1"><button class="button" bind="unselectAllButton"></button></td></tr>
     </table></div></td>
     
     <td><div class="grid-layout layout-tightest"><table>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.js
@@ -118,9 +118,12 @@ Refine.ExcelParserUI.prototype._initialize = function() {
   this._optionContainer.unbind().empty().html(
       DOM.loadHTML("core", "scripts/index/parser-interfaces/excel-parser-ui.html"));
   this._optionContainerElmts = DOM.bind(this._optionContainer);
-  this._optionContainerElmts.previewButton.click(function() { self._updatePreview(); });
-  
+  this._optionContainerElmts.previewButton.click(function() { self._updatePreview(); });  
   this._optionContainerElmts.previewButton.html($.i18n('core-buttons/update-preview'));
+  this._optionContainerElmts.selectAllButton.click(function() { self._selectAll(); }); 
+  this._optionContainerElmts.selectAllButton.html($.i18n('core-buttons/select-all'));
+  this._optionContainerElmts.unselectAllButton.click(function() { self._unselectAll(); }); 
+  this._optionContainerElmts.unselectAllButton.html($.i18n('core-buttons/unselect-all'));
   $('#or-import-worksheet').text($.i18n('core-index-import/import-worksheet'));
   $('#or-import-ignore').text($.i18n('core-index-parser/ignore-first'));
   $('#or-import-lines').text($.i18n('core-index-parser/lines-beg'));
@@ -142,6 +145,7 @@ Refine.ExcelParserUI.prototype._initialize = function() {
     var checkbox = $('<input>')
     .attr('id', id)
     .attr('type', 'checkbox')
+    .attr('class', 'core-excel-worksheet')
     .attr('index', i)
     .appendTo(td0);
     if (this.selected) {
@@ -222,3 +226,23 @@ Refine.ExcelParserUI.prototype._updatePreview = function() {
 	  self._progressContainer.hide();
   });
 };
+
+Refine.ExcelParserUI.prototype._selectAll = function() {
+  var self = this;
+
+  $(".core-excel-worksheet").each(function(index, value){
+    $(value).prop('checked', true);
+  });
+  
+  self._scheduleUpdatePreview();
+}
+
+Refine.ExcelParserUI.prototype._unselectAll = function() {
+  var self = this;
+
+  $(".core-excel-worksheet").each(function(index, value){
+    $(value).prop('checked', false);
+  });
+
+  self._scheduleUpdatePreview();
+}


### PR DESCRIPTION
Implemented "Select All" and "Unselect All" buttons on the Excel Worksheet importer, as described in Issue #1974.

![Captura de tela de 2019-04-01 14-57-32](https://user-images.githubusercontent.com/57977/55348887-9f869f80-548e-11e9-9da2-505337ea3ea3.png)
