### PR TITLE
fix Google Sheets importer when URL is missing a trailing slash (#2380)

### DIFF
--- a/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
@@ -183,7 +183,7 @@ abstract public class GoogleAPIExtension {
          throws IllegalArgumentException {
       URL urlAsUrl;
       
-      Matcher matcher = Pattern.compile("(?<=\\/d\\/).*(?=\\/.*)").matcher(url);
+      Matcher matcher = Pattern.compile("(?<=/d/).*?(?=[/?#]|$)").matcher(url);
       if (matcher.find()) {
           return matcher.group(0);
       }

--- a/extensions/gdata/tests/src/com/google/refine/extension/gdata/GoogleAPIExtensionTest.java
+++ b/extensions/gdata/tests/src/com/google/refine/extension/gdata/GoogleAPIExtensionTest.java
@@ -1,48 +1,38 @@
 package com.google.refine.extension.gdata;
 
+import com.google.refine.ProjectManager;
 import org.testng.annotations.Test;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.*;
 
-public class SpreadsheetRETest {
+public class GoogleAPIExtensionTest {
 
-	/**
-	 * We cannot call {@link GoogleAPIExtension#extractSpreadSheetId(String url) } here,
-	 * otherwise, we'll get NullPointerException during its class initialization.
-	 *
-	 * So we just copy the regex and test it here.
-	 */
 	@Test
 	public void reTest() {
+		ProjectManager.singleton = mock(ProjectManager.class);
+
 		String spreadSheetId = "16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0";
 
 		String url1 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0/edit#gid=0";
-		assertEquals(extractSpreadSheetId(url1), spreadSheetId);
+		assertEquals(GoogleAPIExtension.extractSpreadSheetId(url1), spreadSheetId);
 
 		String url2 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0/";
-		assertEquals(extractSpreadSheetId(url2), spreadSheetId);
+		assertEquals(GoogleAPIExtension.extractSpreadSheetId(url2), spreadSheetId);
 
 		String url3 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0?foo=bar";
-		assertEquals(extractSpreadSheetId(url3), spreadSheetId);
+		assertEquals(GoogleAPIExtension.extractSpreadSheetId(url3), spreadSheetId);
 
 		String url4 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0/?foo=bar";
-		assertEquals(extractSpreadSheetId(url4), spreadSheetId);
+		assertEquals(GoogleAPIExtension.extractSpreadSheetId(url4), spreadSheetId);
 
 		String url5 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0#foo";
-		assertEquals(extractSpreadSheetId(url5), spreadSheetId);
+		assertEquals(GoogleAPIExtension.extractSpreadSheetId(url5), spreadSheetId);
 
 		String url6 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0";
-		assertEquals(extractSpreadSheetId(url6), spreadSheetId);
-	}
-
-	private String extractSpreadSheetId(String url) {
-		Matcher matcher = Pattern.compile("(?<=/d/).*?(?=[/?#]|$)").matcher(url);
-		if (matcher.find()) {
-			return matcher.group();
-		}
-		return null;
+		assertEquals(GoogleAPIExtension.extractSpreadSheetId(url6), spreadSheetId);
 	}
 }

--- a/extensions/gdata/tests/src/com/google/refine/extension/gdata/GoogleAPIExtensionTest.java
+++ b/extensions/gdata/tests/src/com/google/refine/extension/gdata/GoogleAPIExtensionTest.java
@@ -12,7 +12,9 @@ import static org.testng.Assert.*;
 public class GoogleAPIExtensionTest {
 
 	@Test
-	public void reTest() {
+	public void extractSpreadSheetIdTest() {
+		// GoogleAPIExtension will call ProjectManager.singleton.getPreferenceStore() during class initialization,
+		// which will cause NullPointerException if this line is omitted.
 		ProjectManager.singleton = mock(ProjectManager.class);
 
 		String spreadSheetId = "16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0";

--- a/extensions/gdata/tests/src/com/google/refine/extension/gdata/SpreadsheetRETest.java
+++ b/extensions/gdata/tests/src/com/google/refine/extension/gdata/SpreadsheetRETest.java
@@ -1,0 +1,48 @@
+package com.google.refine.extension.gdata;
+
+import org.testng.annotations.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.testng.Assert.*;
+
+public class SpreadsheetRETest {
+
+	/**
+	 * We cannot call {@link GoogleAPIExtension#extractSpreadSheetId(String url) } here,
+	 * otherwise, we'll get NullPointerException during its class initialization.
+	 *
+	 * So we just copy the regex and test it here.
+	 */
+	@Test
+	public void reTest() {
+		String spreadSheetId = "16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0";
+
+		String url1 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0/edit#gid=0";
+		assertEquals(extractSpreadSheetId(url1), spreadSheetId);
+
+		String url2 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0/";
+		assertEquals(extractSpreadSheetId(url2), spreadSheetId);
+
+		String url3 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0?foo=bar";
+		assertEquals(extractSpreadSheetId(url3), spreadSheetId);
+
+		String url4 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0/?foo=bar";
+		assertEquals(extractSpreadSheetId(url4), spreadSheetId);
+
+		String url5 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0#foo";
+		assertEquals(extractSpreadSheetId(url5), spreadSheetId);
+
+		String url6 = "https://docs.google.com/spreadsheets/d/16L0JfpBWPfBJTqKtm-YU5-UBWLpkwXII-IRLMLnoKw0";
+		assertEquals(extractSpreadSheetId(url6), spreadSheetId);
+	}
+
+	private String extractSpreadSheetId(String url) {
+		Matcher matcher = Pattern.compile("(?<=/d/).*?(?=[/?#]|$)").matcher(url);
+		if (matcher.find()) {
+			return matcher.group();
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Close #2380 .

I changed the regex to extract the spreadSheetId from spreadsheet url and add corresponding tests for the new regex.