### PR TITLE
FIX: #2521 Replaced Project Delete to use red color text instead of blue 'X'

### DIFF
--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -218,7 +218,8 @@ Refine.OpenProjectUI.prototype._renderProjects = function(data) {
       .addClass("delete-project")
       .attr("title",$.i18n('core-index-open/del-title'))
       .attr("href","")
-      .html("<img src='images/close.png' />")
+      .css("color","red")
+      .html("Delete")
       .click(function() {
         if (window.confirm($.i18n('core-index-open/del-body') + project.name + "\"?")) {
           Refine.postCSRF(


### PR DESCRIPTION
Signed-off-by: Agha Saad Fraz <agha.saad04@gmail.com>

Fix #2521 
A minor change of replacing the Blue 'X' to Red-colored Delete text as it was confusing users 