### PR TITLE
Change "reference manual" to "product reference"

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,9 +1,9 @@
 ---
 id: index
-title: OpenRefine reference manual
+title: OpenRefine product reference
 sidebar_label: Index
 ---
 
-This site is just a prototype to propose a basic publishing infrastructure for OpenRefine's new reference manual.
+This site is just a prototype to propose a basic publishing infrastructure for OpenRefine's new product reference.
 
 The structure on the left hand side is just a placeholder, as are the contents of all pages.


### PR DESCRIPTION
Let's see if this PR gets automatically labeled as being about documentation.