### PR TITLE
Fix imprecise facet statistics in records mode

### DIFF
--- a/main/src/com/google/refine/browsing/util/ExpressionNominalValueGrouper.java
+++ b/main/src/com/google/refine/browsing/util/ExpressionNominalValueGrouper.java
@@ -36,7 +36,6 @@ package com.google.refine.browsing.util;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;

--- a/main/tests/server/src/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
@@ -51,7 +51,6 @@ import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 
-
 public class ExpressionNominalValueGrouperTests extends RefineTest {
     // dependencies    
     //Variables
@@ -173,5 +172,36 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
       Assert.assertTrue(grouper.choices.containsKey(dateTimeStringValue));
       Assert.assertEquals(grouper.choices.get(dateTimeStringValue).decoratedValue.label,dateTimeStringValue);
       Assert.assertEquals(grouper.choices.get(dateTimeStringValue).decoratedValue.value.toString(),dateTimeStringValue);
+    }
+
+    @Test
+    public void expressionNominalValueGrouperRecords() throws Exception {
+        String completeProjectJson = "col1,col2,col3\n"
+                + "record1,1,a\n"
+                + ",,a\n"
+                + ",1,a\n"
+                + "record2,,a\n"
+                + ",1,a\n";
+
+        project = createCSVProject(completeProjectJson);
+        bindings = new Properties();
+        bindings.put("project", project);
+
+        eval = MetaParser.parse("value");
+        grouper = new ExpressionNominalValueGrouper(eval, "col2", 1);
+        try {
+            grouper.start(project);
+            int c = project.recordModel.getRecordCount();
+            for (int r = 0; r < c; r++) {
+                grouper.visit(project, project.recordModel.getRecord(r));
+            }
+        } finally {
+            grouper.end(project);
+        }
+
+        Assert.assertEquals(grouper.blankCount, 2);
+        Assert.assertEquals(grouper.choices.size(), 1);
+        Assert.assertTrue(grouper.choices.containsKey(integerStringValue));
+        Assert.assertEquals(grouper.choices.get(integerStringValue).count, 2);
     }
 }

--- a/main/tests/server/src/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
@@ -179,7 +179,7 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
         String completeProjectJson = "col1,col2,col3\n"
                 + "record1,1,a\n"
                 + ",,a\n"
-                + ",1,a\n"
+                + ",,a\n"
                 + "record2,,a\n"
                 + ",1,a\n";
 
@@ -199,7 +199,7 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
             grouper.end(project);
         }
 
-        Assert.assertEquals(grouper.blankCount, 2);
+        Assert.assertEquals(grouper.blankCount, 3);
         Assert.assertEquals(grouper.choices.size(), 1);
         Assert.assertTrue(grouper.choices.containsKey(integerStringValue));
         Assert.assertEquals(grouper.choices.get(integerStringValue).count, 2);


### PR DESCRIPTION
Fixes #2588 

The bug results because the `ExpressionNominalValueGrouper` used in `ListFacet` treats row data in the same way in both row and record modes.

To fix this, we have to make sure we do not double count instances of unique non blank data in record mode. I added some additional scratch pad variables instead of creating additional methods (e.g. `visitRecordRow`) because it feels cleaner this way.

I also added a test for the `ExpressionNominalValueGrouper`. Although I tried to reuse the project set up in `@BeforeMethod`, I was facing a lot of trouble changing the project to run in record mode. Hence, I am currently using `parseCSVProject` for a small CSV example that I came up with for this issue.