### PR TITLE
Add .metadata to ignore Eclipse plugins meta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ test-out/
 /bin
 open-refine.log
 .vscode
+.metadata # Eclipse plugins specific
 
 .idea
 *.iml


### PR DESCRIPTION
I noticed on PR #2555 that we should have ignored the Eclipse plugins ,metadata folder