### PR TITLE
Add Netlify link required for a team open source account

### DIFF
--- a/docs/core/Footer.js
+++ b/docs/core/Footer.js
@@ -99,6 +99,7 @@ class Footer extends React.Component {
         </section>
 
         <section className="copyright">{this.props.config.copyright}</section>
+        <section className="copyright">Hosted by <a href="https://www.netlify.com/">Netlify</a></section>
       </footer>
     );
   }


### PR DESCRIPTION
Somehow the Netlify integration is currently tied to my account, to get a team account we can apply for an open source plan which requires linking back to Netlify from our site. This does it in a discreet way.