### PR TITLE
Remove informational logging from tests that are passing

### DIFF
--- a/main/src/com/google/refine/exporters/sql/SqlCreateBuilder.java
+++ b/main/src/com/google/refine/exporters/sql/SqlCreateBuilder.java
@@ -62,9 +62,7 @@ public class SqlCreateBuilder {
 
         List<JsonNode> columnOptionArray = options == null ? Collections.emptyList() : JSONUtilities.getArray(options, "columns");
         boolean trimColNames = options == null ? false : JSONUtilities.getBoolean(options, "trimColumnNames", false);
-        
-        
-      
+
         int count = columnOptionArray.size();
 
         for (int i = 0; i < count; i++) {
@@ -75,8 +73,8 @@ public class SqlCreateBuilder {
                 String size = JSONUtilities.getString(columnOptions, "size", "");
                 boolean allowNull = JSONUtilities.getBoolean(columnOptions, "allowNull", true);
                 String defaultValue = JSONUtilities.getString(columnOptions, "defaultValue", null);
-                logger.info("allowNull::{}" , allowNull);
-                
+                logger.debug("allowNull::{}" , allowNull);
+
                 String allowNullStr = "NULL";
                 if(!allowNull) {
                     allowNullStr = "NOT NULL";

--- a/main/tests/server/src/com/google/refine/exporters/sql/SqlExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/sql/SqlExporterTests.java
@@ -134,13 +134,11 @@ public class SqlExporterTests extends RefineTest {
         }
         
         String result = writer.toString();
-        logger.info("result = \n" + result);
+        logger.debug("result = \n" + result);
         Assert.assertNotNull(result);
         assertNotEquals(writer.toString(), SqlExporter.NO_OPTIONS_PRESENT_ERROR);
         boolean checkResult = result.contains("CREATE TABLE " + tableName);
-        //logger.info("checkResult1 =" + checkResult);
         checkResult = result.contains("INSERT INTO " + tableName);
-       // logger.info("checkResult2 =" + checkResult);
         Assert.assertEquals(checkResult,  true);
    
     }
@@ -196,7 +194,6 @@ public class SqlExporterTests extends RefineTest {
         ObjectNode optionsJson = (ObjectNode) createOptionsFromProject(tableName, null,null);
         optionsJson.put("includeStructure", false);
         when(options.getProperty("options")).thenReturn(optionsJson.toString());
-       // logger.info("Options = " + optionsJson.toString());
 
         try {
             SUT.export(project, options, engine, writer);
@@ -205,7 +202,6 @@ public class SqlExporterTests extends RefineTest {
         }
         
         String result = writer.toString();
-        //logger.info("result = \n" + result);
         Assert.assertNotNull(result);
         assertNotEquals(writer.toString(), SqlExporter.NO_OPTIONS_PRESENT_ERROR);
         boolean checkResult = result.contains("CREATE TABLE " + tableName);
@@ -223,7 +219,6 @@ public class SqlExporterTests extends RefineTest {
         ObjectNode optionsJson = (ObjectNode) createOptionsFromProject(tableName, null, null);
         optionsJson.put("includeContent", false);
         when(options.getProperty("options")).thenReturn(optionsJson.toString());
-        //logger.info("Options = " + optionsJson.toString());
 
         try {
             SUT.export(project, options, engine, writer);
@@ -232,7 +227,6 @@ public class SqlExporterTests extends RefineTest {
         }
         
         String result = writer.toString();
-       // logger.info("result = \n" + result);
         Assert.assertNotNull(result);
         assertNotEquals(writer.toString(), SqlExporter.NO_OPTIONS_PRESENT_ERROR);
         boolean checkResult = result.contains("CREATE TABLE " + tableName);
@@ -252,7 +246,6 @@ public class SqlExporterTests extends RefineTest {
         optionsJson.put("includeDropStatement", true);
         
         when(options.getProperty("options")).thenReturn(optionsJson.toString());
-        //logger.info("Options = " + optionsJson.toString());
 
         try {
             SUT.export(project, options, engine, writer);
@@ -261,23 +254,19 @@ public class SqlExporterTests extends RefineTest {
         }
         
         String result = writer.toString();
-        //logger.info("result = " + result);
-        
+
         Assert.assertNotNull(result);
 //        assertNotEquals(writer.toString(), SqlExporter.NO_OPTIONS_PRESENT_ERROR);
 //        assertNotEquals(writer.toString(), SqlExporter.NO_COL_SELECTED_ERROR);
         
         boolean checkResult = result.contains("CREATE TABLE " + tableName);
         Assert.assertEquals(checkResult,  true);
-        //logger.info("checkResult1 = " + checkResult);
        
         checkResult = result.contains("INSERT INTO " + tableName );
         Assert.assertEquals(checkResult,  true);
-        //logger.info("checkResult2 = " + checkResult);
         
         checkResult = result.contains("DROP TABLE IF EXISTS " + tableName + ";");
         Assert.assertEquals(checkResult,  true);
-        //logger.info("checkResult3 = " + checkResult);
    
     }
 
@@ -288,12 +277,10 @@ public class SqlExporterTests extends RefineTest {
         String type = "CHAR";
         String size = "2";
         JsonNode optionsJson = createOptionsFromProject(tableName, type, size);
-       // logger.info("Options:: = " + optionsJson.toString());
         List<String> columns = project.columnModel.columns.stream().map(col -> col.getName()).collect(Collectors.toList());
        
         sqlCreateBuilder  = new SqlCreateBuilder(tableName, columns, optionsJson);
         String createSql = sqlCreateBuilder.getCreateSQL();
-        //logger.info("createSql = \n" + createSql);
         Assert.assertNotNull(createSql);
         boolean result = createSql.contains(type + "(" + size + ")");
         Assert.assertEquals(result,  true);
@@ -312,7 +299,6 @@ public class SqlExporterTests extends RefineTest {
         
         
         when(options.getProperty("options")).thenReturn(optionsJson.toString());
-        //logger.info("Options = " + optionsJson.toString());
 
         try {
             SUT.export(project, options, engine, writer);
@@ -322,9 +308,7 @@ public class SqlExporterTests extends RefineTest {
         
         String result = writer.toString();
         Assert.assertNotNull(result);
-        //logger.info("\nresult = " + result);
-       // logger.info("\nNull Count:" + countWordInString(result, "null"));
-        
+
         int countNull = countWordInString(result, "null");
         Assert.assertEquals(countNull, inNull);
 
@@ -349,11 +333,11 @@ public class SqlExporterTests extends RefineTest {
         }
         
         String result = writer.toString();
-        logger.info("\nresult:={} ", result);
+        logger.debug("\nresult:={} ", result);
         Assert.assertNotNull(result);
      
         int countNull = countWordInString(result, "NOT NULL");
-        logger.info("\nNot Null Count: {}" , countNull);
+        logger.debug("\nNot Null Count: {}" , countNull);
         Assert.assertEquals(countNull, noOfCols);
 
     }
@@ -377,7 +361,7 @@ public class SqlExporterTests extends RefineTest {
         }
         
         String result = writer.toString();
-        logger.info("\nresult:={} ", result);
+        logger.debug("\nresult:={} ", result);
 
         Assert.assertTrue(result.contains("INSERT INTO sql_table_test (column0,column1,column2,column3) VALUES \n" + 
         		"( 'It''s row0cell0','It''s row0cell1','It''s row0cell2','It''s row0cell3' )"));
@@ -465,7 +449,6 @@ public class SqlExporterTests extends RefineTest {
         List<Column> cols = project.columnModel.columns;
       
         cols.forEach(c -> {
-            //logger.info("Column Name = " + c.getName());
             ObjectNode columnModel = ParsingUtilities.mapper.createObjectNode();
             columnModel.put("name", c.getName());
             if(type != null) {
@@ -483,7 +466,6 @@ public class SqlExporterTests extends RefineTest {
                 columnModel.put("type", type);
             }
             if(size != null) {
-               // logger.info(" Size = " + size);
                 columnModel.put("size", size);
             }
             
@@ -502,7 +484,6 @@ public class SqlExporterTests extends RefineTest {
        List<Column> cols = project.columnModel.columns;
      
        cols.forEach(c -> {
-           //logger.info("Column Name = " + c.getName());
            ObjectNode columnModel = ParsingUtilities.mapper.createObjectNode();
            columnModel.put("name", c.getName());
            if(type != null) {
@@ -520,7 +501,6 @@ public class SqlExporterTests extends RefineTest {
                columnModel.put("type", type);
            }
            if(size != null) {
-              // logger.info(" Size = " + size);
                columnModel.put("size", size);
            }
            
@@ -541,7 +521,6 @@ public class SqlExporterTests extends RefineTest {
        List<Column> cols = project.columnModel.columns;
      
        cols.forEach(c -> {
-           //logger.info("Column Name = " + c.getName());
            ObjectNode columnModel = ParsingUtilities.mapper.createObjectNode();
            columnModel.put("name", c.getName());
            if(type != null) {
@@ -559,7 +538,6 @@ public class SqlExporterTests extends RefineTest {
                columnModel.put("type", type);
            }
            if(size != null) {
-              // logger.info(" Size = " + size);
                columnModel.put("size", size);
            }
           
@@ -578,7 +556,5 @@ public class SqlExporterTests extends RefineTest {
         double randomnum = Math.floor(Math.random() * (10 * precision - 1 * precision) + 1 * precision) / (1*precision);
         return randomnum;
     }
-    
-   
-  
+
 }

--- a/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
@@ -81,12 +81,12 @@ public class JsonImporterTests extends ImporterTest {
     public void setUp(Method method){
         super.setUp();
         SUT = new JsonImporter();
-        logger.info("About to run test method: " + method.getName());
+        logger.debug("About to run test method: " + method.getName());
     }
 
     @AfterMethod
     public void tearDown(ITestResult result) {
-//        logger.info("Finished test method: " + result.getMethod().getMethodName());
+        logger.debug("Finished test method: " + result.getMethod().getMethodName());
         SUT = null;
         if (inputStream != null) {
             try {

--- a/main/tests/server/src/com/google/refine/importers/XmlImportUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/XmlImportUtilitiesTests.java
@@ -215,7 +215,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
         } catch (Exception e){
             Assert.fail();
         }
-        log(project);
+
         assertProjectCreated(project, 0, 6);
 
         Assert.assertEquals(project.rows.get(0).cells.size(), 4);
@@ -239,7 +239,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
         } catch (Exception e){
             Assert.fail();
         }
-        log(project);
+
         assertProjectCreated(project, 0, 6);
         Assert.assertEquals(project.rows.get(0).cells.size(), 4);
         Assert.assertEquals(project.rows.get(5).cells.size(), 5);
@@ -269,7 +269,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
         columnGroup.subgroups.put("e", subGroup);
 
         XmlImportUtilitiesStub.createColumnsFromImport(project, columnGroup);
-        log(project);
+
         assertProjectCreated(project, 4, 0);
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "hello");
         Assert.assertEquals(project.columnModel.columns.get(1).getName(), "world");
@@ -296,7 +296,6 @@ public class XmlImportUtilitiesTests extends RefineTest {
             Assert.fail();
         }
 
-        log(project);
         assertProjectCreated(project, 0, 6);
 
         Assert.assertEquals(project.rows.get(0).cells.size(), 4);
@@ -314,7 +313,6 @@ public class XmlImportUtilitiesTests extends RefineTest {
         } catch (Exception e) {
             Assert.fail();
         }
-        log(project);
         Assert.assertNotNull(project.rows);
         Assert.assertEquals(project.rows.size(), 1);
         Row row = project.rows.get(0);
@@ -335,7 +333,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
         } catch (Exception e) {
             Assert.fail();
         }
-        log(project);
+
         Assert.assertNotNull(project.rows);
         Assert.assertEquals(project.rows.size(), 2);
 
@@ -360,7 +358,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
         } catch (Exception e) {
             Assert.fail();
         }
-        log(project);
+
         Assert.assertNotNull(project.rows);
         Assert.assertEquals(project.rows.size(), 1);
         Row row = project.rows.get(0);
@@ -385,7 +383,6 @@ public class XmlImportUtilitiesTests extends RefineTest {
         } catch (Exception e) {
             Assert.fail();
         }
-        log(project);
 
         Assert.assertEquals(columnGroup.subgroups.size(), 1);
         Assert.assertEquals(columnGroup.name, "");
@@ -413,7 +410,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
         } catch (Exception e) {
             Assert.fail();
         }
-        log(project);
+
         Assert.assertNotNull(project.rows);
         Assert.assertEquals(project.rows.size(), 1);
         Row row = project.rows.get(0);
@@ -436,7 +433,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
         } catch (Exception e) {
             Assert.fail();
         }
-        log(project);
+
         Assert.assertNotNull(project.rows);
         Assert.assertEquals(project.rows.size(), 1);
         Row row = project.rows.get(0);

--- a/main/tests/server/src/com/google/refine/importers/XmlImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/XmlImporterTests.java
@@ -97,7 +97,6 @@ public class XmlImporterTests extends ImporterTest {
     public void canParseSample(){
         RunTest(getSample());
 
-        log(project);
         assertProjectCreated(project, 4, 6);
 
         Row row = project.rows.get(0);
@@ -110,7 +109,6 @@ public class XmlImporterTests extends ImporterTest {
     public void canParseDeeplyNestedSample(){
         RunTest(getDeeplyNestedSample(), getNestedOptions(job, SUT));
 
-        log(project);
         assertProjectCreated(project, 4, 6);
 
         Row row = project.rows.get(0);
@@ -123,7 +121,6 @@ public class XmlImporterTests extends ImporterTest {
     public void canParseSampleWithMixedElement(){
         RunTest(getMixedElementSample(), getNestedOptions(job, SUT));
 
-        log(project);
         assertProjectCreated(project, 4, 6);
         
         Row row = project.rows.get(0);
@@ -147,7 +144,6 @@ public class XmlImporterTests extends ImporterTest {
     public void canParseSampleWithDuplicateNestedElements(){
         RunTest(getSampleWithDuplicateNestedElements());
 
-        log(project);
         assertProjectCreated(project, 4, 12);
 
         Row row = project.rows.get(0);
@@ -163,7 +159,6 @@ public class XmlImporterTests extends ImporterTest {
 
         RunTest(getSampleWithLineBreak());
 
-        log(project);
         assertProjectCreated(project, 4, 6);
 
         Row row = project.rows.get(3);
@@ -177,7 +172,6 @@ public class XmlImporterTests extends ImporterTest {
     public void testElementsWithVaryingStructure(){
         RunTest(getSampleWithVaryingStructure());
 
-        log(project);
         assertProjectCreated(project, 5, 6);
 
         Assert.assertEquals(project.columnModel.getColumnByCellIndex(4).getName(), "book - genre");
@@ -194,7 +188,7 @@ public class XmlImporterTests extends ImporterTest {
     @Test
     public void testElementWithNestedTree(){
         RunTest(getSampleWithTreeStructure());
-        log(project);
+
         assertProjectCreated(project, 5, 6);
 
         Assert.assertEquals(project.columnModel.columnGroups.size(),1);


### PR DESCRIPTION
No issue. This removes a bunch of logging messages left over from development by either changing them from `info` to `debug` level or removing them altogether.

I'd like to get rid of the stack traces from the expected exceptions too, but they're logged from the production code, not the test code in most cases.

The end goal is to have the tests be quiet when they're passing so that the offending problem is easily spotted when they're failing.