### PR TITLE
Infinite scrolling

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -108,9 +108,9 @@ DataTableView.prototype.render = function() {
       '<div class="viewpanel-rowrecord" bind="rowRecordControls">'+$.i18n('core-views/show-as')+': ' +
         '<span bind="modeSelectors"></span>' + 
       '</div>' +
-      '<div class="viewpanel-pagesize" bind="pageSizeControls"></div>' +
+      // '<div class="viewpanel-pagesize" bind="pageSizeControls"></div>' +
       '<div class="viewpanel-sorting" bind="sortingControls"></div>' +
-      '<div class="viewpanel-paging" bind="pagingControls"></div>' +
+      // '<div class="viewpanel-paging" bind="pagingControls"></div>' +
     '</div>' +
     '<div bind="dataTableContainer" class="data-table-container">' +
       '<table class="data-table">'+

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -584,7 +584,7 @@ DataTableView.prototype._adjustNextSetClasses = function(start, top) {
 
   if($('.data-table tbody tr').length > this._pageSize + 2 && start > this._pageSize && top == null) {
     console.log('Deleting above rows');
-    $('.data-table tbody tr').slice(1, $('.data-table tbody tr').length - 2 * this._pageSize).remove();
+    $('.data-table tbody tr').slice(1, Math.max(0, $('.data-table tbody tr').length - 2 * this._pageSize)).remove();
     this._pageStart = start - this._pageSize;
   }
 
@@ -746,7 +746,9 @@ DataTableView.prototype._onClickNextPage = function(elmt, evt) {
 };
 
 DataTableView.prototype._onBottomTable = function(scrollPosition, table, elmt, evt) {
-  this._showRowsBottom(scrollPosition, table, this._totalSize);
+  if(this._totalSize < theProject.rowModel.filtered) {
+    this._showRowsBottom(scrollPosition, table, this._totalSize);
+  }
 };
 
 DataTableView.prototype._onTopTable = function(scrollPosition, table, elmt, evt) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -508,15 +508,16 @@ DataTableView.prototype._adjustDataTables = function() {
   var self = this;
 
   this._sizeRowFirst = $('tr:eq(1)').height();
-  this._sizeRowsTotal = this._sizeRowFirst * theProject.rowModel.total;
+  this._sizeRowsTotal = this._sizeRowFirst * theProject.metadata.rowCount;
 
   window.adjustNextSetClasses = function() {
-    var heightToAdd = self._sizeRowsTotal - self._totalSize * self._sizeRowFirst;
-    console.log(self._sizeRowFirst + ' ' + self._sizeRowsTotal);
-    console.log(heightToAdd);
-    document.querySelector('.data-table').insertRow(self._totalSize + 1);
-    $('tr:last').css('height', heightToAdd);
-    $('tr:last').addClass('last-row');
+    var heightToAdd = self._sizeRowsTotal - ($('tr').length - 1) * self._sizeRowFirst;
+    
+    if(self._totalSize < theProject.rowModel.total) {
+      document.querySelector('.data-table').insertRow(self._totalSize + 1);
+      $('tr:last').css('height', heightToAdd);
+      $('tr:last').addClass('last-row');
+    }
     $('tr:nth-last-child(50)').addClass('load-next-set');
   }
   adjustNextSetClasses();

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -83,7 +83,6 @@ DataTableView.prototype.getSorting = function() {
 };
 
 DataTableView.prototype.resize = function() {
-  this._headerTop = $('thead').offset().top + $('thead').height();
   var topHeight =
     this._div.find(".viewpanel-header").outerHeight(true);
   var tableContainerIntendedHeight = this._div.innerHeight() - topHeight;
@@ -500,6 +499,18 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   }
   loadRows();
 
+  var total = 0, row;
+  for (var i = 1; i < table.rows.length; i++) {
+      row = table.rows[i];
+      total += row.offsetHeight;
+  }
+  this._sizeRowFirst = total / this._pageSize;
+  this._sizeRowsTotal = this._sizeRowFirst * theProject.metadata.rowCount;
+  this._sizeSinglePage = this._sizeRowFirst * this._pageSize;
+  document.querySelector('tbody').insertRow(0).setAttribute('class', 'first-row');
+  this._headerTop = $('thead').offset().top + $('thead').height();
+  this._adjustNextSetClasses();
+
   var flag = 0;
   $(table.parentNode.parentNode).bind('scroll', function(evt) {
     self._downwardDirection = self._scrollTop < $(this).scrollTop();
@@ -549,17 +560,6 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
       flag = 0;
     }, 250));
   });
