### PR TITLE
Clean up i18n support for import / export

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/schema-alignment-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/schema-alignment-dialog.js
@@ -32,11 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 var SchemaAlignment = {};
-
-SchemaAlignment._cleanName = function(s) {
-  return s.replace(/\W/g, " ").replace(/\s+/g, " ").toLowerCase();
-};
-
 var SchemaAlignmentDialog = {};
 
 /**

--- a/main/src/com/google/refine/commands/project/ExportRowsCommand.java
+++ b/main/src/com/google/refine/commands/project/ExportRowsCommand.java
@@ -100,6 +100,9 @@ public class ExportRowsCommand extends Command {
                 contentType = exporter.getContentType();
             }
             response.setHeader("Content-Type", contentType);
+            String path = request.getPathInfo();
+            String filename = path.substring(path.lastIndexOf('/') + 1);
+            response.setHeader("Content-Disposition", "attachment; filename=" + filename);
             
             if (exporter instanceof WriterExporter) {
                 String encoding = params.getProperty("encoding");

--- a/main/src/com/google/refine/commands/project/ExportRowsCommand.java
+++ b/main/src/com/google/refine/commands/project/ExportRowsCommand.java
@@ -100,9 +100,13 @@ public class ExportRowsCommand extends Command {
                 contentType = exporter.getContentType();
             }
             response.setHeader("Content-Type", contentType);
-            String path = request.getPathInfo();
-            String filename = path.substring(path.lastIndexOf('/') + 1);
-            response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+
+            String preview = params.getProperty("preview");
+            if (!"true".equals(preview)) {
+                String path = request.getPathInfo();
+                String filename = path.substring(path.lastIndexOf('/') + 1);
+                response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+            }
             
             if (exporter instanceof WriterExporter) {
                 String encoding = params.getProperty("encoding");

--- a/main/src/com/google/refine/exporters/HtmlTableExporter.java
+++ b/main/src/com/google/refine/exporters/HtmlTableExporter.java
@@ -60,14 +60,16 @@ public class HtmlTableExporter implements WriterExporter {
             @Override
             public void startFile(JsonNode options) {
                 try {
-                    writer.write("<html>\n");
+                    writer.write("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" " +
+                            " \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">\n");
+                    writer.write("<html xmlns=\"http://www.w3.org/1999/xhtml\">\n");
                     writer.write("<head>\n");
                     writer.write("<title>"); 
                     writer.write(ProjectManager.singleton.getProjectMetadata(project.id).getName());
                     writer.write("</title>\n");
-                    writer.write("<meta charset=\"utf-8\" />\n");
+                    writer.write("<meta charset=\"UTF-8\" />\n");
                     writer.write("</head>\n");
-    
+
                     writer.write("<body>\n");
                     writer.write("<table>\n");
                 } catch (IOException e) {
@@ -85,6 +87,7 @@ public class HtmlTableExporter implements WriterExporter {
                     // Ignore
                 }
             }
+
 
             @Override
             public void addRow(List<CellData> cells, boolean isHeader) {
@@ -106,7 +109,7 @@ public class HtmlTableExporter implements WriterExporter {
                                     writer.write(StringEscapeUtils.escapeHtml4(cellData.link));
                                     writer.write("\">");
                                 }
-                                writer.write(StringEscapeUtils.escapeXml10(cellData.text));
+                                writer.write(StringEscapeUtils.escapeXml11(cellData.text));
                                 if (cellData.link != null) {
                                     writer.write("</a>");
                                 }
@@ -120,7 +123,7 @@ public class HtmlTableExporter implements WriterExporter {
                 }
             }
         };
-        
+
         CustomizableTabularExporterUtilities.exportRows(
                 project, engine, params, serializer);
     }

--- a/main/src/com/google/refine/exporters/TemplatingExporter.java
+++ b/main/src/com/google/refine/exporters/TemplatingExporter.java
@@ -57,7 +57,7 @@ public class TemplatingExporter implements WriterExporter {
 
     @Override
     public String getContentType() {
-        return "application/x-unknown";
+        return "text/plain";
     }
     
     protected static class TemplateConfig {

--- a/main/src/com/google/refine/exporters/sql/SqlInsertBuilder.java
+++ b/main/src/com/google/refine/exporters/sql/SqlInsertBuilder.java
@@ -132,7 +132,7 @@ public class SqlInsertBuilder {
                         
                         if(type.equals(SqlData.SQL_TYPE_NUMERIC)) {//test if number is numeric (decimal(p,s) number is valid)
                            
-                            if(!NumberUtils.isNumber(val.getText())){
+                            if(!NumberUtils.isCreatable(val.getText())){
                                 throw new SqlExporterException(
                                         val.getText() + " is not compatible with column type :" + type);
                             }
@@ -179,15 +179,14 @@ public class SqlInsertBuilder {
         }
 
         boolean trimColNames = options == null ? false : JSONUtilities.getBoolean(options, "trimColumnNames", false);
-        String colNamesWithSep = columns.stream().map(col -> col.replaceAll("\\s", "")).collect(Collectors.joining(","));;
+        String colNamesWithSep = columns.stream().map(col -> col.replaceAll("\\s", "")).collect(Collectors.joining(","));
         if(!trimColNames) {
            colNamesWithSep = columns.stream().collect(Collectors.joining(","));  
         }
-        
+
         String valuesString = values.toString();
-        valuesString = valuesString.substring(0, valuesString.length() - 1);
-        
-        
+        valuesString = valuesString.substring(0, Integer.max(0, valuesString.length() - 1));
+
         StringBuffer sql = new StringBuffer();
 
         sql.append("INSERT INTO ").append(table);

--- a/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
+++ b/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
@@ -47,8 +47,6 @@ import javax.servlet.ServletException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonParseException;
-
 import com.google.refine.importers.tree.TreeReader.Token;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Project;

--- a/main/src/com/google/refine/importing/DefaultImportingController.java
+++ b/main/src/com/google/refine/importing/DefaultImportingController.java
@@ -47,7 +47,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.RefineServlet;

--- a/main/tests/server/src/com/google/refine/exporters/HtmlExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/HtmlExporterTests.java
@@ -116,9 +116,12 @@ public class HtmlExporterTests extends RefineTest {
             Assert.fail();
         }
 
-        Assert.assertEquals(writer.toString(), "<html>\n" +
+        Assert.assertEquals(writer.toString(),
+                "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" " +
+                " \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">\n" +
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n" +
                 "<head>\n" + "<title>" + TEST_PROJECT_NAME + "</title>\n" + 
-                "<meta charset=\"utf-8\" />\n" + 
+                "<meta charset=\"UTF-8\" />\n" +
                 "</head>\n" +
                 "<body>\n" +
                 "<table>\n" +
@@ -143,9 +146,12 @@ public class HtmlExporterTests extends RefineTest {
             Assert.fail();
         }
 
-        Assert.assertEquals(writer.toString(), "<html>\n" +
+        Assert.assertEquals(writer.toString(),
+                "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" " +
+                " \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">\n" +
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n" +
                 "<head>\n" + "<title>" + TEST_PROJECT_NAME + "</title>\n" + 
-                "<meta charset=\"utf-8\" />\n" + 
+                "<meta charset=\"UTF-8\" />\n" +
                 "</head>\n" +
                 "<body>\n" +
                 "<table>\n" +
@@ -170,9 +176,12 @@ public class HtmlExporterTests extends RefineTest {
             Assert.fail();
         }
 
-        Assert.assertEquals(writer.toString(), "<html>\n" +
+        Assert.assertEquals(writer.toString(),
+                "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" " +
+                " \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">\n" +
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n" +
                 "<head>\n" + "<title>" + TEST_PROJECT_NAME + "</title>\n" + 
-                "<meta charset=\"utf-8\" />\n" +
+                "<meta charset=\"UTF-8\" />\n" +
                 "</head>\n" +
                 "<body>\n" +
                 "<table>\n" +
@@ -197,9 +206,12 @@ public class HtmlExporterTests extends RefineTest {
             Assert.fail();
         }
 
-        Assert.assertEquals(writer.toString(), "<html>\n" +
+        Assert.assertEquals(writer.toString(),
+                "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\" " +
+                " \"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">\n" +
+                "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n" +
                 "<head>\n" + "<title>" + TEST_PROJECT_NAME + "</title>\n" + 
-                "<meta charset=\"utf-8\" />\n" +
+                "<meta charset=\"UTF-8\" />\n" +
                 "</head>\n" +
                 "<body>\n" +
                 "<table>\n" +

--- a/main/webapp/modules/core/scripts/dialogs/custom-tabular-exporter-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/custom-tabular-exporter-dialog.js
@@ -314,13 +314,11 @@ CustomTabularExporterDialog.prototype._postExport = function(preview) {
     .attr("value", encoding)
     .appendTo(form);
   }
-  if (!preview) {
-    $('<input />')
-    .attr("name", "contentType")
-    .attr("value", "application/x-unknown") // force download
-    .appendTo(form);
-  }
-  
+  $('<input />')
+  .attr("name", "preview")
+  .attr("value", preview)
+  .appendTo(form);
+
   document.body.appendChild(form);
 
   window.open(" ", "refine-export");

--- a/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.js
@@ -143,7 +143,7 @@ TemplatingExporterDialog.prototype._updatePreview = function() {
 };
 
 TemplatingExporterDialog.prototype._export = function() {
-    var name = $.trim(theProject.metadata.name).replace(/\s+/g, '-');
+    var name = ExporterManager.stripNonFileChars(theProject.metadata.name);
     var form = document.createElement("form");
     $(form)
         .css("display", "none")

--- a/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.js
@@ -143,7 +143,7 @@ TemplatingExporterDialog.prototype._updatePreview = function() {
 };
 
 TemplatingExporterDialog.prototype._export = function() {
-    var name = $.trim(theProject.metadata.name.replace(/\W/g, ' ')).replace(/\s+/g, '-');
+    var name = $.trim(theProject.metadata.name).replace(/\s+/g, '-');
     var form = document.createElement("form");
     $(form)
         .css("display", "none")

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/parsing-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/parsing-panel.js
@@ -60,7 +60,7 @@ Refine.DefaultImportingController.prototype._showParsingPanel = function(hasFile
   if (!(this._projectName) && this._job.config.fileSelection.length > 0) {
     var index = this._job.config.fileSelection[0];
     var record = this._job.config.retrievalRecord.files[index];
-    this._projectName = $.trim(record.fileName.replace(/\W/g, ' ').replace(/\s+/g, ' '));
+    this._projectName = $.trim(record.fileName.replace(/[\._-]/g, ' ').replace(/\s+/g, ' '));
   }
   if (this._projectName) {
     this._parsingPanelElmts.projectNameInput[0].value = this._projectName;

--- a/main/webapp/modules/core/scripts/project/exporters.js
+++ b/main/webapp/modules/core/scripts/project/exporters.js
@@ -105,8 +105,9 @@ ExporterManager.prototype._initializeUI = function() {
 };
 
 ExporterManager.stripNonFileChars = function(name) {
-    //prohibited characters in file name of linux (/) and windows (\/:*?"<>|)
-    return $.trim(name.replace(/[\\*\/:?"<>|]/g, ' ')).replace(/\s+/g, '-');
+    // prohibited characters in file name of linux (/) and windows (\/:*?"<>|)
+    // and MacOS https://stackoverflow.com/a/47455094/167425
+    return $.trim(name.replace(/[\\*\/:;,?"<>|#]/g, ' ')).replace(/\s+/g, '-');
 };
 
 ExporterManager.handlers.exportRows = function(format, ext) {
@@ -125,7 +126,7 @@ ExporterManager.handlers.exportRows = function(format, ext) {
 };
 
 ExporterManager.prepareExportRowsForm = function(format, includeEngine, ext) {
-  var name = $.trim(theProject.metadata.name.replace(/\W/g, ' ')).replace(/\s+/g, '-');
+  var name = ExporterManager.stripNonFileChars(theProject.metadata.name);
   var form = document.createElement("form");
   $(form)
   .css("display", "none")

--- a/main/webapp/modules/core/scripts/project/exporters.js
+++ b/main/webapp/modules/core/scripts/project/exporters.js
@@ -112,10 +112,6 @@ ExporterManager.stripNonFileChars = function(name) {
 
 ExporterManager.handlers.exportRows = function(format, ext) {
   var form = ExporterManager.prepareExportRowsForm(format, true, ext);
-  $('<input />')
-  .attr("name", "contentType")
-  .attr("value", "application/x-unknown") // force download
-  .appendTo(form);
 
   document.body.appendChild(form);
 

--- a/main/webapp/modules/core/scripts/project/exporters.js
+++ b/main/webapp/modules/core/scripts/project/exporters.js
@@ -126,7 +126,7 @@ ExporterManager.handlers.exportRows = function(format, ext) {
 };
 
 ExporterManager.prepareExportRowsForm = function(format, includeEngine, ext) {
-  var name = ExporterManager.stripNonFileChars(theProject.metadata.name);
+  var name = encodeURI(ExporterManager.stripNonFileChars(theProject.metadata.name));
   var form = document.createElement("form");
   $(form)
   .css("display", "none")
@@ -156,7 +156,7 @@ ExporterManager.prepareExportRowsForm = function(format, includeEngine, ext) {
 };
 
 ExporterManager.handlers.exportProjectToLocal = function() {
-  var name = ExporterManager.stripNonFileChars(theProject.metadata.name);
+  var name = encodeURI(ExporterManager.stripNonFileChars(theProject.metadata.name));
   var form = document.createElement("form");
   $(form)
   .css("display", "none")


### PR DESCRIPTION
This pull request combines the two previous pull requests (#2711 & #2712) since they ended up being intertwined.

Fixes #1197. Fixes #1352. Those issues contain test data files. The basic pieces are:
- #1197 - use `ContentDisposition: attachment` to force download instead of `ContentType: application/x-unknown`. The funky content type is what was interfering with the non-BMP UTF-8 characters. Took a while to figure that out!
- As part of the above, switch to consistently using option `preview: true` to control preview vs download. It was used in some place, but others used the content type.
- While investigating 1197 I tried upgrading our HTML output to XHTML 1.1, which didn't help, but seemed useful, so I left it in.
- #1352 - Multinational characters are now supported on both import and export. On import just the characters "\._-" are converted to spaces and everything else, including, notably, international characters, are left untouched. On output, a multi-OS filename character blacklist is used, including "\*/:;,?"<>|#". Some are not technically illegal, but just a pain to deal with. The cleaning is centralized in `ExporterManager.stripNonFileChars()` which we now use wherever this is needed.
- The SQL exporter still needs more love. It will output multinational characters in the SQL filename, but still aggressively cleans the table, but doesn't appear to clean the column names. One improvement that I made is that the user can now see the cleaned tablename during their preview.