### PR TITLE
Fix: Enable auto complete in chrome

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
@@ -58,7 +58,6 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
                 }
             });
         }
-        event.preventDefault();
     });
   }
 };


### PR DESCRIPTION
Addressed issue #1778. Now auto-fill works in both Chrome and Firefox.

**Test With Chrome:**
Before submitting:
![chromB](https://user-images.githubusercontent.com/32441682/76369339-fdb03980-6311-11ea-995f-3aff9fc95af6.png)
After submitting with text **t1**:
![chromA](https://user-images.githubusercontent.com/32441682/76369356-086ace80-6312-11ea-83ba-89eda1e9d3e9.png)

**Test With Firefox**
Before submitting:
![fb](https://user-images.githubusercontent.com/32441682/76369378-17518100-6312-11ea-8051-e8324b608864.png)
After submitting with text **t 3**:
![fa](https://user-images.githubusercontent.com/32441682/76369380-1a4c7180-6312-11ea-994d-6118f46ff52b.png)

