### PR TITLE
POI works better reading files directly

### DIFF
--- a/main/src/com/google/refine/importers/ExcelImporter.java
+++ b/main/src/com/google/refine/importers/ExcelImporter.java
@@ -45,12 +45,13 @@ import java.util.List;
 import org.apache.poi.ooxml.POIXMLException;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.poifs.filesystem.FileMagic;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.apache.poi.poifs.filesystem.FileMagic;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,43 +84,39 @@ public class ExcelImporter extends TabularImportingParserBase {
             for (int index = 0;index < fileRecords.size();index++) {
                 ObjectNode fileRecord = fileRecords.get(index);
                 File file = ImportingUtilities.getFile(job, fileRecord);
-                InputStream is = new FileInputStream(file);
 
-                if (!is.markSupported()) {
-                  is = new BufferedInputStream(is);
-                }
-
+                Workbook wb = null;
                 try {
-                    Workbook wb = FileMagic.valueOf(is) == FileMagic.OOXML ?
-                            new XSSFWorkbook(is) :
-                                new HSSFWorkbook(new POIFSFileSystem(is));
+                    wb = FileMagic.valueOf(file) == FileMagic.OOXML ? new XSSFWorkbook(file) :
+                                 new HSSFWorkbook(new POIFSFileSystem(file));
 
-                            int sheetCount = wb.getNumberOfSheets();
-                            for (int i = 0; i < sheetCount; i++) {
-                                Sheet sheet = wb.getSheetAt(i);
-                                int rows = sheet.getLastRowNum() - sheet.getFirstRowNum() + 1;
+                    int sheetCount = wb.getNumberOfSheets();
+                    for (int i = 0; i < sheetCount; i++) {
+                        Sheet sheet = wb.getSheetAt(i);
+                        int rows = sheet.getLastRowNum() - sheet.getFirstRowNum() + 1;
 
-                                ObjectNode sheetRecord = ParsingUtilities.mapper.createObjectNode();
-                                JSONUtilities.safePut(sheetRecord, "name",  file.getName() + "#" + sheet.getSheetName());
-                                JSONUtilities.safePut(sheetRecord, "fileNameAndSheetIndex", file.getName() + "#" + i);
-                                JSONUtilities.safePut(sheetRecord, "rows", rows);
-                                if (rows > 1) {
-                                    JSONUtilities.safePut(sheetRecord, "selected", true);
-                                } else {
-                                    JSONUtilities.safePut(sheetRecord, "selected", false);
-                                }
-                                JSONUtilities.append(sheetRecords, sheetRecord);
-                            }
-                            wb.close();
+                        ObjectNode sheetRecord = ParsingUtilities.mapper.createObjectNode();
+                        JSONUtilities.safePut(sheetRecord, "name",  file.getName() + "#" + sheet.getSheetName());
+                        JSONUtilities.safePut(sheetRecord, "fileNameAndSheetIndex", file.getName() + "#" + i);
+                        JSONUtilities.safePut(sheetRecord, "rows", rows);
+                        if (rows > 1) {
+                            JSONUtilities.safePut(sheetRecord, "selected", true);
+                        } else {
+                            JSONUtilities.safePut(sheetRecord, "selected", false);
+                        }
+                        JSONUtilities.append(sheetRecords, sheetRecord);
+                    }
                 } finally {
-                    is.close();
+                    if (wb != null) {
+                        wb.close();
+                    }
                 }
             }                
         } catch (IOException e) {
             logger.error("Error generating parser UI initialization data for Excel file", e);
         } catch (IllegalArgumentException e) {
             logger.error("Error generating parser UI initialization data for Excel file (only Excel 97 & later supported)", e);
-        } catch (POIXMLException e) {
+        } catch (POIXMLException|InvalidFormatException e) {
             logger.error("Error generating parser UI initialization data for Excel file - invalid XML", e);
         }
         


### PR DESCRIPTION
Doesn't solve https://github.com/OpenRefine/OpenRefine/issues/2593 but it will speed up existing code a bit. When you pass an InputStream to POI, it moves the data to a temp file - accessing with the file in the first place avoids this step.