### PR TITLE
Use parentheses for JAVA_OPTIONS on Unix/Linux

### DIFF
--- a/refine
+++ b/refine
@@ -103,7 +103,7 @@ load_configs() {
    if [ "${TEMP_CONFIG}" = "" ] ; then
        error "Could not create temporary file to load configurations"
    fi
-   cat $1 | egrep "^[A-Z]" | sed 's/^\(.*\)$/export \1/' > ${TEMP_CONFIG}
+   cat $1 | egrep "^[A-Z]" | sed 's/^\([^=]*\)=\(.*\)$/export \1=(\2)/' > ${TEMP_CONFIG}
    . ${TEMP_CONFIG}
    rm ${TEMP_CONFIG}
 }

--- a/refine.ini
+++ b/refine.ini
@@ -15,11 +15,8 @@ REFINE_MIN_MEMORY=1400M
 
 # Some sample configurations. These have no defaults.
 #JAVA_HOME=C:\Program Files\Java\jdk1.8.0_151
-# For Windows users, configure JAVA_OPTIONS like below
 #JAVA_OPTIONS=-XX:+UseParallelGC -verbose:gc -Drefine.headless=true
 #JAVA_OPTIONS=-Drefine.data_dir=C:\Users\user\AppData\Roaming\OpenRefine
-# For Unix/Linux users, remember to add parentheses
-#JAVA_OPTIONS=(-XX:+UseParallelGC -verbose:gc -Drefine.headless=true)
 
 # Uncomment to increase autosave period to 60 mins (default: 5 minutes) for better performance of long-lasting transformations
 #REFINE_AUTOSAVE_PERIOD=60

--- a/refine.ini
+++ b/refine.ini
@@ -15,8 +15,11 @@ REFINE_MIN_MEMORY=1400M
 
 # Some sample configurations. These have no defaults.
 #JAVA_HOME=C:\Program Files\Java\jdk1.8.0_151
+# For Windows users, configure JAVA_OPTIONS like below
 #JAVA_OPTIONS=-XX:+UseParallelGC -verbose:gc -Drefine.headless=true
 #JAVA_OPTIONS=-Drefine.data_dir=C:\Users\user\AppData\Roaming\OpenRefine
+# For Unix/Linux users, remember to add parentheses
+#JAVA_OPTIONS=(-XX:+UseParallelGC -verbose:gc -Drefine.headless=true)
 
 # Uncomment to increase autosave period to 60 mins (default: 5 minutes) for better performance of long-lasting transformations
 #REFINE_AUTOSAVE_PERIOD=60

--- a/refine.ini
+++ b/refine.ini
@@ -15,6 +15,7 @@ REFINE_MIN_MEMORY=1400M
 
 # Some sample configurations. These have no defaults.
 #JAVA_HOME=C:\Program Files\Java\jdk1.8.0_151
+# Notice, only the last uncommented JAVA_OPTIONS will work
 #JAVA_OPTIONS=-XX:+UseParallelGC -verbose:gc -Drefine.headless=true
 #JAVA_OPTIONS=-Drefine.data_dir=C:\Users\user\AppData\Roaming\OpenRefine
 

--- a/refine.ini
+++ b/refine.ini
@@ -16,7 +16,7 @@ REFINE_MIN_MEMORY=1400M
 # Some sample configurations. These have no defaults.
 #JAVA_HOME=C:\Program Files\Java\jdk1.8.0_151
 # Use a single JAVA_OPTIONS that includes any JVM options you need upon OpenRefine startup
-#JAVA_OPTIONS=-XX:+UseParallelGC -verbose:gc -Drefine.headless=true
+#JAVA_OPTIONS=-XX:+UseParallelGC -verbose:gc -Drefine.headless=true -Drefine.data_dir=C:\Users\user\AppData\Roaming\OpenRefine
 
 # Uncomment to increase autosave period to 60 mins (default: 5 minutes) for better performance of long-lasting transformations
 #REFINE_AUTOSAVE_PERIOD=60

--- a/refine.ini
+++ b/refine.ini
@@ -15,7 +15,7 @@ REFINE_MIN_MEMORY=1400M
 
 # Some sample configurations. These have no defaults.
 #JAVA_HOME=C:\Program Files\Java\jdk1.8.0_151
-# Notice, only the last uncommented JAVA_OPTIONS will work
+# Use a single JAVA_OPTIONS that includes any JVM options you need upon OpenRefine startup
 #JAVA_OPTIONS=-XX:+UseParallelGC -verbose:gc -Drefine.headless=true
 #JAVA_OPTIONS=-Drefine.data_dir=C:\Users\user\AppData\Roaming\OpenRefine
 

--- a/refine.ini
+++ b/refine.ini
@@ -17,7 +17,6 @@ REFINE_MIN_MEMORY=1400M
 #JAVA_HOME=C:\Program Files\Java\jdk1.8.0_151
 # Use a single JAVA_OPTIONS that includes any JVM options you need upon OpenRefine startup
 #JAVA_OPTIONS=-XX:+UseParallelGC -verbose:gc -Drefine.headless=true
-#JAVA_OPTIONS=-Drefine.data_dir=C:\Users\user\AppData\Roaming\OpenRefine
 
 # Uncomment to increase autosave period to 60 mins (default: 5 minutes) for better performance of long-lasting transformations
 #REFINE_AUTOSAVE_PERIOD=60


### PR DESCRIPTION
Close #2396 .

Just added some comments to clarify the configuration of JAVA_OPTIONS on Unix/Linux.