### PR TITLE
Use release convention for Maven compiler config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>13</release>
           <encoding>UTF-8</encoding>
           <showDeprecation>false</showDeprecation>
         </configuration>


### PR DESCRIPTION
Can we move to using latest OpenJDK ?  (I'm using OpenJDK 13)
Regardless, we should use the newer "release" convention instead of source/target which wrecks havoc for me on Windows dev environment and switching Maven toolchains for other software.  Maybe Linux users are not prone to env issues as much (a reason Windows created WSL in the first place).  Anyways, some further context on using the "release" flag: https://stackoverflow.com/questions/43102787/what-is-the-release-flag-in-the-java-9-compiler

It's also possible to combine both properties and profile, and just use activation as shown: https://stackoverflow.com/questions/55404641/configure-maven-compiler-plugin-so-it-works-both-with-jdk-8-and-jdk-12-in-sprin