### PR TITLE
Update the check_running() function in refine

### DIFF
--- a/refine
+++ b/refine
@@ -157,7 +157,8 @@ check_running() {
 
     if [ "$CURL" ] ; then
         curl -s -S -f $URL > /dev/null 2>&1
-        if [ "$?" = "7" ] || [ "$?" = "22" ] ; then
+        CURL_RETURN=$?
+        if [ $CURL_RETURN -eq "7" ] || [ $CURL_RETURN -eq "22" ]  ; then
             NOT_RUNNING="1"
         fi
     elif [ "$WGET" ] ; then


### PR DESCRIPTION
In strict shell environments, the "$?" is reset when evaluated.
Here, the "boolean if" statements compares it to "7", then reset it and compares it to "22".
If the "$?" is intially "22", it is not evaluated and the NOT_RUNNING variable is ignored while it shouldn't. this leads to the error
"Something is already running on http://127.0.0.1:3333/"

To avoid this, the solution is to first affect the value of "$?" to a non-system variable and then evaluate this new variable.