### PR TITLE
Fix order dependent NPE in LoadLanguage test

### DIFF
--- a/main/tests/server/src/com/google/refine/commands/lang/LoadLanguageCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/lang/LoadLanguageCommandTests.java
@@ -33,74 +33,74 @@ public class LoadLanguageCommandTests extends CommandTestBase {
         FileProjectManager.initialize(TestUtils.createTempDirectory("openrefine-test-workspace-dir"));
     }
 
-	@BeforeMethod
-	public void setUpCommand() {
-		command = new LoadLanguageCommand();
-		ButterflyModule coreModule = mock(ButterflyModule.class);
-		
-		when(coreModule.getName()).thenReturn("core");
-		when(coreModule.getPath()).thenReturn(new File("webapp/modules/core"));
-		RefineServlet servlet = mock(RefineServlet.class);
-		when(servlet.getModule("core")).thenReturn(coreModule);
-		command.init(servlet);
-	}
-	
-	@Test
-	public void testLoadLanguages() throws ServletException, IOException {
-		when(request.getParameter("module")).thenReturn("core");
-		when(request.getParameterValues("lang")).thenReturn(new String[] {"en"});
-		
-		command.doPost(request, response);
-		
-		JsonNode response = ParsingUtilities.mapper.readValue(writer.toString(), JsonNode.class);
-		assertTrue(response.has("dictionary"));
-		assertTrue(response.has("lang"));
-	}
-	
-	@Test
-	public void testLoadUnknownLanguage() throws ServletException, IOException {
-		when(request.getParameter("module")).thenReturn("core");
-		when(request.getParameterValues("lang")).thenReturn(new String[] {"foobar"});
-		
-		command.doPost(request, response);
-		
-		JsonNode response = ParsingUtilities.mapper.readValue(writer.toString(), JsonNode.class);
-		assertTrue(response.has("dictionary"));
-		assertEquals(response.get("lang").asText(), "en");
-	}
-	
-	@Test
-	public void testLoadNoLanguage() throws JsonParseException, JsonMappingException, IOException, ServletException {
-	    when(request.getParameter("module")).thenReturn("core");
-	    when(request.getParameter("lang")).thenReturn("");
-	    
-	    command.doPost(request, response);
-	    
-	    JsonNode response = ParsingUtilities.mapper.readValue(writer.toString(), JsonNode.class);
+    @BeforeMethod
+    public void setUpCommand() {
+        command = new LoadLanguageCommand();
+        ButterflyModule coreModule = mock(ButterflyModule.class);
+
+        when(coreModule.getName()).thenReturn("core");
+        when(coreModule.getPath()).thenReturn(new File("webapp/modules/core"));
+        RefineServlet servlet = mock(RefineServlet.class);
+        when(servlet.getModule("core")).thenReturn(coreModule);
+        command.init(servlet);
+    }
+
+    @Test
+    public void testLoadLanguages() throws ServletException, IOException {
+        when(request.getParameter("module")).thenReturn("core");
+        when(request.getParameterValues("lang")).thenReturn(new String[] {"en"});
+
+        command.doPost(request, response);
+
+        JsonNode response = ParsingUtilities.mapper.readValue(writer.toString(), JsonNode.class);
+        assertTrue(response.has("dictionary"));
+        assertTrue(response.has("lang"));
+    }
+
+    @Test
+    public void testLoadUnknownLanguage() throws ServletException, IOException {
+        when(request.getParameter("module")).thenReturn("core");
+        when(request.getParameterValues("lang")).thenReturn(new String[] {"foobar"});
+
+        command.doPost(request, response);
+
+        JsonNode response = ParsingUtilities.mapper.readValue(writer.toString(), JsonNode.class);
         assertTrue(response.has("dictionary"));
         assertEquals(response.get("lang").asText(), "en");
-	}
-	
-	@Test
-	public void testLanguageFallback() throws JsonParseException, JsonMappingException, IOException {
-		String fallbackJson = "{"
-				+ "\"foo\":\"hello\","
-				+ "\"bar\":\"world\""
-				+ "}";
-		String preferredJson = "{"
-				+ "\"foo\":\"hallo\""
-				+ "}";
-		String expectedJson = "{"
-				+ "\"foo\":\"hallo\","
-				+ "\"bar\":\"world\""
-				+ "}";
-		ObjectNode fallback = ParsingUtilities.mapper.readValue(fallbackJson, ObjectNode.class);
-		ObjectNode preferred = ParsingUtilities.mapper.readValue(preferredJson, ObjectNode.class);
-		ObjectNode expected = ParsingUtilities.mapper.readValue(expectedJson, ObjectNode.class);
-		
-		ObjectNode merged = LoadLanguageCommand.mergeLanguages(preferred, fallback);
-		
-		assertEquals(merged, expected);
-	}
+    }
+
+    @Test
+    public void testLoadNoLanguage() throws JsonParseException, JsonMappingException, IOException, ServletException {
+        when(request.getParameter("module")).thenReturn("core");
+        when(request.getParameter("lang")).thenReturn("");
+
+        command.doPost(request, response);
+
+        JsonNode response = ParsingUtilities.mapper.readValue(writer.toString(), JsonNode.class);
+        assertTrue(response.has("dictionary"));
+        assertEquals(response.get("lang").asText(), "en");
+    }
+
+    @Test
+    public void testLanguageFallback() throws JsonParseException, JsonMappingException, IOException {
+        String fallbackJson = "{"
+                + "\"foo\":\"hello\","
+                + "\"bar\":\"world\""
+                + "}";
+        String preferredJson = "{"
+                + "\"foo\":\"hallo\""
+                + "}";
+        String expectedJson = "{"
+                + "\"foo\":\"hallo\","
+                + "\"bar\":\"world\""
+                + "}";
+        ObjectNode fallback = ParsingUtilities.mapper.readValue(fallbackJson, ObjectNode.class);
+        ObjectNode preferred = ParsingUtilities.mapper.readValue(preferredJson, ObjectNode.class);
+        ObjectNode expected = ParsingUtilities.mapper.readValue(expectedJson, ObjectNode.class);
+
+        ObjectNode merged = LoadLanguageCommand.mergeLanguages(preferred, fallback);
+
+        assertEquals(merged, expected);
+    }
 }
 

--- a/main/tests/server/src/com/google/refine/commands/lang/LoadLanguageCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/lang/LoadLanguageCommandTests.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import javax.servlet.ServletException;
 
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -19,12 +20,19 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.RefineServlet;
 import com.google.refine.commands.CommandTestBase;
+import com.google.refine.io.FileProjectManager;
 import com.google.refine.util.ParsingUtilities;
+import com.google.refine.util.TestUtils;
 
 import edu.mit.simile.butterfly.ButterflyModule;
 
 public class LoadLanguageCommandTests extends CommandTestBase {
-	
+
+    @BeforeTest
+    public void setUpTest() throws IOException {
+        FileProjectManager.initialize(TestUtils.createTempDirectory("openrefine-test-workspace-dir"));
+    }
+
 	@BeforeMethod
 	public void setUpCommand() {
 		command = new LoadLanguageCommand();


### PR DESCRIPTION
Fixes #2895. The test fails consistently if run on its own, but can succeed if another test that correctly initializes the ProjectManager runs first. This patch adds the local initialization of a FileProjectManager.

The second commit is whitespace changes only to fix the indentation in the module (remove tabs).