### PR TITLE
Migrate reconciliation calls to OkHTTP

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -23,6 +23,7 @@
          Jena 3.15.0 doesn't work. Versions through 3.14.0 appear to, but we'll be conservative
     -->
     <jena.version>3.9.0</jena.version>
+    <okhttp.version>4.7.2</okhttp.version>
   </properties>
 
   <scm>
@@ -360,6 +361,11 @@
       <artifactId>juniversalchardet</artifactId>
       <version>2.3.2</version>
     </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
+    </dependency>
 
     <!-- test dependencies -->
 
@@ -390,7 +396,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>4.7.2</version>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/main/tests/server/src/com/google/refine/commands/recon/GuessTypesOfColumnCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/recon/GuessTypesOfColumnCommandTests.java
@@ -1,23 +1,154 @@
 package com.google.refine.commands.recon;
 
-import com.google.refine.commands.CommandTestBase;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-public class GuessTypesOfColumnCommandTests extends CommandTestBase {
+import com.google.refine.RefineTest;
+import com.google.refine.commands.Command;
+import com.google.refine.model.Project;
+import com.google.refine.util.TestUtils;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+public class GuessTypesOfColumnCommandTests extends RefineTest {
+    
+    HttpServletRequest request = null;
+    HttpServletResponse response = null;
+    GuessTypesOfColumnCommand command = null;
+    StringWriter writer = null;
+    Project project = null;
 	
 	@BeforeMethod
 	public void setUpCommand() {
 		command = new GuessTypesOfColumnCommand();
+		command.setSampleSize(2);
+		request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        writer = new StringWriter();
+        try {
+            when(response.getWriter()).thenReturn(new PrintWriter(writer));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+		project = createCSVProject(
+		        "foo,bar\n"
+		        + "France,b\n"
+		        + "Japan,d\n"
+		        + "Paraguay,x");
+		
 	}
 	
 	@Test
 	public void testCSRFProtection() throws ServletException, IOException {
 		command.doPost(request, response);
-		assertCSRFCheckFailed();
+		TestUtils.assertEqualAsJson("{\"code\":\"error\",\"message\":\"Missing or invalid csrf_token parameter\"}", writer.toString());
+	}
+	
+	@Test
+	public void testGuessTypes() throws IOException, ServletException, InterruptedException {
+	    when(request.getParameter("project")).thenReturn(Long.toString(project.id));
+	    when(request.getParameter("columnName")).thenReturn("foo");
+	    when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+	    
+	    String expectedQuery = "queries=%7B%22q1%22%3A%7B%22query%22%3A%22Japan%22%2C%22limit%22"+
+	            "%3A3%7D%2C%22q0%22%3A%7B%22query%22%3A%22France%22%2C%22limit%22%3A3%7D%7D";
+	    
+	    String serviceResponse = "{\n" + 
+	            "  \"q0\": {\n" + 
+	            "    \"result\": [\n" + 
+	            "      {\n" + 
+	            "        \"id\": \"Q17\",\n" + 
+	            "        \"name\": \"Japan\",\n" + 
+	            "        \"type\": [\n" + 
+	            "          {\n" + 
+	            "            \"id\": \"Q3624078\",\n" + 
+	            "            \"name\": \"sovereign state\"\n" + 
+	            "          },\n" + 
+	            "          {\n" + 
+	            "            \"id\": \"Q112099\",\n" + 
+	            "            \"name\": \"island nation\"\n" + 
+	            "          },\n" + 
+	            "          {\n" + 
+	            "            \"id\": \"Q6256\",\n" + 
+	            "            \"name\": \"country\"\n" + 
+	            "          }\n" + 
+	            "        ]\n" + 
+	            "      }\n" + 
+	            "    ]\n" + 
+	            "  },\n" + 
+	            "  \"q1\": {\n" + 
+	            "    \"result\": [\n" + 
+	            "      {\n" + 
+	            "        \"id\": \"Q142\",\n" + 
+	            "        \"name\": \"France\",\n" + 
+	            "        \"type\": [\n" + 
+	            "          {\n" + 
+	            "            \"id\": \"Q3624078\",\n" + 
+	            "            \"name\": \"sovereign state\"\n" + 
+	            "          },\n" + 
+	            "          {\n" + 
+	            "            \"id\": \"Q20181813\",\n" + 
+	            "            \"name\": \"colonial power\"\n" + 
+	            "          }\n" + 
+	            "        ]\n" + 
+	            "      }\n" + 
+	            "    ]\n" + 
+	            "  }\n" + 
+	            "}";
+	    
+	    String guessedTypes = "{\n" + 
+	            "       \"code\" : \"ok\",\n" + 
+	            "       \"types\" : [ {\n" + 
+	            "         \"count\" : 2,\n" + 
+	            "         \"id\" : \"Q3624078\",\n" + 
+	            "         \"name\" : \"sovereign state\",\n" + 
+	            "         \"score\" : 2\n" + 
+	            "       }, {\n" + 
+	            "         \"count\" : 1,\n" + 
+	            "         \"id\" : \"Q112099\",\n" + 
+	            "         \"name\" : \"island nation\",\n" + 
+	            "         \"score\" : 0.6666666666666666\n" + 
+	            "       }, {\n" + 
+	            "         \"count\" : 1,\n" + 
+	            "         \"id\" : \"Q20181813\",\n" + 
+	            "         \"name\" : \"colonial power\",\n" + 
+	            "         \"score\" : 0.5\n" + 
+	            "       }, {\n" + 
+	            "         \"count\" : 1,\n" + 
+	            "         \"id\" : \"Q6256\",\n" + 
+	            "         \"name\" : \"country\",\n" + 
+	            "         \"score\" : 0.3333333333333333\n" + 
+	            "       } ]\n" + 
+	            "     }";
+	    
+	    try (MockWebServer server = new MockWebServer()) {
+            server.start();
+            HttpUrl url = server.url("/api");
+            server.enqueue(new MockResponse().setBody(serviceResponse));
+            
+            when(request.getParameter("service")).thenReturn(url.toString());
+            
+            command.doPost(request, response);
+            
+            TestUtils.assertEqualAsJson(guessedTypes, writer.toString());
+            
+            RecordedRequest request = server.takeRequest();
+            Assert.assertEquals(request.getBody().readUtf8(), expectedQuery);
+	    }
 	}
 }


### PR DESCRIPTION
Fixes #2903 .

There are so many things that would deserve refactoring in these classes, it's a bit of a can of worms. Because my intention is to include this in 3.4, I have tried to keep the patch as small as possible.

It could arguably be even more minimal if I had kept the `HttpUrlConnection`-based code and patched it to handle permanent redirects, but that really feels wrong to me.

The changes to `StandardReconConfig` are covered by existing tests.
I did not add tests specifically for HTTP redirects even if they are the purpose of this PR - that would amount to testing the library we rely on.

Still to come: migrate the data extension operation as well.
