### PR TITLE
Use SXSSFWorkbook in XlsExporter

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -253,12 +253,12 @@
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi</artifactId>
-      <version>4.1.1</version>
+      <version>4.1.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.poi</groupId>
       <artifactId>poi-ooxml</artifactId>
-      <version>4.1.1</version>
+      <version>4.1.2</version>
     </dependency>
     <dependency>
       <groupId>org.odftoolkit</groupId>

--- a/main/src/com/google/refine/exporters/XlsExporter.java
+++ b/main/src/com/google/refine/exporters/XlsExporter.java
@@ -48,7 +48,7 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.WorkbookUtil;
-import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.refine.ProjectManager;
@@ -72,7 +72,7 @@ public class XlsExporter implements StreamExporter {
     public void export(final Project project, Properties params, Engine engine,
             OutputStream outputStream) throws IOException {
 
-        final Workbook wb = xml ? new XSSFWorkbook() : new HSSFWorkbook();
+        final Workbook wb = xml ? new SXSSFWorkbook() : new HSSFWorkbook();
         
         TabularSerializer serializer = new TabularSerializer() {
             Sheet s;


### PR DESCRIPTION
* to improve memory usage when exporting xlsx files
* indirectly related to https://github.com/OpenRefine/OpenRefine/issues/2593