### PR TITLE
Corrects wrong trim label for json importer config

### DIFF
--- a/main/webapp/modules/core/scripts/index/parser-interfaces/json-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/json-parser-ui.html
@@ -17,7 +17,7 @@
       <tr><td width="1%"><input type="checkbox" bind="storeEmptyStringsCheckbox" id="$store-empty-strings" value=true/></td>
         <td colspan="2"><label for="$store-empty-strings" id="or-import-preserve"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="trimStringsCheckbox" id="$trim" /></td>
-        <td><label for="$guess" id="or-import-trim"></label></td></tr>
+        <td><label for="$trim" id="or-import-trim"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="guessCellValueTypesCheckbox" id="$guess" /></td>
         <td><label for="$guess" id="or-import-parseCell"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="includeFileSourcesCheckbox" id="$include-file-sources" /></td>


### PR DESCRIPTION
On clicking the `Trim leading & trailing whitespace from strings` checkbox in json importer configuration, the next checkbox i.e. `Parse cell text into numbers, dates, …` gets clicked. This is due to the wrong id in label for trim. This PR fixes that.