### PR TITLE
Fix: the wrong label for regex checkbox in split multi cell dialog

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/split-multi-valued-cells-dialog.html
+++ b/main/webapp/modules/core/scripts/views/data-table/split-multi-valued-cells-dialog.html
@@ -15,7 +15,7 @@
             <tr><td></td>
               <td bind="or_views_separator"></td>
               <td><input size="10" value="," bind="separatorInput" />
-                <input type="checkbox" bind="regexInput" id="$split-column-regex" />
+                <input type="checkbox" bind="regexInput" id="$split-multi-valued-cells-regex" />
                 <label for="$split-multi-valued-cells-regex" bind="or_views_regExp"></label></td>
             </tr>
             <tr>


### PR DESCRIPTION
Clicking on `regular expression` label does not check that checkbox. This PR fixes the wrong id for that checkbox.