### PR TITLE
Refactoring the data table into a single container

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -619,7 +619,6 @@ DataTableCellUI.prototype._startEdit = function(elmt) {
             self._cell = o.cell;
             self._dataTableView._updateCell(self._rowIndex, self._cellIndex, self._cell);
             self._render();
-            self._dataTableView._adjustDataTables();
           }
         }
       );

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -91,6 +91,7 @@ DataTableView.prototype.render = function() {
   var scrollLeft = (oldTableDiv.length > 0) ? oldTableDiv[0].scrollLeft : 0;
 
   var html = $(
+  	
     '<div class="viewpanel-header">' +
       '<div class="viewpanel-rowrecord" bind="rowRecordControls">'+$.i18n('core-views/show-as')+': ' +
         '<span bind="modeSelectors"></span>' + 
@@ -99,11 +100,11 @@ DataTableView.prototype.render = function() {
       '<div class="viewpanel-sorting" bind="sortingControls"></div>' +
       '<div class="viewpanel-paging" bind="pagingControls"></div>' +
     '</div>' +
-    '<div bind="dataHeaderTableContainer" class="data-header-table-container">' +
-      '<table bind="headerTable" class="data-header-table"></table>' +
-    '</div>' +
     '<div bind="dataTableContainer" class="data-table-container">' +
-      '<table bind="table" class="data-table"></table>' +
+      '<table bind="table" class="data-table">'+
+        '<thead bind="headerTable" class="data-header-table">'+
+        '</thead>'+
+      '</table>' +
     '</div>'
   );
   var elmts = DOM.bind(html);

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -329,7 +329,6 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
       self._columnHeaderUIs.push(columnHeaderUI);
     }
   };
-
   for (var i = 0; i < columns.length; i++) {
     createColumnHeader(columns[i], i);
   }
