### PR TITLE
[bash] set cross *Nix bang line

### DIFF
--- a/refine
+++ b/refine
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ########################################################## 
 #               OpenRefine Control System             #


### PR DESCRIPTION
Systems like NixOS don't use the path `/bin` for executables.
By default, `bash` must be available in `env`.