### PR TITLE
Remove useless condition

### DIFF
--- a/main/src/com/google/refine/clustering/binning/Metaphone3.java
+++ b/main/src/com/google/refine/clustering/binning/Metaphone3.java
@@ -3259,8 +3259,7 @@ public class Metaphone3 {
 				if(Internal_Hard_G())
 				{
 					// don't encode KG or KK if e.g. "mcgill"
-					if(!((m_current == 2) && StringAt(0, 2, "MC", "")) 
-						   || ((m_current == 3) && StringAt(0, 3, "MAC", "")))
+					if(!((m_current == 2) && StringAt(0, 2, "MC", ""))) 
 					{
 						if(SlavoGermanic())
 						{


### PR DESCRIPTION
**It's known that m_current != 3 at this point**

This condition always produces the same result as the value of the involved variable that was narrowed before.