-
-  var total = 0, row;
-  for (var i = 1; i < table.rows.length; i++) {
-      row = table.rows[i];
-      total += row.offsetHeight;
-  }
-  this._sizeRowFirst = total / this._pageSize;
-  this._sizeRowsTotal = this._sizeRowFirst * theProject.metadata.rowCount;
-  this._sizeSinglePage = this._sizeRowFirst * this._pageSize;
-  document.querySelector('tbody').insertRow(0).setAttribute('class', 'first-row');
-  this._adjustNextSetClasses();
 };
 
 DataTableView.prototype.getPageNumberSrcolling = function(scrollPosition) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -613,7 +613,7 @@ DataTableView.prototype._adjustNextSetClassesSpeed = function(modifiedScrollPosi
   var heightToAddTop = modifiedScrollPosition;
   var heightToAddBottom = Math.max(0, this._sizeRowsTotal - (modifiedScrollPosition + this._sizeSinglePage));
 
-  $('.data-table tbody tr').slice(1, $('.data-table tbody tr').length - this._pageSize).remove();
+  $('.data-table tbody tr').slice(1, $('.data-table tbody tr').length - theProject.rowModel.rows.length).remove();
 
   $('.data-table tbody tr:first').css('height', heightToAddTop);
 

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -509,6 +509,8 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   this._sizeSinglePage = this._sizeRowFirst * this._pageSize;
   document.querySelector('.data-table tbody').insertRow(0).setAttribute('class', 'first-row');
   this._headerTop = $('thead').offset().top + $('thead').height();
+  this._pageStart = 0;
+  this._totalSize = this._pageSize;
   this._adjustNextSetClasses();
 
   var flag = 0;

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -510,7 +510,7 @@ DataTableView.prototype._adjustNextSetClasses = function() {
   var heightToAdd = this._sizeRowsTotal - ($('tr').length - 1) * this._sizeRowFirst;
 
   if(this._totalSize < theProject.rowModel.total) {
-    document.querySelector('.data-table').insertRow(this._totalSize + 1);
+    document.querySelector('.data-table').insertRow();
     $('tr:last').css('height', heightToAdd);
     $('tr:last').addClass('last-row');
   }

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -78,7 +78,10 @@ DataTableView.prototype.getSorting = function() {
 };
 
 DataTableView.prototype.resize = function() {
-  this._adjustDataTables();
+  this._sizeRowFirst = $('tr:eq(1)').height();
+  this._sizeRowsTotal = this._sizeRowFirst * theProject.metadata.rowCount;
+
+  this._adjustNextSetClasses();
   
   var topHeight =
     this._div.find(".viewpanel-header").outerHeight(true);
@@ -503,24 +506,15 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   });
 };
 
-DataTableView.prototype._adjustDataTables = function() {
-  console.log('_adjustDataTables');
-  var self = this;
+DataTableView.prototype._adjustNextSetClasses = function() {
+  var heightToAdd = this._sizeRowsTotal - ($('tr').length - 1) * this._sizeRowFirst;
 
-  this._sizeRowFirst = $('tr:eq(1)').height();
-  this._sizeRowsTotal = this._sizeRowFirst * theProject.metadata.rowCount;
-
-  window.adjustNextSetClasses = function() {
-    var heightToAdd = self._sizeRowsTotal - ($('tr').length - 1) * self._sizeRowFirst;
-    
-    if(self._totalSize < theProject.rowModel.total) {
-      document.querySelector('.data-table').insertRow(self._totalSize + 1);
-      $('tr:last').css('height', heightToAdd);
-      $('tr:last').addClass('last-row');
-    }
-    $('tr:nth-last-child(50)').addClass('load-next-set');
+  if(this._totalSize < theProject.rowModel.total) {
+    document.querySelector('.data-table').insertRow(this._totalSize + 1);
+    $('tr:last').css('height', heightToAdd);
+    $('tr:last').addClass('last-row');
   }
-  adjustNextSetClasses();
+  $('tr:nth-last-child(50)').addClass('load-next-set');
 };
 
 DataTableView.prototype._showRows = function(start, onDone) {
@@ -535,6 +529,8 @@ DataTableView.prototype._showRows = function(start, onDone) {
 };
 
 DataTableView.prototype._showRowsBottom = function(table, start, onDone) {
+  var self = this;
+
   this._totalSize += this._pageSize;
   $('tr.load-next-set').removeClass('load-next-set');
 
@@ -542,7 +538,7 @@ DataTableView.prototype._showRowsBottom = function(table, start, onDone) {
     table.deleteRow(table.rows.length - 1);
 
     loadRows();
-    adjustNextSetClasses();
+    self._adjustNextSetClasses();
 
     if (onDone) {
       onDone();
@@ -597,7 +593,9 @@ DataTableView.prototype._onClickNextPage = function(elmt, evt) {
 };
 
 DataTableView.prototype._onBottomTable = function(table, elmt, evt) {
-  this._showRowsBottom(table, theProject.rowModel.start + this._pageSize);
+  if(this._totalSize < theProject.rowModel.total) {
+    this._showRowsBottom(table, theProject.rowModel.start + this._pageSize);
+  }
 };
 
 DataTableView.prototype._onClickFirstPage = function(elmt, evt) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -548,12 +548,12 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     }, 250));
   });
 
-  var total = 0;
+  var total = 0, row;
   for (var i = 1; i < table.rows.length; i++) {
       row = table.rows[i];
       total += row.offsetHeight;
   }
-  this._sizeRowFirst = total / 100;
+  this._sizeRowFirst = total / this._pageSize;
   this._sizeRowsTotal = this._sizeRowFirst * theProject.metadata.rowCount;
   this._sizeSinglePage = this._sizeRowFirst * this._pageSize;
   document.querySelector('tbody').insertRow(0).setAttribute('class', 'first-row');

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -508,39 +508,39 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   this._totalSize = this._pageSize;
   this._adjustNextSetClasses();
 
-  var flag = 0;
+  var prevOperationSet = false;
   $(table.parentNode.parentNode).bind('scroll', function(evt) {
     self._downwardDirection = self._scrollTop < $(this).scrollTop();
 
     try {
-      var element = document.querySelectorAll('.load-next-set');
-      element = element[element.length - 1];
-      var position = element.getBoundingClientRect();
-      var element2 = document.querySelector('.load-next-set');
-      var position2 = element2.getBoundingClientRect();
+      var nextSet = document.querySelectorAll('.load-next-set');
+      var prevSet = nextSet[0];
+      nextSet = nextSet[nextSet.length - 1];
+      var positionNextSet = nextSet.getBoundingClientRect();
+      var positionPrevSet = prevSet.getBoundingClientRect();
     } catch (err) {
-      var position = {top: undefined, bottom: undefined};
-      var position2 = {top: undefined, bottom: undefined};
+      var positionNextSet = {top: undefined, bottom: undefined};
+      var positionPrevSet = {top: undefined, bottom: undefined};
     }
     var lastElement = document.querySelector('.last-row');
     var positionLastElement = lastElement.getBoundingClientRect();
     var firstElement = document.querySelector('.first-row');
     var positionFirstElement = firstElement.getBoundingClientRect();
     
-    if(self._downwardDirection && !flag) {
-      if((position.top >= 0 && position.bottom <= window.innerHeight) || 
-        (positionLastElement.top < window.innerHeight && positionLastElement.top > 0)) {
-        flag = true;
-        self._onBottomTable(self._scrollTop, table, this, evt);
+    if(!prevOperationSet) {
+      if(self._downwardDirection) {
+        if((positionNextSet.top >= 0 && positionNextSet.bottom <= window.innerHeight) || 
+          (positionLastElement.top < window.innerHeight && positionLastElement.top > 0)) {
+          self._onBottomTable(self._scrollTop, table, this, evt);
+        }
       }
-    }
-
-    if(!self._downwardDirection && !flag) {
-      if(position2.top >= 0 && position2.bottom <= window.innerHeight || 
-        (positionFirstElement.bottom > 0 && positionFirstElement.bottom < window.innerHeight)) {
-        flag = true;
-        self._onTopTable(self._scrollTop, table, this, evt);
+      if(!self._downwardDirection) {
+        if(positionPrevSet.top >= 0 && positionPrevSet.bottom <= window.innerHeight || 
+          (positionFirstElement.bottom > 0 && positionFirstElement.bottom < window.innerHeight)) {
+          self._onTopTable(self._scrollTop, table, this, evt);
+        }
       }
+      prevOperationSet = true;
     }
 
     clearTimeout($.data(this, 'scrollTimer'));
@@ -554,7 +554,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
         var goto = self.getPageNumberSrcolling(self._scrollTop);
         self._onChangeGotoScrolling(self._scrollTop, goto, table);
       }
-      flag = 0;
+      prevOperationSet = false;
     }, 250));
     self._scrollTop = $(this).scrollTop();
   });

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -465,7 +465,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     if((positionLastElement.top <= 0 && positionLastElement.bottom >= 0) || (positionFirstElement.top < self._headerTop + 1 && positionFirstElement.bottom >= window.innerHeight)) {
       clearTimeout($.data(this, 'scrollTimer'));
       $.data(this, 'scrollTimer', setTimeout(function() {
-        self.getPageNumberSrcolling(self._scrollTop, table);
+        self.getPageNumberScrolling(self._scrollTop, table);
         prevOperationSet = false;
       }, 250));
     }
