### PR TITLE
Replaced isInstance method by instanceOf operator

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/QAWarning.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/QAWarning.java
@@ -23,15 +23,14 @@
  ******************************************************************************/
 package org.openrefine.wikidata.qa;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import org.jsoup.helper.Validate;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jsoup.helper.Validate;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * A class to represent a QA warning emitted by the Wikidata schema This could
@@ -155,7 +154,7 @@ public class QAWarning implements Comparable<QAWarning> {
 
     @Override
     public boolean equals(Object other) {
-        if (other == null || !QAWarning.class.isInstance(other)) {
+        if (!(other instanceof QAWarning)) {
             return false;
         }
         QAWarning otherWarning = (QAWarning) other;

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/CalendarScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/CalendarScrutinizer.java
@@ -14,7 +14,7 @@ public class CalendarScrutinizer extends ValueScrutinizer {
 
 	@Override
 	public void scrutinize(Value value) {
-		if(TimeValue.class.isInstance(value)) {
+		if(value instanceof TimeValue) {
 			TimeValue time = (TimeValue)value;
 			if(time.getPreferredCalendarModel().equals(earliestGregorian.getPreferredCalendarModel()) &&
 			   time.getPrecision() >= 10 &&

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/FormatScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/FormatScrutinizer.java
@@ -23,15 +23,15 @@
  ******************************************************************************/
 package org.openrefine.wikidata.qa.scrutinizers;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Pattern;
-
 import org.openrefine.wikidata.qa.QAWarning;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
 import org.wikidata.wdtk.datamodel.interfaces.StringValue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * A scrutinizer that detects incorrect formats in text values (mostly
@@ -74,7 +74,7 @@ public class FormatScrutinizer extends SnakScrutinizer {
 
     @Override
     public void scrutinize(Snak snak, EntityIdValue entityId, boolean added) {
-        if (StringValue.class.isInstance(snak.getValue())) {
+        if (snak.getValue() instanceof StringValue) {
             String value = ((StringValue) snak.getValue()).getString();
             PropertyIdValue pid = snak.getPropertyId();
             Pattern pattern = getPattern(pid);

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstraintScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstraintScrutinizer.java
@@ -23,18 +23,14 @@
  ******************************************************************************/
 package org.openrefine.wikidata.qa.scrutinizers;
 
+import org.openrefine.wikidata.qa.QAWarning;
+import org.wikidata.wdtk.datamodel.interfaces.*;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-
-import org.openrefine.wikidata.qa.QAWarning;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.Value;
 
 /**
  * A scrutinizer that checks for missing inverse statements in edit batches.
@@ -82,7 +78,7 @@ public class InverseConstraintScrutinizer extends StatementScrutinizer {
         }
 
         Value mainSnakValue = statement.getClaim().getMainSnak().getValue();
-        if (ItemIdValue.class.isInstance(mainSnakValue)) {
+        if (mainSnakValue instanceof ItemIdValue) {
             PropertyIdValue pid = statement.getClaim().getMainSnak().getPropertyId();
             PropertyIdValue inversePid = getInverseConstraint(pid);
             if (inversePid != null) {

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/QuantityScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/QuantityScrutinizer.java
@@ -1,13 +1,9 @@
 package org.openrefine.wikidata.qa.scrutinizers;
 
-import java.util.Set;
-
 import org.openrefine.wikidata.qa.QAWarning;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
+import org.wikidata.wdtk.datamodel.interfaces.*;
+
+import java.util.Set;
 
 /**
  * Scrutinizer checking for units and bounds in quantities.
@@ -24,7 +20,7 @@ public class QuantityScrutinizer extends SnakScrutinizer {
 
     @Override
     public void scrutinize(Snak snak, EntityIdValue entityId, boolean added) {
-        if (QuantityValue.class.isInstance(snak.getValue()) && added) {
+        if (snak.getValue() instanceof QuantityValue && added) {
             PropertyIdValue pid = snak.getPropertyId();
             QuantityValue value = (QuantityValue)snak.getValue();
             

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/WhitespaceScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/WhitespaceScrutinizer.java
@@ -23,15 +23,15 @@
  ******************************************************************************/
 package org.openrefine.wikidata.qa.scrutinizers;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.regex.Pattern;
-
 import org.openrefine.wikidata.qa.QAWarning;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.StringValue;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
 
 /**
  * Scrutinizes strings for trailing / leading whitespace, and others
@@ -57,9 +57,9 @@ public class WhitespaceScrutinizer extends ValueScrutinizer {
     @Override
     public void scrutinize(Value value) {
         String str = null;
-        if (MonolingualTextValue.class.isInstance(value)) {
+        if (value instanceof MonolingualTextValue) {
             str = ((MonolingualTextValue) value).getText();
-        } else if (StringValue.class.isInstance(value)) {
+        } else if (value instanceof StringValue) {
             str = ((StringValue) value).getString();
         }
 


### PR DESCRIPTION
In case when we know, the kind of class we want to check before runtime, we should prefer using instanceOf operator in place of isInstance method.