### PR TITLE
Bump Jena from 3.6.0 to 3.15.0

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -308,22 +308,27 @@
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-arq</artifactId>
-      <version>3.6.0</version>
+      <version>3.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-base</artifactId>
-      <version>3.6.0</version>
+      <version>3.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-cmds</artifactId>
-      <version>3.6.0</version>
+      <version>3.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-core</artifactId>
-      <version>3.6.0</version>
+      <version>3.15.0</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>com.metaweb</groupId>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -19,6 +19,7 @@
     <jee.port>3333</jee.port>
     <refine.data>/tmp/refine</refine.data>
     <powermock.version>2.0.7</powermock.version>
+    <jena.version>3.15.0</jena.version>
   </properties>
 
   <scm>
@@ -308,22 +309,22 @@
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-arq</artifactId>
-      <version>3.15.0</version>
+      <version>${jena.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-base</artifactId>
-      <version>3.15.0</version>
+      <version>${jena.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-cmds</artifactId>
-      <version>3.15.0</version>
+      <version>${jena.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-core</artifactId>
-      <version>3.15.0</version>
+      <version>${jena.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/main/src/com/google/refine/importers/RdfTripleImporter.java
+++ b/main/src/com/google/refine/importers/RdfTripleImporter.java
@@ -84,6 +84,8 @@ public class RdfTripleImporter extends ImportingParserBase {
         try {
             switch (mode) {
             case NT:
+                // TODO: The standard lang name is "N-TRIPLE"
+                // we may need to switch if we change packagings
                 model.read(input, null, "NT");
                 break;
             case N3:
@@ -93,6 +95,7 @@ public class RdfTripleImporter extends ImportingParserBase {
                 model.read(input, null, "TTL");
                 break;
             case JSONLD:
+                // TODO: The standard lang name is "JSONLD"
                 model.read(input, null, "JSON-LD");
                 break;
             case RDFXML:


### PR DESCRIPTION
This replaces #2705 and #2706. All the Jena dependencies need to be updated at the same time.

This introduces a new explicit dependency on Apache commons-io, which really should be a transitive dependency of Jena=>jsonldjava=>commons-io, but for Jena 3.8+, the transitive dependency no longer works.

Ideally we would switch to using a single Jena dependency, like the recommended `apache-jena-libs` but that doesn't work for us (it can't find the JSON-LD parser), so I'll leave that for a later time.