### PR TITLE
Remove unused scrutinizer specific methods

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/ConstraintFetcher.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/ConstraintFetcher.java
@@ -23,15 +23,12 @@
  ******************************************************************************/
 package org.openrefine.wikidata.qa;
 
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
 import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * An object that fetches constraints about properties.
@@ -40,109 +37,6 @@ import java.util.Set;
  *
  */
 public interface ConstraintFetcher {
-
-    /**
-     * Retrieves the regular expression for formatting a property, or null if there
-     * is no such constraint
-     * 
-     * @param pid
-     * @return the expression of a regular expression which should be compatible
-     *         with java.util.regex
-     */
-    String getFormatRegex(PropertyIdValue pid);
-
-    /**
-     * Retrieves the property that is the inverse of a given property
-     * 
-     * @param pid
-     *            the property to retrieve the inverse for
-     * @return the pid of the inverse property
-     */
-    PropertyIdValue getInversePid(PropertyIdValue pid);
-    
-    /**
-     * Is this property supposed to be symmetric (its own inverse)?
-     */
-    boolean isSymmetric(PropertyIdValue pid);
-
-    /**
-     * Can this property be used as values?
-     */
-    boolean allowedAsValue(PropertyIdValue pid);
-
-    /**
-     * Can this property be used as qualifiers?
-     */
-    boolean allowedAsQualifier(PropertyIdValue pid);
-
-    /**
-     * Can this property be used in a reference?
-     */
-    boolean allowedAsReference(PropertyIdValue pid);
-
-    /**
-     * Get the list of allowed qualifiers (as property ids) for this property (null
-     * if any)
-     */
-    Set<PropertyIdValue> allowedQualifiers(PropertyIdValue pid);
-
-    /**
-     * Get the list of mandatory qualifiers (as property ids) for this property
-     * (null if any)
-     */
-    Set<PropertyIdValue> mandatoryQualifiers(PropertyIdValue pid);
-    
-    /**
-     * Get the set of allowed values for this property (null if no such constraint).
-     * This set may contain null if one of the allowed values in novalue or somevalue.
-     */
-    Set<Value> allowedValues(PropertyIdValue pid);
-    
-    /**
-     * Get the set of disallowed values for this property (null if no such constraint).
-     * This set may contain null if one of the allowed values in novalue or somevalue.
-     */
-    Set<Value> disallowedValues(PropertyIdValue pid);
-
-    /**
-     * Is this property expected to have at most one value per item?
-     */
-    boolean hasSingleValue(PropertyIdValue pid);
-    
-    /**
-     * Is this property expected to have a single best value only?
-     */
-    boolean hasSingleBestValue(PropertyIdValue pid);
-
-    /**
-     * Is this property expected to have distinct values?
-     */
-    boolean hasDistinctValues(PropertyIdValue pid);
-
-    /**
-     * Is this property expected to have more than one value per item?
-     */
-    boolean hasMultiValue(PropertyIdValue pid);
-
-    /**
-     * Can statements using this property have uncertainty bounds?
-     */
-    boolean boundsAllowed(PropertyIdValue pid);
-
-    /**
-     * Is this property expected to have integer values only?
-     */
-    boolean integerValued(PropertyIdValue pid);
-    
-    /**
-     * Returns the allowed units for this property. If empty, no unit is allowed. If null, any unit is allowed.
-     */
-    Set<ItemIdValue> allowedUnits(PropertyIdValue pid);
-    
-    /**
-     * Can this property be used on items?
-     */
-    boolean usableOnItems(PropertyIdValue pid);
 
     /**
      * Gets the list of constraints of a particular type for a property
@@ -165,39 +59,5 @@ public interface ConstraintFetcher {
      * @return
      */
     List<Value> findValues(List<SnakGroup> groups, String pid);
-
-    /**
-     * Retrieves the lower bound of the range
-     * required in difference-within-range constraint
-     *
-     * @param pid
-     * @return minimum value
-     */
-    QuantityValue getMinimumValue(PropertyIdValue pid);
-
-    /**
-     * Retrieves the upper bound of the range
-     * required in difference-within-range constraint
-     *
-     * @param pid
-     * @return maximum value
-     */
-    QuantityValue getMaximumValue(PropertyIdValue pid);
-
-    /**
-     * Retrieves the lower value property for calculating the difference
-     * required in difference-within-range constraint
-     *
-     * @param pid
-     *            the property to calculate difference with
-     * @return the pid of the lower bound property
-     */
-    PropertyIdValue getLowerPropertyId(PropertyIdValue pid);
-
-    /**
-     * Is this property expected to have a value whose difference
-     * with its lower bound property should be in a range?
-     */
-    boolean hasDiffWithinRange(PropertyIdValue pid);
 
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/WikidataConstraintFetcher.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/WikidataConstraintFetcher.java
@@ -24,13 +24,18 @@
 package org.openrefine.wikidata.qa;
 
 import org.openrefine.wikidata.utils.EntityCache;
-import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.implementation.QuantityValueImpl;
-import org.wikidata.wdtk.datamodel.interfaces.*;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.Snak;
+import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
+import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
+import org.wikidata.wdtk.datamodel.interfaces.Value;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -45,56 +50,6 @@ public class WikidataConstraintFetcher implements ConstraintFetcher {
 
     public static String WIKIDATA_CONSTRAINT_PID = "P2302";
 
-    public static String FORMAT_CONSTRAINT_QID = "Q21502404";
-    public static String FORMAT_REGEX_PID = "P1793";
-
-    public static String INVERSE_CONSTRAINT_QID = "Q21510855";
-    public static String INVERSE_PROPERTY_PID = "P2306";
-    public static String SYMMETRIC_CONSTRAINT_QID = "Q21510862";
-
-    public static String SCOPE_CONSTRAINT_QID = "Q53869507";
-    public static String SCOPE_CONSTRAINT_PID = "P5314";
-    public static String SCOPE_CONSTRAINT_VALUE_QID = "Q54828448";
-    public static String SCOPE_CONSTRAINT_QUALIFIER_QID = "Q54828449";
-    public static String SCOPE_CONSTRAINT_REFERENCE_QID = "Q54828450";
-
-    public static String USED_ONLY_AS_QUALIFIER_CONSTRAINT_QID = "Q21510863";
-
-    public static String USED_ONLY_AS_REFERENCE_CONSTRAINT_QID = "Q21528959";
-
-    public static String ALLOWED_QUALIFIERS_CONSTRAINT_QID = "Q21510851";
-    public static String ALLOWED_QUALIFIERS_CONSTRAINT_PID = "P2306";
-
-    public static String MANDATORY_QUALIFIERS_CONSTRAINT_QID = "Q21510856";
-    public static String MANDATORY_QUALIFIERS_CONSTRAINT_PID = "P2306";
-    
-    public static String ALLOWED_VALUES_CONSTRAINT_QID = "Q21510859";
-    public static String ALLOWED_VALUES_CONSTRAINT_PID = "P2305";
-
-    public static String DISALLOWED_VALUES_CONSTRAINT_QID = "Q52558054";
-    public static String DISALLOWED_VALUES_CONSTRAINT_PID = "P2305";
-
-    public static String SINGLE_VALUE_CONSTRAINT_QID = "Q19474404";
-    public static String SINGLE_BEST_VALUE_CONSTRAINT_QID = "Q52060874";
-    public static String DISTINCT_VALUES_CONSTRAINT_QID = "Q21502410";
-
-    public static String MULTI_VALUE_CONSTRAINT_QID = "Q21510857";
-
-    public static String DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID = "Q21510854";
-    public static String DIFFERENCE_WITHIN_RANGE_CONSTRAINT_PID = "P2306";
-    public static String MINIMUM_VALUE_PID = "P2313";
-    public static String MAXIMUM_VALUE_PID = "P2312";
-
-    public static String NO_BOUNDS_CONSTRAINT_QID = "Q51723761";
-    public static String INTEGER_VALUED_CONSTRAINT_QID = "Q52848401";
-    
-    public static String ALLOWED_UNITS_CONSTRAINT_QID = "Q21514353";
-    public static String ALLOWED_UNITS_CONSTRAINT_PID = "P2305";
-    
-    public static String ALLOWED_ENTITY_TYPES_QID = "Q52004125";
-    public static String ALLOWED_ITEM_TYPE_QID = "Q29934200";
-    public static String ALLOWED_ENTITY_TYPES_PID = "P2305";
-
     // The following constraints still need to be implemented:
 
     public static String TYPE_CONSTRAINT_QID = "Q21503250";
@@ -103,170 +58,6 @@ public class WikidataConstraintFetcher implements ConstraintFetcher {
     
     public WikidataConstraintFetcher(EntityCache cache) {
         entityCache = cache;
-    }
-
-    @Override
-    public String getFormatRegex(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, FORMAT_CONSTRAINT_QID);
-        if (specs != null) {
-            List<Value> regexes = findValues(specs, FORMAT_REGEX_PID);
-            if (!regexes.isEmpty()) {
-                return ((StringValue) regexes.get(0)).getString();
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public PropertyIdValue getInversePid(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, INVERSE_CONSTRAINT_QID);
-
-        if (specs != null) {
-            List<Value> inverses = findValues(specs, INVERSE_PROPERTY_PID);
-            if (!inverses.isEmpty()) {
-                return (PropertyIdValue) inverses.get(0);
-            }
-        }
-        return null;
-    }
-
-    @Override
-    public boolean allowedAsValue(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, SCOPE_CONSTRAINT_QID);
-        
-        if (specs != null) {
-            ItemIdValue target = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_VALUE_QID);
-            return findValues(specs, SCOPE_CONSTRAINT_PID).contains(target);
-        }
-        return true;
-    }
-
-    @Override
-    public boolean allowedAsQualifier(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, SCOPE_CONSTRAINT_QID);
-        
-        if (specs != null) {
-            ItemIdValue target = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_QUALIFIER_QID);
-            return findValues(specs, SCOPE_CONSTRAINT_PID).contains(target);
-        }
-        return true;
-    }
-
-    @Override
-    public boolean allowedAsReference(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, SCOPE_CONSTRAINT_QID);
-        
-        if (specs != null) {
-            ItemIdValue target = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_REFERENCE_QID);
-            return findValues(specs, SCOPE_CONSTRAINT_PID).contains(target);
-        }
-        return true;
-    }
-
-    @Override
-    public Set<PropertyIdValue> allowedQualifiers(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, ALLOWED_QUALIFIERS_CONSTRAINT_QID);
-
-        if (specs != null) {
-            List<Value> properties = findValues(specs, ALLOWED_QUALIFIERS_CONSTRAINT_PID);
-            return properties.stream()
-                    .filter(e -> e != null)
-                    .map(e -> (PropertyIdValue) e)
-                    .collect(Collectors.toSet());
-        }
-        return null;
-    }
-
-    @Override
-    public Set<PropertyIdValue> mandatoryQualifiers(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, MANDATORY_QUALIFIERS_CONSTRAINT_QID);
-
-        if (specs != null) {
-            List<Value> properties = findValues(specs, MANDATORY_QUALIFIERS_CONSTRAINT_PID);
-            return properties.stream()
-                    .filter(e -> e != null)
-                    .map(e -> (PropertyIdValue) e)
-                    .collect(Collectors.toSet());
-        }
-        return null;
-    }
-
-    @Override
-    public boolean hasSingleValue(PropertyIdValue pid) {
-        return getSingleConstraint(pid, SINGLE_VALUE_CONSTRAINT_QID) != null;
-    }
-    
-    @Override
-    public boolean hasSingleBestValue(PropertyIdValue pid) {
-        return getSingleConstraint(pid, SINGLE_BEST_VALUE_CONSTRAINT_QID) != null;
-    }
-
-    @Override
-    public boolean hasDistinctValues(PropertyIdValue pid) {
-        return getSingleConstraint(pid, DISTINCT_VALUES_CONSTRAINT_QID) != null;
-    }
-
-    @Override
-    public boolean hasMultiValue(PropertyIdValue pid) {
-        return getSingleConstraint(pid, MULTI_VALUE_CONSTRAINT_QID) != null;
-    }
-
-    @Override
-    public boolean isSymmetric(PropertyIdValue pid) {
-        return getSingleConstraint(pid, SYMMETRIC_CONSTRAINT_QID) != null;
-    }
-
-    @Override
-    public Set<Value> allowedValues(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, ALLOWED_VALUES_CONSTRAINT_QID);
-
-        if (specs != null) {
-            List<Value> properties = findValues(specs, ALLOWED_VALUES_CONSTRAINT_PID);
-            return properties.stream().collect(Collectors.toSet());
-        }
-        return null;
-    }
-
-    @Override
-    public Set<Value> disallowedValues(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, DISALLOWED_VALUES_CONSTRAINT_QID);
-
-        if (specs != null) {
-            List<Value> properties = findValues(specs, DISALLOWED_VALUES_CONSTRAINT_PID);
-            return properties.stream().collect(Collectors.toSet());
-        }
-        return null;
-    }
-    
-    @Override
-    public boolean boundsAllowed(PropertyIdValue pid) {
-        return getSingleConstraint(pid, NO_BOUNDS_CONSTRAINT_QID) == null;
-    }
-    
-    @Override
-    public boolean integerValued(PropertyIdValue pid) {
-        return getSingleConstraint(pid, INTEGER_VALUED_CONSTRAINT_QID) != null;
-    }
-    
-    @Override
-    public Set<ItemIdValue> allowedUnits(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, ALLOWED_UNITS_CONSTRAINT_QID);
-
-        if (specs != null) {
-            List<Value> properties = findValues(specs, ALLOWED_UNITS_CONSTRAINT_PID);
-            return properties.stream().map(e -> e == null ? null : (ItemIdValue) e).collect(Collectors.toSet());
-        }
-        return null;
-    }
-    
-    @Override
-    public boolean usableOnItems(PropertyIdValue pid) {
-        List<SnakGroup> constraint = getSingleConstraint(pid, ALLOWED_ENTITY_TYPES_QID);
-        if (constraint != null) {
-            return findValues(constraint, ALLOWED_ENTITY_TYPES_PID).contains(
-                    Datamodel.makeWikidataItemIdValue(ALLOWED_ITEM_TYPE_QID));
-        }
-        return true;
     }
 
     /**
@@ -346,85 +137,6 @@ public class WikidataConstraintFetcher implements ConstraintFetcher {
             }
         }
         return results;
-    }
-
-    protected List<QuantityValue> getValues(List<SnakGroup> groups, String pid) {
-        List<QuantityValue> results = new ArrayList<>();
-        for (SnakGroup group : groups) {
-            if (group.getProperty().getId().equals(pid)) {
-                for (Snak snak : group.getSnaks())
-                    results.add((QuantityValueImpl) snak.getValue());
-            }
-        }
-        return results;
-    }
-
-    /**
-     * Is this property expected to have a value whose difference
-     * with its lower bound property should be in a range?
-     */
-    @Override
-    public boolean hasDiffWithinRange(PropertyIdValue pid) {
-        return getSingleConstraint(pid, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID) != null;
-    }
-
-    /**
-     * Retrieves the lower value property for calculating the difference
-     * required in difference-within-range constraint
-     *
-     * @param pid
-     *            the property to calculate difference with
-     * @return the pid of the lower bound property
-     */
-    @Override
-    public PropertyIdValue getLowerPropertyId(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID);
-        if (specs != null) {
-            List<Value> lowerValueProperty = findValues(specs, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_PID);
-            if (!lowerValueProperty.isEmpty()) {
-                return (PropertyIdValue) lowerValueProperty.get(0);
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Retrieves the lower bound of the range
-     * required in difference-within-range constraint
-     *
-     * @param pid
-     * @return minimum value
-     */
-    @Override
-    public QuantityValue getMinimumValue(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID);
-        if (specs != null) {
-            List<QuantityValue> minValue = getValues(specs, MINIMUM_VALUE_PID);
-            if (!minValue.isEmpty()) {
-                return minValue.get(0);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Retrieves the upper bound of the range
-     * required in difference-within-range constraint
-     *
-     * @param pid
-     * @return maximum value
-     */
-    @Override
-    public QuantityValue getMaximumValue(PropertyIdValue pid) {
-        List<SnakGroup> specs = getSingleConstraint(pid, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID);
-        if (specs != null) {
-            List<QuantityValue> maxValue = getValues(specs, MAXIMUM_VALUE_PID);
-            if (!maxValue.isEmpty()) {
-                return maxValue.get(0);
-            }
-        }
-        return null;
     }
 
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/WikidataConstraintFetcherTests.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/WikidataConstraintFetcherTests.java
@@ -23,79 +23,14 @@
  ******************************************************************************/
 package org.openrefine.wikidata.qa;
 
-import java.util.regex.Pattern;
-
 import org.openrefine.wikidata.utils.EntityCacheStub;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 
 public class WikidataConstraintFetcherTests {
 
     private ConstraintFetcher fetcher;
 
-    private PropertyIdValue headOfGovernment;
-    private PropertyIdValue startTime;
-    private PropertyIdValue endTime;
-    private PropertyIdValue instanceOf;
-    private PropertyIdValue gridId;
-    private PropertyIdValue partOf;
-    private PropertyIdValue mother;
-    private PropertyIdValue child;
-
     public WikidataConstraintFetcherTests() {
         fetcher = new WikidataConstraintFetcher(new EntityCacheStub());
-        headOfGovernment = Datamodel.makeWikidataPropertyIdValue("P6");
-        startTime = Datamodel.makeWikidataPropertyIdValue("P580");
-        endTime = Datamodel.makeWikidataPropertyIdValue("P582");
-        instanceOf = Datamodel.makeWikidataPropertyIdValue("P31");
-        gridId = Datamodel.makeWikidataPropertyIdValue("P2427");
-        partOf = Datamodel.makeWikidataPropertyIdValue("P361");
-        mother = Datamodel.makeWikidataPropertyIdValue("P25");
-        child = Datamodel.makeWikidataPropertyIdValue("P40");
     }
 
-    @Test
-    public void testGetFormatConstraint() {
-        String regex = fetcher.getFormatRegex(gridId);
-        Pattern pattern = Pattern.compile(regex);
-
-        Assert.assertTrue(pattern.matcher("grid.470811.b").matches());
-        Assert.assertFalse(pattern.matcher("501100006367").matches());
-
-        Assert.assertNull(fetcher.getFormatRegex(instanceOf));
-    }
-
-    @Test
-    public void testGetInverseConstraint() {
-        Assert.assertEquals(fetcher.getInversePid(mother), child);
-    }
-
-    @Test
-    public void testAllowedQualifiers() {
-        Assert.assertTrue(fetcher.allowedQualifiers(headOfGovernment).contains(startTime));
-        Assert.assertTrue(fetcher.allowedQualifiers(headOfGovernment).contains(endTime));
-        Assert.assertFalse(fetcher.allowedQualifiers(headOfGovernment).contains(headOfGovernment));
-        Assert.assertNull(fetcher.allowedQualifiers(startTime));
-    }
-
-    @Test
-    public void testMandatoryQualifiers() {
-        Assert.assertTrue(fetcher.mandatoryQualifiers(headOfGovernment).contains(startTime));
-        Assert.assertFalse(fetcher.mandatoryQualifiers(headOfGovernment).contains(endTime));
-        Assert.assertNull(fetcher.allowedQualifiers(startTime));
-    }
-
-    @Test
-    public void testSingleValue() {
-        Assert.assertFalse(fetcher.hasSingleValue(headOfGovernment));
-        Assert.assertTrue(fetcher.hasSingleValue(mother));
-    }
-
-    @Test
-    public void testDistinctValues() {
-        Assert.assertFalse(fetcher.hasDistinctValues(partOf));
-        Assert.assertTrue(fetcher.hasDistinctValues(gridId));
-    }
 }


### PR DESCRIPTION
After adding the code for fetching parameters for different scrutinizers in their corresponding classes, we should remove the redundant code from the ConstraintFetcher interface and WikidataConstraintFetcherClass.