### PR TITLE
Update perform-edits-dialog.js to trap [RETURN] in editSummary and proceed to action

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
@@ -31,21 +31,16 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
     formCopy.submit();
 
     if(elmts.editSummary.val().length == 0) {
-        elmts.editSummary.focus();
+      elmts.editSummary.focus();
     } else {
-        Refine.postProcess(
+      Refine.postProcess(
         "wikidata",
         "perform-wikibase-edits",
         {},
-        {
-            summary: elmts.editSummary.val(),
-        },
+        { summary: elmts.editSummary.val(), },
         { includeEngine: true, cellsChanged: true, columnStatsChanged: true },
-        { onDone:
-            function() {
-            dismiss();
-            }
-        });
+        { onDone: function() { dismiss(); }
+      });
     }
   }
   
@@ -54,18 +49,18 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
    .attr('href','https://www.wikidata.org/wiki/User:'+logged_in_username);
   
   frame.find('.cancel-button').click(function() {
-     dismiss();
+    dismiss();
   });
 
   this._elmts.editSummary.keypress(function (evt) {
     if (evt.which === 13) {
-      evt.preventDefault();
       doFormSubmit();
+      evt.preventDefault();
     }
   });
 
   if (max_severity === 'CRITICAL') {
-      elmts.performEditsButton.prop("disabled",true).addClass("button-disabled");
+    elmts.performEditsButton.prop("disabled",true).addClass("button-disabled");
   } else {
     elmts.performEditsButton.click(function() {
       doFormSubmit();

--- a/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
@@ -32,35 +32,56 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
 
   var hiddenIframe = $('#hiddenIframe').contents();
 
+  this._elmts.editSummary.keypress(function (evt) {
+    evt.preventDefault();
+    if (evt.which === 13) {
+    	PerformEditsDialog.doFormSubmit();
+    }
+  });
+
   if (max_severity === 'CRITICAL') {
       elmts.performEditsButton.prop("disabled",true).addClass("button-disabled");
   } else {
     elmts.performEditsButton.click(function() {
-        hiddenIframe.find('body').append(
-                elmts.performEditsForm.clone());
-        var formCopy = hiddenIframe.find("#wikibase-perform-edits-form");
-        formCopy.submit();
-
-        if(elmts.editSummary.val().length == 0) {
-            elmts.editSummary.focus();
-        } else {
-            Refine.postProcess(
-            "wikidata",
-            "perform-wikibase-edits",
-            {},
-            {
-                summary: elmts.editSummary.val(),
-            },
-            { includeEngine: true, cellsChanged: true, columnStatsChanged: true },
-            { onDone:
-                function() {
-                dismiss();
-                }
-            });
-        }
+    	PerformEditsDialog.doFormSubmit();
     });
   }
 };
+
+PerformEditsDialog.doFormSubmit = function() {
+  var self = this;
+  var elmts = this._elmts;
+
+  var dismiss = function() {
+    DialogSystem.dismissUntil(self._level - 1);
+  };
+
+  var hiddenIframe = $('#hiddenIframe').contents();
+
+	hiddenIframe.find('body').append(
+					elmts.performEditsForm.clone());
+	var formCopy = hiddenIframe.find("#wikibase-perform-edits-form");
+	formCopy.submit();
+
+	if(elmts.editSummary.val().length == 0) {
+			elmts.editSummary.focus();
+	} else {
+			Refine.postProcess(
+			"wikidata",
+			"perform-wikibase-edits",
+			{},
+			{
+					summary: elmts.editSummary.val(),
+			},
+			{ includeEngine: true, cellsChanged: true, columnStatsChanged: true },
+			{ onDone:
+					function() {
+					dismiss();
+					}
+			});
+	}
+}
+
 
 PerformEditsDialog.updateEditCount = function(edit_count) {
   this._elmts.reviewYourEdits.html(

--- a/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
@@ -18,10 +18,37 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
   this._elmts.performEditsButton.text($.i18n('perform-wikidata-edits/perform-edits'));
   this._elmts.cancelButton.text($.i18n('perform-wikidata-edits/cancel'));
 
+	var hiddenIframe = $('#hiddenIframe').contents();
+
   var dismiss = function() {
     DialogSystem.dismissUntil(self._level - 1);
   };
 
+
+	var doFormSubmit = function() {
+		hiddenIframe.find('body').append(elmts.performEditsForm.clone());
+		var formCopy = hiddenIframe.find("#wikibase-perform-edits-form");
+		formCopy.submit();
+
+		if(elmts.editSummary.val().length == 0) {
+				elmts.editSummary.focus();
+		} else {
+				Refine.postProcess(
+				"wikidata",
+				"perform-wikibase-edits",
+				{},
+				{
+						summary: elmts.editSummary.val(),
+				},
+				{ includeEngine: true, cellsChanged: true, columnStatsChanged: true },
+				{ onDone:
+						function() {
+						dismiss();
+						}
+				});
+		}
+	}
+	
   elmts.loggedInUsername
    .text(logged_in_username)
    .attr('href','https://www.wikidata.org/wiki/User:'+logged_in_username);
@@ -30,12 +57,10 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
      dismiss();
   });
 
-  var hiddenIframe = $('#hiddenIframe').contents();
-
   this._elmts.editSummary.keypress(function (evt) {
     evt.preventDefault();
     if (evt.which === 13) {
-    	PerformEditsDialog.doFormSubmit();
+    	doFormSubmit();
     }
   });
 
@@ -43,45 +68,10 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
       elmts.performEditsButton.prop("disabled",true).addClass("button-disabled");
   } else {
     elmts.performEditsButton.click(function() {
-    	PerformEditsDialog.doFormSubmit();
+    	doFormSubmit();
     });
   }
 };
