### PR TITLE
Fix: Data losses when importing multiple sheets from same Excell file

### DIFF
--- a/main/src/com/google/refine/importers/ImporterUtilities.java
+++ b/main/src/com/google/refine/importers/ImporterUtilities.java
@@ -139,6 +139,10 @@ public class ImporterUtilities {
                         // Already taken name
                         i++;
                     } else {
+                        // Want to update currentFileColumnNames
+                        if(! currentFileColumnNames.contains(columnName)){
+                            currentFileColumnNames.add(columnName);
+                        }
                         return column;
                     }
                 } else {

--- a/main/src/com/google/refine/importers/TabularImportingParserBase.java
+++ b/main/src/com/google/refine/importers/TabularImportingParserBase.java
@@ -111,7 +111,6 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
         }
         
         List<String> columnNames = new ArrayList<String>();
-
         boolean hasOurOwnColumnNames = headerLines > 0;
         
         List<Object> cells = null;
@@ -137,6 +136,7 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
                         } else {
                             columnName = cell.toString().trim();
                         }
+                        
                         ImporterUtilities.appendColumnName(columnNames, c, columnName);
                     }
                     
@@ -146,6 +146,7 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
                     }
                 } else { // data lines
                     Row row = new Row(columnNames.size());
+
                     if (storeBlankRows) {
                         rowsWithData++;
                     } else if (cells.size() > 0) {

--- a/main/src/com/google/refine/importers/TabularImportingParserBase.java
+++ b/main/src/com/google/refine/importers/TabularImportingParserBase.java
@@ -109,9 +109,8 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
         if (includeFileSources) {
             filenameColumnIndex = addFilenameColumn(project);
         }
-
-        // Try to reuse previous columnNames if possible to avoid mismatching cells and columns.
-        List<String> columnNames = project.columnModel.getColumnNames();
+        
+        List<String> columnNames = new ArrayList<String>();
 
         boolean hasOurOwnColumnNames = headerLines > 0;
         
@@ -138,7 +137,6 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
                         } else {
                             columnName = cell.toString().trim();
                         }
-                        
                         ImporterUtilities.appendColumnName(columnNames, c, columnName);
                     }
                     
