### PR TITLE
improve native caching during JSON serialization

### DIFF
--- a/main/src/com/google/refine/util/SerializationFilters.java
+++ b/main/src/com/google/refine/util/SerializationFilters.java
@@ -109,7 +109,7 @@ public class SerializationFilters {
         @Override
         public void serialize(Double arg0, JsonGenerator gen, SerializerProvider s)
                 throws IOException {
-            if (new Double(arg0.longValue()).equals(arg0)) {
+            if (Double.valueOf(arg0.longValue()).equals(arg0)) {
                 gen.writeNumber(arg0.longValue());
             } else {
                 gen.writeNumber(arg0);


### PR DESCRIPTION
If a new {@code Double} instance is not required, this method
should generally be used in preference to the constructor
{@link #Double(double)}, as this method is likely to yield
significantly better space and time performance by caching
frequently requested values.

This helps performance slightly depending on JVM used and processor as I discuss in a comment here:
https://stackoverflow.com/questions/10577610/what-is-the-difference-between-double-parsedoublestring-and-double-valueofstr?lq=1#comment108527648_10577630