### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve OpenRefine
 title: ''
-labels: bug, triage needed
+labels: bug, to be reviewed
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Create a report to help us improve OpenRefine
+title: ''
+labels: bug, triage needed
+assignees: ''
 
 ---
 
@@ -9,13 +12,15 @@ about: Create a report to help us improve OpenRefine
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. Go to '...'
+1. <!-- Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
-4. See error
+4. See error -->
+
+
 
 **Current Results**
-<!-- What results occured or were shown. -->
+<!-- What results occurred or were shown. -->
 
 **Expected behavior**
 <!-- A clear and concise description of what you expected to happen or to show. -->
@@ -23,13 +28,13 @@ Steps to reproduce the behavior:
 **Screenshots**
 <!-- If applicable, add screenshots to help explain your problem. -->
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS, Windows 10, Linux, Ubuntu 18.04]
- - Browser Version: [e.g. Chrome 19, Firefox 61, Safari, NOTE: OpenRefine does not support IE but works OK in most cases]
- - JRE or JDK Version:[output of "java -version" e.g. JRE 1.8.0_181]
+**Desktop<!--  (please complete the following information)-->:**
+ - OS: <!--  e.g. iOS, Windows 10, Linux, Ubuntu 18.04 -->
+ - Browser Version: <!--  e.g. Chrome 19, Firefox 61, Safari, NOTE: OpenRefine does not support IE but works OK in most cases -->
+ - JRE or JDK Version: <!--  output of "java -version" e.g. JRE 1.8.0_181 -->
 
-**OpenRefine (please complete the following information):**
- - Version [e.g. OpenRefine 3.0 Beta]
+**OpenRefine <!--(please complete the following information)-->:**
+ - Version <!--  e.g. OpenRefine 3.0 Beta] -->
 
 **Datasets**
 <!-- If you are allowed and are OK with making your data public, it would be awesome if you can include or attach the data causing the issue or a URL pointing to where the data is.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for OpenRefine
+title: ''
+labels: enhancement, triage needed
+assignees: ''
 
 ---
 


### PR DESCRIPTION
Make boilerplate/suggestions into comments so they don't show up in final issue if people forget to edit them out.

Add default labels to identify issues needing triage.