### PR TITLE
Handle long column names in key/value columnize dialog

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/key-value-columnize.html
+++ b/main/webapp/modules/core/scripts/views/data-table/key-value-columnize.html
@@ -9,9 +9,9 @@
           <td bind="or_views_noteCol"></td>
         </tr>
         <tr>
-          <td><select bind="keyColumnSelect" size="15" style="width: 100%;"></select></td>
-          <td><select bind="valueColumnSelect" size="15" style="width: 100%;"></select></td>
-          <td><select bind="noteColumnSelect" size="15" style="width: 100%;"></select></td>
+          <td><select bind="keyColumnSelect" size="15" style="width: 100%; overflow: auto;"></select></td>
+          <td><select bind="valueColumnSelect" size="15" style="width: 100%; overflow: auto;"></select></td>
+          <td><select bind="noteColumnSelect" size="15" style="width: 100%; overflow: auto;"></select></td>
         </tr>
       </table></div>
     </div>

--- a/main/webapp/modules/core/scripts/views/data-table/key-value-columnize.html
+++ b/main/webapp/modules/core/scripts/views/data-table/key-value-columnize.html
@@ -2,7 +2,7 @@
   <div class="dialog-border">
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body" bind="dialogBody">
-      <div class="grid-layout layout-normal layout-full grid-layout-for-ui"><table>
+      <div class="grid-layout layout-normal layout-full grid-layout-for-ui"><table style="table-layout: fixed">
         <tr>
           <td bind="or_views_keyCol"></td>
           <td bind="or_views_valCol"></td>

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
@@ -679,6 +679,16 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
 
       $('<option>').attr("value", column2.name).text(column2.name).appendTo(elmts.noteColumnSelect);
     }
+
+    var currentHeight = dialog.outerHeight();
+    var currentWidth = dialog.outerWidth();
+    dialog.resizable({
+      alsoResize: ".dialog-border .dialog-body",
+      handles: "e, w, se",
+      minHeight: currentHeight,
+      maxHeight: currentHeight,
+      minWidth: currentWidth
+    });
   };
 
   MenuSystem.appendTo(menu, [ "core/transpose" ], [


### PR DESCRIPTION
changes for issue #898:
* made "Columnize by Key/Value columns" dialog resizable
* set overflow styling, which solves the issue in Chromium-based browsers (Chrome, Edge, Opera) but doesn't work in FireFox and WebKit-based browsers (like Epiphany @ Linux, not tested in Safari but most likely won't work either)