### PR TITLE
Remove commons-digester dependency

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -203,11 +203,6 @@
       <version>3.10</version>
     </dependency>
     <dependency>
-      <groupId>commons-digester</groupId>
-      <artifactId>commons-digester</artifactId>
-      <version>1.8.1</version>
-    </dependency>
-    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <version>1.4</version>


### PR DESCRIPTION
Replaces #2743 where dependabot wants to update an unused dependency.