### PR TITLE
Fix update to deprecated Google Drive credential code

### DIFF
--- a/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 
 import com.google.api.client.auth.oauth2.AuthorizationCodeResponseUrl;
+import com.google.api.client.auth.oauth2.BearerToken;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeRequestUrl;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeTokenRequest;
 import com.google.api.client.auth.oauth2.Credential;
@@ -110,7 +111,7 @@ abstract public class GoogleAPIExtension {
       }
     
     static public Drive getDriveService(String token) {
-        Credential credential =  new Credential.Builder(null).build().setAccessToken(token);
+        Credential credential =  new Credential.Builder(BearerToken.authorizationHeaderAccessMethod()).build().setAccessToken(token);
 
         return new Drive.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential).setHttpRequestInitializer(new HttpRequestInitializer() {
             @Override


### PR DESCRIPTION
No issue. Restore missing piece of commit 42354c0 so that Builder has the method parameter that it needs.

Not sure what happened here, but the code that I committed isn't the same as I tested with and it doesn't work. This fixes it. 