### PR TITLE
Fix i18n. Fixes #2805

### DIFF
--- a/extensions/database/module/scripts/project/database-exporters.js
+++ b/extensions/database/module/scripts/project/database-exporters.js
@@ -38,7 +38,7 @@ $.ajax({
     },
     success : function(data) {
         dictionary = data['dictionary'];
-        dictionary = data['lang'];
+        lang = data['lang'];
     }
 });
 $.i18n().load(dictionary, lang);


### PR DESCRIPTION
Fixes #2805. 
Fix database extensions exporter which is corrupting the dictionary name with the value of the language.