### PR TITLE
Update Google API dependencies for GData extension

### DIFF
--- a/extensions/gdata/pom.xml
+++ b/extensions/gdata/pom.xml
@@ -127,24 +127,14 @@
       <version>4.5.12</version>
     </dependency>
     <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson</artifactId>
-      <version>1.23.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.oauth-client</groupId>
-      <artifactId>google-oauth-client-jetty</artifactId>
-      <version>1.23.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-drive</artifactId>
-      <version>v3-rev101-1.23.0</version>
+      <version>v3-rev20200413-1.30.9</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-sheets</artifactId>
-      <version>v4-rev502-1.23.0</version>
+      <version>v4-rev20200508-1.30.9</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -152,7 +142,6 @@
       <version>${jackson.version}</version>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>

--- a/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
@@ -20,7 +20,7 @@ import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson.JacksonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.sheets.v4.Sheets;

--- a/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 import com.google.api.client.auth.oauth2.AuthorizationCodeResponseUrl;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeRequestUrl;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest;
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleTokenResponse;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestInitializer;
@@ -110,8 +110,8 @@ abstract public class GoogleAPIExtension {
       }
     
     static public Drive getDriveService(String token) {
-        GoogleCredential credential = new GoogleCredential().setAccessToken(token);
-        
+        Credential credential =  new Credential.Builder(null).build().setAccessToken(token);
+
         return new Drive.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential).setHttpRequestInitializer(new HttpRequestInitializer() {
             @Override
             public void initialize(HttpRequest httpRequest) throws IOException {
@@ -156,7 +156,7 @@ abstract public class GoogleAPIExtension {
      * @throws IOException
      */
     public static Sheets getSheetsService(String token) throws IOException {
-        GoogleCredential credential = new GoogleCredential().setAccessToken(token);
+        Credential credential =  new Credential.Builder(null).build().setAccessToken(token);
         int connectTimeout = getConnectTimeout();
         int readTimeout = getReadTimeout();
         


### PR DESCRIPTION
This replaces dependabot's PR #2735 by dropping the unnecessary dependencies. It also updates the Google Drive and Google Sheets dependencies so that everything is up-to-date, replacing #2656 #2674.

Works with both the current and the repaired Google Sheets code.