### PR TITLE
Issue 2306: Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ target/
 # Ignore Apache Maven default download path
 apache-maven-*/
 apache-maven-*-bin.tar.gz
+/.metadata/

--- a/extensions/gdata/src/com/google/refine/extension/gdata/SpreadsheetSerializer.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/SpreadsheetSerializer.java
@@ -81,7 +81,7 @@ final class SpreadsheetSerializer implements TabularSerializer {
         
         for (int c = 0; c < cells.size(); c++) {
             CellData cellData = cells.get(c);
-                cellDatas.add(cellData2sheetCellData(cellData));
+            cellDatas.add(cellData2sheetCellData(cellData));
         }
         
         rowData.setValues(cellDatas);

--- a/extensions/gdata/src/com/google/refine/extension/gdata/SpreadsheetSerializer.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/SpreadsheetSerializer.java
@@ -81,9 +81,7 @@ final class SpreadsheetSerializer implements TabularSerializer {
         
         for (int c = 0; c < cells.size(); c++) {
             CellData cellData = cells.get(c);
-            if (cellData != null && cellData.text != null) {
                 cellDatas.add(cellData2sheetCellData(cellData));
-            }
         }
         
         rowData.setValues(cellDatas);


### PR DESCRIPTION
The for loop had a null checker, if the cell is empty it wouldn't be added to the Sheets Cell ArrayList, hence the empty cells weren't recognized and the remaining cells were shifted to the left. 

Removing the null checker allows for all the cells to be added to the Sheet, including the ones which are empty.