### PR TITLE
Fix race in Process Manager

### DIFF
--- a/main/tests/server/src/com/google/refine/process/ProcessManagerTests.java
+++ b/main/tests/server/src/com/google/refine/process/ProcessManagerTests.java
@@ -51,6 +51,13 @@ public class ProcessManagerTests {
         processManager.queueProcess(process1);
         processManager.queueProcess(process2);
         processManager.onFailedProcess(process1, new IllegalArgumentException("unexpected error"));
+        // Wait for process to complete to avoid race where they serialize with
+        // different values for status: running vs done
+        int total = 0;
+        while (processManager.hasPending() && total < 1000) {
+            Thread.sleep(100);
+            total += 100;
+        }
         String processJson = ParsingUtilities.defaultWriter.writeValueAsString(process2);
         TestUtils.isSerializedTo(processManager, "{"
                 + "\"processes\":["+processJson+"],\n"

--- a/main/tests/server/src/com/google/refine/util/TestUtils.java
+++ b/main/tests/server/src/com/google/refine/util/TestUtils.java
@@ -26,7 +26,6 @@
  ******************************************************************************/
 package com.google.refine.util;
 
-import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.io.File;
@@ -83,8 +82,8 @@ public class TestUtils {
             JsonNode jsonB = mapper.readValue(actual, JsonNode.class);
             if (!jsonA.equals(jsonB)) {
                 jsonDiff(expected, actual);
+                fail("Objects above are not equal as JSON strings.");
             }
-            assertTrue(jsonA.equals(jsonB));
         } catch(Exception e) {
             fail("\""+expected+"\" and \""+actual+"\" are not equal as JSON strings.");
         }
@@ -115,15 +114,11 @@ public class TestUtils {
                 writer = ParsingUtilities.defaultWriter;
             }
             String jacksonJson = writer.writeValueAsString(o);
-            if(!equalAsJson(targetJson, jacksonJson)) {
-                System.out.println("jackson, "+o.getClass().getName());
-                jsonDiff(targetJson, jacksonJson);
-            }
-    	    assertEqualAsJson(targetJson, jacksonJson);
-    	} catch (JsonProcessingException e) {
-    	    e.printStackTrace();
-    	    fail("jackson serialization failed");
-    	}
+            assertEqualAsJson(targetJson, jacksonJson);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+            fail("jackson serialization failed");
+        }
     }
     
     /**


### PR DESCRIPTION
No issue. One of the Process Manager tests can fail intermittently (It failed on an edit of the README)  due to a race where the process under test finishes between the two test points so that the status changes from `running` to `done` causing the serialized JSON comparison to fail.

This PR fixes the race and also cleans up the test utility methods which were printing two copies of the diff.