### PR TITLE
Fix Wikidata login CSRF issue.

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/commands/LoginCommand.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/commands/LoginCommand.java
@@ -45,7 +45,11 @@ public class LoginCommand extends Command {
     		respondCSRFError(response);
     		return;
     	}
-    	
+    	respond(request, response);
+    }
+    
+    protected void respond(HttpServletRequest request, HttpServletResponse response)
+    	throws ServletException, IOException {
         String username = request.getParameter("wb-username");
         String password = request.getParameter("wb-password");
         String remember = request.getParameter("remember-credentials");
@@ -74,6 +78,6 @@ public class LoginCommand extends Command {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
-        doPost(request, response);
+        respond(request, response);
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/LoginCommandTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/LoginCommandTest.java
@@ -34,4 +34,10 @@ public class LoginCommandTest extends CommandTest {
     	command.doPost(request, response);
     	TestUtils.assertEqualAsJson("{\"code\":\"error\",\"message\":\"Missing or invalid csrf_token parameter\"}", writer.toString());
     }
+    
+    @Test
+    public void testGetNotCsrfProtected() throws ServletException, IOException {
+    	command.doGet(request, response);
+    	TestUtils.assertEqualAsJson("{\"logged_in\":false,\"username\":null}", writer.toString());
+    }
 }


### PR DESCRIPTION
Closes #2228.

The issue was due to the fact that the GET endpoint also required CSRF protection.