### PR TITLE
Prevent XML importer from creating many empty lines (#1095)

### DIFF
--- a/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
+++ b/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
@@ -457,6 +457,7 @@ public class XmlImportUtilities extends TreeImportUtilities {
         int level,
         ImportParameters parameter
     ) throws TreeReaderException {
+        boolean nestedEntitySeen = false;
         if (logger.isTraceEnabled()) {
             logger.trace("processSubRecord(Project,TreeReader,ImportColumnGroup,ImportRecord) lvl:"+level+" "+columnGroup);
         }
@@ -494,6 +495,7 @@ public class XmlImportUtilities extends TreeImportUtilities {
         while (parser.hasNext()) {
             Token eventType = parser.next();
             if (eventType == Token.StartEntity) {
+             nestedEntitySeen = true;
                 processSubRecord(
                     project,
                     parser,
@@ -508,11 +510,15 @@ public class XmlImportUtilities extends TreeImportUtilities {
                 String colName = parser.getFieldName();
                 if (value instanceof String) {
                     String text = (String) value;
-                    if(parameter.trimStrings) {
+                 
+                   if (!nestedEntitySeen || !text.trim().isEmpty())    // Ignore white space 
+                    {  
+                    if (parameter.trimStrings) {
                         text = text.trim();
                     }
                     addCell(project, thisColumnGroup, record, colName, text, 
                             parameter.storeEmptyStrings, parameter.guessDataType);
+                }
                 } else {
                     addCell(project, thisColumnGroup, record, colName, value);
                 }

--- a/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
+++ b/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
@@ -457,7 +457,6 @@ public class XmlImportUtilities extends TreeImportUtilities {
         int level,
         ImportParameters parameter
     ) throws TreeReaderException {
-        boolean nestedEntitySeen = false;
         if (logger.isTraceEnabled()) {
             logger.trace("processSubRecord(Project,TreeReader,ImportColumnGroup,ImportRecord) lvl:"+level+" "+columnGroup);
         }
@@ -495,7 +494,6 @@ public class XmlImportUtilities extends TreeImportUtilities {
         while (parser.hasNext()) {
             Token eventType = parser.next();
             if (eventType == Token.StartEntity) {
-             nestedEntitySeen = true;
                 processSubRecord(
                     project,
                     parser,
@@ -511,7 +509,7 @@ public class XmlImportUtilities extends TreeImportUtilities {
                 if (value instanceof String) {
                     String text = (String) value;
                  
-                   if (!nestedEntitySeen || !text.trim().isEmpty())    // Ignore white space 
+                   if ( !text.trim().isEmpty())    // Ignore white space 
                     {  
                     if (parameter.trimStrings) {
                         text = text.trim();


### PR DESCRIPTION
Closes #1095
After reading the comments on issue #1095  i tried to resolve.
Now,there is no need to uncheck "preserve empty strings" and check "Trim leading & trailing whitespace from strings" While importing XML file. 
Please review it and let me know if i have done any mistake :)