### PR TITLE
Correct mimetype for Google Drive project exports

### DIFF
--- a/extensions/gdata/src/com/google/refine/extension/gdata/UploadCommand.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/UploadCommand.java
@@ -167,10 +167,10 @@ public class UploadCommand extends Command {
             contentHints.setThumbnail(tn); 
 
             File fileMetadata = new File();
-            fileMetadata.setName(name)
+            fileMetadata.setName(name + ".tar.gz")
                 .setDescription(METADATA_DESCRIPTION)
                 .setContentHints(contentHints);
-            FileContent projectContent = new FileContent("application/zip", filePath);
+            FileContent projectContent = new FileContent("application/x-gzip", filePath);
             File file = GoogleAPIExtension.getDriveService(token)
                     .files().create(fileMetadata, projectContent)
                 .setFields("id")


### PR DESCRIPTION
Fixes #2797. Changes mimetype from zip to gzip and adds .tar.gz extension to the name.

Testing this depends on #2828 for a functional Google Drive export.