@@ -474,7 +474,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   });
 };
 
-DataTableView.prototype.getPageNumberSrcolling = function(scrollPosition, table) {
+DataTableView.prototype.getPageNumberScrolling = function(scrollPosition, table) {
   // Loading sign
   if(document.querySelector('div#body').classList.contains('hide-left-panel'))
     var width = 0.5 * window.innerWidth;

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -365,8 +365,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     tdIndex.appendChild(div);
 
     for (var i = 0; i < columns.length; i++) {
-      var column = columns[i];
-      var td = tr.insertCell(-1);
+      tr.insertCell(-1);
     }
 
     return tr;

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -49,7 +49,7 @@ function DataTableView(div) {
   this._sizeRowsTotal = 0;
   this._sizeSinglePage = 0;
   this._scrollTop = 0;
-  this._downwardDirection;
+  this._downwardDirection = true;
   this._pageStart = 0;
 
   this._currentPageNumber = 1;
@@ -487,8 +487,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
       var row = rows[r];
       if(start != null) {
         var tr = table.insertRow(r + 1);
-      }
-      else {
+      } else {
         var tr = table.insertRow(table.rows.length);
       }
       if (theProject.rowModel.mode == "row-based" || "j" in row) {
@@ -549,10 +548,15 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     }, 250));
   });
 
-  this._sizeRowFirst = $('tr:eq(1)').height();
+  var total = 0;
+  for (var i = 1; i < table.rows.length; i++) {
+      row = table.rows[i];
+      total += row.offsetHeight;
+  }
+  this._sizeRowFirst = total / 100;
   this._sizeRowsTotal = this._sizeRowFirst * theProject.metadata.rowCount;
   this._sizeSinglePage = this._sizeRowFirst * this._pageSize;
-  var firstRow = document.querySelector('tbody').insertRow(0).setAttribute('class', 'first-row');
+  document.querySelector('tbody').insertRow(0).setAttribute('class', 'first-row');
   this._adjustNextSetClasses();
 };
 
