### PR TITLE
Restrict copied jars to runtime dependencies

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -100,6 +100,7 @@
             </goals>
             <configuration>
                 <outputDirectory>webapp/WEB-INF/lib</outputDirectory>
+                <includeScope>runtime</includeScope>
             </configuration>
             </execution>
         </executions>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -352,7 +352,11 @@
       <artifactId>guava</artifactId>
       <version>24.1.1-jre</version>
     </dependency>
-
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.3.1</version>
+    </dependency>
 
     <!-- test dependencies -->
 
@@ -367,11 +371,6 @@
       <artifactId>mockito-core</artifactId>
       <version>3.3.3</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <version>2.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>


### PR DESCRIPTION
 Fixes #2777.

This removes the following jars from `main/webapp/WEB-INF/lib`:

```
powermock-reflect-2.0.7.jar
annotations-13.0.jar
mockito-core-3.3.3.jar
mockwebserver-4.7.2.jar
powermock-api-support-2.0.7.jar
javax.inject-1.jar
powermock-core-2.0.7.jar
javassist-3.27.0-GA.jar
aopalliance-1.0.jar
kotlin-stdlib-1.3.71.jar
jcommander-1.72.jar
byte-buddy-1.10.5.jar
kotlin-stdlib-common-1.3.70.jar
hamcrest-core-1.3.jar
snakeyaml-1.21.jar
junit-4.13.jar
testng-7.1.0.jar
okio-2.6.0.jar
byte-buddy-agent-1.10.5.jar
okhttp-4.7.2.jar
powermock-module-testng-common-2.0.7.jar
powermock-api-mockito2-2.0.7.jar
objenesis-2.6.jar
guice-4.1.0-no_aop.jar
powermock-module-testng-2.0.7.jar
servlet-api-2.5.jar
```

The last one being removed because it is already provided by the `server` module.