### PR TITLE
Update WDTK to 0.11.1

### DIFF
--- a/extensions/wikidata/pom.xml
+++ b/extensions/wikidata/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <powermock.version>2.0.2</powermock.version>
+    <wdtk.version>0.11.1</wdtk.version>
   </properties>
 
   <build>
@@ -128,17 +129,17 @@
     <dependency>
       <groupId>org.wikidata.wdtk</groupId>
       <artifactId>wdtk-wikibaseapi</artifactId>
-      <version>0.11.0</version>
+      <version>${wdtk.version}</version>
     </dependency>
     <dependency>
       <groupId>org.wikidata.wdtk</groupId>
       <artifactId>wdtk-datamodel</artifactId>
-      <version>0.11.0</version>
+      <version>${wdtk.version}</version>
     </dependency>
     <dependency>
       <groupId>org.wikidata.wdtk</groupId>
       <artifactId>wdtk-util</artifactId>
-      <version>0.11.0</version>
+      <version>${wdtk.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Closes #2526.

The build will initially fail because it will take some time for the artifacts to be published on Maven Central, we can just re-run the build before merging.