### PR TITLE
Fix cannot edit cell

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -614,8 +614,8 @@ DataTableCellUI.prototype._startEdit = function(elmt) {
 
             self._cell = o.cell;
             self._dataTableView._updateCell(self._rowIndex, self._cellIndex, self._cell);
-            self._render();
             self._dataTableView._adjustDataTables();
+            self._dataTableView.render();
           }
         }
       );


### PR DESCRIPTION
Address issue #1062.
**Bug Description**
When there is two or more filters and we clicked edit button as soon as the page is loaded, the cell is not updated as expected.
If we refresh the page, we can see the cell correctly updated.

**Cause of Error** 
When we click the edit button as soon as the filtered table is loaded,  a new `DataTableCellUI` is being created and rendered in the front-end. The edit is processed as expected but the front-end is actually displaying another object.

Once we refresh, a new CellUI object is created using `dataTableView` (with expected updated values) so user can see the expected cell.

**Fix** 
Once **dataTableView** has update user's expected value, we use **dataTableView** to re-rendered the cells in the page.