@@ -148,7 +146,6 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
                     }
                 } else { // data lines
                     Row row = new Row(columnNames.size());
-                    
                     if (storeBlankRows) {
                         rowsWithData++;
                     } else if (cells.size() > 0) {

--- a/main/src/com/google/refine/importers/TabularImportingParserBase.java
+++ b/main/src/com/google/refine/importers/TabularImportingParserBase.java
@@ -109,8 +109,10 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
         if (includeFileSources) {
             filenameColumnIndex = addFilenameColumn(project);
         }
-        
-        List<String> columnNames = new ArrayList<String>();
+
+        // Try to reuse previous columnNames if possible to avoid mismatching cells and columns.
+        List<String> columnNames = project.columnModel.getColumnNames();
+
         boolean hasOurOwnColumnNames = headerLines > 0;
         
         List<Object> cells = null;

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -65,16 +65,16 @@ import com.google.refine.importers.ExcelImporter;
 import com.google.refine.util.ParsingUtilities;
 
 public class ExcelImporterTests extends ImporterTest {
-
+    
     private static final double EPSILON = 0.0000001;
     private static final int SHEETS = 3;
     private static final int ROWS = 5;
     private static final int COLUMNS = 6;
-
+    
     //private static final File xlsxFile = createSpreadsheet(true);
     private static final File xlsFile = createSpreadsheet(false);
     private static final File xlsxFile = createSpreadsheet(true);
-
+    
     @Override
     @BeforeTest
     public void init() {
@@ -97,7 +97,7 @@ public class ExcelImporterTests extends ImporterTest {
         SUT = null;
         super.tearDown();
     }
-
+    
     //---------------------read tests------------------------
     @Test
     public void readXls() throws FileNotFoundException, IOException{
@@ -107,21 +107,21 @@ public class ExcelImporterTests extends ImporterTest {
         sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
         sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
-
+        
         whenGetIntegerOption("ignoreLines", options, 0);
         whenGetIntegerOption("headerLines", options, 0);
         whenGetIntegerOption("skipDataLines", options, 0);
         whenGetIntegerOption("limit", options, -1);
         whenGetBooleanOption("storeBlankCellsAsNulls",options,true);
-
+        
         InputStream stream = new FileInputStream(xlsFile);
-
+        
         try {
             parseOneFile(SUT, stream);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
-
+        
         Assert.assertEquals(project.rows.size(), ROWS * SHEETS);
         Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
         Assert.assertEquals(project.columnModel.columns.size(), COLUMNS + SHEETS - 1);
@@ -134,7 +134,7 @@ public class ExcelImporterTests extends ImporterTest {
 
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
-
+        
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
@@ -145,7 +145,7 @@ public class ExcelImporterTests extends ImporterTest {
         verify(options, times(SHEETS)).get("limit");
         verify(options, times(SHEETS)).get("storeBlankCellsAsNulls");
     }
-
+    
     @Test
     public void readXlsx() throws FileNotFoundException, IOException{
 
@@ -154,21 +154,21 @@ public class ExcelImporterTests extends ImporterTest {
         sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
         sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
-
+        
         whenGetIntegerOption("ignoreLines", options, 0);
         whenGetIntegerOption("headerLines", options, 0);
         whenGetIntegerOption("skipDataLines", options, 0);
         whenGetIntegerOption("limit", options, -1);
         whenGetBooleanOption("storeBlankCellsAsNulls",options,true);
-
+        
         InputStream stream = new FileInputStream(xlsxFile);
-
+        
         try {
             parseOneFile(SUT, stream);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
-
+        
         Assert.assertEquals(project.rows.size(), ROWS * SHEETS);
         Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
         Assert.assertEquals(project.columnModel.columns.size(), COLUMNS + SHEETS - 1);
@@ -182,7 +182,7 @@ public class ExcelImporterTests extends ImporterTest {
 
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
-
+        
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
@@ -193,7 +193,7 @@ public class ExcelImporterTests extends ImporterTest {
         verify(options, times(SHEETS)).get("limit");
         verify(options, times(SHEETS)).get("storeBlankCellsAsNulls");
     }
-
+    
     private static File createSpreadsheet(boolean xml) {
 
         final Workbook wb = xml ? new XSSFWorkbook() : new HSSFWorkbook();
@@ -249,7 +249,6 @@ public class ExcelImporterTests extends ImporterTest {
             return null;
         }
         return file;
-
     }
 
 }

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -125,8 +125,6 @@ public class ExcelImporterTests extends ImporterTest {
         
         Assert.assertEquals(project.rows.size(), ROWS);
         Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
-        Assert.assertEquals(project.columnModel.columns.size(), COLUMNS);
-
         Assert.assertEquals(((Number)project.rows.get(1).getCellValue(0)).doubleValue(),1.1, EPSILON);
         Assert.assertEquals(((Number)project.rows.get(2).getCellValue(0)).doubleValue(),2.2, EPSILON);
 
@@ -136,7 +134,6 @@ public class ExcelImporterTests extends ImporterTest {
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
-        // We will read SHEETS sheets from created xls file.
         verify(options, times(1)).get("ignoreLines");
         verify(options, times(1)).get("headerLines");
         verify(options, times(1)).get("skipDataLines");
@@ -167,8 +164,6 @@ public class ExcelImporterTests extends ImporterTest {
         
         Assert.assertEquals(project.rows.size(), ROWS);
         Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
-        Assert.assertEquals(project.columnModel.columns.size(), COLUMNS);
-
         Assert.assertEquals(((Number)project.rows.get(1).getCellValue(0)).doubleValue(),1.1, EPSILON);
         Assert.assertEquals(((Number)project.rows.get(2).getCellValue(0)).doubleValue(),2.2, EPSILON);
 
@@ -178,7 +173,6 @@ public class ExcelImporterTests extends ImporterTest {
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
-        // We will read SHEETS sheets from created xls file.
         verify(options, times(1)).get("ignoreLines");
         verify(options, times(1)).get("headerLines");
         verify(options, times(1)).get("skipDataLines");
@@ -186,6 +180,7 @@ public class ExcelImporterTests extends ImporterTest {
         verify(options, times(1)).get("storeBlankCellsAsNulls");
     }
 
+	
     @Test
     public void readMultiSheetXls() throws FileNotFoundException, IOException{
 
@@ -310,6 +305,7 @@ public class ExcelImporterTests extends ImporterTest {
 
                 c = r.createCell(col++);
                 c.setCellValue(""); // string
+
                 //            HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
                 //            hl.setLabel(cellData.text);
                 //            hl.setAddress(cellData.link);
@@ -330,6 +326,7 @@ public class ExcelImporterTests extends ImporterTest {
             return null;
         }
         return file;
+		
     }
  
    private static File createSheetsWithDifferentColumns(boolean xml) {
@@ -367,9 +364,6 @@ public class ExcelImporterTests extends ImporterTest {
                     c = r.createCell(col++);
                     c.setCellValue(i + s);
                 }
-                //            HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
-                //            hl.setLabel(cellData.text);
-                //            hl.setAddress(cellData.link);
             }
 
         }

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -74,6 +74,9 @@ public class ExcelImporterTests extends ImporterTest {
     //private static final File xlsxFile = createSpreadsheet(true);
     private static final File xlsFile = createSpreadsheet(false);
     private static final File xlsxFile = createSpreadsheet(true);
+
+    private static final File xlsFileWithMultiSheets = createSheetsWithDifferentColumns(false);
+    private static final File xlsxFileWithMultiSheets = createSheetsWithDifferentColumns(true);
     
     @Override
     @BeforeTest
@@ -104,8 +107,6 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
-        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
-        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
         
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -122,15 +123,12 @@ public class ExcelImporterTests extends ImporterTest {
             Assert.fail(e.getMessage());
         }
         
-        Assert.assertEquals(project.rows.size(), ROWS * SHEETS);
+        Assert.assertEquals(project.rows.size(), ROWS);
         Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
-        Assert.assertEquals(project.columnModel.columns.size(), COLUMNS + SHEETS - 1);
+        Assert.assertEquals(project.columnModel.columns.size(), COLUMNS);
 
         Assert.assertEquals(((Number)project.rows.get(1).getCellValue(0)).doubleValue(),1.1, EPSILON);
         Assert.assertEquals(((Number)project.rows.get(2).getCellValue(0)).doubleValue(),2.2, EPSILON);
-        // Check the value read from the second sheet.
-        Assert.assertEquals(((Number)project.rows.get(ROWS).getCellValue(0)).doubleValue(),0.0, EPSILON);
-        Assert.assertEquals(((Number)project.rows.get(ROWS).getCellValue(COLUMNS)).doubleValue(),1.0, EPSILON);
 
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
@@ -139,11 +137,11 @@ public class ExcelImporterTests extends ImporterTest {
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
         // We will read SHEETS sheets from created xls file.
-        verify(options, times(SHEETS)).get("ignoreLines");
-        verify(options, times(SHEETS)).get("headerLines");
-        verify(options, times(SHEETS)).get("skipDataLines");
-        verify(options, times(SHEETS)).get("limit");
-        verify(options, times(SHEETS)).get("storeBlankCellsAsNulls");
+        verify(options, times(1)).get("ignoreLines");
+        verify(options, times(1)).get("headerLines");
+        verify(options, times(1)).get("skipDataLines");
+        verify(options, times(1)).get("limit");
+        verify(options, times(1)).get("storeBlankCellsAsNulls");
     }
     
     @Test
@@ -151,8 +149,6 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
-        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
-        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
         
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -169,6 +165,97 @@ public class ExcelImporterTests extends ImporterTest {
             Assert.fail(e.getMessage());
         }
         
+        Assert.assertEquals(project.rows.size(), ROWS);
+        Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
+        Assert.assertEquals(project.columnModel.columns.size(), COLUMNS);
+
+        Assert.assertEquals(((Number)project.rows.get(1).getCellValue(0)).doubleValue(),1.1, EPSILON);
+        Assert.assertEquals(((Number)project.rows.get(2).getCellValue(0)).doubleValue(),2.2, EPSILON);
+
+        Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
+        Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
+        
+        Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
+        Assert.assertNull((String)project.rows.get(1).getCellValue(5));
+
+        // We will read SHEETS sheets from created xls file.
+        verify(options, times(1)).get("ignoreLines");
+        verify(options, times(1)).get("headerLines");
+        verify(options, times(1)).get("skipDataLines");
+        verify(options, times(1)).get("limit");
+        verify(options, times(1)).get("storeBlankCellsAsNulls");
+    }
+
+    @Test
+    public void readMultiSheetXls() throws FileNotFoundException, IOException{
+
+        ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
+        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
+        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
+        whenGetArrayOption("sheets", options, sheets);
+
+        whenGetIntegerOption("ignoreLines", options, 0);
+        whenGetIntegerOption("headerLines", options, 0);
+        whenGetIntegerOption("skipDataLines", options, 0);
+        whenGetIntegerOption("limit", options, -1);
+        whenGetBooleanOption("storeBlankCellsAsNulls",options,true);
+
+        InputStream stream = new FileInputStream(xlsFileWithMultiSheets);
+
+        try {
+            parseOneFile(SUT, stream);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+
+        Assert.assertEquals(project.rows.size(), ROWS * SHEETS);
+        Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
+        Assert.assertEquals(project.columnModel.columns.size(), COLUMNS + SHEETS - 1);
+
+        Assert.assertEquals(((Number)project.rows.get(1).getCellValue(0)).doubleValue(),1.1, EPSILON);
+        Assert.assertEquals(((Number)project.rows.get(2).getCellValue(0)).doubleValue(),2.2, EPSILON);
+        // Check the value read from the second sheet.
+        Assert.assertEquals(((Number)project.rows.get(ROWS).getCellValue(0)).doubleValue(),0.0, EPSILON);
+        Assert.assertEquals(((Number)project.rows.get(ROWS).getCellValue(COLUMNS)).doubleValue(),1.0, EPSILON);
+
+        Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
+        Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
+
+        Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
+        Assert.assertNull((String)project.rows.get(1).getCellValue(5));
+
+        // We will read SHEETS sheets from created xls file.
+        verify(options, times(SHEETS)).get("ignoreLines");
+        verify(options, times(SHEETS)).get("headerLines");
+        verify(options, times(SHEETS)).get("skipDataLines");
+        verify(options, times(SHEETS)).get("limit");
+        verify(options, times(SHEETS)).get("storeBlankCellsAsNulls");
+    }
+
+    @Test
+    public void readMultiSheetXlsx() throws FileNotFoundException, IOException{
+
+        ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
+        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
+        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
+        whenGetArrayOption("sheets", options, sheets);
+
+        whenGetIntegerOption("ignoreLines", options, 0);
+        whenGetIntegerOption("headerLines", options, 0);
+        whenGetIntegerOption("skipDataLines", options, 0);
+        whenGetIntegerOption("limit", options, -1);
+        whenGetBooleanOption("storeBlankCellsAsNulls",options,true);
+
+        InputStream stream = new FileInputStream(xlsxFileWithMultiSheets);
+
+        try {
+            parseOneFile(SUT, stream);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+
         Assert.assertEquals(project.rows.size(), ROWS * SHEETS);
         Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
         Assert.assertEquals(project.columnModel.columns.size(), COLUMNS + SHEETS - 1);
@@ -182,7 +269,7 @@ public class ExcelImporterTests extends ImporterTest {
 
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
-        
+
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
@@ -193,8 +280,59 @@ public class ExcelImporterTests extends ImporterTest {
         verify(options, times(SHEETS)).get("limit");
         verify(options, times(SHEETS)).get("storeBlankCellsAsNulls");
     }
-    
+
     private static File createSpreadsheet(boolean xml) {
+
+        final Workbook wb = xml ? new XSSFWorkbook() : new HSSFWorkbook();
+
+        for (int s = 0; s < SHEETS; s++) {
+            Sheet sheet = wb.createSheet("Test Sheet " + s);
+
+            for (int row = 0; row < ROWS; row++) {
+                int col = 0;
+                Row r = sheet.createRow(row);
+                Cell c;
+
+                c = r.createCell(col++);
+                c.setCellValue(row * 1.1); // double
+
+                c = r.createCell(col++);
+                c.setCellValue(row % 2 == 0); // boolean
+
+                c = r.createCell(col++);
+                c.setCellValue(Calendar.getInstance()); // calendar
+
+                c = r.createCell(col++);
+                c.setCellValue(new Date()); // date
+
+                c = r.createCell(col++);
+                c.setCellValue(" Row " + row + " Col " + col); // string
+
+                c = r.createCell(col++);
+                c.setCellValue(""); // string
+                //            HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
+                //            hl.setLabel(cellData.text);
+                //            hl.setAddress(cellData.link);
+            }
+
+        }
+
+        File file = null;
+        try {
+            file = File.createTempFile("openrefine-importer-test", xml ? ".xlsx" : ".xls");
+            file.deleteOnExit();
+            OutputStream outputStream = new FileOutputStream(file);
+            wb.write(outputStream);
+            outputStream.flush();
+            outputStream.close();
+            wb.close();
+        } catch (IOException e) {
+            return null;
+        }
+        return file;
+    }
+ 
+   private static File createSheetsWithDifferentColumns(boolean xml) {
 
         final Workbook wb = xml ? new XSSFWorkbook() : new HSSFWorkbook();
 

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -65,16 +65,16 @@ import com.google.refine.importers.ExcelImporter;
 import com.google.refine.util.ParsingUtilities;
 
 public class ExcelImporterTests extends ImporterTest {
-    
+
     private static final double EPSILON = 0.0000001;
     private static final int SHEETS = 3;
     private static final int ROWS = 5;
     private static final int COLUMNS = 6;
-    
+
     //private static final File xlsxFile = createSpreadsheet(true);
     private static final File xlsFile = createSpreadsheet(false);
     private static final File xlsxFile = createSpreadsheet(true);
-    
+
     @Override
     @BeforeTest
     public void init() {
@@ -97,86 +97,103 @@ public class ExcelImporterTests extends ImporterTest {
         SUT = null;
         super.tearDown();
     }
-    
+
     //---------------------read tests------------------------
     @Test
     public void readXls() throws FileNotFoundException, IOException{
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
+        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
-        
+
         whenGetIntegerOption("ignoreLines", options, 0);
         whenGetIntegerOption("headerLines", options, 0);
         whenGetIntegerOption("skipDataLines", options, 0);
         whenGetIntegerOption("limit", options, -1);
         whenGetBooleanOption("storeBlankCellsAsNulls",options,true);
-        
+
         InputStream stream = new FileInputStream(xlsFile);
-        
+
         try {
             parseOneFile(SUT, stream);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
-        
-        Assert.assertEquals(project.rows.size(), ROWS);
+
+        Assert.assertEquals(project.rows.size(), ROWS * SHEETS);
         Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
+        Assert.assertEquals(project.columnModel.columns.size(), COLUMNS + SHEETS - 1);
+
         Assert.assertEquals(((Number)project.rows.get(1).getCellValue(0)).doubleValue(),1.1, EPSILON);
         Assert.assertEquals(((Number)project.rows.get(2).getCellValue(0)).doubleValue(),2.2, EPSILON);
+        // Check the value read from the second sheet.
+        Assert.assertEquals(((Number)project.rows.get(ROWS).getCellValue(0)).doubleValue(),0.0, EPSILON);
+        Assert.assertEquals(((Number)project.rows.get(ROWS).getCellValue(COLUMNS)).doubleValue(),1.0, EPSILON);
 
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
-        
+
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
-        verify(options, times(1)).get("ignoreLines");
-        verify(options, times(1)).get("headerLines");
-        verify(options, times(1)).get("skipDataLines");
-        verify(options, times(1)).get("limit");
-        verify(options, times(1)).get("storeBlankCellsAsNulls");
+        // We will read SHEETS sheets from created xls file.
+        verify(options, times(SHEETS)).get("ignoreLines");
+        verify(options, times(SHEETS)).get("headerLines");
+        verify(options, times(SHEETS)).get("skipDataLines");
+        verify(options, times(SHEETS)).get("limit");
+        verify(options, times(SHEETS)).get("storeBlankCellsAsNulls");
     }
-    
+
     @Test
     public void readXlsx() throws FileNotFoundException, IOException{
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
+        sheets.add(ParsingUtilities.mapper.readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
-        
+
         whenGetIntegerOption("ignoreLines", options, 0);
         whenGetIntegerOption("headerLines", options, 0);
         whenGetIntegerOption("skipDataLines", options, 0);
         whenGetIntegerOption("limit", options, -1);
         whenGetBooleanOption("storeBlankCellsAsNulls",options,true);
-        
+
         InputStream stream = new FileInputStream(xlsxFile);
-        
+
         try {
             parseOneFile(SUT, stream);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
-        
-        Assert.assertEquals(project.rows.size(), ROWS);
+
+        Assert.assertEquals(project.rows.size(), ROWS * SHEETS);
         Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
+        Assert.assertEquals(project.columnModel.columns.size(), COLUMNS + SHEETS - 1);
+
         Assert.assertEquals(((Number)project.rows.get(1).getCellValue(0)).doubleValue(),1.1, EPSILON);
         Assert.assertEquals(((Number)project.rows.get(2).getCellValue(0)).doubleValue(),2.2, EPSILON);
+        // Check the value read from the second sheet.
+        Assert.assertEquals(((Number)project.rows.get(ROWS).getCellValue(0)).doubleValue(),0.0, EPSILON);
+        Assert.assertEquals(((Number)project.rows.get(ROWS).getCellValue(COLUMNS)).doubleValue(),1.0, EPSILON);
+
 
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
-        
+
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
-        verify(options, times(1)).get("ignoreLines");
-        verify(options, times(1)).get("headerLines");
-        verify(options, times(1)).get("skipDataLines");
-        verify(options, times(1)).get("limit");
-        verify(options, times(1)).get("storeBlankCellsAsNulls");
+        // We will read SHEETS sheets from created xls file.
+        verify(options, times(SHEETS)).get("ignoreLines");
+        verify(options, times(SHEETS)).get("headerLines");
+        verify(options, times(SHEETS)).get("skipDataLines");
+        verify(options, times(SHEETS)).get("limit");
+        verify(options, times(SHEETS)).get("storeBlankCellsAsNulls");
     }
-    
+
     private static File createSpreadsheet(boolean xml) {
 
         final Workbook wb = xml ? new XSSFWorkbook() : new HSSFWorkbook();
@@ -207,6 +224,11 @@ public class ExcelImporterTests extends ImporterTest {
                 c = r.createCell(col++);
                 c.setCellValue(""); // string
 
+                // Create extra columns to ensure sheet(i+1) has more columns than sheet(i)
+                for(int i = 0; i < s; i++){
+                    c = r.createCell(col++);
+                    c.setCellValue(i + s);
+                }
                 //            HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
                 //            hl.setLabel(cellData.text);
                 //            hl.setAddress(cellData.link);
@@ -227,7 +249,7 @@ public class ExcelImporterTests extends ImporterTest {
             return null;
         }
         return file;
-        
+
     }
 
 }

--- a/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
@@ -52,6 +52,7 @@ import com.google.refine.importers.ImporterUtilities;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
+import com.google.refine.model.Column;
 
 public class ImporterUtilitiesTests extends RefineTest {
     
@@ -157,4 +158,26 @@ public class ImporterUtilitiesTests extends RefineTest {
         Assert.assertEquals( project.columnModel.columns.get(2).getName(), "Column");
     }
 
+    @Test
+    public void testGetOrAllocateColumn(){
+        Project project = new Project();
+        List<String> columnNames = new ArrayList<String>();
+        columnNames.add("Column 1");
+        columnNames.add("Column 2");
+        columnNames.add("Column 3");
+        // Set up column names in project
+        ImporterUtilities.setupColumns(project, columnNames);
+        Assert.assertEquals( project.columnModel.columns.get(0).getName(), "Column 1" );
+        Assert.assertEquals( project.columnModel.columns.get(1).getName(), "Column 2" );
+        Assert.assertEquals( project.columnModel.columns.get(2).getName(), "Column 3");
+
+        // This will mock the situation of importing another sheet from the same file.
+        // Expect newColumnNames can be updated using column names.
+        List<String> newColumnNames = new ArrayList<String>();
+        Column c0 = ImporterUtilities.getOrAllocateColumn(project, newColumnNames, 0, false);
+        Column c1 = ImporterUtilities.getOrAllocateColumn(project, newColumnNames, 1, false);
+        Assert.assertEquals(c0.getName(), "Column 1");
+        Assert.assertEquals(c1.getName(), "Column 2");
+        Assert.assertEquals(newColumnNames.size(), 2);
+    }
 }


### PR DESCRIPTION
Issue as noted as issue #1792 . 
Generally speaking, this error can occur when importing multiple sheets from one source file with some later sheets have more columns than the a previous one and the columnns share the same name.

**Cause of Issue**
In the test file, _sheet2_ has more columns than _sheet1_ and each column has the same name in both sheets.

When loading the second sheet, in lin 113 of `TabularImportingParserBase`, the columnNames is initialized to `[]` while the names of _column1_ to _column15_ are stored already in the _project_ variable.  

Without reusing the previous column names, _column 16_ is then treated as the 1st column when reading data from _sheet 2_ (since columnNames is initialized to `[]` instead of being `[column1 ... column15]`)

**Testing**
- Pass `./refine test`

- Belows are the same test case reproduced from as described in issue #1792 . I changed some values from the test.xls to make it more readable.
Preview after setting up the read options:
![after](https://user-images.githubusercontent.com/32441682/76585054-25db9c00-64bc-11ea-90ee-60547f008891.png)
Showing sheet two only:
![single](https://user-images.githubusercontent.com/32441682/76585057-270cc900-64bc-11ea-8c6f-13121acdd6ba.png)

attached test file: 
[test.xlsx](https://github.com/OpenRefine/OpenRefine/files/4327594/test.xlsx)
