### PR TITLE
Update to Butterfly 1.0.4 - fixes #2917

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -173,7 +173,7 @@
     <dependency>
       <groupId>org.openrefine.dependencies</groupId>
       <artifactId>butterfly</artifactId>
-      <version>1.0.3</version>
+      <version>1.0.4</version>
     </dependency>
     <dependency>
       <groupId>org.mozilla</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -175,7 +175,7 @@
     <dependency>
       <groupId>org.openrefine.dependencies</groupId>
       <artifactId>butterfly</artifactId>
-      <version>1.0.3</version>
+      <version>1.0.4</version>
     </dependency>
     <dependency>
       <groupId>org.mozilla</groupId>


### PR DESCRIPTION
Fixes #2917
Update to Butterfly 1.0.4 which catches NoClassDefFound errors for Butterfly modules (ie OpenRefine extensions) which are missing Java dependencies (e.g. those built against earlier versions of OpenRefine)

[Obviously, this has a dependency on Butterfly 1.0.4 being published first]