### PR TITLE
Use ContentDisposition instead of ContentType to control download

### DIFF
--- a/main/src/com/google/refine/commands/project/ExportRowsCommand.java
+++ b/main/src/com/google/refine/commands/project/ExportRowsCommand.java
@@ -100,6 +100,13 @@ public class ExportRowsCommand extends Command {
                 contentType = exporter.getContentType();
             }
             response.setHeader("Content-Type", contentType);
+
+            String preview = params.getProperty("preview");
+            if (!"true".equals(preview)) {
+                String path = request.getPathInfo();
+                String filename = path.substring(path.lastIndexOf('/') + 1);
+                response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+            }
             
             if (exporter instanceof WriterExporter) {
                 String encoding = params.getProperty("encoding");

--- a/main/src/com/google/refine/exporters/TemplatingExporter.java
+++ b/main/src/com/google/refine/exporters/TemplatingExporter.java
@@ -57,7 +57,7 @@ public class TemplatingExporter implements WriterExporter {
 
     @Override
     public String getContentType() {
-        return "application/x-unknown";
+        return "text/plain";
     }
     
     protected static class TemplateConfig {

--- a/main/webapp/modules/core/scripts/dialogs/custom-tabular-exporter-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/custom-tabular-exporter-dialog.js
@@ -314,13 +314,11 @@ CustomTabularExporterDialog.prototype._postExport = function(preview) {
     .attr("value", encoding)
     .appendTo(form);
   }
-  if (!preview) {
-    $('<input />')
-    .attr("name", "contentType")
-    .attr("value", "application/x-unknown") // force download
-    .appendTo(form);
-  }
-  
+  $('<input />')
+  .attr("name", "preview")
+  .attr("value", preview)
+  .appendTo(form);
+
   document.body.appendChild(form);
 
   window.open(" ", "refine-export");

--- a/main/webapp/modules/core/scripts/dialogs/sql-exporter-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/sql-exporter-dialog.js
@@ -357,14 +357,11 @@ function SqlExporterDialog(options) {
       .attr("value", encoding)
       .appendTo(form);
     }
-    if (!preview) {
-      $('<input />')
-      .attr("name", "contentType")
-      .attr("value", "application/x-unknown") // force download
-      .appendTo(form);
-    }
-    
-   // alert("form::" + form);
+    $('<input />')
+    .attr("name", "preview")
+    .attr("value", preview)
+    .appendTo(form);
+
     document.body.appendChild(form);
   
     window.open(" ", "refine-export");

--- a/main/webapp/modules/core/scripts/project/exporters.js
+++ b/main/webapp/modules/core/scripts/project/exporters.js
@@ -111,10 +111,6 @@ ExporterManager.stripNonFileChars = function(name) {
 
 ExporterManager.handlers.exportRows = function(format, ext) {
   var form = ExporterManager.prepareExportRowsForm(format, true, ext);
-  $('<input />')
-  .attr("name", "contentType")
-  .attr("value", "application/x-unknown") // force download
-  .appendTo(form);
 
   document.body.appendChild(form);
 


### PR DESCRIPTION
Fixes #1197. Previously we were using a funky ContentType (`application/x-unknown`) to attempt to force a file download rather than display in browser, but this conflicted with attempts to save UTF-8 which was outside the Basic Multilingual Plane (BMP).
    
By switching to `ContentDisposition: attachment`, which has been the preferred method for a number of years, we can avoid this conflict.
