### PR TITLE
Disable Maven git plugin when .git directory is absent.

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -247,6 +247,7 @@
             <verbose>false</verbose>
             <generateGitPropertiesFile>true</generateGitPropertiesFile>
             <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+            <failOnNoGitDirectory>false</failOnNoGitDirectory>
             <format>json</format>
             <gitDescribe>
                 <skip>false</skip>


### PR DESCRIPTION
Closes #2047