### PR TITLE
Support refine-dev.ini for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ target/
 # Ignore Apache Maven default download path
 apache-maven-*/
 apache-maven-*-bin.tar.gz
+
+# Ignore refine-dev.ini
+refine-dev.ini

--- a/refine
+++ b/refine
@@ -569,6 +569,7 @@ run() {
     CLASSPATH="$REFINE_CLASSES_DIR${SEP}$REFINE_LIB_DIR/*"
 
     RUN_CMD=("$JAVA" -cp "$CLASSPATH" "${OPTS[@]}" "com.google.refine.Refine")
+    echo "${RUN_CMD[@]}"
 
     echo "Starting OpenRefine at 'http://${REFINE_HOST}:${REFINE_PORT}/'"
     echo ""
@@ -751,7 +752,13 @@ fi
 
 # ----- Load configurations -------------------------------------
 
-load_configs refine.ini
+if [ -f "refine-dev.ini" ]; then
+  echo "Using refine-dev.ini for configuration"
+  load_configs refine-dev.ini
+else
+  echo "Using refine.ini for configuration"
+  load_configs refine.ini
+fi
 
 # ----- Make sure there is an appropriate java environment is available -------------
 

--- a/refine.bat
+++ b/refine.bat
@@ -67,9 +67,20 @@ rem --- Read ini file -----------------------------------------------
 
 set OPTS=
 
+if exist refine-dev.ini goto readDevConfig
+echo Using refine.ini for configuration
 for /f "tokens=1,* delims==" %%a in (refine.ini) do (
     set %%a=%%b
 )
+goto endConfigReading
+
+:readDevConfig
+echo Using refine-dev.ini for configuration
+for /f "tokens=1,* delims==" %%a in (refine-dev.ini) do (
+    set %%a=%%b
+)
+
+:endConfigReading
 
 rem --- Check JAVA_HOME ---------------------------------------------
 

--- a/refine.ini
+++ b/refine.ini
@@ -1,6 +1,10 @@
 # NOTE: This file is not read if you run the Refine executable directly
 # It is only read of you use the refine shell script or refine.bat
 
+# FOR DEVELOPERS: you can copy refine.ini and rename it to refine-dev.ini
+# Configurations in refine.ini will be ignored if refine-dev.ini exists
+# refine-dev.ini won't be tracked by Git, so feel free to put your custom configurations in it
+
 no_proxy="localhost,127.0.0.1"
 #REFINE_PORT=3334
 #REFINE_HOST=127.0.0.1


### PR DESCRIPTION
Close #2480 

Developers can now add custom configurations to `refine-dev.ini`, this file won't be tracked by Git. 

OpenRefine will still use `refine.ini` for configuration if `refine-dev.ini` doesn't exist.