### PR TITLE
Fix Excel date import - Fixes #1908

### DIFF
--- a/main/src/com/google/refine/expr/functions/ToDate.java
+++ b/main/src/com/google/refine/expr/functions/ToDate.java
@@ -39,6 +39,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -201,5 +202,17 @@ public class ToDate implements Function {
     @Override
     public String getReturns() {
         return "date";
+    }
+
+    public static boolean isDate(Object o) {
+        return o instanceof OffsetDateTime;
+    }
+
+    public static OffsetDateTime toDate(Date date) {
+        return date.toInstant().atOffset(ZoneOffset.UTC);
+    }
+
+    public static OffsetDateTime toDate(Calendar date) {
+        return date.toInstant().atOffset(ZoneOffset.UTC);
     }
 }

--- a/main/src/com/google/refine/expr/functions/ToDate.java
+++ b/main/src/com/google/refine/expr/functions/ToDate.java
@@ -39,7 +39,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -204,15 +203,4 @@ public class ToDate implements Function {
         return "date";
     }
 
-    public static boolean isDate(Object o) {
-        return o instanceof OffsetDateTime;
-    }
-
-    public static OffsetDateTime toDate(Date date) {
-        return date.toInstant().atOffset(ZoneOffset.UTC);
-    }
-
-    public static OffsetDateTime toDate(Calendar date) {
-        return date.toInstant().atOffset(ZoneOffset.UTC);
-    }
 }

--- a/main/src/com/google/refine/importers/ExcelImporter.java
+++ b/main/src/com/google/refine/importers/ExcelImporter.java
@@ -58,7 +58,6 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.ProjectMetadata;
-import com.google.refine.expr.functions.ToDate;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingUtilities;
 import com.google.refine.model.Cell;
@@ -249,7 +248,7 @@ public class ExcelImporter extends TabularImportingParserBase {
             double d = cell.getNumericCellValue();
             
             if (DateUtil.isCellDateFormatted(cell)) {
-                value = ToDate.toDate(DateUtil.getJavaDate(d));
+                value = ParsingUtilities.toDate(DateUtil.getJavaDate(d));
                 // TODO: If we had a time datatype, we could use something like the following
                 // to distinguish times from dates (although Excel doesn't really make the distinction)
                 // Another alternative would be to look for values < 0.60

--- a/main/src/com/google/refine/importers/ExcelImporter.java
+++ b/main/src/com/google/refine/importers/ExcelImporter.java
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.importers;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -59,6 +58,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.ProjectMetadata;
+import com.google.refine.expr.functions.ToDate;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingUtilities;
 import com.google.refine.model.Cell;
@@ -249,7 +249,7 @@ public class ExcelImporter extends TabularImportingParserBase {
             double d = cell.getNumericCellValue();
             
             if (DateUtil.isCellDateFormatted(cell)) {
-                value = DateUtil.getJavaDate(d);
+                value = ToDate.toDate(DateUtil.getJavaDate(d));
                 // TODO: If we had a time datatype, we could use something like the following
                 // to distinguish times from dates (although Excel doesn't really make the distinction)
                 // Another alternative would be to look for values < 0.60

--- a/main/src/com/google/refine/importers/OdsImporter.java
+++ b/main/src/com/google/refine/importers/OdsImporter.java
@@ -55,7 +55,6 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.ProjectMetadata;
-import com.google.refine.expr.functions.ToDate;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingUtilities;
 import com.google.refine.model.Cell;
@@ -218,7 +217,7 @@ public class OdsImporter extends TabularImportingParserBase {
         } else if ("float".equals(cellType)) {
             value = cell.getDoubleValue();
         } else if ("date".equals(cellType)) {
-            value = ToDate.toDate(cell.getDateValue());
+            value = ParsingUtilities.toDate(cell.getDateValue());
         } else if ("currency".equals(cellType)) {
             value = cell.getCurrencyValue();
         } else if ("percentage".equals(cellType)) {

--- a/main/src/com/google/refine/importers/OdsImporter.java
+++ b/main/src/com/google/refine/importers/OdsImporter.java
@@ -55,6 +55,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.ProjectMetadata;
+import com.google.refine.expr.functions.ToDate;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingUtilities;
 import com.google.refine.model.Cell;
@@ -217,7 +218,7 @@ public class OdsImporter extends TabularImportingParserBase {
         } else if ("float".equals(cellType)) {
             value = cell.getDoubleValue();
         } else if ("date".equals(cellType)) {
-            value = cell.getDateValue().toInstant().atOffset(ZoneOffset.UTC);
+            value = ToDate.toDate(cell.getDateValue());
         } else if ("currency".equals(cellType)) {
             value = cell.getCurrencyValue();
         } else if ("percentage".equals(cellType)) {
@@ -289,5 +290,4 @@ public class OdsImporter extends TabularImportingParserBase {
             return null;
         }
     }
-
-} 
+}

--- a/main/src/com/google/refine/util/ParsingUtilities.java
+++ b/main/src/com/google/refine/util/ParsingUtilities.java
@@ -44,6 +44,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Properties;
 import java.util.TimeZone;
@@ -238,6 +239,18 @@ public class ParsingUtilities {
         Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("Z"));
         cal.setTimeInMillis(offsetDateTime.toInstant().toEpochMilli());
         return cal;
+    }
+
+    public static boolean isDate(Object o) {
+        return o instanceof OffsetDateTime;
+    }
+
+    public static OffsetDateTime toDate(Date date) {
+        return date.toInstant().atOffset(ZoneOffset.UTC);
+    }
+
+    public static OffsetDateTime toDate(Calendar date) {
+        return date.toInstant().atOffset(ZoneOffset.UTC);
     }
 
 	public static ObjectNode evaluateJsonStringToObjectNode(String optionsString) {

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -63,7 +63,6 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.refine.expr.functions.ToDate;
 import com.google.refine.importers.ExcelImporter;
 import com.google.refine.util.ParsingUtilities;
 
@@ -137,8 +136,8 @@ public class ExcelImporterTests extends ImporterTest {
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
-        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(2))); // Calendar
-        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(3))); // Date
+        assertTrue(ParsingUtilities.isDate(project.rows.get(1).getCellValue(2))); // Calendar
+        assertTrue(ParsingUtilities.isDate(project.rows.get(1).getCellValue(3))); // Date
 
         verify(options, times(1)).get("ignoreLines");
         verify(options, times(1)).get("headerLines");
