### PR TITLE
Fix #2454 - Menu too small for text

### DIFF
--- a/main/webapp/modules/core/styles/util/menu.less
+++ b/main/webapp/modules/core/styles/util/menu.less
@@ -66,7 +66,6 @@ a.menu-item {
   padding: 5px 7px;
   text-decoration: none;
   color: #000;
-  white-space: pre;
   }
 
 a.menu-item:hover, a.menu-item.menu-expanded {


### PR DESCRIPTION
Signed-off-by: Agha Saad Fraz <agha.saad04@gmail.com>

## Fix #2454 

### Issue:
When we switch to a different language and try to apply some features on our column. The text overflows the menu container.

![image](https://user-images.githubusercontent.com/36513474/77246921-aaad7f00-6c4d-11ea-96a9-a35844a06585.png)


### Solution:
Changed the styling such that the text fits in the menu container and split into multiple lines.

![image](https://user-images.githubusercontent.com/36513474/77246908-86ea3900-6c4d-11ea-86da-c283e52b641b.png)