### PR TITLE
Add new option for deleting tags associated to releases

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -89,7 +89,11 @@ jobs:
       uses: dev-drprasad/delete-older-releases@v0.1.0
       with:
         repo: OpenRefine/OpenRefine-nightly-releases
+        # Specifies number of latest releases (sorted by created_at) to keep. Pass 0 if you want to delete all releases
         keep_latest: 10
+        # Specifies whether to delete tags associated to older releases or not.
+        # Older tags without any associated releases will not be deleted
+        delete_tags: true  
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_REPO_TOKEN }}
 


### PR DESCRIPTION
Graciously, Reddy has added a new option for us to `delete_tags`
https://github.com/dev-drprasad/delete-older-releases#delete_tags

Also, Reddy mentioned in his PR we can just do manual cleanup (via Git cli) for the old tags that are not associated to a release.