### PR TITLE
Support default project name and column name for GREL cross() function

### DIFF
--- a/main/src/com/google/refine/LookupCacheManager.java
+++ b/main/src/com/google/refine/LookupCacheManager.java
@@ -3,6 +3,7 @@ package com.google.refine;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.HasFieldsListImpl;
 import com.google.refine.expr.WrappedRow;
+import com.google.refine.expr.functions.Cross;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
@@ -74,6 +75,14 @@ public class LookupCacheManager {
         ProjectMetadata targetProjectMetadata = ProjectManager.singleton.getProjectMetadata(lookup.targetProjectID);
         if (targetProject == null) {
             return;
+        }
+
+        // if this is a lookup on the index column
+        if (lookup.targetColumnName.equals(Cross.INDEX_COLUMN_NAME)) {
+            for (int r = 0; r < targetProject.rows.size(); r++) {
+                lookup.valueToRowIndices.put(String.valueOf(r) , Collections.singletonList(r));
+            }
+            return; // return directly
         }
 
         Column targetColumn = targetProject.columnModel.getColumnByName(lookup.targetColumnName);

--- a/main/src/com/google/refine/expr/functions/Cross.java
+++ b/main/src/com/google/refine/expr/functions/Cross.java
@@ -41,24 +41,37 @@ import com.google.refine.expr.EvalError;
 import com.google.refine.expr.WrappedCell;
 import com.google.refine.grel.ControlFunctionRegistry;
 import com.google.refine.grel.Function;
+import com.google.refine.model.Project;
 import com.google.refine.util.GetProjectIDException;
 import com.google.refine.util.LookupException;
 
 public class Cross implements Function {
 
+    public static final String INDEX_COLUMN_NAME = "_OpenRefine_Index_Column_Name_";
+
     @Override
     public Object call(Properties bindings, Object[] args) {
-        if (args.length == 3) {
+        if (1 <= args.length && args.length <= 3) {
             // 1st argument can take either value or cell(for backward compatibility)
             Object v = args[0];
-            Object targetProjectName = args[1];
-            Object targetColumnName = args[2];
+            // if 2nd argument is omitted or set to "", use the current project name
+            Object targetProjectName = "";
+            boolean isCurrentProject = false;
+            if (args.length < 2 || args[1].equals("")) {
+                isCurrentProject = true;
+            } else {
+                targetProjectName = args[1];
+            }
+            // if 3rd argument is omitted or set to "", use the index column
+            Object targetColumnName = args.length < 3 || args[2].equals("") ? INDEX_COLUMN_NAME: args[2];
+
             long targetProjectID;
             ProjectLookup lookup;
 
             if (v != null && targetProjectName instanceof String && targetColumnName instanceof String) {
                 try {
-                    targetProjectID = ProjectManager.singleton.getProjectID((String) targetProjectName);
+                    targetProjectID = isCurrentProject ? ((Project) bindings.get("project")).id :
+                            ProjectManager.singleton.getProjectID((String) targetProjectName);
                 } catch (GetProjectIDException e) {
                     return new EvalError(e.getMessage());
                 }
@@ -76,17 +89,21 @@ public class Cross implements Function {
                 }
             }
         }
-        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects a cell or value, a project name to look up, and a column name in that project");
+
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects a cell or value, a project name to look up (optional), and a column name in that project (optional)");
     }
 
     @Override
     public String getDescription() {
-        return "Looks up the given value in the target column of the target project, returns an array of matched rows, cell will be interpreted as cell.value. Two values match if and only if they have the same string representation";
+        return "Looks up the given value in the target column of the target project, returns an array of matched rows. Two values match if and only if they have the same string representation. " +
+                "The first argument will be interpreted as cell.value if set to cell. " +
+                "The second argument will be interpreted as the current project name if omitted or set to \"\". " +
+                "The third argument will be interpreted as the index (starts from 0) column if omitted or set to \"\"";
     }
 
     @Override
     public String getParams() {
-        return "cell or value, string projectName, string columnName";
+        return "cell or value, string projectName (optional), string columnName (optional)";
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
@@ -164,6 +164,49 @@ public class CrossTests extends RefineTest {
     }
 
     @Test
+    // lookup the row with index 0 in the current project
+    public void crossFunctionOneArgumentTest() throws Exception {
+        Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 0)).get(0)).row);
+        String address = row.getCell(1).value.toString();
+        Assert.assertEquals(address, "mary");
+    }
+
+    @Test
+    public void crossFunctionOneArgumentTest1() throws Exception {
+        Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 0, "")).get(0)).row);
+        String address = row.getCell(1).value.toString();
+        Assert.assertEquals(address, "mary");
+    }
+
+    @Test
+    public void crossFunctionOneArgumentTest2() throws Exception {
+        Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 1, "", "")).get(0)).row);
+        String address = row.getCell(1).value.toString();
+        Assert.assertEquals(address, "john");
+    }
+
+    @Test
+    public void crossFunctionTwoArgumentTest() throws Exception {
+        Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", "lamp", "", "gift")).get(0)).row);
+        String address = row.getCell(1).value.toString();
+        Assert.assertEquals(address, "mary");
+    }
+
+    @Test
+    public void crossFunctionTwoArgumentTest1() throws Exception {
+        Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 0, "My Address Book")).get(0)).row);
+        String address = row.getCell(1).value.toString();
+        Assert.assertEquals(address, "120 Main St.");
+    }
+
+    @Test
+    public void crossFunctionTwoArgumentTest2() throws Exception {
+        Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 0, "My Address Book", "")).get(0)).row);
+        String address = row.getCell(1).value.toString();
+        Assert.assertEquals(address, "120 Main St.");
+    }
+
+    @Test
     public void crossFunctionOneToOneTest() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", "mary", "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
