### PR TITLE
Tweak CI build settings - refs #2861

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
         - brew services start mysql
         - brew services start postgresql
         - brew services start mariadb@10.3
-        #- sleep 15 # wait for databases to start up
+        - sleep 15 # wait for databases to start up
         # Homebrew postgres workaround - create expected user postgres
         - /usr/local/opt/postgres/bin/createuser -s postgres
         # FIXME this is duplicated from linux config, but don't know a better way to do it

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ dist: bionic
 jobs:
   include:
     - dist: trusty # Fastest build first
-      jdk: oraclejdk8
+      jdk: oraclejdk8 # Trusty default
+    - jdk: openjdk11 # Bionic default
     - jdk: openjdk13
-    - jdk: oraclejdk11
     - os: osx
       osx_image: xcode11.6 # macOS 10.15.4, Oracle JDK 14.0.1
       language: java
@@ -42,6 +42,9 @@ jobs:
   allow_failures:
     - jdk: openjdk-ea
     - jdk: oraclejdk-ea
+    # JDKs below need to be installed and installation fails frequently
+    - jdk: openjdk12
+    - jdk: openjdk13
 
 addons:
   mariadb: '10.3'


### PR DESCRIPTION
- On Mac, sleep for a bit after database server startup before trying to connect
- Use default JDKs on each build platform to avoid having to do Java installs (Xenial Oracle JDK 8, Bionic OpenJDK 11, OS X Oracle JDK 14)
- Make jobs which require installations optional so they don't fail the build (OpenJDK 12 & 13)