### PR TITLE
Change pref name for ui.browsing.pageSize

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 function DataTableView(div) {
   this._div = div;
 
-  this._gridPagesSizes = JSON.parse(Refine.getPreference("ui.gridPaginationSize", null));
+  this._gridPagesSizes = JSON.parse(Refine.getPreference("ui.browsing.pageSize", null));
   this._gridPagesSizes = this._checkPaginationSize(this._gridPagesSizes, [ 5, 10, 25, 50 ]);
   this._pageSize = ( this._gridPagesSizes[0] < 10 ) ? 10 : this._gridPagesSizes[0];
 


### PR DESCRIPTION
(Related to I #2624)

Change the preference key name `ui.gridPaginationSize` to `ui.browsing.pageSize`.

@wetneb: per @tfmorris suggestion in I #2520, I would change the preference key.
Since it's the choices, is could also be: `ui.browsing.pageSizeChoices`. But that is probably too long.

Regards,
   Antoine