@@ -342,16 +341,13 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
   var rows = theProject.rowModel.rows;
   var renderRow = function(tr, r, row, even) {
     $(tr).empty();
-
     var cells = row.cells;
-
     var tdStar = tr.insertCell(tr.cells.length);
     var star = $('<a href="javascript:{}">&nbsp;</a>')
     .addClass(row.starred ? "data-table-star-on" : "data-table-star-off")
     .appendTo(tdStar)
     .click(function() {
       var newStarred = !row.starred;
-
       Refine.postCoreProcess(
         "annotate-one-row",
         { row: row.i, starred: newStarred },
@@ -367,14 +363,12 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
         "json"
       );
     });
-
     var tdFlag = tr.insertCell(tr.cells.length);
     var flag = $('<a href="javascript:{}">&nbsp;</a>')
     .addClass(row.flagged ? "data-table-flag-on" : "data-table-flag-off")
     .appendTo(tdFlag)
     .click(function() {
       var newFlagged = !row.flagged;
-
       Refine.postCoreProcess(
         "annotate-one-row",
         { row: row.i, flagged: newFlagged },
@@ -432,53 +426,10 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
   });
 };
 
-DataTableView.prototype._adjustDataTables = function() {
-  var dataTable = this._div.find('.data-table');
-  var headerTable = this._div.find('.data-header-table');
-  if (dataTable.length === 0 || headerTable.length === 0) {
-    return;
-  }
-  dataTable = dataTable[0];
-  headerTable = headerTable[0];
-  
-  if (dataTable.rows.length === 0) {
-    return;
-  }
-  
-  var dataTr = dataTable.rows[0];
-  var headerTr = headerTable.rows[headerTable.rows.length - 1];
-  
-  var marginColumnWidths =
-    $(dataTr.cells[0]).outerWidth(true) +
-    $(dataTr.cells[1]).outerWidth(true) +
-    $(dataTr.cells[2]).outerWidth(true) -
-    DOM.getHPaddings($(headerTr.cells[0])) + 1;
-  
-  $(headerTable)
-    .find('> tbody > tr > td:first-child')
-    .width('1%')
-    .children()
-      .first()
-      .width(marginColumnWidths);
-  
-  for (var i = 1; i < headerTr.cells.length; i++) {
-    var headerTd = $(headerTr.cells[i]);
-    var dataTd = $(dataTr.cells[i + 2]);
-    var commonWidth = Math.max(
-      Math.min(headerTd.width(), 100),
-      dataTd.width()
-    );
-    headerTd.width('1%').find('> div').width(commonWidth);
-    dataTd.children().first().width(commonWidth);
-  }
-  
-  this._adjustDataTableScroll();
-};
-
 DataTableView.prototype._adjustDataTableScroll = function() {
   var dataTableContainer = this._div.find('.data-table-container');
-  var headerTableContainer = this._div.find('.data-header-table-container');
-  if (dataTableContainer.length > 0 && headerTableContainer.length > 0) {
+  var headerTableContainer = this._div.find('.data-header-table');
+  if (dataTableContainer.length > 0 || headerTableContainer.length > 0) {
     headerTableContainer
       .find('> .data-header-table')
       .css('left', '-' + dataTableContainer[0].scrollLeft + 'px');

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -100,7 +100,7 @@ DataTableView.prototype.render = function() {
     '</div>' +
     '<div bind="dataTableContainer" class="data-table-container">' +
       '<table class="data-table">'+
-        '<thead bind="tableHeader" class="data-table-header" style="background: #ebeef8">'+
+        '<thead bind="tableHeader" class="data-table-header">'+
         '</thead>'+
         '<tbody bind="table" class="data-table">'+
         '</tbody>'+

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -70,8 +70,7 @@ DataTableView.prototype.getSorting = function() {
 DataTableView.prototype.resize = function() {
   
   var topHeight =
-    this._div.find(".viewpanel-header").outerHeight(true) +
-    this._div.find(".data-header-table-container").outerHeight(true);
+    this._div.find(".viewpanel-header").outerHeight(true);
   var tableContainerIntendedHeight = this._div.innerHeight() - topHeight;
   
   var tableContainer = this._div.find(".data-table-container").css("display", "block");
@@ -100,9 +99,11 @@ DataTableView.prototype.render = function() {
       '<div class="viewpanel-paging" bind="pagingControls"></div>' +
     '</div>' +
     '<div bind="dataTableContainer" class="data-table-container">' +
-      '<table bind="table" class="data-table">'+
-        '<thead bind="headerTable" class="data-header-table">'+
+      '<table class="data-table">'+
+        '<thead bind="tableHeader" class="data-table-header">'+
         '</thead>'+
+        '<tbody bind="table" class="data-table">'+
+        '</tbody>'+
       '</table>' +
     '</div>'
   );
@@ -133,7 +134,7 @@ DataTableView.prototype.render = function() {
     this._renderSortingControls(elmts.sortingControls);
   }
 
-  this._renderDataTables(elmts.table[0], elmts.headerTable[0]);
+  this._renderDataTables(elmts.table[0], elmts.tableHeader[0]);
   this._div.empty().append(html);
 
   // show/hide null values in cells
@@ -210,7 +211,7 @@ DataTableView.prototype._renderPagingControls = function(pageSizeControls, pagin
   .appendTo(pageSizeControls);
 };
 
-DataTableView.prototype._renderDataTables = function(table, headerTable) {
+DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   var self = this;
 
   var columns = theProject.columnModel.columns;
@@ -223,7 +224,7 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
 
   var renderColumnKeys = function(keys) {
     if (keys.length > 0) {
-      var tr = headerTable.insertRow(headerTable.rows.length);
+      var tr = tableHeader.insertRow(tableHeader.rows.length);
       $(tr.insertCell(0)).attr('colspan', '3'); // star, flag, row index
 
       for (var c = 0; c < columns.length; c++) {
@@ -250,7 +251,7 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
     var nextLayer = [];
 
     if (groups.length > 0) {
-      var tr = headerTable.insertRow(headerTable.rows.length);
+      var tr = tableHeader.insertRow(tableHeader.rows.length);
 
       for (var c = 0; c < columns.length; c++) {
         var foundGroup = false;
@@ -301,7 +302,7 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
    *------------------------------------------------------------
    */
 
-  var trHead = headerTable.insertRow(headerTable.rows.length);
+  var trHead = tableHeader.insertRow(tableHeader.rows.length);
   DOM.bind(
       $(trHead.insertCell(trHead.cells.length))
       .attr("colspan", "3")

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -100,7 +100,7 @@ DataTableView.prototype.render = function() {
     '</div>' +
     '<div bind="dataTableContainer" class="data-table-container">' +
       '<table class="data-table">'+
-        '<thead bind="tableHeader" class="data-table-header">'+
+        '<thead bind="tableHeader" class="data-table-header" style="background: #ebeef8">'+
         '</thead>'+
         '<tbody bind="table" class="data-table">'+
         '</tbody>'+

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -252,7 +252,6 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
 
     if (groups.length > 0) {
       var tr = headerTable.insertRow(headerTable.rows.length);
-      $(tr.insertCell(0)).attr('colspan', '3'); // star, flag, row index
 
       for (var c = 0; c < columns.length; c++) {
         var foundGroup = false;

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -68,7 +68,6 @@ DataTableView.prototype.getSorting = function() {
 };
 
 DataTableView.prototype.resize = function() {
-  this._adjustDataTables();
   
   var topHeight =
     this._div.find(".viewpanel-header").outerHeight(true) +
@@ -357,7 +356,6 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
           onDone: function(o) {
             row.starred = newStarred;
             renderRow(tr, r, row, even);
-            self._adjustDataTables();
           }
         },
         "json"
@@ -378,7 +376,6 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
           onDone: function(o) {
             row.flagged = newFlagged;
             renderRow(tr, r, row, even);
-            self._adjustDataTables();
           }
         },
         "json"

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -417,20 +417,6 @@ DataTableView.prototype._renderDataTables = function(table, headerTable) {
     }
     renderRow(tr, r, row, even);
   }
-  
-  $(table.parentNode).bind('scroll', function(evt) {
-    self._adjustDataTableScroll();
-  });
-};
-
-DataTableView.prototype._adjustDataTableScroll = function() {
-  var dataTableContainer = this._div.find('.data-table-container');
-  var headerTableContainer = this._div.find('.data-header-table');
-  if (dataTableContainer.length > 0 || headerTableContainer.length > 0) {
-    headerTableContainer
-      .find('> .data-header-table')
-      .css('left', '-' + dataTableContainer[0].scrollLeft + 'px');
-  }
 };
 
 DataTableView.prototype._showRows = function(start, onDone) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -89,7 +89,6 @@ DataTableView.prototype.render = function() {
   var scrollLeft = (oldTableDiv.length > 0) ? oldTableDiv[0].scrollLeft : 0;
 
   var html = $(
-  	
     '<div class="viewpanel-header">' +
       '<div class="viewpanel-rowrecord" bind="rowRecordControls">'+$.i18n('core-views/show-as')+': ' +
         '<span bind="modeSelectors"></span>' + 
@@ -225,20 +224,20 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   var renderColumnKeys = function(keys) {
     if (keys.length > 0) {
       var tr = tableHeader.insertRow(tableHeader.rows.length);
-      $(tr.insertCell(0)).attr('colspan', '3'); // star, flag, row index
+      $(tr.appendChild(document.createElement("th"))).attr('colspan', '3'); // star, flag, row index
 
       for (var c = 0; c < columns.length; c++) {
         var column = columns[c];
-        var td = tr.insertCell(tr.cells.length);
+        var th = tr.appendChild(document.createElement("th"));
         if (self._collapsedColumnNames.hasOwnProperty(column.name)) {
-          $(td).html('&nbsp;');
+          $(th).html('&nbsp;');
         } else {
           for (var k = 0; k < keys.length; k++) {
             // if a node is a key in the tree-based data (JSON/XML/etc), then also display a dropdown arrow (non-functional currently)
             // See https://github.com/OpenRefine/OpenRefine/blob/master/main/src/com/google/refine/model/ColumnGroup.java
             // and https://github.com/OpenRefine/OpenRefine/tree/master/main/src/com/google/refine/importers/tree
-            if (c == keys[k]) { 
-              $('<img />').attr("src", "../images/down-arrow.png").appendTo(td);
+            if (c == keys[k]) {
+              $('<img />').attr("src", "../images/down-arrow.png").appendTo(th);
               break;
             }
           }
@@ -252,6 +251,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
 
     if (groups.length > 0) {
       var tr = tableHeader.insertRow(tableHeader.rows.length);
+      $(tr.appendChild(document.createElement("th"))).attr('colspan', '3'); // star, flag, row index
 
       for (var c = 0; c < columns.length; c++) {
         var foundGroup = false;
@@ -265,10 +265,10 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
           }
         }
 
-        var td = tr.insertCell(tr.cells.length);
+        var th = tr.appendChild(document.createElement("th"));
         if (foundGroup) {
-          td.setAttribute("colspan", columnGroup.columnSpan);
-          td.style.background = "#FF6A00";
+          th.setAttribute("colspan", columnGroup.columnSpan);
+          th.style.background = "#FF6A00";
 
           if (columnGroup.keyColumnIndex >= 0) {
             keys.push(columnGroup.keyColumnIndex);
@@ -304,7 +304,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
 
   var trHead = tableHeader.insertRow(tableHeader.rows.length);
   DOM.bind(
-      $(trHead.insertCell(trHead.cells.length))
+      $(trHead.appendChild(document.createElement("th")))
       .attr("colspan", "3")
       .addClass("column-header")
       .html(
@@ -317,18 +317,19 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   });
   this._columnHeaderUIs = [];
   var createColumnHeader = function(column, index) {
-    var td = trHead.insertCell(trHead.cells.length);
-    $(td).addClass("column-header").attr('title', column.name);
+    var th = trHead.appendChild(document.createElement("th"));
+    $(th).addClass("column-header").attr('title', column.name);
     if (self._collapsedColumnNames.hasOwnProperty(column.name)) {
-      $(td).html("&nbsp;").click(function(evt) {
+      $(th).html("&nbsp;").click(function(evt) {
         delete self._collapsedColumnNames[column.name];
         self.render();
       });
     } else {
-      var columnHeaderUI = new DataTableColumnHeaderUI(self, column, index, td);
+      var columnHeaderUI = new DataTableColumnHeaderUI(self, column, index, th);
       self._columnHeaderUIs.push(columnHeaderUI);
     }
   };
+
   for (var i = 0; i < columns.length; i++) {
     createColumnHeader(columns[i], i);
   }
@@ -362,6 +363,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
         "json"
       );
     });
+    
     var tdFlag = tr.insertCell(tr.cells.length);
     var flag = $('<a href="javascript:{}">&nbsp;</a>')
     .addClass(row.flagged ? "data-table-flag-on" : "data-table-flag-off")

--- a/main/webapp/modules/core/styles/common.less
+++ b/main/webapp/modules/core/styles/common.less
@@ -37,7 +37,7 @@ html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pr
 article, aside, figure, footer, header, hgroup, nav, section { display: block; }
 ul { list-style-position: inside; }
 a { margin: 0; padding: 0; font-size: 100%; vertical-align: baseline; background: transparent; }
-table { border-collapse: collapse; border-spacing: 0; }
+table { border-collapse: collapse; border-spacing: 0; background: @fill_primary;}
 input, select { vertical-align: middle; }
 
 body { 

--- a/main/webapp/modules/core/styles/common.less
+++ b/main/webapp/modules/core/styles/common.less
@@ -37,7 +37,7 @@ html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pr
 article, aside, figure, footer, header, hgroup, nav, section { display: block; }
 ul { list-style-position: inside; }
 a { margin: 0; padding: 0; font-size: 100%; vertical-align: baseline; background: transparent; }
-table { border-collapse: collapse; border-spacing: 0; background: @fill_primary;}
+table { border-collapse: collapse; border-spacing: 0; }
 input, select { vertical-align: middle; }
 
 body { 

--- a/main/webapp/modules/core/styles/index/default-importing-parsing-panel.less
+++ b/main/webapp/modules/core/styles/index/default-importing-parsing-panel.less
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 @import-less url("../theme.less");
 
 .default-importing-parsing-data-panel {
-  font-size: 1.1em;
+  font-size: 1.12em;
   position: absolute;
   overflow: auto;
   }

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -58,6 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .data-table-header {
   width: 1px;
   position: relative;
+  background: #ebeef8
   }
   
 .data-table-container {

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -58,11 +58,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .data-table-header {
   width: 1px;
   position: relative;
-  background: #ebeef8
+  background: #ebeef8;
   }
   
 .data-table-container {
   overflow: auto;
+  border-top: 1px solid @chrome_primary;
   }
 
 .data-table-header, .data-table {
@@ -70,19 +71,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   padding: 0;
   font-size: 1.05em;
   border-collapse: collapse;
-  dispay: table;
   }
-
 
 .data-table td, .data-table-header td {
   padding: 2px 5px;
   }
+
 .data-table td {
   border-bottom: 1px dotted #ddd;
   border-right: 1px solid #ddd;
   }
+
 .data-table-header td {
-  border-top: 1px solid @chrome_primary;
   border-bottom: 1px dotted @chrome_primary;
   border-right: 1px solid @chrome_primary;
   }

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -69,7 +69,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   padding: 0;
   font-size: 1.05em;
   border-collapse: collapse;
+  dispay: table;
   }
+
 
 .data-table td, .data-table-header td {
   padding: 2px 5px;
@@ -109,6 +111,7 @@ table.data-table-header td.column-header, table.data-table td.column-header {
 table.data-table td.column-header {
   background: @fill_primary;
   border-bottom: 2px solid @chrome_primary;
+  background-clip: padding-box;
   }
 
 .column-header-name {

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -55,14 +55,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   font-weight: bold;
   }
 
-.data-header-table-container {
-  border-top: 1px solid @chrome_primary;
-  border-bottom: 2px solid @chrome_primary;
-  background: @fill_primary;
-  overflow: visible;
-  }
 
-.data-header-table {
+.data-table-header {
   width: 1px;
   position: relative;
   }
@@ -71,7 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   overflow: auto;
   }
 
-.data-header-table, .data-table {
+.data-table-header, .data-table {
   margin: 0;
   padding: 0;
   font-size: 1.1em;
@@ -87,19 +81,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   cursor: col-resize;       
 }
 
-.data-table td, .data-header-table td {
+.data-table td, .data-table-header td {
   padding: 2px 5px;
   }
 .data-table td {
   border-bottom: 1px dotted #ddd;
   border-right: 1px solid #ddd;
   }
-.data-header-table td {
+.data-table-header td {
   border-bottom: 1px dotted @chrome_primary;
   border-right: 1px solid @chrome_primary;
   }
 
-table.data-header-table > tbody > tr > td {
+table.data-table-header > tbody > tr > td {
   overflow: hidden !important;
   }
 
@@ -111,7 +105,7 @@ table.data-table > tbody > tr.contextual > td > div {
   opacity: 0.3;
   }
 
-table.data-header-table td.column-header, table.data-table td.column-header {
+table.data-table-header td.column-header, table.data-table td.column-header {
   vertical-align: top;
   white-space: nowrap;
   cursor: pointer;

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -55,7 +55,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   font-weight: bold;
   }
 
-
 .data-table-header {
   width: 1px;
   position: relative;
@@ -68,18 +67,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .data-table-header, .data-table {
   margin: 0;
   padding: 0;
-  font-size: 1.1em;
+  font-size: 1.05em;
   border-collapse: collapse;
   }
-  .resizer {
-  position: absolute;
-  top: 0;
-  right: -8px;
-  bottom: 0;
-  left: auto;
-  width: 16px;    
-  cursor: col-resize;       
-}
 
 .data-table td, .data-table-header td {
   padding: 2px 5px;
@@ -89,6 +79,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   border-right: 1px solid #ddd;
   }
 .data-table-header td {
+  border-top: 1px solid @chrome_primary;
   border-bottom: 1px dotted @chrome_primary;
   border-right: 1px solid @chrome_primary;
   }

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -58,7 +58,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .data-table-header {
   width: 1px;
   position: relative;
-  background: #ebeef8;
   }
   
 .data-table-container {
@@ -107,6 +106,10 @@ table > thead > tr > th {
 
 table.data-table > tbody > tr.odd > td {
   background: @fill_secondary;
+  }
+
+table.data-table > tbody > tr.even > td {
+  background: white;
   }
 
 table.data-table > tbody > tr.contextual > td > div {

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -73,7 +73,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   border-collapse: separate;
   }
 
-.data-table td, .data-table-header th {
+.data-table td, .data-table-header td, .data-table-header th {
   padding: 2px 5px;
   }
 
@@ -82,7 +82,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   border-right: 0.02rem solid #ddd;
   }
 
-.data-table-header th {
+.data-table-header td, .data-table-header th {
   border-bottom: 0.02rem dotted @chrome_primary;
   border-right: 0.02rem solid @chrome_primary;
   }
@@ -103,6 +103,10 @@ th {
   text-align: left;
   }
 
+table.data-header-table > tbody > tr > td {
+  overflow: hidden !important;
+  }
+
 table > thead > tr > th {
   overflow: hidden !important;
   }
@@ -115,7 +119,8 @@ table.data-table > tbody > tr.contextual > td > div {
   opacity: 0.3;
   }
 
-table.data-table-header th.column-header, table.data-table th.column-header {
+table.data-table-header td.column-header, table.data-table-header th.column-header,
+table.data-table td.column-header, table.data-table th.column-header {
   vertical-align: top;
   white-space: nowrap;
   cursor: pointer;
@@ -125,7 +130,7 @@ table.data-table-header th.column-header, table.data-table th.column-header {
   }
 
 /* For the preview in the importing stage */
-table.data-table th.column-header {
+table.data-table td.column-header, table.data-table th.column-header {
   background: @fill_primary;
   border-bottom: 0.12rem solid @chrome_primary;
   }

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -73,7 +73,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   border-collapse: collapse;
   }
 
-.data-table td, .data-table-header td {
+.data-table td, .data-table-header th {
   padding: 2px 5px;
   }
 
@@ -82,12 +82,26 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   border-right: 1px solid #ddd;
   }
 
-.data-table-header td {
+.data-table-header th {
   border-bottom: 1px dotted @chrome_primary;
   border-right: 1px solid @chrome_primary;
   }
 
-table.data-table-header > tbody > tr > td {
+table {
+  position: relative;
+  }
+
+th.column-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  }
+
+th {
+  text-align: left;
+  }
+
+table > thead > tr > th {
   overflow: hidden !important;
   }
 
@@ -99,7 +113,7 @@ table.data-table > tbody > tr.contextual > td > div {
   opacity: 0.3;
   }
 
-table.data-table-header td.column-header, table.data-table td.column-header {
+table.data-table-header th.column-header, table.data-table th.column-header {
   vertical-align: top;
   white-space: nowrap;
   cursor: pointer;
@@ -109,7 +123,7 @@ table.data-table-header td.column-header, table.data-table td.column-header {
   }
 
 /* For the preview in the importing stage */
-table.data-table td.column-header {
+table.data-table th.column-header {
   background: @fill_primary;
   border-bottom: 2px solid @chrome_primary;
   background-clip: padding-box;

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -58,6 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .data-table-header {
   width: 1px;
   position: relative;
+  background: @fill_primary;
   }
   
 .data-table-container {
@@ -69,7 +70,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   margin: 0;
   padding: 0;
   font-size: 1.05em;
-  border-collapse: collapse;
+  border-collapse: separate;
   }
 
 .data-table td, .data-table-header th {
@@ -77,13 +78,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 .data-table td {
-  border-bottom: 1px dotted #ddd;
-  border-right: 1px solid #ddd;
+  border-bottom: 0.02rem dotted #ddd;
+  border-right: 0.02rem solid #ddd;
   }
 
 .data-table-header th {
-  border-bottom: 1px dotted @chrome_primary;
-  border-right: 1px solid @chrome_primary;
+  border-bottom: 0.02rem dotted @chrome_primary;
+  border-right: 0.02rem solid @chrome_primary;
   }
 
 table {
@@ -91,9 +92,11 @@ table {
   }
 
 th.column-header {
+  position: -webkit-sticky; /* Safari */ 
   position: sticky;
   top: 0;
   z-index: 1;
+  will-change: transform;
   }
 
 th {
@@ -106,10 +109,6 @@ table > thead > tr > th {
 
 table.data-table > tbody > tr.odd > td {
   background: @fill_secondary;
-  }
-
-table.data-table > tbody > tr.even > td {
-  background: white;
   }
 
 table.data-table > tbody > tr.contextual > td > div {
@@ -128,8 +127,7 @@ table.data-table-header th.column-header, table.data-table th.column-header {
 /* For the preview in the importing stage */
 table.data-table th.column-header {
   background: @fill_primary;
-  border-bottom: 2px solid @chrome_primary;
-  background-clip: padding-box;
+  border-bottom: 0.12rem solid @chrome_primary;
   }
 
 .column-header-name {

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .viewpanel-rowrecord, .viewpanel-pagesize, .viewpanel-sorting {
   top: @padding_normal;
   padding: 0 10px 0 0;
-   float: left;
+  float: left;
   }
 
 .viewpanel-paging {

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -77,6 +77,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   font-size: 1.1em;
   border-collapse: collapse;
   }
+  .resizer {
+  position: absolute;
+  top: 0;
+  right: -8px;
+  bottom: 0;
+  left: auto;
+  width: 16px;    
+  cursor: col-resize;       
+}
 
 .data-table td, .data-header-table td {
   padding: 2px 5px;


### PR DESCRIPTION
Continuation for #2422 

- Fixed the orange bars
- Added a sticky header
> Only for `column-header` row (one with column names). The entire header group for XML/JSON (with the node structure) is not sticky yet.
- Fixed border of header elements in Firefox