### PR TITLE
support configurable credentials for gdata

### DIFF
--- a/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
@@ -32,8 +32,10 @@ import edu.mit.simile.butterfly.ButterflyModule;
 
 abstract public class GoogleAPIExtension {
     protected static final String SERVICE_APP_NAME = "OpenRefine-Google-Service";
-    private static final String CLIENT_ID = "";
-    private static final String CLIENT_SECRET = ""; 
+    // We can set the second param to a default client_id for release version
+    private static final String CLIENT_ID = System.getProperty("ext.gdata.clientid", "");
+    // We can set the second param to a default client_secret for release version
+    private static final String CLIENT_SECRET = System.getProperty("ext.gdata.clientsecret", "");
     
     /** Global instance of the HTTP transport. */
     protected static final HttpTransport HTTP_TRANSPORT = new NetHttpTransport();

--- a/refine
+++ b/refine
@@ -888,6 +888,12 @@ fi
 add_option "-Dpython.path=$JYTHONPATH"
 add_option "-Dpython.cachedir=$HOME/.local/share/google/refine/cachedir"
 
+if [ ! -z "$GDATA_CLIENT_ID" ] ; then
+    if [ ! -z "$GDATA_CLIENT_SECRET" ] ; then
+        add_option "-Dext.gdata.clientid=$GDATA_CLIENT_ID" "-Dext.gdata.clientsecret=$GDATA_CLIENT_SECRET"
+    fi
+fi
+
 # ----- Respond to the action given --------------------------------------------
 case "$ACTION" in
   build) build_prepare; mvn process-resources; mvn compile\ test-compile;;

--- a/refine.bat
+++ b/refine.bat
@@ -181,6 +181,11 @@ if not "%REFINE_LIB_DIR%" == "" goto gotLibDir
 set REFINE_LIB_DIR=server\target\lib
 :gotLibDir
 
+if "%GDATA_CLIENT_ID%" == "" goto skipGDataCredentials
+if "%GDATA_CLIENT_SECRET%" == "" goto skipGDataCredentials
+set OPTS=%OPTS% -Dext.gdata.clientid=%GDATA_CLIENT_ID% -Dext.gdata.clientsecret=%GDATA_CLIENT_SECRET%
+:skipGDataCredentials
+
 rem ----- Respond to the action ----------------------------------------------------------
 
 set ACTION=%1

--- a/refine.ini
+++ b/refine.ini
@@ -20,3 +20,13 @@ REFINE_MIN_MEMORY=1400M
 
 # Uncomment to increase autosave period to 60 mins (default: 5 minutes) for better performance of long-lasting transformations
 #REFINE_AUTOSAVE_PERIOD=60
+
+# OAuth credentials configurations for Google Data
+# Default OAuth credentials for Google Data have been embedded in the release version of OpenRefine
+# So if you'are a user, you can just skip these configurations, but it's recommended to use your own credentials
+# If you are a developer, you'll need to acquire them by yourself
+# To get your own credentials, please see the wiki: https://github.com/OpenRefine/OpenRefine/wiki/Google-Extension
+# The wiki will guide you to get a client_id/client_secret pair
+# After getting the client_id and client_secret, put them bellow
+#GDATA_CLIENT_ID=your_client_id
+#GDATA_CLIENT_SECRET=your_client_secret


### PR DESCRIPTION
Close #2383 

Now the OAuth client_id/client_secret for gdata extension are configurable at `refine.ini`.