### PR TITLE
Standardise 'edit' cell dialogue with 'toNumber()' when parsing String to Number

### DIFF
--- a/main/src/com/google/refine/commands/cell/EditOneCellCommand.java
+++ b/main/src/com/google/refine/commands/cell/EditOneCellCommand.java
@@ -103,7 +103,11 @@ public class EditOneCellCommand extends Command {
             Serializable value = null;
 
             if ("number".equals(type)) {
-                value = Double.parseDouble(valueString);
+                try {
+                    value = Long.parseLong(valueString);
+                } catch (NumberFormatException e) {
+                    value = Double.parseDouble(valueString);
+                }
             } else if ("boolean".equals(type)) {
                 value = "true".equalsIgnoreCase(valueString);
             } else if ("date".equals(type)) {

--- a/main/tests/server/src/com/google/refine/commands/cell/EditOneCellCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/cell/EditOneCellCommandTests.java
@@ -3,6 +3,7 @@ package com.google.refine.commands.cell;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertTrue;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -21,7 +22,9 @@ import com.google.refine.model.Project;
 import com.google.refine.util.TestUtils;
 
 public class EditOneCellCommandTests extends RefineTest {
-	
+
+	private static final String PARSABLE_DOUBLE_NUMBER = "12345.123";
+	private static final String PARSABLE_LONG_NUMBER = "12345";
 	protected Project project = null;
 	protected HttpServletRequest request = null;
     protected HttpServletResponse response = null;
@@ -59,6 +62,42 @@ public class EditOneCellCommandTests extends RefineTest {
 		assertEquals("a", project.rows.get(0).cells.get(0).value);
 		assertEquals("b", project.rows.get(0).cells.get(1).value);
 		assertEquals("e", project.rows.get(1).cells.get(0).value);
+		assertEquals("d", project.rows.get(1).cells.get(1).value);
+	}
+	
+	@Test
+	public void testNumberParsing_parsableLong() throws ServletException, IOException {
+		when(request.getParameter("project")).thenReturn(Long.toString(project.id));
+		when(request.getParameter("row")).thenReturn("1");
+		when(request.getParameter("cell")).thenReturn("0");
+		when(request.getParameter("type")).thenReturn("number");
+		when(request.getParameter("value")).thenReturn(PARSABLE_LONG_NUMBER);
+		when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+
+		command.doPost(request, response);
+
+		assertEquals("a", project.rows.get(0).cells.get(0).value);
+		assertEquals("b", project.rows.get(0).cells.get(1).value);
+		assertTrue(project.rows.get(1).cells.get(0).value instanceof Long);
+		assertEquals(new Long(12345), project.rows.get(1).cells.get(0).value);
+		assertEquals("d", project.rows.get(1).cells.get(1).value);
+	}
+
+	@Test
+	public void testNumberParsing_parsableDouble() throws ServletException, IOException {
+		when(request.getParameter("project")).thenReturn(Long.toString(project.id));
+		when(request.getParameter("row")).thenReturn("1");
+		when(request.getParameter("cell")).thenReturn("0");
+		when(request.getParameter("type")).thenReturn("number");
+		when(request.getParameter("value")).thenReturn(PARSABLE_DOUBLE_NUMBER);
+		when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+
+		command.doPost(request, response);
+
+		assertEquals("a", project.rows.get(0).cells.get(0).value);
+		assertEquals("b", project.rows.get(0).cells.get(1).value);
+		assertTrue(project.rows.get(1).cells.get(0).value instanceof Double);
+		assertEquals(12345.123, project.rows.get(1).cells.get(0).value);
 		assertEquals("d", project.rows.get(1).cells.get(1).value);
 	}
 	


### PR DESCRIPTION
Fixes #2163 

```
The implementation for two ways of parsing String to Number 
in cells is inconsistent:

1. 'Edit' cell dialogue and switch type to 'number':
Tries to parse String as a Double.

2. Using 'toNumber()' in cell transformations:
Tries to parse String as a Long, then parse String as a Double.

This PR modifies the 'edit' cell dialogue implementation 
to standardise with the latter, with the aim of eliminating 
inconsistent handling.
```