@@ -328,7 +371,7 @@ public class CrossTests extends RefineTest {
     @Test
     public void crossFunctionNonLiteralValue() throws Exception {
         Assert.assertEquals(((EvalError) invoke("cross", null, "My Address Book", "friend")).message,
-                "cross expects a cell or value, a project name to look up, and a column name in that project");
+                "cross expects a cell or value, a project name to look up (optional), and a column name in that project (optional)");
     }
     
     /**
@@ -346,10 +389,14 @@ public class CrossTests extends RefineTest {
             return function.call(bindings,args);
         }
     }
-    
+
     @Test
     public void serializeCross() {
-        String json = "{\"description\":\"Looks up the given value in the target column of the target project, returns an array of matched rows, cell will be interpreted as cell.value. Two values match if and only if they have the same string representation\",\"params\":\"cell or value, string projectName, string columnName\",\"returns\":\"array\"}";
+        String json = "{\"description\":\"Looks up the given value in the target column of the target project, returns an array of matched rows. Two values match if and only if they have the same string representation. " +
+                "The first argument will be interpreted as cell.value if set to cell. " +
+                "The second argument will be interpreted as the current project name if omitted or set to \\\"\\\". " +
+                "The third argument will be interpreted as the index (starts from 0) column if omitted or set to \\\"\\\"\"," +
+                "\"params\":\"cell or value, string projectName (optional), string columnName (optional)\",\"returns\":\"array\"}";
         TestUtils.isSerializedTo(new Cross(), json);
     }
 }


### PR DESCRIPTION
(Closes #2504) 

Can #200 be closed by this PR?

Currently, cross() can take 3 arguments: 
```
cross(cell or value, string projectName, string columnName)
```

In this PR, I added the following enhancements as mentioned in #2504 :

1. projectName will be optional and will be interpreted as the current project name if omitted or set to "".
2. columnName will also be optional and will be interpreted as the index column if omitted or set to "". Note that I don't mean a column with the name "index" by saying "the index column", it's actually a column with name "_OpenRefine_Index_Column_Name_", which is the inner name of the index column. See [Cross.java](https://github.com/OpenRefine/OpenRefine/pull/2518/commits/5d063f7ca965d1a8b8346fa528ed5a4bff0e687a#diff-d4f3fbf156f6686e6d9b4358766804edR50) for more details.

With these two enhancements, the cross() function will be more flexible.

We can use `cross(targetValue, "", targetColumn)` to lookup the given value in the given column of the current project.

We can use `cross(targetRowIndex)` to access another row in the current project. Similarly, we can use `cross(targetRowIndex, targetProjectName)` or `cross(targetRowIndex, targetProjectName, "")` to access a specified row in the target project. So this PR can be taken as a solution for #200 .

One interesting thing is that we already have an embedded "rowIndex" variable for GREL, so we can use `cross(rowIndex + offset)` to access a row relative to the current row. 


![new](https://user-images.githubusercontent.com/29347603/81496277-24c2c180-92e9-11ea-8762-69d64d7ee01d.png)

