### PR TITLE
Improve Google Sheets upload

### DIFF
--- a/extensions/gdata/src/com/google/refine/extension/gdata/SpreadsheetSerializer.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/SpreadsheetSerializer.java
@@ -78,22 +78,26 @@ class SpreadsheetSerializer implements TabularSerializer {
         com.google.api.services.sheets.v4.model.CellData sheetCellData = new com.google.api.services.sheets.v4.model.CellData();
         
         ExtendedValue ev = new ExtendedValue();
-        if (cellData.value instanceof String) {
-            ev.setStringValue((String) cellData.value);
-        } else if (cellData.value instanceof Integer) {
-            ev.setNumberValue(new Double((Integer) cellData.value));
-        } else if (cellData.value instanceof Double) {
-            ev.setNumberValue((Double) cellData.value);
-        } else if (cellData.value instanceof OffsetDateTime) {
-            // supposedly started internally as a double, but not sure how to transform correctly
-            // ev.setNumberValue((Double) cellData.value);
-            ev.setStringValue(cellData.value.toString());
-        } else if (cellData.value instanceof Boolean) {
-            ev.setBoolValue((Boolean) cellData.value);
-        } else if (cellData == null || cellData.value == null) {
-            ev.setStringValue("");
+        if (cellData != null) {
+            if (cellData.value instanceof String) {
+                ev.setStringValue((String) cellData.value);
+            } else if (cellData.value instanceof Integer) {
+                ev.setNumberValue(new Double((Integer) cellData.value));
+            } else if (cellData.value instanceof Double) {
+                ev.setNumberValue((Double) cellData.value);
+            } else if (cellData.value instanceof OffsetDateTime) {
+                // supposedly started internally as a double, but not sure how to transform correctly
+                // ev.setNumberValue((Double) cellData.value);
+                ev.setStringValue(cellData.value.toString());
+            } else if (cellData.value instanceof Boolean) {
+                ev.setBoolValue((Boolean) cellData.value);
+            } else if (cellData.value == null) {
+                ev.setStringValue("");
+            } else {
+                ev.setStringValue(cellData.value.toString());
+            }
         } else {
-            ev.setStringValue(cellData.value.toString());
+            ev.setStringValue("");
         }
 
         sheetCellData.setUserEnteredValue(ev);

--- a/extensions/gdata/src/com/google/refine/extension/gdata/SpreadsheetSerializer.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/SpreadsheetSerializer.java
@@ -2,6 +2,7 @@ package com.google.refine.extension.gdata;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -77,14 +78,26 @@ class SpreadsheetSerializer implements TabularSerializer {
         com.google.api.services.sheets.v4.model.CellData sheetCellData = new com.google.api.services.sheets.v4.model.CellData();
         
         ExtendedValue ev = new ExtendedValue();
-        if (cellData == null || cellData.value == null) {
+        if (cellData.value instanceof String) {
+            ev.setStringValue((String) cellData.value);
+        } else if (cellData.value instanceof Integer) {
+            ev.setNumberValue(new Double((Integer) cellData.value));
+        } else if (cellData.value instanceof Double) {
+            ev.setNumberValue((Double) cellData.value);
+        } else if (cellData.value instanceof OffsetDateTime) {
+            // supposedly started internally as a double, but not sure how to transform correctly
+            // ev.setNumberValue((Double) cellData.value);
+            ev.setStringValue(cellData.value.toString());
+        } else if (cellData.value instanceof Boolean) {
+            ev.setBoolValue((Boolean) cellData.value);
+        } else if (cellData == null || cellData.value == null) {
             ev.setStringValue("");
         } else {
             ev.setStringValue(cellData.value.toString());
         }
 
         sheetCellData.setUserEnteredValue(ev);
-        
+
         return sheetCellData;
     }
     

--- a/extensions/gdata/src/com/google/refine/extension/gdata/UploadCommand.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/UploadCommand.java
@@ -195,6 +195,7 @@ public class UploadCommand extends Command {
         try {
             File body = new File();
             body.setName(name);
+            // TODO: Internationalize (i18n)
             body.setDescription("Spreadsheet uploaded from OpenRefine project: " + name);
             body.setMimeType("application/vnd.google-apps.spreadsheet");
 

--- a/extensions/gdata/tests/src/com/google/refine/extension/gdata/SpreadsheetSerializerTests.java
+++ b/extensions/gdata/tests/src/com/google/refine/extension/gdata/SpreadsheetSerializerTests.java
@@ -5,6 +5,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 import java.io.StringWriter;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,6 +17,7 @@ import org.testng.annotations.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.AppendDimensionRequest;
+import com.google.api.services.sheets.v4.model.ExtendedValue;
 import com.google.api.services.sheets.v4.model.Request;
 import com.google.api.services.sheets.v4.model.RowData;
 import com.google.refine.exporters.TabularSerializer.CellData;
@@ -78,5 +81,40 @@ public class SpreadsheetSerializerTests {
             }
         }
         fail("Failed to find AppendDimensionRequest for columns > 26");
+    }
+
+    @Test
+    public void testDataTypes() {
+        SUT.startFile(options); // options is null, but unused
+        List<CellData> row = new ArrayList<>();
+        row.add(new CellData("null value", null, "null value", null));
+        row.add(new CellData("string value", "a string", "a string as string", null));
+        row.add(new CellData("integer value", 42, "42", null));
+        row.add(new CellData("double value", new Double(42), "42.0", null));
+        row.add(new CellData("boolean value", true, "true", null));
+        OffsetDateTime now = OffsetDateTime.now(ZoneId.of("Z"));
+        row.add(new CellData("datetime value", now, now.toString(), null));
+
+        SUT.addRow(row, false);
+
+        List<Request> requests = SUT.prepareBatch(SUT.getRows());
+        assertEquals(requests.size(), 1);
+        List<RowData> rows = requests.get(0).getAppendCells().getRows();
+        assertEquals(rows.size(), 1);
+        List<com.google.api.services.sheets.v4.model.CellData> values = rows.get(0).getValues();
+        assertEquals(values.size(), 6);
+        ExtendedValue value = values.get(0).getUserEnteredValue();
+        assertEquals(value.getStringValue(), "");
+        value = values.get(1).getUserEnteredValue();
+        assertEquals(value.getStringValue(), "a string");
+        value = values.get(2).getUserEnteredValue();
+        assertEquals(value.getNumberValue(), new Double(42));
+        value = values.get(3).getUserEnteredValue();
+        assertEquals(value.getNumberValue(), new Double(42));
+        value = values.get(4).getUserEnteredValue();
+        assertEquals(value.getBoolValue(), Boolean.TRUE);
+        value = values.get(5).getUserEnteredValue();
+        assertEquals(value.getStringValue(), now.toString());
+
     }
 }

--- a/extensions/gdata/tests/src/com/google/refine/extension/gdata/SpreadsheetSerializerTests.java
+++ b/extensions/gdata/tests/src/com/google/refine/extension/gdata/SpreadsheetSerializerTests.java
@@ -1,0 +1,82 @@
+package com.google.refine.extension.gdata;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.model.AppendDimensionRequest;
+import com.google.api.services.sheets.v4.model.Request;
+import com.google.api.services.sheets.v4.model.RowData;
+import com.google.refine.exporters.TabularSerializer.CellData;
+
+public class SpreadsheetSerializerTests {
+
+    private class SpreadsheetSerializerStub extends SpreadsheetSerializer {
+
+        SpreadsheetSerializerStub(Sheets service, String spreadsheetId, List<Exception> exceptions) {
+            super(service, spreadsheetId, exceptions);
+        }
+
+        protected List<RowData> getRows() {
+            return rows;
+        }
+
+    }
+
+    // dependencies
+    StringWriter writer;
+    JsonNode options = null;
+    Sheets service;
+    List<Exception> exceptions = new ArrayList<>();
+
+    // System Under Test
+    SpreadsheetSerializerStub SUT;
+
+    @BeforeMethod
+    public void SetUp() {
+        service = mock(Sheets.class);
+        SUT = new SpreadsheetSerializerStub(service, "spreadsheet1", exceptions);
+        writer = new StringWriter();
+    }
+
+    @AfterMethod
+    public void TearDown() {
+        SUT = null;
+        service = null;
+        exceptions.clear();
+        writer = null;
+        options = null;
+    }
+
+    @Test
+    public void test30columns() {
+        SUT.startFile(options); // options is null, but unused
+        List<CellData> cells = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            String colnum = Integer.toString(i);
+            CellData cell = new CellData("col" + colnum, "text" + colnum, "text" + colnum, null);
+            cells.add(cell);
+        }
+        SUT.addRow(cells, true);
+        SUT.addRow(cells, false);
+
+        List<Request> requests = SUT.prepareBatch(SUT.getRows());
+        assertEquals(requests.size(), 2);
+        for (Request request : requests) {
+            if (request.getAppendDimension() instanceof AppendDimensionRequest) {
+                return;
+            }
+        }
+        fail("Failed to find AppendDimensionRequest for columns > 26");
+    }
+}


### PR DESCRIPTION
Fixes #2760 along with a variety of problems that I found when testing fixes for it and fixes #2306..

- upload in chunks instead of serializing the entire document at once
- Free up resources as we go
- stop if an error occurs
- reduce batch size to try and stay in 10MB request size limit
  (but need a more dynamic way to do this probably for very wide
   sheets or sheets with large values)
- preserves cell data type on upload - fixes #2785.

I'll open issues for some of the other things. The whole thing is kind of a mess.