### PR TITLE
Adding a more sensible JAVA_OPTIONS recipe for GC

### DIFF
--- a/refine.ini
+++ b/refine.ini
@@ -15,8 +15,10 @@ REFINE_MIN_MEMORY=1400M
 
 # Some sample configurations. These have no defaults.
 #JAVA_HOME=C:\Program Files\Java\jdk1.8.0_151
+
 # Use a single JAVA_OPTIONS that includes any JVM options you need upon OpenRefine startup
-#JAVA_OPTIONS=-XX:+UseParallelGC -verbose:gc -Drefine.headless=true -Drefine.data_dir=C:\Users\user\AppData\Roaming\OpenRefine
+#JAVA_OPTIONS=-XX:+UseG1GC -XX:+UseStringDeduplication -Drefine.headless=true -Drefine.data_dir=C:\Users\user\AppData\Roaming\OpenRefine
+JAVA_OPTIONS=-XX:+UseG1GC -XX:+UseStringDeduplication
 
 # Uncomment to increase autosave period to 60 mins (default: 5 minutes) for better performance of long-lasting transformations
 #REFINE_AUTOSAVE_PERIOD=60


### PR DESCRIPTION
Substantial memory savings can be had when using G1GC and String Deduplication available in the JVM with OpenRefine, even before we move to Apache Spark.  I suggest that we enable this by default:

With:
`JAVA_OPTIONS=-XX:+UseG1GC -XX:+UseStringDeduplication`

![image](https://user-images.githubusercontent.com/986438/77384217-d1091280-6d52-11ea-86e7-88e40932ed14.png)

Without:

![image](https://user-images.githubusercontent.com/986438/77384240-df572e80-6d52-11ea-9264-ab20cf4b8a9e.png)
