### PR TITLE
Show correct data type in data table cell editor

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -543,7 +543,10 @@ DataTableCellUI.prototype._startEdit = function(elmt) {
   elmts.or_views_ctrlEnter.html($.i18n('core-views/ctrl-enter'));
   elmts.cancelButton.html($.i18n('core-buttons/cancel'));
   elmts.or_views_esc.html($.i18n('core-buttons/esc'));
-  
+
+  var cellDataType = typeof originalContent === "string" ? "text" : typeof originalContent;
+  elmts.typeSelect.val(cellDataType);
+
   MenuSystem.showMenu(menu, function(){});
   MenuSystem.positionMenuLeftRight(menu, $(this._td));
 

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -545,6 +545,7 @@ DataTableCellUI.prototype._startEdit = function(elmt) {
   elmts.or_views_esc.html($.i18n('core-buttons/esc'));
 
   var cellDataType = typeof originalContent === "string" ? "text" : typeof originalContent;
+  cellDataType = ("t" in this._cell && this._cell.t !=  null) ? this._cell.t : cellDataType;
   elmts.typeSelect.val(cellDataType);
 
   MenuSystem.showMenu(menu, function(){});


### PR DESCRIPTION
Fixes #2424 .

The application does not remember the data type of a cell as a cell only stores information related to the cell value. Hence, to show the correct data type on the front end, we can just use `typeof` to get the data type of the cell before rendering the HTML. This way of using `typeof` is also consistent with the rest of the application (e.g. the rest of the code in `cell-ui.js` etc).

This works with different languages as well since the `select` values are in English regardless how OpenRefine is localised.