### PR TITLE
Cell serialization fixes

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/editing/NewItemLibrary.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/editing/NewItemLibrary.java
@@ -134,7 +134,9 @@ public class NewItemLibrary {
 	                ReconConfig config = column.getReconConfig();
 	                if (config instanceof StandardReconConfig) {
 	                	StandardReconConfig stdConfig = (StandardReconConfig)config;
-	                	stdConfig.computeFeatures(recon, cell.getValueAsString());
+										if (cell instanceof (String)) {
+	                		stdConfig.computeFeatures(recon, cell.getValue());
+										}
 	                }
                 }
             }

--- a/extensions/wikidata/src/org/openrefine/wikidata/editing/NewItemLibrary.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/editing/NewItemLibrary.java
@@ -134,8 +134,8 @@ public class NewItemLibrary {
 	                ReconConfig config = column.getReconConfig();
 	                if (config instanceof StandardReconConfig) {
 	                	StandardReconConfig stdConfig = (StandardReconConfig)config;
-										if (cell instanceof (String)) {
-	                		stdConfig.computeFeatures(recon, cell.getValue());
+										if (cell.getValue() instanceof String) {
+	                		stdConfig.computeFeatures(recon, (String) cell.getValue());
 										}
 	                }
                 }

--- a/main/src/com/google/refine/model/Cell.java
+++ b/main/src/com/google/refine/model/Cell.java
@@ -102,7 +102,7 @@ public class Cell implements HasFields {
     
     @JsonProperty("v")
     @JsonInclude(Include.NON_NULL)
-    public String getValueAsString() {
+    public Object getValue() {
         if (value != null && !ExpressionUtils.isError(value)) {
             Instant instant = null;
             if (value instanceof OffsetDateTime) {
@@ -119,8 +119,9 @@ public class Cell implements HasFields {
                  return ((Double)value).toString();
             } else if (value instanceof Float
                     && (((Float)value).isNaN() || ((Float)value).isInfinite())) {
-                // TODO: Skip?  Write as string?
                 return ((Float)value).toString();
+            } else if (value instanceof Boolean || value instanceof Number){
+                return value;
             } else {
                 return value.toString();
             }

--- a/main/tests/server/src/com/google/refine/tests/model/CellTests.java
+++ b/main/tests/server/src/com/google/refine/tests/model/CellTests.java
@@ -95,4 +95,18 @@ public class CellTests {
         String json = "{\"v\":\"2018-03-04T08:09:10Z\",\"t\":\"date\"}";
         TestUtils.isSerializedTo(Cell.loadStreaming(json, pool), json);
     }
+
+    @Test
+    public void serializeNumberCell() throws Exception {
+        String json = "{\"v\": 1}";
+        Cell c = Cell.loadStreaming(json, pool);
+        TestUtils.isSerializedTo(c, json);
+    }
+    
+    @Test
+    public void serializeBooleanCell() throws Exception {
+        String json = "{\"v\": true}";
+        Cell c = Cell.loadStreaming(json, pool);
+        TestUtils.isSerializedTo(c, json);
+    }
 }

--- a/main/tests/server/src/com/google/refine/tests/model/CellTests.java
+++ b/main/tests/server/src/com/google/refine/tests/model/CellTests.java
@@ -26,6 +26,10 @@
  ******************************************************************************/
 package com.google.refine.tests.model;
 
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -107,6 +111,54 @@ public class CellTests {
     public void serializeBooleanCell() throws Exception {
         String json = "{\"v\": true}";
         Cell c = Cell.loadStreaming(json, pool);
+        TestUtils.isSerializedTo(c, json);
+    }
+    
+    @Test
+    public void serializeDatewithOffset() throws Exception {
+        OffsetDateTime dateTimeValue = OffsetDateTime.parse("2017-05-12T05:45:00+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        Cell c = new Cell(dateTimeValue, null);
+        String json = "{\"v\":\"2017-05-12T04:45:00Z\",\"t\":\"date\"}";
+        TestUtils.isSerializedTo(c, json);
+    }
+    
+    @Test
+    public void serializeLocalDate() throws Exception {
+        LocalDateTime dateTimeValue = LocalDateTime.of(2017,5,12,0,0,0);
+        Cell c = new Cell(dateTimeValue, null);
+        String json = "{\"v\":\"2017-05-12T00:00:00Z\",\"t\":\"date\"}";
+        TestUtils.isSerializedTo(c, json);
+    }
+    
+    @Test
+    public void serializeDoubleNan() throws Exception {
+        double dn = Double.NaN;
+        Cell c = new Cell(dn, null);
+        String json = "{\"v\":\"NaN\"}";
+        TestUtils.isSerializedTo(c, json);
+    }
+    
+    @Test
+    public void serializeFloatNan() throws Exception {
+        Float fn = Float.NaN;
+        Cell c = new Cell(fn, null);
+        String json = "{\"v\":\"NaN\"}";
+        TestUtils.isSerializedTo(c, json);
+    }
+    
+    @Test
+    public void serializeDoubleInfinity() throws Exception {
+        double di = Double.POSITIVE_INFINITY;
+        Cell c = new Cell(di, null);
+        String json = "{\"v\":\"Infinity\"}";
+        TestUtils.isSerializedTo(c, json);
+    }
+    
+    @Test
+    public void serializeFloatInfinity() throws Exception {
+        Float fi = Float.POSITIVE_INFINITY;
+        Cell c = new Cell(fi, null);
+        String json = "{\"v\":\"Infinity\"}";
         TestUtils.isSerializedTo(c, json);
     }
 }


### PR DESCRIPTION
This PR adds more tests for cell serialization for various types of cell data, and ensures that number, date and boolean cells are serialized in the correct way.

Also modifies wikidata extension to only try to compute recon features such as name match, levenshtein distance etc when the cell contains a string