### PR TITLE
[#2280] Add fill down and blank down operations for all columns

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -875,11 +875,11 @@ DataTableView.prototype._createSortingMenu = function(elmt) {
 };
 
 var doAllFillDown = function() {
-  doFillDown(0);
+  doFillDown(theProject.columnModel.columns.length - 1);
 };
 
 var doFillDown = function(colIndex) {
-  if (colIndex < theProject.columnModel.columns.length) {
+  if (colIndex >= 0) {
     Refine.postCoreProcess(
         "fill-down",
         {
@@ -889,7 +889,7 @@ var doFillDown = function(colIndex) {
         {modelsChanged: true},
         {
           onDone: function() {
-            doFillDown(++colIndex);
+            doFillDown(--colIndex);
           }
         }
     );

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -765,34 +765,12 @@ DataTableView.prototype._createMenuForAllColumns = function(elmt) {
         {
           label: $.i18n('core-views/fill-down'),
           id: "core/fill-down",
-          click: function() {
-            for (var i = 0; i < theProject.columnModel.columns.length; i++) {
-              Refine.postCoreProcess(
-                  "fill-down",
-                  {
-                    columnName: theProject.columnModel.columns[i].name
-                  },
-                  null,
-                  { modelsChanged: true }
-              );
-            }
-          }
+          click: doAllFillDown
         },
         {
           label: $.i18n('core-views/blank-down'),
           id: "core/blank-down",
-          click: function() {
-            for (var i = 0; i < theProject.columnModel.columns.length; i++) {
-              Refine.postCoreProcess(
-                  "blank-down",
-                  {
-                    columnName: theProject.columnModel.columns[i].name
-                  },
-                  null,
-                  { modelsChanged: true }
-              );
-            }
-          }
+          click: doAllBlankDown
         }
       ]
     },
@@ -894,6 +872,32 @@ DataTableView.prototype._createSortingMenu = function(elmt) {
   }
 
   MenuSystem.createAndShowStandardMenu(items, elmt, { horizontal: false });
+};
+
+var doAllFillDown = function() {
+  for (var i = 0; i < theProject.columnModel.columns.length; i++) {
+    Refine.postCoreProcess(
+        "fill-down",
+        {
+          columnName: theProject.columnModel.columns[i].name
+        },
+        null,
+        { modelsChanged: true }
+    );
+  }
+};
+
+var doAllBlankDown = function() {
+  for (var i = 0; i < theProject.columnModel.columns.length; i++) {
+    Refine.postCoreProcess(
+        "blank-down",
+        {
+          columnName: theProject.columnModel.columns[i].name
+        },
+        null,
+        { modelsChanged: true }
+    );
+  }
 };
 
 

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -760,6 +760,39 @@ DataTableView.prototype._createMenuForAllColumns = function(elmt) {
           click: function() {
             new ColumnReorderingDialog();
           }
+        },
+        {},
+        {
+          label: $.i18n('core-views/fill-down'),
+          id: "core/fill-down",
+          click: function() {
+            for (var i = 0; i < theProject.columnModel.columns.length; i++) {
+              Refine.postCoreProcess(
+                  "fill-down",
+                  {
+                    columnName: theProject.columnModel.columns[i].name
+                  },
+                  null,
+                  { modelsChanged: true }
+              );
+            }
+          }
+        },
+        {
+          label: $.i18n('core-views/blank-down'),
+          id: "core/blank-down",
+          click: function() {
+            for (var i = 0; i < theProject.columnModel.columns.length; i++) {
+              Refine.postCoreProcess(
+                  "blank-down",
+                  {
+                    columnName: theProject.columnModel.columns[i].name
+                  },
+                  null,
+                  { modelsChanged: true }
+              );
+            }
+          }
         }
       ]
     },

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -875,27 +875,45 @@ DataTableView.prototype._createSortingMenu = function(elmt) {
 };
 
 var doAllFillDown = function() {
-  for (var i = 0; i < theProject.columnModel.columns.length; i++) {
+  doFillDown(0);
+};
+
+var doFillDown = function(colIndex) {
+  if (colIndex < theProject.columnModel.columns.length) {
     Refine.postCoreProcess(
         "fill-down",
         {
-          columnName: theProject.columnModel.columns[i].name
+          columnName: theProject.columnModel.columns[colIndex].name
         },
         null,
-        { modelsChanged: true }
+        {modelsChanged: true},
+        {
+          onDone: function() {
+            doFillDown(++colIndex);
+          }
+        }
     );
   }
 };
 
 var doAllBlankDown = function() {
-  for (var i = 0; i < theProject.columnModel.columns.length; i++) {
+  doBlankDown(0);
+};
+
+var doBlankDown = function(colIndex) {
+  if (colIndex < theProject.columnModel.columns.length) {
     Refine.postCoreProcess(
         "blank-down",
         {
-          columnName: theProject.columnModel.columns[i].name
+          columnName: theProject.columnModel.columns[colIndex].name
         },
         null,
-        { modelsChanged: true }
+        { modelsChanged: true },
+        {
+          onDone: function() {
+            doBlankDown(++colIndex);
+          }
+        }
     );
   }
 };


### PR DESCRIPTION
Resolves #2280 

```
There are use cases where users would want to apply
fill down/blank down operations for all columns. Users
would have to toggle the fill down/blank down operation
for each column in order to achieve that.

Let's add a fill down/blank down operation under the 
'All' > 'Edit Columns' drop down that applies the operation 
for all columns at once which will save the users' effort.
```