### PR TITLE
Added if brackets to single statement if-blocks

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/CommonDescriptionScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/CommonDescriptionScrutinizer.java
@@ -41,7 +41,9 @@ public class CommonDescriptionScrutinizer extends DescriptionScrutinizer {
         labels.addAll(update.getLabelsIfNew()); // merge
         for (MonolingualTextValue label : labels) {
             String labelText = label.getText();
-            if (labelText == null) continue;
+            if (labelText == null) {
+                continue;
+            }
             labelText = labelText.trim();
             if (labelText.equals(descText)) {
                 QAWarning issue = new QAWarning(descIdenticalWithLabel, null, QAWarning.Severity.WARNING, 1);

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/DescriptionScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/DescriptionScrutinizer.java
@@ -1,6 +1,5 @@
 package org.openrefine.wikidata.qa.scrutinizers;
 
-import org.openrefine.wikidata.qa.QAWarning;
 import org.openrefine.wikidata.updates.ItemUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 
@@ -17,9 +16,13 @@ public abstract class DescriptionScrutinizer extends EditScrutinizer {
         descriptions.addAll(update.getDescriptionsIfNew()); // merge
         for (MonolingualTextValue description : descriptions) {
             String descText = description.getText();
-            if (descText == null) continue;
+            if (descText == null) {
+                continue;
+            }
             descText = descText.trim();
-            if (descText.length() == 0) continue; // avoid NullPointerException
+            if (descText.length() == 0) {
+                continue; // avoid NullPointerException
+            }
 
             scrutinize(update, descText, description.getLanguageCode());
         }

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/EnglishDescriptionScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/EnglishDescriptionScrutinizer.java
@@ -16,7 +16,9 @@ public class EnglishDescriptionScrutinizer extends DescriptionScrutinizer {
 
     @Override
     public void scrutinize(ItemUpdate update, String descText, String lang) {
-        if (!LANG.equalsIgnoreCase(lang)) return;
+        if (!LANG.equalsIgnoreCase(lang)) {
+            return;
+        }
 
         checkPunctuationSign(update, descText);
         checkUppercase(update, descText);


### PR DESCRIPTION
There were some if-blocks without braces that were having one line of code. Syntactically, it was correct but it makes the maintainability of the code harder and increases the chances of error.