### PR TITLE
Adjust Travis build environments - fixes #2861

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ dist: bionic
 
 jobs:
   include:
-    - jdk: openjdk14
-    - jdk: oraclejdk11
-    - dist: trusty
+    - dist: trusty # Fastest build first
       jdk: oraclejdk8
+    - jdk: openjdk13
+    - jdk: oraclejdk11
     - os: osx
-      osx_image: xcode9.4 # macOS 10.13, Oracle JDK 13.0.1
+      osx_image: xcode11.6 # macOS 10.15.4, Oracle JDK 14.0.1
       language: java
       services: # not supported on os x
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,49 @@
+os: linux
 language: java
-dist: xenial
-jdk:
-  - openjdk8
-  - oraclejdk11
-  - openjdk11
-  - openjdk12
-  
+dist: bionic
+
+jobs:
+  include:
+    - jdk: openjdk14
+    - jdk: oraclejdk11
+    - os: osx
+      osx_image: xcode11.6
+      language: java
+      services: # not supported on os x
+      addons:
+        homebrew:
+          packages:
+            - mysql
+            - mariadb@10.3
+      before_script:
+        - brew services start mysql
+        - brew services start postgresql
+        - brew services start mariadb@10.3
+        #- sleep 15 # wait for databases to start up
+        # Homebrew postgres workaround - create expected user postgres
+        - /usr/local/opt/postgres/bin/createuser -s postgres
+        # FIXME this is duplicated from linux config, but don't know a better way to do it
+        - mysql -u root -e 'CREATE DATABASE test_db;'
+        - mysql -u root test_db < extensions/database/tests/conf/travis-mysql.sql
+        - psql -c 'CREATE DATABASE test_db;' -U postgres
+        - psql -U postgres test_db < extensions/database/tests/conf/travis-pgsql.sql
+        - cp extensions/database/tests/conf/travis_tests.xml extensions/database/tests/conf/tests.xml
+    - dist: trusty
+      jdk: oraclejdk8
+    - jdk: openjdk13
+    - jdk: openjdk12
+      dist: xenial # just for a little variety
+# Jacoco doesn't work with Java 16 and this workaround doesn't work
+#    - jdk: oraclejdk-ea
+#      script: mvn test
+#      after_success: mvn prepare-package -DskipTests=true
+#    - jdk: openjdk-ea
+#      script: mvn test
+#      after_success: mvn prepare-package -DskipTests=true
+  allow_failures:
+    - jdk: openjdk-ea
+    - jdk: oraclejdk-ea
+
 addons:
   mariadb: '10.3'
   
@@ -18,14 +56,17 @@ env:
   - secure: "VmS4He99YlI6rdmw8Q25OZ9kUp11sRbt0W1QMBvA5lzNSmhN1Q1KtaMj9AGwpCZWcyGWri4AQxEmloARxACxQHXRmNE7ro2DESGw46RAocBAf+RfBxYTifIyUGu5TnSCQhz56SkgpyWpedZAZWyah9ZxgUMfet4KXFUfeiUgYQA="
   
 before_install:
-  # create test database for mysql, mariadb and postgresql
+  # Fake out packaging for Travis builds before mvn install
+  - cp packaging/travis_pom.xml packaging/pom.xml
+  - mvn process-resources
+
+before_script:
+  # create test databases for mysql, mariadb and postgresql
   - mysql -u root -e 'CREATE DATABASE test_db;'
   - mysql -u root test_db < extensions/database/tests/conf/travis-mysql.sql
   - psql -c 'CREATE DATABASE test_db;' -U postgres
   - psql -U postgres test_db < extensions/database/tests/conf/travis-pgsql.sql
   - cp extensions/database/tests/conf/travis_tests.xml extensions/database/tests/conf/tests.xml
-  - cp packaging/travis_pom.xml packaging/pom.xml
-  - mvn process-resources
 
 script:
   - mvn jacoco:prepare-agent test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ jobs:
   include:
     - jdk: openjdk14
     - jdk: oraclejdk11
+    - dist: trusty
+      jdk: oraclejdk8
     - os: osx
-      osx_image: xcode11.6
+      osx_image: xcode9.4 # macOS 10.13, Oracle JDK 13.0.1
       language: java
       services: # not supported on os x
       addons:
@@ -28,9 +30,6 @@ jobs:
         - psql -c 'CREATE DATABASE test_db;' -U postgres
         - psql -U postgres test_db < extensions/database/tests/conf/travis-pgsql.sql
         - cp extensions/database/tests/conf/travis_tests.xml extensions/database/tests/conf/tests.xml
-    - dist: trusty
-      jdk: oraclejdk8
-    - jdk: openjdk13
     - jdk: openjdk12
       dist: xenial # just for a little variety
 # Jacoco doesn't work with Java 16 and this workaround doesn't work


### PR DESCRIPTION
Fixes #2861
- Only builds one each of JDK 8,11-14
- Fixes all validator warnings
- Switches default build environment to bionic
- Uses trusty for an Oracle JDK 8 build
- Adds OS X build
- Adds JDK 13 & 14 builds
- Adds placeholder for JDK 16 builds (but Jacoco doesn't currently support it, so commented out)
- Reorders build jobs so that most informative ones run first
- Split before_install into before_install and before_script sections