### PR TITLE
Update SqlCreateBuilder.java

### DIFF
--- a/main/src/com/google/refine/exporters/sql/SqlCreateBuilder.java
+++ b/main/src/com/google/refine/exporters/sql/SqlCreateBuilder.java
@@ -146,7 +146,7 @@ public class SqlCreateBuilder {
         StringBuffer sql = new StringBuffer();
 
         boolean includeDrop = JSONUtilities.getBoolean(options, "includeDropStatement", false);
-        boolean addIfExist = options == null ? false : JSONUtilities.getBoolean(options, "includeIfExistWithDropStatement", true);
+        boolean addIfExist = JSONUtilities.getBoolean(options, "includeIfExistWithDropStatement", true);
         if (includeDrop) {
             if(addIfExist) {
                 sql.append("DROP TABLE IF EXISTS " + table + ";\n");


### PR DESCRIPTION
**Bug:** Nullcheck of SqlCreateBuilder.options at line 149 of value previously dereferenced in com.google.refine.exporters.sql.SqlCreateBuilder.getCreateSQL()

**A value is checked here to see whether it is null, but this value can't be null because it was previously dereferenced and if it were null a null pointer exception would have occurred at the earlier dereference.** Essentially, this code and the previous dereference disagree as to whether this value is allowed to be null. Either the check is redundant or the previous dereference is erroneous.