### PR TITLE
Fix reference to undefined surfireArgs param

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <jee.port>3333</jee.port>
     <refine.data>/tmp/refine</refine.data>
     <surefire.version>2.22.2</surefire.version>
+    <surefireArgs></surefireArgs>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson.version>2.11.0</jackson.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire.version}</version>
         <configuration>
-          <argLine>${surefireArgs} -Dfile.encoding=cp1252</argLine>
+          <argLine>@{surefireArgs} -Dfile.encoding=cp1252</argLine>
           <suiteXmlFiles>
             <suiteXmlFile>main/tests/server/conf/tests.xml</suiteXmlFile>
           </suiteXmlFiles>


### PR DESCRIPTION
Fixes #2780 

I didn't look into this too deeply, so it might be that defining an empty `surefireArgs` param is a better way to go, but either way it needs to be made consistent. I suspect that Eclipse is being pickier than Maven about missing parameters.