### PR TITLE
Add server-side language fallback.

### DIFF
--- a/main/tests/server/src/com/google/refine/commands/lang/LoadLanguageCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/lang/LoadLanguageCommandTests.java
@@ -2,14 +2,8 @@ package com.google.refine.commands.lang;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.refine.RefineServlet;
-import com.google.refine.commands.CommandTestBase;
-import com.google.refine.util.ParsingUtilities;
-
-import edu.mit.simile.butterfly.ButterflyModule;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,6 +13,16 @@ import javax.servlet.ServletException;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.refine.RefineServlet;
+import com.google.refine.commands.CommandTestBase;
+import com.google.refine.util.ParsingUtilities;
+
+import edu.mit.simile.butterfly.ButterflyModule;
+
 public class LoadLanguageCommandTests extends CommandTestBase {
 	
 	@BeforeMethod
@@ -26,11 +30,11 @@ public class LoadLanguageCommandTests extends CommandTestBase {
 		command = new LoadLanguageCommand();
 		ButterflyModule coreModule = mock(ButterflyModule.class);
 		
-        when(coreModule.getName()).thenReturn("core");
-        when(coreModule.getPath()).thenReturn(new File("webapp/modules/core"));
-        RefineServlet servlet = mock(RefineServlet.class);
-        when(servlet.getModule("core")).thenReturn(coreModule);
-        command.init(servlet);
+		when(coreModule.getName()).thenReturn("core");
+		when(coreModule.getPath()).thenReturn(new File("webapp/modules/core"));
+		RefineServlet servlet = mock(RefineServlet.class);
+		when(servlet.getModule("core")).thenReturn(coreModule);
+		command.init(servlet);
 	}
 	
 	@Test
@@ -43,6 +47,41 @@ public class LoadLanguageCommandTests extends CommandTestBase {
 		JsonNode response = ParsingUtilities.mapper.readValue(writer.toString(), JsonNode.class);
 		assertTrue(response.has("dictionary"));
 		assertTrue(response.has("lang"));
+	}
+	
+	@Test
+	public void testLoadUnknownLanguage() throws ServletException, IOException {
+		when(request.getParameter("module")).thenReturn("core");
+		when(request.getParameterValues("lang")).thenReturn(new String[] {"foobar"});
+		
+		command.doPost(request, response);
+		
+		JsonNode response = ParsingUtilities.mapper.readValue(writer.toString(), JsonNode.class);
+		assertTrue(response.has("dictionary"));
+		ssertEquals(response.get("lang").asText(), "foobar");
+	}
+		
+	
+	@Test
+	public void testLanguageFallback() throws JsonParseException, JsonMappingException, IOException {
+		String fallbackJson = "{"
+				+ "\"foo\":\"hello\","
+				+ "\"bar\":\"world\""
+				+ "}";
+		String preferredJson = "{"
+				+ "\"foo\":\"hallo\""
+				+ "}";
+		String expectedJson = "{"
+				+ "\"foo\":\"hallo\","
+				+ "\"bar\":\"world\""
+				+ "}";
+		ObjectNode fallback = ParsingUtilities.mapper.readValue(fallbackJson, ObjectNode.class);
+		ObjectNode preferred = ParsingUtilities.mapper.readValue(preferredJson, ObjectNode.class);
+		ObjectNode expected = ParsingUtilities.mapper.readValue(expectedJson, ObjectNode.class);
+		
+		ObjectNode merged = LoadLanguageCommand.mergeLanguages(preferred, fallback);
+		
+		assertEquals(merged, expected);
 	}
 }
 

--- a/main/tests/server/src/com/google/refine/commands/lang/LoadLanguageCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/lang/LoadLanguageCommandTests.java
@@ -58,7 +58,7 @@ public class LoadLanguageCommandTests extends CommandTestBase {
 		
 		JsonNode response = ParsingUtilities.mapper.readValue(writer.toString(), JsonNode.class);
 		assertTrue(response.has("dictionary"));
-		ssertEquals(response.get("lang").asText(), "foobar");
+		assertEquals(response.get("lang").asText(), "foobar");
 	}
 		
 	


### PR DESCRIPTION
This allows to keep the same Javascript calls to load languages, so it
does not require any change for extensions to benefit from this.

Closes #1350. Fixes #2209.