### PR TITLE
Ignore insecure cookie alert in LGTM

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,2 @@
+queries:
+  - exclude: java/insecure-cookie


### PR DESCRIPTION
In #2756 I think we have a spurious alert, because OpenRefine can be used over HTTP locally and therefore cookies should not need to be sent over HTTPS by default. This attempts to disable this check in LGTM.