### PR TITLE
Strip parentheses from imported filenames when constructing default project name

### DIFF
--- a/main/webapp/modules/core/scripts/index/default-importing-controller/parsing-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/parsing-panel.js
@@ -60,7 +60,7 @@ Refine.DefaultImportingController.prototype._showParsingPanel = function(hasFile
   if (!(this._projectName) && this._job.config.fileSelection.length > 0) {
     var index = this._job.config.fileSelection[0];
     var record = this._job.config.retrievalRecord.files[index];
-    this._projectName = $.trim(record.fileName.replace(/[\._-]/g, ' ').replace(/\s+/g, ' '));
+    this._projectName = $.trim(record.fileName.replace(/[\._-()]/g, ' ').replace(/\s+/g, ' '));
   }
   if (this._projectName) {
     this._parsingPanelElmts.projectNameInput[0].value = this._projectName;


### PR DESCRIPTION
Fixes #2776.