### PR TITLE
Translate Sort link to the language of the UI

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -149,7 +149,7 @@ DataTableView.prototype._renderSortingControls = function(sortingControls) {
 
   $('<a href="javascript:{}"></a>')
   .addClass("action")
-  .text($.i18n('core-views/first') + " ")
+  .text($.i18n('core-views/sort') + " ")
   .append($('<img>').attr("src", "../images/down-arrow.png"))
   .appendTo(sortingControls)
   .click(function() {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -149,7 +149,7 @@ DataTableView.prototype._renderSortingControls = function(sortingControls) {
 
   $('<a href="javascript:{}"></a>')
   .addClass("action")
-  .text("Sort ")
+  .text($.i18n('core-views/first') + " ")
   .append($('<img>').attr("src", "../images/down-arrow.png"))
   .appendTo(sortingControls)
   .click(function() {


### PR DESCRIPTION
Fixes #2233 

```
After a sort is made, the Sort link that is displayed does not
reflect to the corresponding language of the UI.

This PR adds the translation of the corresponding language
of the UI to the Sort link.
```