### PR TITLE
Fix bug when both trim and autodetect are enabled in tabular parser.

### DIFF
--- a/main/src/com/google/refine/importers/TabularImportingParserBase.java
+++ b/main/src/com/google/refine/importers/TabularImportingParserBase.java
@@ -167,11 +167,12 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
                             } else if (ExpressionUtils.isNonBlankData(value)) {
                                 Serializable storedValue;
                                 if (value instanceof String) {
+                                	if(trimStrings) {
+                                        value = ((String) value).trim();
+                                    }
                                     storedValue = guessCellValueTypes ?
                                         ImporterUtilities.parseCellValue((String) value) : (String) value;
-                                    if(trimStrings) {
-                                        storedValue = ((String) storedValue).toString().trim();
-                                    }
+                                    
                                 } else {
                                     storedValue = ExpressionUtils.wrapStorable(value);
                                 }

--- a/main/tests/server/src/com/google/refine/importers/TsvCsvImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/TsvCsvImporterTests.java
@@ -245,6 +245,27 @@ public class TsvCsvImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(0).cells.get(1).value, " 3.4 ");
         Assert.assertEquals(project.rows.get(0).cells.get(2).value, " data3 ");
     }
+    
+    @Test(groups = {  }, dataProvider = "CSV-TSV-AutoDetermine")
+    public void trimAndAutodetectDatatype(String sep){
+        //create input to test with
+        String inputSeparator =  sep == null ? "\t" : sep;
+        String input = " data1 " + inputSeparator + " 3.4 " + inputSeparator + " data3 ";
+
+        try {
+            prepareOptions(sep, -1, 0, 0, 0, true, false, true);
+            parseOneFile(SUT, new StringReader(input));
+        } catch (Exception e) {
+            Assert.fail("Exception during file parse",e);
+        }
+        Assert.assertEquals(project.columnModel.columns.size(), 3);
+        Assert.assertEquals(project.rows.size(), 1);
+        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
+        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
+        Assert.assertEquals(project.rows.get(0).cells.get(1).value, Double.parseDouble("3.4"));
+        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+    }
+
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
     public void readCanAddNull(String sep){


### PR DESCRIPTION
Closes #2584, which occurs when both trimming and type detection are enabled in a tabular parser (such as the CSV/TSV parser).

Cell value trimming was introduced after cell datatype detection, whereas it should be the other way around.