### PR TITLE
Creating new Github Sponsors FUNDING file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+open_collective: openrefine
+github: wetneb, ostephens, tcbuzor, thadguidry


### PR DESCRIPTION
This enables the new Github Sponsors button (we are beta testers of this feature now).  Will work with Open Collective on issues as they come up.  For user payouts, Github is starting with Stripe as the default payment processor.  But doesn't matter if some of us cannot use Stripe as we are beta testing this for contributors for can/cannot and will be providing feedback to Github.  Don't worry, I'll guide us through it and use core mailing list.

I'm super excited to see a Bountysource like system in Github finally becoming a reality!!!! (they have a lot planned for the future around Sponsorship and this is only the beginning)