### PR TITLE
Set client timeout limit in chainGetJSON()

### DIFF
--- a/main/webapp/modules/core/scripts/util/ajax.js
+++ b/main/webapp/modules/core/scripts/util/ajax.js
@@ -42,10 +42,15 @@ Ajax.chainGetJSON = function() {
       var data = a[i++];
       var callback = a[i++];
 
-      $.getJSON(url, data, function(o) {
+      $.ajax({
+        dataType: "json",
+        url: url,
+        data: data,
+        timeout: 30000
+      }).done(function(o) {
         callback(o);
         next();
-      }, "json");
+      });
     } else if (i < a.length) {
       var finalCallback = a[i++];
       finalCallback();


### PR DESCRIPTION
By setting a client side timeout one can avoid net::ERR_NETWORK_IO_SUSPENDED errors caused by the OS network layer being suspended [1]. This allows the client to handle higher level errors.

The jQuery.getJSON() function does not have a parameter for timeout management.

[1]: https://cs.chromium.org/chromium/src/net/http/http_network_layer.cc?q=ERR_NETWORK_IO_SUSPENDED&sq=package:chromium&dr=C&l=42