### PR TITLE
Wikidata: Use distinct tabs for QS and schema export.

### DIFF
--- a/extensions/wikidata/module/langs/translation-en.json
+++ b/extensions/wikidata/module/langs/translation-en.json
@@ -6,6 +6,7 @@
     "wikidata-extension/perform-edits-on-wikidata": "Upload edits to Wikidata",
     "wikidata-extension/export-to-qs": "Export to QuickStatements",
     "wikidata-extension/export-schema": "Export schema",
+    "wikidata-extension/export-wikidata-schema": "Export Wikidata schema",
     "wikidata-extension/quickstatements-export-name": "QuickStatements",
     "wikidata-schema/dialog-header": "Align to Wikidata",
     "wikidata-schema/dialog-explanation": "The Wikidata schema below specifies how your tabular data will be transformed into Wikidata edits. You can drag and drop the column names below in most input boxes: for each row, edits will be generated with the values in these columns.",

--- a/extensions/wikidata/module/langs/translation-fr.json
+++ b/extensions/wikidata/module/langs/translation-fr.json
@@ -149,6 +149,7 @@
     "warnings-messages/invalid-entity-type/body": "Les utilisations de {property_entity} sur des éléments tels que {example_entity} sont invalides.",
     "wikidata-extension/import-wikidata-schema": "Importer un schéma",
     "wikidata-extension/export-schema": "Exporter le schéma",
+    "wikidata-extension/export-wikidata-schema": "Exporter le schéma Wikidata",
     "import-wikibase-schema/dialog-header": "Importer un schéma Wikidata",
     "import-wikibase-schema/file-label": "A partir du fichier JSON : ",
     "import-wikibase-schema/schema-label": "Ou à partir d'un texte JSON :",

--- a/extensions/wikidata/module/langs/translation-it.json
+++ b/extensions/wikidata/module/langs/translation-it.json
@@ -68,6 +68,7 @@
     "perform-wikidata-edits/edit-summary-placeholder": "qualche parola per descrivere le tue modifiche",
     "wikidata-extension/import-wikidata-schema": "Importa schema",
     "wikidata-extension/export-schema": "Esporta schema",
+    "wikidata-extension/export-wikidata-schema": "Esporta schema Wikidata",
     "perform-wikidata-edits/perform-edits": "Carica modifiche",
     "perform-wikidata-edits/cancel": "Annulla",
     "perform-wikidata-edits/analyzing-edits": "Analisi delle modifiche apportate…",

--- a/extensions/wikidata/module/scripts/menu-bar-extension.js
+++ b/extensions/wikidata/module/scripts/menu-bar-extension.js
@@ -51,7 +51,7 @@ WikibaseExporterMenuBar.exportTo = function(format) {
     $(form).css("display", "none")
         .attr("method", "post")
         .attr("action", "command/core/export-rows/"+targetUrl)
-        .attr("target", "gridworks-export");
+        .attr("target", "gridworks-export-"+format);
     $('<input />')
         .attr("name", "engine")
         .attr("value", JSON.stringify(ui.browsingEngine.getJSON()))

--- a/extensions/wikidata/module/scripts/menu-bar-extension.js
+++ b/extensions/wikidata/module/scripts/menu-bar-extension.js
@@ -33,7 +33,7 @@ ExporterManager.MenuItems.push(
 ExporterManager.MenuItems.push(
         {               
             id:"exportWikibaseSchema",
-            label: $.i18n('wikidata-extension/export-schema'),
+            label: $.i18n('wikidata-extension/export-wikidata-schema'),
             click: function() { WikibaseExporterMenuBar.checkSchemaAndExport("wikibase-schema"); }
         }
 );


### PR DESCRIPTION
Closes #2097.

@sjoerddebruin could you try out this version to see if it works for you?
```
git clone https://github.com/OpenRefine/OpenRefine
cd OpenRefine
git checkout issue-2097-wikidata-export
./refine
```
(assuming you use Linux and have Maven installed)
