### PR TITLE
Mock HTTP calls in data extension tests.

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -18,6 +18,7 @@
     <jee.path>/</jee.path>
     <jee.port>3333</jee.port>
     <refine.data>/tmp/refine</refine.data>
+    <powermock.version>2.0.2</powermock.version>
   </properties>
 
   <scm>
@@ -463,7 +464,18 @@
       <artifactId>jaxb-api</artifactId>
       <version>2.3.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-testng</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+     </dependency>
+     <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+     </dependency> 
   </dependencies>
-
 </project>
 

--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
+import org.powermock.modules.testng.PowerMockTestCase;
 import org.slf4j.Logger;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -75,7 +76,7 @@ import edu.mit.simile.butterfly.ButterflyModule;
 /**
  * A base class containing various utilities to help testing Refine.
  */
-public class RefineTest {
+public class RefineTest extends PowerMockTestCase {
 
     protected Logger logger;
     

--- a/main/tests/server/src/com/google/refine/process/LongRunningProcessStub.java
+++ b/main/tests/server/src/com/google/refine/process/LongRunningProcessStub.java
@@ -1,0 +1,31 @@
+package com.google.refine.process;
+
+/**
+ * A long running process that we can actually run in the main
+ * thread of the test runner, because during tests it is actually
+ * expected to be quick.
+ * 
+ * It wraps an existing LongRunningProcess
+ * 
+ * @author Antonin Delpeuch
+ *
+ */
+public class LongRunningProcessStub extends LongRunningProcess {
+	
+	protected LongRunningProcess wrapped;
+
+	public LongRunningProcessStub(Process process) {
+		super("some description");
+		this.wrapped = (LongRunningProcess)process;
+	}
+	
+	public void run() {
+		wrapped.getRunnable().run();
+	}
+
+	@Override
+	protected Runnable getRunnable() {
+		return wrapped.getRunnable();
+	}
+
+}


### PR DESCRIPTION
Closes #1904 and should also speed things up a bit (no need to wait for 10 seconds at each test!)