### PR TITLE
Don't remove data.suggest in _destroy function

### DIFF
--- a/main/webapp/modules/core/externals/suggest/suggest-4_3.js
+++ b/main/webapp/modules/core/externals/suggest/suggest-4_3.js
@@ -280,7 +280,6 @@
       $(window)
         .unbind("resize.suggest", this.onresize)
         .unbind("scroll.suggest", this.onresize);
-      this.input.removeData("data.suggest");
     },
 
     invalidate_position: function() {


### PR DESCRIPTION
Will resolve https://github.com/OpenRefine/OpenRefine/issues/2166

Since the data is re-set when an input is edited, it seems safe to not remove the data here.

An alternative for fixing #2166 would be to clear the actual input UI, but that would require re-entering the information after changing the type. I think the solution proposed here is the most user friendly way to fix this.