### PR TITLE
Create new pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,6 @@
+Fixes issue # .
+
+Changes proposed in this pull request:
+- 
+- 
+- 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,4 +1,4 @@
-Fixes issue # .
+Fixes #{issue number here}
 
 Changes proposed in this pull request:
 - 


### PR DESCRIPTION
We will eventually want to support different types of Pull requests (issues, docs, etc.) and GitHub supports a Template directory where many templates can be used for different kinds of PR's and can have different automation flows with query parameters.  This will be a useful starting point as we build out more automation (@ostephens docs effort) and expand our contributors.

Details here: 
- https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates
- https://help.github.com/en/github/managing-your-work-on-github/about-automation-for-issues-and-pull-requests-with-query-parameters