### PR TITLE
Disable error message when workspace.json does not exist.

### DIFF
--- a/main/src/com/google/refine/io/FileProjectManager.java
+++ b/main/src/com/google/refine/io/FileProjectManager.java
@@ -363,11 +363,13 @@ public class FileProjectManager extends ProjectManager  {
 
         boolean found = false;
 
-        try {
-        	ParsingUtilities.mapper.readerForUpdating(this).readValue(file);
-            found = true;
-        } catch(IOException e) {
-        	logger.warn(e.toString());
+        if (file.exists() || file.canRead()) {
+	        try {
+	        	ParsingUtilities.mapper.readerForUpdating(this).readValue(file);
+	            found = true;
+	        } catch(IOException e) {
+	        	logger.warn(e.toString());
+	        }
         }
 
         return found;


### PR DESCRIPTION
Fixes #1989. @felixlohmeier if you want to have a look to confirm the fix is as you expected, that would be great.