@@ -205,8 +204,8 @@ public class ExcelImporterTests extends ImporterTest {
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
 
-        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(2))); // Calendar
-        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(3))); // Date
+        assertTrue(ParsingUtilities.isDate(project.rows.get(1).getCellValue(2))); // Calendar
+        assertTrue(ParsingUtilities.isDate(project.rows.get(1).getCellValue(3))); // Date
 
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
@@ -267,8 +266,8 @@ public class ExcelImporterTests extends ImporterTest {
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
 
-        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(2))); // Calendar
-        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(3))); // Date
+        assertTrue(ParsingUtilities.isDate(project.rows.get(1).getCellValue(2))); // Calendar
+        assertTrue(ParsingUtilities.isDate(project.rows.get(1).getCellValue(3))); // Date
 
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
@@ -317,8 +316,8 @@ public class ExcelImporterTests extends ImporterTest {
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
 
-        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(2))); // Calendar
-        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(3))); // Date
+        assertTrue(ParsingUtilities.isDate(project.rows.get(1).getCellValue(2))); // Calendar
+        assertTrue(ParsingUtilities.isDate(project.rows.get(1).getCellValue(3))); // Date
 
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -36,6 +36,7 @@ package com.google.refine.importers;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -49,6 +50,7 @@ import java.util.Date;
 
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -61,6 +63,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.refine.expr.functions.ToDate;
 import com.google.refine.importers.ExcelImporter;
 import com.google.refine.util.ParsingUtilities;
 
@@ -134,6 +137,9 @@ public class ExcelImporterTests extends ImporterTest {
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
+        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(2))); // Calendar
+        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(3))); // Date
+
         verify(options, times(1)).get("ignoreLines");
         verify(options, times(1)).get("headerLines");
         verify(options, times(1)).get("skipDataLines");
@@ -198,7 +204,10 @@ public class ExcelImporterTests extends ImporterTest {
 
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
-        
+
+        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(2))); // Calendar
+        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(3))); // Date
+
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
@@ -258,6 +267,9 @@ public class ExcelImporterTests extends ImporterTest {
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
 
+        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(2))); // Calendar
+        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(3))); // Date
+
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
 
@@ -302,9 +314,11 @@ public class ExcelImporterTests extends ImporterTest {
         Assert.assertEquals(((Number)project.rows.get(ROWS).getCellValue(0)).doubleValue(),0.0, EPSILON);
         Assert.assertEquals(((Number)project.rows.get(ROWS).getCellValue(COLUMNS)).doubleValue(),1.0, EPSILON);
 
-
         Assert.assertFalse((Boolean)project.rows.get(1).getCellValue(1));
         Assert.assertTrue((Boolean)project.rows.get(2).getCellValue(1));
+
+        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(2))); // Calendar
+        assertTrue(ToDate.isDate(project.rows.get(1).getCellValue(3))); // Date
 
         Assert.assertEquals((String)project.rows.get(1).getCellValue(4)," Row 1 Col 5");
         Assert.assertNull((String)project.rows.get(1).getCellValue(5));