@@ -690,7 +694,7 @@ DataTableView.prototype._showRowsBottomSpeed = function(modifiedScrollPosition, 
 
 DataTableView.prototype._onChangeGotoScrolling = function(scrollPosition, gotoPageNumber, table, elmt, evt) {
   var modifiedScrollPosition = this._sizeRowFirst * (gotoPageNumber) * this._pageSize; 
-  this._showRowsBottomSpeed(modifiedScrollPosition, scrollPosition, table, (gotoPageNumber - 1) * this._pageSize);
+  this._showRowsBottomSpeed(modifiedScrollPosition, scrollPosition, table, gotoPageNumber * this._pageSize);
 };
 
 DataTableView.prototype._onChangeGotoPage = function(elmt, evt) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -514,7 +514,11 @@ DataTableView.prototype._adjustNextSetClasses = function() {
     $('tr:last').css('height', heightToAdd);
     $('tr:last').addClass('last-row');
   }
-  $('tr:nth-last-child(50)').addClass('load-next-set');
+  if (theProject.rowModel.mode == "record-based") {
+    $('tr.record').eq(-51).addClass('load-next-set');
+  } else {
+    $('tr').eq(-52).addClass('load-next-set');
+  }
 };
 
 DataTableView.prototype._showRows = function(start, onDone) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -672,7 +672,6 @@ DataTableView.prototype._showRowsSpeed = function(modifiedScrollPosition, scroll
   var self = this;
 
   this._totalSize = start +  this._pageSize;
-  $('tr.load-next-set').removeClass('load-next-set');
 
   Refine.fetchRows(start, this._pageSize, function() {
     $('.last-row').remove();

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -560,7 +560,7 @@ DataTableView.prototype._showRowsBottom = function(table, start, onDone) {
   Refine.fetchRows(start, this._pageSize, function() {
     $('.last-row').remove();
 
-    loadRows();
+    loadRows(start);
     self._adjustNextSetClasses(start);
 
     if (onDone) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -474,16 +474,16 @@ DataTableView.prototype.getPageNumberSrcolling = function(scrollPosition, table)
   if(document.querySelector('div#body').classList.contains('hide-left-panel'))
     var width = 0.5 * window.innerWidth;
   else var width = 150 + 0.5 * window.innerWidth;
-  window.img = document.createElement('img');
-  img.setAttribute('src', 'images/large-spinner.gif');
-  img.style.zIndex = '10';
-  img.style.top = '55%';
-  img.style.left = width + 'px';
-  img.style.position = 'fixed';
-  table.appendChild(img);
+  var loadingImg = document.createElement('img');
+  loadingImg.setAttribute('src', 'images/large-spinner.gif');
+  loadingImg.style.zIndex = '10';
+  loadingImg.style.top = '55%';
+  loadingImg.style.left = width + 'px';
+  loadingImg.style.position = 'fixed';
+  table.appendChild(loadingImg);
 
   var goto = Math.floor(scrollPosition / this._sizeSinglePage);
-  this._onChangeGotoScrolling(scrollPosition, goto, table);
+  this._onChangeGotoScrolling(scrollPosition, goto, table, loadingImg);
 };
 
 DataTableView.prototype._adjustNextSetClasses = function(start, top) {
@@ -513,7 +513,7 @@ DataTableView.prototype._adjustNextSetClasses = function(start, top) {
   this._addHeights(heightToAddTop, heightToAddBottom);
 };
 
-DataTableView.prototype._addHeights = function(heightToAddTop, heightToAddBottom, table) {
+DataTableView.prototype._addHeights = function(heightToAddTop, heightToAddBottom, table, loadingImg) {
   $('.data-table tbody tr:first').css('height', heightToAddTop);
 
   document.querySelector('.data-table').insertRow();
@@ -528,17 +528,17 @@ DataTableView.prototype._addHeights = function(heightToAddTop, heightToAddBottom
       $('.data-table tbody tr').eq(this._pageSize / 2).addClass('load-next-set');
     }
   }
-  if(table !== undefined) table.removeChild(img);
+  if(table !== undefined) table.removeChild(loadingImg);
 };
 
-DataTableView.prototype._adjustNextSetClassesSpeed = function(start, table) {
+DataTableView.prototype._adjustNextSetClassesSpeed = function(start, table, loadingImg) {
   var heightToAddTop = Math.max(0, start * this._sizeRowFirst);
   var heightToAddBottom = Math.max(0, this._sizeRowsTotal - this._totalSize * this._sizeRowFirst);
 
   $('.data-table tbody tr').slice(1, $('.data-table tbody tr').length - theProject.rowModel.rows.length).remove();
   this._pageStart = this._totalSize - this._pageSize;
 
-  this._addHeights(heightToAddTop, heightToAddBottom, table);
+  this._addHeights(heightToAddTop, heightToAddBottom, table, loadingImg);
 };
 
 DataTableView.prototype._showRows = function(start, onDone) {
@@ -586,7 +586,7 @@ DataTableView.prototype._showRowsTop = function(table, start, limit, onDone) {
   }, this._sorting);
 };
 
-DataTableView.prototype._showRowsSpeed = function(table, start, onDone) {
+DataTableView.prototype._showRowsSpeed = function(table, start, loadingImg, onDone) {
   var self = this;
 
   this._totalSize = start +  this._pageSize;
@@ -595,7 +595,7 @@ DataTableView.prototype._showRowsSpeed = function(table, start, onDone) {
     $('.last-row').remove();
 
     loadRows(start);
-    self._adjustNextSetClassesSpeed(start, table);
+    self._adjustNextSetClassesSpeed(start, table, loadingImg);
 
     if (onDone) {
       onDone();
@@ -603,10 +603,10 @@ DataTableView.prototype._showRowsSpeed = function(table, start, onDone) {
   }, this._sorting);
 };
 
-DataTableView.prototype._onChangeGotoScrolling = function(scrollPosition, gotoPageNumber, table, elmt, evt) {
+DataTableView.prototype._onChangeGotoScrolling = function(scrollPosition, gotoPageNumber, table, loadingImg, elmt, evt) {
   var row = scrollPosition / this._sizeRowFirst;
   row -= this._pageSize / 2.5;
-  this._showRowsSpeed(table, Math.floor(row));
+  this._showRowsSpeed(table, Math.floor(row), loadingImg);
 };
 
 DataTableView.prototype._onBottomTable = function(table, elmt, evt) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -518,11 +518,16 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     self._downwardDirection = self._scrollTop < $(this).scrollTop();
     self._scrollTop = $(this).scrollTop();
 
-    var element = document.querySelectorAll('.load-next-set');
-    element = element[element.length - 1];
-    var position = element.getBoundingClientRect();
-    var element2 = document.querySelector('.load-next-set');
-    var position2 = element2.getBoundingClientRect();
+    try {
+      var element = document.querySelectorAll('.load-next-set');
+      element = element[element.length - 1];
+      var position = element.getBoundingClientRect();
+      var element2 = document.querySelector('.load-next-set');
+      var position2 = element2.getBoundingClientRect();
+    } catch (err) {
+      var position = {top: undefined, bottom: undefined};
+      var position2 = {top: undefined, bottom: undefined};
+    }
     var lastElement = document.querySelector('.last-row');
     var positionLastElement = lastElement.getBoundingClientRect();
     var firstElement = document.querySelector('.first-row');
@@ -599,12 +604,14 @@ DataTableView.prototype._addHeights = function(heightToAddTop, heightToAddBottom
   $('tr:last').css('height', heightToAddBottom);
   $('tr:last').addClass('last-row');
 
-  if (theProject.rowModel.mode == "record-based") {
-    $('tr.record').eq(-1 * (this._pageSize / 2 + 1)).addClass('load-next-set');
-    $('tr.record').eq(this._pageSize / 2 + 1).addClass('load-next-set');
-  } else {
-    $('tr').eq(-1 * (this._pageSize / 2 + 2)).addClass('load-next-set');
-    $('tr').eq(this._pageSize / 2 + 1).addClass('load-next-set');
+  if(theProject.rowModel.rows.length >= this._pageSize) {
+    if (theProject.rowModel.mode == "record-based") {
+      $('tr.record').eq(-1 * (this._pageSize / 2 + 1)).addClass('load-next-set');
+      $('tr.record').eq(this._pageSize / 2 + 1).addClass('load-next-set');
+    } else {
+      $('tr').eq(-1 * (this._pageSize / 2 + 2)).addClass('load-next-set');
+      $('tr').eq(this._pageSize / 2 + 1).addClass('load-next-set');
+    }
   }
 }
 

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -577,20 +577,30 @@ DataTableView.prototype.getPageNumberSrcolling = function(scrollPosition) {
 DataTableView.prototype._adjustNextSetClasses = function(start, top) {
   var heightToAddBottom = Math.max(0, this._sizeRowsTotal - (this._totalSize) * this._sizeRowFirst);
 
-  if(top) {
+  if(!top) {
+    // Deletion of upper rows that are not visible anymore
+    if (theProject.rowModel.mode == "record-based") {
+      if($('.data-table tbody tr.record').length > 2 * this._pageSize) {
+        console.log('Deleting above records');
+        $('.data-table tbody tr').slice(1, $('.data-table tbody tr.record').eq(this._pageSize).index()).remove();
+      }
+    } else if($('.data-table tbody tr').length > 2 * this._pageSize) {
+      console.log('Deleting above rows');
+      $('.data-table tbody tr').slice(1, Math.max(0, $('.data-table tbody tr').length - 2 * this._pageSize)).remove();
+    }
+    this._pageStart = start - this._pageSize;
+  } else {
     this._pageStart = start;
     heightToAddBottom = Math.max(0, this._sizeRowsTotal - (this._pageStart + 2 * this._pageSize) * this._sizeRowFirst);
-  }
 
-  if($('.data-table tbody tr').length > this._pageSize + 2 && start > this._pageSize && top == null) {
-    console.log('Deleting above rows');
-    $('.data-table tbody tr').slice(1, Math.max(0, $('.data-table tbody tr').length - 2 * this._pageSize)).remove();
-    this._pageStart = start - this._pageSize;
-  }
-
-  if($('.data-table tbody tr').length > 2 * this._pageSize + 1 && top) {
-    console.log('Deleting below rows');
-    $('.data-table tbody tr').slice(2 * this._pageSize + 1, $('.data-table tbody tr').length).remove();
+    // Deletion of lower rows that are not visible anymore
+    if (theProject.rowModel.mode == "record-based") {
+      console.log('Deleting below records');
+      $('.data-table tbody tr').slice($('.data-table tbody tr.record').eq(2 * this._pageSize).index(), $('.data-table tbody tr').length).remove();
+    } else {
+      console.log('Deleting below rows');
+      $('.data-table tbody tr').slice(2 * this._pageSize + 1, $('.data-table tbody tr').length).remove();
+    }
   }
 
   var heightToAddTop = (this._pageStart) * this._sizeRowFirst;

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -471,7 +471,9 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
 
 DataTableView.prototype.getPageNumberSrcolling = function(scrollPosition, table) {
   // Loading sign
-  var width = 150 + 0.5 * window.innerWidth;
+  if(document.querySelector('div#body').classList.contains('hide-left-panel'))
+    var width = 0.5 * window.innerWidth;
+  else var width = 150 + 0.5 * window.innerWidth;
   window.img = document.createElement('img');
   img.setAttribute('src', 'images/large-spinner.gif');
   img.style.zIndex = '10';

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -36,7 +36,6 @@ function DataTableView(div) {
 
   this._gridPagesSizes = JSON.parse(Refine.getPreference("ui.browsing.pageSize", null));
   this._gridPagesSizes = this._checkPaginationSize(this._gridPagesSizes, [ 5, 10, 25, 50 ]);
-  // this._pageSize = ( this._gridPagesSizes[0] < 10 ) ? 10 : this._gridPagesSizes[0];
 
   this._pageSize = 100;
   this._showRecon = true;
@@ -108,9 +107,7 @@ DataTableView.prototype.render = function() {
       '<div class="viewpanel-rowrecord" bind="rowRecordControls">'+$.i18n('core-views/show-as')+': ' +
         '<span bind="modeSelectors"></span>' + 
       '</div>' +
-      // '<div class="viewpanel-pagesize" bind="pageSizeControls"></div>' +
       '<div class="viewpanel-sorting" bind="sortingControls"></div>' +
-      // '<div class="viewpanel-paging" bind="pagingControls"></div>' +
     '</div>' +
     '<div bind="dataTableContainer" class="data-table-container">' +
       '<table class="data-table">'+
@@ -378,7 +375,6 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   });
   this._columnHeaderUIs = [];
   var createColumnHeader = function(column, index) {
-    console.log('createColumnHeader');
     var th = trHead.appendChild(document.createElement("th"));
     $(th).addClass("column-header").attr('title', column.name);
     if (self._collapsedColumnNames.hasOwnProperty(column.name)) {
@@ -402,7 +398,6 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
    */
 
   var renderRow = function(tr, r, row, even) {
-    console.log('renderRow');
     $(tr).empty();
     var cells = row.cells;
     var tdStar = tr.insertCell(tr.cells.length);
@@ -535,7 +530,6 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     if(self._downwardDirection && !flag) {
       if((position.top >= 0 && position.bottom <= window.innerHeight) || 
         (positionLastElement.top < window.innerHeight && positionLastElement.top > 0)) {
-        console.log('Loading next set');
         flag = true;
         self._onBottomTable(self._scrollTop, table, this, evt);
       }
@@ -544,7 +538,6 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     if(!self._downwardDirection && !flag) {
       if(position2.top >= 0 && position2.bottom <= window.innerHeight || 
         (positionFirstElement.bottom > 0 && positionFirstElement.bottom < window.innerHeight)) {
-        console.log('Loading upper set');
         flag = true;
         self._onTopTable(self._scrollTop, table, this, evt);
       }
@@ -553,13 +546,11 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     clearTimeout($.data(this, 'scrollTimer'));
     $.data(this, 'scrollTimer', setTimeout(function() {
       if(positionLastElement.top <= 0 && positionLastElement.bottom >= 0) {
-        console.log('Last row is partially visible in screen');
         var goto = self.getPageNumberSrcolling(self._scrollTop);
         self._onChangeGotoScrolling(self._scrollTop, goto, table);
       }
 
       if(positionFirstElement.top < self._headerTop + 1 && positionFirstElement.bottom >= window.innerHeight) {
-        console.log('First row is partially visible in screen');
         var goto = self.getPageNumberSrcolling(self._scrollTop);
         self._onChangeGotoScrolling(self._scrollTop, goto, table);
       }
@@ -572,7 +563,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
 DataTableView.prototype.getPageNumberSrcolling = function(scrollPosition) {
   var num = Math.floor(scrollPosition / this._sizeSinglePage);
   return num;
-}
+};
 
 DataTableView.prototype._adjustNextSetClasses = function(start, top) {
   var heightToAddBottom = Math.max(0, this._sizeRowsTotal - this._totalSize * this._sizeRowFirst);
@@ -581,11 +572,9 @@ DataTableView.prototype._adjustNextSetClasses = function(start, top) {
     // Deletion of upper rows that are not visible anymore
     if (theProject.rowModel.mode == "record-based") {
       if($('.data-table tbody tr.record').length > 2 * this._pageSize) {
-        console.log('Deleting above records');
         $('.data-table tbody tr').slice(1, $('.data-table tbody tr.record').eq(this._pageSize).index()).remove();
       }
     } else if($('.data-table tbody tr').length > 2 * this._pageSize) {
-      console.log('Deleting above rows');
       $('.data-table tbody tr').slice(1, Math.max(0, $('.data-table tbody tr').length - 2 * this._pageSize)).remove();
     }
     this._pageStart = start - this._pageSize;
@@ -593,10 +582,8 @@ DataTableView.prototype._adjustNextSetClasses = function(start, top) {
     this._pageStart = start;
     // Deletion of lower rows that are not visible anymore
     if (theProject.rowModel.mode == "record-based") {
-      console.log('Deleting below records');
       $('.data-table tbody tr').slice($('.data-table tbody tr.record').eq(2 * this._pageSize).index(), $('.data-table tbody tr').length).remove();
     } else {
-      console.log('Deleting below rows');
       $('.data-table tbody tr').slice(2 * this._pageSize + 1, $('.data-table tbody tr').length).remove();
     }
   }
@@ -620,7 +607,7 @@ DataTableView.prototype._addHeights = function(heightToAddTop, heightToAddBottom
       $('.data-table tbody tr').eq(this._pageSize / 2).addClass('load-next-set');
     }
   }
-}
+};
 
 DataTableView.prototype._adjustNextSetClassesSpeed = function(modifiedScrollPosition, start) {
   var heightToAddTop = modifiedScrollPosition;
@@ -630,11 +617,6 @@ DataTableView.prototype._adjustNextSetClassesSpeed = function(modifiedScrollPosi
   this._pageStart = this._totalSize - this._pageSize;
 
   this._addHeights(heightToAddTop, heightToAddBottom);
-};
-
-var setScroll = function(scrollPosition) {
-    console.log("setScroll");
-    $('.data-table-container').scrollTop(scrollPosition);
 };
 
 DataTableView.prototype._showRows = function(start, onDone) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -668,7 +668,7 @@ DataTableView.prototype._showRowsTop = function(scrollPosition, table, start, on
   }, this._sorting);
 };
 
-DataTableView.prototype._showRowsBottomSpeed = function(modifiedScrollPosition, scrollPosition, table, start, onDone) {
+DataTableView.prototype._showRowsSpeed = function(modifiedScrollPosition, scrollPosition, table, start, onDone) {
   var self = this;
 
   this._totalSize = start +  this._pageSize;
@@ -688,7 +688,7 @@ DataTableView.prototype._showRowsBottomSpeed = function(modifiedScrollPosition, 
 
 DataTableView.prototype._onChangeGotoScrolling = function(scrollPosition, gotoPageNumber, table, elmt, evt) {
   var modifiedScrollPosition = this._sizeRowFirst * (gotoPageNumber) * this._pageSize; 
-  this._showRowsBottomSpeed(modifiedScrollPosition, scrollPosition, table, gotoPageNumber * this._pageSize);
+  this._showRowsSpeed(modifiedScrollPosition, scrollPosition, table, gotoPageNumber * this._pageSize);
 };
 
 DataTableView.prototype._onChangeGotoPage = function(elmt, evt) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -638,7 +638,6 @@ DataTableView.prototype._showRowsBottom = function(scrollPosition, table, start,
   var self = this;
 
   this._totalSize = start + this._pageSize;
-  $('tr.load-next-set').removeClass('load-next-set');
 
   Refine.fetchRows(start, this._pageSize, function() {
     $('.last-row').remove();
@@ -656,8 +655,6 @@ DataTableView.prototype._showRowsTop = function(scrollPosition, table, start, on
   var self = this;
 
   this._totalSize = start + 2 * this._pageSize;
-
-  $('tr.load-next-set').removeClass('load-next-set');
 
   Refine.fetchRows(start, this._pageSize, function() {
     $('.last-row').remove();
@@ -682,7 +679,6 @@ DataTableView.prototype._showRowsBottomSpeed = function(modifiedScrollPosition, 
 
     loadRows();
     self._adjustNextSetClassesSpeed(modifiedScrollPosition, start);
-    setScroll(scrollPosition);
 
     if (onDone) {
       onDone();

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -81,14 +81,7 @@ DataTableView.prototype.getSorting = function() {
   return this._sorting;
 };
 
-DataTableView.prototype.resize = function() {
-  this._sizeRowFirst = $('tr:eq(1)').height();
-  this._sizeRowsTotal = this._sizeRowFirst * theProject.metadata.rowCount;
-  this._sizeSinglePage = this._sizeRowFirst * this._pageSize;
-  var firstRow = document.querySelector('tbody').insertRow(0).setAttribute('class', 'first-row');
-
-  this._adjustNextSetClasses();
-  
+DataTableView.prototype.resize = function() {  
   var topHeight =
     this._div.find(".viewpanel-header").outerHeight(true);
   var tableContainerIntendedHeight = this._div.innerHeight() - topHeight;
@@ -509,7 +502,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   var flag = 0;
   $(table.parentNode.parentNode).bind('scroll', function(evt) {
     self._downwardDirection = self._scrollTop < $(this).scrollTop();
-    // self._scrollTop = $(this).scrollTop();
+    self._scrollTop = $(this).scrollTop();
 
     var element = document.querySelectorAll('.load-next-set');
     element = element[element.length - 1];
@@ -554,8 +547,13 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
       }
       flag = 0;
     }, 250));
-    self._scrollTop = $(this).scrollTop();
   });
+
+  this._sizeRowFirst = $('tr:eq(1)').height();
+  this._sizeRowsTotal = this._sizeRowFirst * theProject.metadata.rowCount;
+  this._sizeSinglePage = this._sizeRowFirst * this._pageSize;
+  var firstRow = document.querySelector('tbody').insertRow(0).setAttribute('class', 'first-row');
+  this._adjustNextSetClasses();
 };
 
 DataTableView.prototype.getPageNumberSrcolling = function(scrollPosition) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -618,7 +618,7 @@ DataTableView.prototype._onBottomTable = function(table, elmt, evt) {
 DataTableView.prototype._onTopTable = function(table, elmt, evt) {
   if(this._pageStart - this._pageSize >= 0) {
     this._showRowsTop(table, this._pageStart - this._pageSize, this._pageSize);
-  } else {
+  } else if(this._pageStart) {
     this._showRowsTop(table, 0, this._pageStart);
   }
 };

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -448,8 +448,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
           (positionLastElement.top < window.innerHeight && positionLastElement.top > 0)) {
           self._onBottomTable(self._scrollTop, table, this, evt);
         }
-      }
-      if(!self._downwardDirection) {
+      } else {
         if(positionPrevSet.top >= 0 && positionPrevSet.bottom <= window.innerHeight || 
           (positionFirstElement.bottom > 0 && positionFirstElement.bottom < window.innerHeight)) {
           self._onTopTable(self._scrollTop, table, this, evt);
@@ -458,13 +457,19 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
       prevOperationSet = true;
     }
 
-    clearTimeout($.data(this, 'scrollTimer'));
-    $.data(this, 'scrollTimer', setTimeout(function() {
-      if((positionLastElement.top <= 0 && positionLastElement.bottom >= 0) || (positionFirstElement.top < self._headerTop + 1 && positionFirstElement.bottom >= window.innerHeight)) {
-        self.getPageNumberSrcolling(self._scrollTop, table);
-      }
+    clearTimeout($.data(this, 'resetPrevOperationSet'));
+    $.data(this, 'resetPrevOperationSet', setTimeout(function() {
       prevOperationSet = false;
-    }, 250));
+    }, 50));
+
+    if((positionLastElement.top <= 0 && positionLastElement.bottom >= 0) || (positionFirstElement.top < self._headerTop + 1 && positionFirstElement.bottom >= window.innerHeight)) {
+      clearTimeout($.data(this, 'scrollTimer'));
+      $.data(this, 'scrollTimer', setTimeout(function() {
+        self.getPageNumberSrcolling(self._scrollTop, table);
+        prevOperationSet = false;
+      }, 250));
+    }
+
     self._scrollTop = $(this).scrollTop();
   });
 };

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -507,7 +507,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
   this._sizeRowFirst = total / this._pageSize;
   this._sizeRowsTotal = this._sizeRowFirst * theProject.metadata.rowCount;
   this._sizeSinglePage = this._sizeRowFirst * this._pageSize;
-  document.querySelector('tbody').insertRow(0).setAttribute('class', 'first-row');
+  document.querySelector('.data-table tbody').insertRow(0).setAttribute('class', 'first-row');
   this._headerTop = $('thead').offset().top + $('thead').height();
   this._adjustNextSetClasses();
 
@@ -575,19 +575,19 @@ DataTableView.prototype._adjustNextSetClasses = function(start, top) {
     heightToAddBottom = Math.max(0, this._sizeRowsTotal - (this._pageStart + 2 * this._pageSize) * this._sizeRowFirst);
   }
 
-  if($('tbody tr').length > this._pageSize + 2 && start > this._pageSize && top == null) {
+  if($('.data-table tbody tr').length > this._pageSize + 2 && start > this._pageSize && top == null) {
     console.log('Deleting above rows');
-    $('tbody tr').slice(1, $('tbody tr').length - 2 * this._pageSize).remove();
+    $('.data-table tbody tr').slice(1, $('.data-table tbody tr').length - 2 * this._pageSize).remove();
     this._pageStart = start - this._pageSize;
   }
 
-  if($('tbody tr').length > 2 * this._pageSize + 1 && top) {
+  if($('.data-table tbody tr').length > 2 * this._pageSize + 1 && top) {
     console.log('Deleting below rows');
-    $('tbody tr').slice(2 * this._pageSize + 1, $('tbody tr').length).remove();
+    $('.data-table tbody tr').slice(2 * this._pageSize + 1, $('.data-table tbody tr').length).remove();
   }
 
   var heightToAddTop = (this._pageStart) * this._sizeRowFirst;
-  $('tbody tr:first').css('height', heightToAddTop);
+  $('.data-table tbody tr:first').css('height', heightToAddTop);
 
   this._addHeights(heightToAddTop, heightToAddBottom);
 };
@@ -611,9 +611,9 @@ DataTableView.prototype._adjustNextSetClassesSpeed = function(modifiedScrollPosi
   var heightToAddTop = modifiedScrollPosition;
   var heightToAddBottom = Math.max(0, this._sizeRowsTotal - (modifiedScrollPosition + this._sizeSinglePage));
 
-  $('tbody tr').slice(1, $('tbody tr').length - this._pageSize).remove();
+  $('.data-table tbody tr').slice(1, $('.data-table tbody tr').length - this._pageSize).remove();
 
-  $('tbody tr:first').css('height', heightToAddTop);
+  $('.data-table tbody tr:first').css('height', heightToAddTop);
 
   this._addHeights(heightToAddTop, heightToAddBottom);
 };


### PR DESCRIPTION
This is for the [Infinite Scrolling Project](https://github.com/OpenRefine/OpenRefine/wiki/GSoC-2020%C2%A0Ideas#replace-row-pagination-by-infinite-scrolling) as described by #1027.
_____________________
A rough roadmap for the project:
- [x] Downward scrolling that loads next set of rows
- [x] Scrollbar length to reflect the size of the data-set
- [x] Same for `Record` mode
- [x] Speed scrolling, i.e. dragging the scrollbar to a particular position quickly without loading the intermediate rows
- [x] Virtual scrolling i.e. elements (rows) that are not visible, will not be present in the DOM
- [ ] Smooth scrolling
- [x]  Performance
- [ ] #33, #570, #572, #1134 
> Currently, the scrollbar does not reflect changes made through `previous`, `next` and `goto page`.
_____________________
Datasets:
- https://query.data.world/s/7ccggdq62yhyndv2cgkws5m4kzs7ja
- https://correlatesofwar.org/data-sets/state-system-membership/system2016/
- https://correlatesofwar.org/data-sets/world-religion-data/wrp-national-data-1/@@download/file/WRP_national.csv
_____________________
[Here](https://github.com/OpenRefine/OpenRefine/compare/master...lisa761:scroll) is a rougher version of the changes with more detailed commit history.
> It includes a lot of commented out code to keep track of some alternative methods.

Link to the weekly blogs: https://lisa761.github.io/categories/gsoc/
______________________
P.S. I have let some console outputs (browser) remain for better understanding of flow of control.
