### PR TITLE
Speed up Wikidata uploads

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/editing/EditBatchProcessor.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/editing/EditBatchProcessor.java
@@ -91,6 +91,11 @@ public class EditBatchProcessor {
         this.editor = editor;
         editor.setEditAsBot(true); // this will not do anything if the user does not
         // have a bot flag, and this is generally wanted if they have one.
+
+        // edit at 60 edits/min by default. If Wikidata is overloaded
+        // it will slow us down via the maxlag mechanism.
+        editor.setAverageTimePerEdit(1000);
+
         this.library = library;
         this.summary = summary;
         this.batchSize = batchSize;


### PR DESCRIPTION
Now that WMDE plans to take the query service lag into account when computing the maxlag, we should be able to speed uploads up and rely on the maxlag throttling to slow down when appropriate. This currently enforces a 60 edits/min instead of the previous 30 edits/min.