### PR TITLE
Fixed that does not auto detect XML files from URL #2420

### DIFF
--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -275,6 +275,8 @@ function registerImporting() {
   IM.registerMimeType("text/n3", "text/rdf/n3");
   IM.registerMimeType("text/rdf+n3", "text/rdf/n3");
   IM.registerMimeType("text/turtle", "text/rdf/ttl");
+  IM.registerMimeType("application/xml", "text/xml");
+  IM.registerMimeType("text/xml", "text/xml");
   IM.registerMimeType("application/rdf+xml", "text/rdf/xml");
   IM.registerMimeType("application/ld+json", "text/rdf/ld+json");
 


### PR DESCRIPTION
**Refers**: _Importing an XML file from a URL does not auto detect the correct importer_ #2420

I tested with a number of URLs, all of which worked.
The **content type** response header was: **application / xml** or **text / xml**.