### PR TITLE
Enable gzip compression

### DIFF
--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -344,6 +344,7 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
 
             try {
                 URLConnection urlConnection = url.openConnection();
+                urlConnection.setRequestProperty("Accept-Encoding", "gzip");
                 if (_httpHeadersJson != null) {
                     for (int i = 0; i < _httpHeadersJson.size(); i++) {
                         String headerLabel = _httpHeadersJson.get(i).name;
@@ -353,6 +354,7 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
                         }
                     }
                 }
+
 
                 try {
                     InputStream is = urlConnection.getInputStream();

--- a/main/src/com/google/refine/util/ParsingUtilities.java
+++ b/main/src/com/google/refine/util/ParsingUtilities.java
@@ -68,6 +68,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipException;
+
 public class ParsingUtilities {
     public static JsonFactory jsonFactory = new JsonFactory();
     static {
@@ -133,7 +136,14 @@ public class ParsingUtilities {
     }
     
     static public String inputStreamToString(InputStream is, String encoding) throws IOException {
-        Reader reader = new InputStreamReader(is, encoding);
+        Reader reader;
+        if (encoding.equals("gzip")) {
+            InputStream inputStream = new GZIPInputStream(is);
+            reader = new InputStreamReader(inputStream);
+        } else {
+            reader = new InputStreamReader(is, encoding);
+        }
+        
         try {
             return readerToString(reader);
         } finally {

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -64,12 +64,6 @@ import com.google.refine.process.ProcessManager;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.TestUtils;
 
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
-
-
 
 public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
 
@@ -194,38 +188,6 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
         Assert.assertFalse(process.isRunning());
     }
 
-    @Test
-    public void testGzipEncoding() throws Exception{
-        String url = "https://www.google.com";
-        // Test response is gzip compressed
-        testResponseContentTypeIs(url , "gzip");
-        // Test can parse and store response in cell
-        Row row0 = new Row(2);
-        row0.setCell(0, new Cell(url, null));
-        project.rows.add(row0);
-        EngineDependentOperation op = new ColumnAdditionByFetchingURLsOperation(engine_config,
-                "fruits",
-                "value",
-                OnError.StoreError,
-                "junk",
-                1,
-                50,
-                true,
-                null);
-
-        ProcessManager pm = project.getProcessManager();
-        Process process = op.createProcess(project, options);
-        process.startPerforming(pm);
-        Assert.assertTrue(process.isRunning());
-        try {
-            Thread.sleep(5000);
-        } catch (InterruptedException e) {
-            Assert.fail("Test interrupted");
-        }
-        Assert.assertFalse(process.isRunning());
-        Assert.assertTrue(project.rows.get(0).cells.size() == 2);
-
-    }
     
     /**
      * Fetch invalid URLs
@@ -336,21 +298,4 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
         Assert.assertEquals(headersUsed.get("accept").asText(), acceptValue);
     }
 
-    public void testResponseContentTypeIs(String urlString, String type) {
-        URL url = null;
-        try {
-            url = new URL(urlString);
-        } catch (MalformedURLException e) {
-            Assert.fail();
-        }
-
-        try {
-            URLConnection urlConnection = url.openConnection();
-            urlConnection.setRequestProperty("Accept-Encoding", "gzip, deflate");
-            String encoding = urlConnection.getContentEncoding();
-            Assert.assertEquals(encoding, type);
-        } catch (Exception e) {
-            Assert.fail();
-        }
-    }
 }

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -64,6 +64,12 @@ import com.google.refine.process.ProcessManager;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.TestUtils;
 
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+
+
 
 public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
 
@@ -188,6 +194,39 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
         Assert.assertFalse(process.isRunning());
     }
 
+    @Test
+    public void testGzipEncoding() throws Exception{
+        String url = "https://www.google.com";
+        // Test response is gzip compressed
+        testResponseContentTypeIs(url , "gzip");
+        // Test can parse and store response in cell
+        Row row0 = new Row(2);
+        row0.setCell(0, new Cell(url, null));
+        project.rows.add(row0);
+        EngineDependentOperation op = new ColumnAdditionByFetchingURLsOperation(engine_config,
+                "fruits",
+                "value",
+                OnError.StoreError,
+                "junk",
+                1,
+                50,
+                true,
+                null);
+
+        ProcessManager pm = project.getProcessManager();
+        Process process = op.createProcess(project, options);
+        process.startPerforming(pm);
+        Assert.assertTrue(process.isRunning());
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            Assert.fail("Test interrupted");
+        }
+        Assert.assertFalse(process.isRunning());
+        Assert.assertTrue(project.rows.get(0).cells.size() == 2);
+
+    }
+    
     /**
      * Fetch invalid URLs
      * https://github.com/OpenRefine/OpenRefine/issues/1219
@@ -297,4 +336,21 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
         Assert.assertEquals(headersUsed.get("accept").asText(), acceptValue);
     }
 
+    public void testResponseContentTypeIs(String urlString, String type) {
+        URL url = null;
+        try {
+            url = new URL(urlString);
+        } catch (MalformedURLException e) {
+            Assert.fail();
+        }
+
+        try {
+            URLConnection urlConnection = url.openConnection();
+            urlConnection.setRequestProperty("Accept-Encoding", "gzip, deflate");
+            String encoding = urlConnection.getContentEncoding();
+            Assert.assertEquals(encoding, type);
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
 }

--- a/main/tests/server/src/com/google/refine/util/ParsingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/util/ParsingUtilitiesTests.java
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.util;
 
+import java.io.*;
+import java.util.zip.GZIPOutputStream;
+
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
@@ -125,5 +128,35 @@ public class ParsingUtilitiesTests extends RefineTest {
         String message = "The value ${value} in row ${row_number} and column ${column_number} is not type ${field_type} and format ${field_format}";
         String result = sub.replace(message);
         Assert.assertTrue(result.contains("1234"));
+    }
+    
+    @Test
+    public void testParseGZIPInutstream() throws IOException {
+        // Test decompressing gzip
+        try {
+            String sampleBody = "<HTML>\n" +
+                    "\n" +
+                    "<HEAD>\n" +
+                    "\n" +
+                    "<TITLE>Your Title Here</TITLE>\n" +
+                    "\n" +
+                    "</HEAD>\n" +
+                    "\n" +
+                    "<BODY BGCOLOR=\"FFFFFF\">\n" +
+                    "\n" +
+                    "</BODY>\n" +
+                    "\n" +
+                    "</HTML>";
+            ByteArrayOutputStream obj=new ByteArrayOutputStream();
+            GZIPOutputStream gzip = new GZIPOutputStream(obj);
+            gzip.write(sampleBody.getBytes("UTF-8"));
+            gzip.close();
+            byte[] compressed = obj.toByteArray();
+            
+            String res = ParsingUtilities.inputStreamToString(new ByteArrayInputStream(compressed), "gzip");
+            Assert.assertEquals(res, sampleBody);
+        } catch (Exception e) {
+            Assert.fail();
+        }
     }
 }


### PR DESCRIPTION
**Realted Issue**
As mentioned in issue #2031 , the InputStreamReader does not support GZIP compressed contents. 

Tried to use a GZIPInputStream to address response with `content-encoding:gzip`. 