### PR TITLE
Preserve international characters on import/export

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/schema-alignment-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/schema-alignment-dialog.js
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 var SchemaAlignment = {};
 
 SchemaAlignment._cleanName = function(s) {
+  // FIXME: This drops all international characters
   return s.replace(/\W/g, " ").replace(/\s+/g, " ").toLowerCase();
 };
 

--- a/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.js
@@ -143,7 +143,7 @@ TemplatingExporterDialog.prototype._updatePreview = function() {
 };
 
 TemplatingExporterDialog.prototype._export = function() {
-    var name = $.trim(theProject.metadata.name.replace(/\W/g, ' ')).replace(/\s+/g, '-');
+    var name = $.trim(theProject.metadata.name).replace(/\s+/g, '-');
     var form = document.createElement("form");
     $(form)
         .css("display", "none")

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/parsing-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/parsing-panel.js
@@ -60,7 +60,7 @@ Refine.DefaultImportingController.prototype._showParsingPanel = function(hasFile
   if (!(this._projectName) && this._job.config.fileSelection.length > 0) {
     var index = this._job.config.fileSelection[0];
     var record = this._job.config.retrievalRecord.files[index];
-    this._projectName = $.trim(record.fileName.replace(/\W/g, ' ').replace(/\s+/g, ' '));
+    this._projectName = $.trim(record.fileName.replace(/[\._-]/g, ' ').replace(/\s+/g, ' '));
   }
   if (this._projectName) {
     this._parsingPanelElmts.projectNameInput[0].value = this._projectName;

--- a/main/webapp/modules/core/scripts/project/exporters.js
+++ b/main/webapp/modules/core/scripts/project/exporters.js
@@ -125,7 +125,7 @@ ExporterManager.handlers.exportRows = function(format, ext) {
 };
 
 ExporterManager.prepareExportRowsForm = function(format, includeEngine, ext) {
-  var name = $.trim(theProject.metadata.name.replace(/\W/g, ' ')).replace(/\s+/g, '-');
+  var name = ExporterManager.stripNonFileChars(theProject.metadata.name);
   var form = document.createElement("form");
   $(form)
   .css("display", "none")


### PR DESCRIPTION
Fixes #1352. Preserve non-ASCII characters in project names on
project creation and filenames on export.