@@ -321,37 +335,15 @@ public class ExcelImporterTests extends ImporterTest {
 
         final Workbook wb = xml ? new XSSFWorkbook() : new HSSFWorkbook();
 
+        CellStyle dateStyle = wb.createCellStyle();
+        short dateFormat = wb.createDataFormat().getFormat("yyyy-MM-dd");
+        dateStyle.setDataFormat(dateFormat);
+
         for (int s = 0; s < SHEETS; s++) {
             Sheet sheet = wb.createSheet("Test Sheet " + s);
-
             for (int row = 0; row < ROWS; row++) {
-                int col = 0;
-                Row r = sheet.createRow(row);
-                Cell c;
-
-                c = r.createCell(col++);
-                c.setCellValue(row * 1.1); // double
-
-                c = r.createCell(col++);
-                c.setCellValue(row % 2 == 0); // boolean
-
-                c = r.createCell(col++);
-                c.setCellValue(Calendar.getInstance()); // calendar
-
-                c = r.createCell(col++);
-                c.setCellValue(new Date()); // date
-
-                c = r.createCell(col++);
-                c.setCellValue(" Row " + row + " Col " + col); // string
-
-                c = r.createCell(col++);
-                c.setCellValue(""); // string
-
-                //            HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
-                //            hl.setLabel(cellData.text);
-                //            hl.setAddress(cellData.link);
+                createDataRow(sheet, row, dateStyle, 0);
             }
-
         }
 
         File file = null;
@@ -367,46 +359,21 @@ public class ExcelImporterTests extends ImporterTest {
             return null;
         }
         return file;
-		
     }
- 
+
    private static File createSheetsWithDifferentColumns(boolean xml) {
 
         final Workbook wb = xml ? new XSSFWorkbook() : new HSSFWorkbook();
 
+        CellStyle dateStyle = wb.createCellStyle();
+        short dateFormat = wb.createDataFormat().getFormat("yyyy-MM-dd");
+        dateStyle.setDataFormat(dateFormat);
+
         for (int s = 0; s < SHEETS; s++) {
             Sheet sheet = wb.createSheet("Test Sheet " + s);
-
             for (int row = 0; row < ROWS; row++) {
-                int col = 0;
-                Row r = sheet.createRow(row);
-                Cell c;
-
-                c = r.createCell(col++);
-                c.setCellValue(row * 1.1); // double
-
-                c = r.createCell(col++);
-                c.setCellValue(row % 2 == 0); // boolean
-
-                c = r.createCell(col++);
-                c.setCellValue(Calendar.getInstance()); // calendar
-
-                c = r.createCell(col++);
-                c.setCellValue(new Date()); // date
-
-                c = r.createCell(col++);
-                c.setCellValue(" Row " + row + " Col " + col); // string
-
-                c = r.createCell(col++);
-                c.setCellValue(""); // string
-
-                // Create extra columns to ensure sheet(i+1) has more columns than sheet(i)
-                for(int i = 0; i < s; i++){
-                    c = r.createCell(col++);
-                    c.setCellValue(i + s);
-                }
+                createDataRow(sheet, row, dateStyle, s);
             }
-
         }
 
         File file = null;
@@ -423,5 +390,42 @@ public class ExcelImporterTests extends ImporterTest {
         }
         return file;
     }
+
+private static void createDataRow(Sheet sheet, int row, CellStyle dateCellStyle, int extra_columns) {
+    int col = 0;
+    Row r = sheet.createRow(row);
+    Cell c;
+
+
+    c = r.createCell(col++);
+    c.setCellValue(row * 1.1); // double
+
+    c = r.createCell(col++);
+    c.setCellValue(row % 2 == 0); // boolean
+
+    c = r.createCell(col++);
+    c.setCellValue(Calendar.getInstance()); // calendar
+    c.setCellStyle(dateCellStyle);
+
+    c = r.createCell(col++);
+    c.setCellValue(new Date()); // date
+    c.setCellStyle(dateCellStyle);
+
+    c = r.createCell(col++);
+    c.setCellValue(" Row " + row + " Col " + col); // string
+
+    c = r.createCell(col++);
+    c.setCellValue(""); // string
+
+//    HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
+//    hl.setLabel(cellData.text);
+//    hl.setAddress(cellData.link);
+
+    // Create extra columns to ensure sheet(i+1) has more columns than sheet(i)
+    for(int i = 0; i < extra_columns; i++){
+        c = r.createCell(col++);
+        c.setCellValue(i + extra_columns);
+    }
+}
 
 }


### PR DESCRIPTION
Uses the OpenRefine 3.0+ date type of OffsetDateTime instead of the original java.util.Date.

Also added date tests which I was too lazy to figure out 8 1/2 years ago when I wrote the tests and added some utility methods to centralize date checking and conversion.