-
-PerformEditsDialog.doFormSubmit = function() {
-  var self = this;
-  var elmts = this._elmts;
-
-  var dismiss = function() {
-    DialogSystem.dismissUntil(self._level - 1);
-  };
-
-  var hiddenIframe = $('#hiddenIframe').contents();
-
-	hiddenIframe.find('body').append(
-					elmts.performEditsForm.clone());
-	var formCopy = hiddenIframe.find("#wikibase-perform-edits-form");
-	formCopy.submit();
-
-	if(elmts.editSummary.val().length == 0) {
-			elmts.editSummary.focus();
-	} else {
-			Refine.postProcess(
-			"wikidata",
-			"perform-wikibase-edits",
-			{},
-			{
-					summary: elmts.editSummary.val(),
-			},
-			{ includeEngine: true, cellsChanged: true, columnStatsChanged: true },
-			{ onDone:
-					function() {
-					dismiss();
-					}
-			});
-	}
-}
-
 
 PerformEditsDialog.updateEditCount = function(edit_count) {
   this._elmts.reviewYourEdits.html(

--- a/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
@@ -39,8 +39,8 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
         {},
         { summary: elmts.editSummary.val(), },
         { includeEngine: true, cellsChanged: true, columnStatsChanged: true },
-        { onDone: function() { dismiss(); }
-      });
+        { onDone: function() { dismiss(); } }
+      );
     }
   }
   

--- a/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
@@ -18,37 +18,37 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
   this._elmts.performEditsButton.text($.i18n('perform-wikidata-edits/perform-edits'));
   this._elmts.cancelButton.text($.i18n('perform-wikidata-edits/cancel'));
 
-	var hiddenIframe = $('#hiddenIframe').contents();
+  var hiddenIframe = $('#hiddenIframe').contents();
 
   var dismiss = function() {
     DialogSystem.dismissUntil(self._level - 1);
   };
 
 
-	var doFormSubmit = function() {
-		hiddenIframe.find('body').append(elmts.performEditsForm.clone());
-		var formCopy = hiddenIframe.find("#wikibase-perform-edits-form");
-		formCopy.submit();
+  var doFormSubmit = function() {
+    hiddenIframe.find('body').append(elmts.performEditsForm.clone());
+    var formCopy = hiddenIframe.find("#wikibase-perform-edits-form");
+    formCopy.submit();
 
-		if(elmts.editSummary.val().length == 0) {
-				elmts.editSummary.focus();
-		} else {
-				Refine.postProcess(
-				"wikidata",
-				"perform-wikibase-edits",
-				{},
-				{
-						summary: elmts.editSummary.val(),
-				},
-				{ includeEngine: true, cellsChanged: true, columnStatsChanged: true },
-				{ onDone:
-						function() {
-						dismiss();
-						}
-				});
-		}
-	}
-	
+    if(elmts.editSummary.val().length == 0) {
+        elmts.editSummary.focus();
+    } else {
+        Refine.postProcess(
+        "wikidata",
+        "perform-wikibase-edits",
+        {},
+        {
+            summary: elmts.editSummary.val(),
+        },
+        { includeEngine: true, cellsChanged: true, columnStatsChanged: true },
+        { onDone:
+            function() {
+            dismiss();
+            }
+        });
+    }
+  }
+  
   elmts.loggedInUsername
    .text(logged_in_username)
    .attr('href','https://www.wikidata.org/wiki/User:'+logged_in_username);

--- a/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/perform-edits-dialog.js
@@ -58,9 +58,9 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
   });
 
   this._elmts.editSummary.keypress(function (evt) {
-    evt.preventDefault();
     if (evt.which === 13) {
-    	doFormSubmit();
+      evt.preventDefault();
+      doFormSubmit();
     }
   });
 
@@ -68,15 +68,15 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
       elmts.performEditsButton.prop("disabled",true).addClass("button-disabled");
   } else {
     elmts.performEditsButton.click(function() {
-    	doFormSubmit();
+      doFormSubmit();
     });
   }
 };
 
 PerformEditsDialog.updateEditCount = function(edit_count) {
   this._elmts.reviewYourEdits.html(
-        $.i18n('perform-wikidata-edits/review-your-edits')
-                .replace('{nb_edits}', edit_count));
+    $.i18n('perform-wikidata-edits/review-your-edits')
+      .replace('{nb_edits}', edit_count));
 }
 
 PerformEditsDialog._updateWarnings = function(data) {


### PR DESCRIPTION
Adding PerformEditsDialog.doFormSubmit() to share with keypress() [RETURN] from editField and « Edit Uploads ».

Questions:
* Should I move PerformEditsDialog.doFormSubmit() inside PerformEditsDialog.launch()?
* Should I also trap [RETURN] when the focus is not in `this._elmts.editSummary`?

Regards, Antoine