### PR TITLE
Reuse Constraint IDs and Property IDs

### DIFF
--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/ConstraintTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/ConstraintTest.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import static org.openrefine.wikidata.qa.Constraint.CONSTRAINT_EXCEPTIONS;
 import static org.openrefine.wikidata.qa.Constraint.CONSTRAINT_STATUS;
-import static org.openrefine.wikidata.qa.WikidataConstraintFetcher.SINGLE_VALUE_CONSTRAINT_QID;
+import static org.openrefine.wikidata.qa.scrutinizers.SingleValueScrutinizer.SINGLE_VALUE_CONSTRAINT_QID;
 
 public class ConstraintTest {
 

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/ConstraintTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/ConstraintTest.java
@@ -21,12 +21,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.openrefine.wikidata.qa.Constraint.CONSTRAINT_EXCEPTIONS;
+import static org.openrefine.wikidata.qa.Constraint.CONSTRAINT_STATUS;
+import static org.openrefine.wikidata.qa.WikidataConstraintFetcher.SINGLE_VALUE_CONSTRAINT_QID;
+
 public class ConstraintTest {
 
-    public static ItemIdValue itemIdValue = Datamodel.makeWikidataItemIdValue("Q19474404");
-    public static PropertyIdValue constraintException = Datamodel.makeWikidataPropertyIdValue("P2303");
+    public static ItemIdValue itemIdValue = Datamodel.makeWikidataItemIdValue(SINGLE_VALUE_CONSTRAINT_QID);
+    public static PropertyIdValue constraintException = Datamodel.makeWikidataPropertyIdValue(CONSTRAINT_EXCEPTIONS);
     public static Value exceptionValue = Datamodel.makeWikidataItemIdValue("Q7409772");
-    public static PropertyIdValue constraintStatus = Datamodel.makeWikidataPropertyIdValue("P2316");
+    public static PropertyIdValue constraintStatus = Datamodel.makeWikidataPropertyIdValue(CONSTRAINT_STATUS);
     public static Value statusValue = Datamodel.makeWikidataItemIdValue("Q62026391");
 
     public static Constraint constraint;

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/DifferenceWithinScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/DifferenceWithinScrutinizerTest.java
@@ -23,6 +23,10 @@ import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.openrefine.wikidata.qa.scrutinizers.DifferenceWithinRangeScrutinizer.DIFFERENCE_WITHIN_RANGE_CONSTRAINT_PID;
+import static org.openrefine.wikidata.qa.scrutinizers.DifferenceWithinRangeScrutinizer.DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID;
+import static org.openrefine.wikidata.qa.scrutinizers.DifferenceWithinRangeScrutinizer.MAXIMUM_VALUE_PID;
+import static org.openrefine.wikidata.qa.scrutinizers.DifferenceWithinRangeScrutinizer.MINIMUM_VALUE_PID;
 
 public class DifferenceWithinScrutinizerTest extends ScrutinizerTest{
 
@@ -30,11 +34,11 @@ public class DifferenceWithinScrutinizerTest extends ScrutinizerTest{
     public static PropertyIdValue lowerBoundPid = Datamodel.makeWikidataPropertyIdValue("P569");
     public static QuantityValue minValue = Datamodel.makeQuantityValue(new BigDecimal(0));
     public static QuantityValue maxValue = Datamodel.makeQuantityValue(new BigDecimal(150));
-    public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue("Q21510854");
+    public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue(DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID);
 
-    public static PropertyIdValue propertyParameterPID = Datamodel.makeWikidataPropertyIdValue("P2306");
-    public static PropertyIdValue minimumValuePID = Datamodel.makeWikidataPropertyIdValue("P2313");
-    public static PropertyIdValue maximumValuePID = Datamodel.makeWikidataPropertyIdValue("P2312");
+    public static PropertyIdValue propertyParameterPID = Datamodel.makeWikidataPropertyIdValue(DIFFERENCE_WITHIN_RANGE_CONSTRAINT_PID);
+    public static PropertyIdValue minimumValuePID = Datamodel.makeWikidataPropertyIdValue(MINIMUM_VALUE_PID);
+    public static PropertyIdValue maximumValuePID = Datamodel.makeWikidataPropertyIdValue(MAXIMUM_VALUE_PID);
 
     @Override
     public EditScrutinizer getScrutinizer() {
@@ -59,10 +63,10 @@ public class DifferenceWithinScrutinizerTest extends ScrutinizerTest{
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, constraintQualifiers);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(upperBoundPid, "Q21510854")).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, "P2306")).thenReturn(Collections.singletonList(lowerBoundPid));
-        when(fetcher.findValues(constraintQualifiers, "P2313")).thenReturn(Collections.singletonList(minValue));
-        when(fetcher.findValues(constraintQualifiers, "P2312")).thenReturn(Collections.singletonList(maxValue));
+        when(fetcher.getConstraintsByType(upperBoundPid, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
+        when(fetcher.findValues(constraintQualifiers, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_PID)).thenReturn(Collections.singletonList(lowerBoundPid));
+        when(fetcher.findValues(constraintQualifiers, MINIMUM_VALUE_PID)).thenReturn(Collections.singletonList(minValue));
+        when(fetcher.findValues(constraintQualifiers, MAXIMUM_VALUE_PID)).thenReturn(Collections.singletonList(maxValue));
         setFetcher(fetcher);
 
         scrutinize(updateA);
@@ -87,10 +91,10 @@ public class DifferenceWithinScrutinizerTest extends ScrutinizerTest{
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, constraintQualifiers);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(upperBoundPid, "Q21510854")).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, "P2306")).thenReturn(Collections.singletonList(lowerBoundPid));
-        when(fetcher.findValues(constraintQualifiers, "P2313")).thenReturn(Collections.singletonList(minValue));
-        when(fetcher.findValues(constraintQualifiers, "P2312")).thenReturn(Collections.singletonList(maxValue));
+        when(fetcher.getConstraintsByType(upperBoundPid, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
+        when(fetcher.findValues(constraintQualifiers, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_PID)).thenReturn(Collections.singletonList(lowerBoundPid));
+        when(fetcher.findValues(constraintQualifiers, MINIMUM_VALUE_PID)).thenReturn(Collections.singletonList(minValue));
+        when(fetcher.findValues(constraintQualifiers, MAXIMUM_VALUE_PID)).thenReturn(Collections.singletonList(maxValue));
         setFetcher(fetcher);
 
         scrutinize(updateA);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/DistinctValuesScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/DistinctValuesScrutinizerTest.java
@@ -42,6 +42,7 @@ import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.openrefine.wikidata.qa.scrutinizers.DistinctValuesScrutinizer.DISTINCT_VALUES_CONSTRAINT_QID;
 
 public class DistinctValuesScrutinizerTest extends StatementScrutinizerTest {
 
@@ -49,7 +50,7 @@ public class DistinctValuesScrutinizerTest extends StatementScrutinizerTest {
     public static Value value1 = Datamodel.makeWikidataItemIdValue("Q41673");
     public static Value value2 = Datamodel.makeWikidataItemIdValue("Q43175");
 
-    public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue("Q19474404");
+    public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue(DISTINCT_VALUES_CONSTRAINT_QID);
 
     @Override
     public EditScrutinizer getScrutinizer() {
@@ -69,7 +70,7 @@ public class DistinctValuesScrutinizerTest extends StatementScrutinizerTest {
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue, "Q21502410")).thenReturn(statementList);
+        when(fetcher.getConstraintsByType(propertyIdValue, DISTINCT_VALUES_CONSTRAINT_QID)).thenReturn(statementList);
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -90,7 +91,7 @@ public class DistinctValuesScrutinizerTest extends StatementScrutinizerTest {
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue, "Q21502410")).thenReturn(statementList);
+        when(fetcher.getConstraintsByType(propertyIdValue, DISTINCT_VALUES_CONSTRAINT_QID)).thenReturn(statementList);
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/EntityTypeScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/EntityTypeScrutinizerTest.java
@@ -57,8 +57,8 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue,"Q52004125")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P2305")).thenReturn(Collections.singletonList(allowedValue));
+        when(fetcher.getConstraintsByType(propertyIdValue,ALLOWED_ENTITY_TYPES_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, ALLOWED_ENTITY_TYPES_PID)).thenReturn(Collections.singletonList(allowedValue));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -81,8 +81,8 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue,"Q52004125")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P2305")).thenReturn(Collections.singletonList(itemValue));
+        when(fetcher.getConstraintsByType(propertyIdValue,ALLOWED_ENTITY_TYPES_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, ALLOWED_ENTITY_TYPES_PID)).thenReturn(Collections.singletonList(itemValue));
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/FormatScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/FormatScrutinizerTest.java
@@ -43,6 +43,8 @@ import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.openrefine.wikidata.qa.scrutinizers.FormatScrutinizer.FORMAT_CONSTRAINT_QID;
+import static org.openrefine.wikidata.qa.scrutinizers.FormatScrutinizer.FORMAT_REGEX_PID;
 
 public class FormatScrutinizerTest extends ScrutinizerTest {
 
@@ -52,8 +54,8 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
     public static Value incompleteMatchValue = Datamodel.makeStringValue(".jpg");
     public static String regularExpression = "(?i).+\\.(jpg|jpeg|jpe|png|svg|tif|tiff|gif|xcf|pdf|djvu|webp)";
 
-    public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue("Q21502404");
-    public static PropertyIdValue regularExpressionParameter = Datamodel.makeWikidataPropertyIdValue("P1793");
+    public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue(FORMAT_CONSTRAINT_QID);
+    public static PropertyIdValue regularExpressionParameter = Datamodel.makeWikidataPropertyIdValue(FORMAT_REGEX_PID);
     public static Value regularExpressionFormat = Datamodel.makeStringValue(regularExpression);
 
     @Override
@@ -76,8 +78,8 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue, "Q21502404")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P1793")).thenReturn(Collections.singletonList(regularExpressionFormat));
+        when(fetcher.getConstraintsByType(propertyIdValue, FORMAT_CONSTRAINT_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, FORMAT_REGEX_PID)).thenReturn(Collections.singletonList(regularExpressionFormat));
         setFetcher(fetcher);
         scrutinize(updateA);
         assertWarningsRaised(FormatScrutinizer.type);
@@ -97,8 +99,8 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue, "Q21502404")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P1793")).thenReturn(Collections.singletonList(regularExpressionFormat));
+        when(fetcher.getConstraintsByType(propertyIdValue, FORMAT_CONSTRAINT_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, FORMAT_REGEX_PID)).thenReturn(Collections.singletonList(regularExpressionFormat));
         setFetcher(fetcher);
         scrutinize(updateA);
         assertNoWarningRaised();
@@ -118,8 +120,8 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue, "Q21502404")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P1793")).thenReturn(Collections.singletonList(regularExpressionFormat));
+        when(fetcher.getConstraintsByType(propertyIdValue, FORMAT_CONSTRAINT_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, FORMAT_REGEX_PID)).thenReturn(Collections.singletonList(regularExpressionFormat));
         setFetcher(fetcher);
         scrutinize(updateA);
         assertWarningsRaised(FormatScrutinizer.type);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstaintScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstaintScrutinizerTest.java
@@ -41,6 +41,9 @@ import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.openrefine.wikidata.qa.scrutinizers.InverseConstraintScrutinizer.INVERSE_CONSTRAINT_QID;
+import static org.openrefine.wikidata.qa.scrutinizers.InverseConstraintScrutinizer.INVERSE_PROPERTY_PID;
+import static org.openrefine.wikidata.qa.scrutinizers.InverseConstraintScrutinizer.SYMMETRIC_CONSTRAINT_QID;
 
 public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
 
@@ -50,9 +53,9 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
     public static PropertyIdValue symmetricPropertyID = Datamodel.makeWikidataPropertyIdValue("P3373");
     public static ItemIdValue symmetricPropertyValue = Datamodel.makeWikidataItemIdValue("Q9545711");
 
-    public static ItemIdValue inverseEntityIdValue = Datamodel.makeWikidataItemIdValue("Q21510855");
-    public static ItemIdValue symmetricEntityIdValue = Datamodel.makeWikidataItemIdValue("Q21510862");
-    public static PropertyIdValue propertyParameter = Datamodel.makeWikidataPropertyIdValue("P2306");
+    public static ItemIdValue inverseEntityIdValue = Datamodel.makeWikidataItemIdValue(INVERSE_CONSTRAINT_QID);
+    public static ItemIdValue symmetricEntityIdValue = Datamodel.makeWikidataItemIdValue(SYMMETRIC_CONSTRAINT_QID);
+    public static PropertyIdValue propertyParameter = Datamodel.makeWikidataPropertyIdValue(INVERSE_PROPERTY_PID);
 
     @Override
     public EditScrutinizer getScrutinizer() {
@@ -73,8 +76,8 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
         List<Statement> statementList = constraintParameterStatementList(inverseEntityIdValue, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyId, "Q21510855")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P2306")).thenReturn(Collections.singletonList(inversePropertyID));
+        when(fetcher.getConstraintsByType(propertyId, INVERSE_CONSTRAINT_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(inversePropertyID));
         setFetcher(fetcher);
         scrutinize(update);
         assertWarningsRaised(InverseConstraintScrutinizer.type);
@@ -94,8 +97,8 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
         List<Statement> statementList = constraintParameterStatementList(symmetricEntityIdValue, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(symmetricPropertyID, "Q21510862")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P2306")).thenReturn(Collections.singletonList(symmetricPropertyID));
+        when(fetcher.getConstraintsByType(symmetricPropertyID, SYMMETRIC_CONSTRAINT_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(symmetricPropertyID));
         setFetcher(fetcher);
         scrutinize(update);
         assertWarningsRaised(InverseConstraintScrutinizer.type);
@@ -115,8 +118,8 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
         List<Statement> statementList = constraintParameterStatementList(inverseEntityIdValue, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyId, "Q21510855")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P2306")).thenReturn(Collections.singletonList(inversePropertyID));
+        when(fetcher.getConstraintsByType(propertyId, INVERSE_CONSTRAINT_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(inversePropertyID));
         setFetcher(fetcher);
         scrutinize(update);
         assertNoWarningRaised();

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/MultiValueScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/MultiValueScrutinizerTest.java
@@ -10,24 +10,21 @@ import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.openrefine.wikidata.qa.scrutinizers.MultiValueScrutinizer.MULTI_VALUE_CONSTRAINT_QID;
 
 public class MultiValueScrutinizerTest extends ScrutinizerTest {
 
     public static PropertyIdValue propertyIdValue = Datamodel.makeWikidataPropertyIdValue("P1963");
-    public static Value valueSnak1 = Datamodel.makeWikidataItemIdValue("Q5");
-    public static Value valueSnak2 = Datamodel.makeWikidataItemIdValue("Q4");
-    public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue("Q21510857");
-    public static PropertyIdValue constraintParameter = Datamodel.makeWikidataPropertyIdValue("P2316");
-    public static Value constraintStatus = Datamodel.makeWikidataItemIdValue("Q62026391");
+    public static Value valueSnak = Datamodel.makeWikidataItemIdValue("Q5");
+    public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue(MULTI_VALUE_CONSTRAINT_QID);
 
     @Override
     public EditScrutinizer getScrutinizer() {
@@ -45,13 +42,9 @@ public class MultiValueScrutinizerTest extends ScrutinizerTest {
         ItemUpdate update = new ItemUpdateBuilder(idA).addStatement(TestingData.generateStatement(idA, idB))
                 .addStatement(TestingData.generateStatement(idA, idB)).addStatement(statement1).addStatement(statement2).build();
 
-        Snak snak = Datamodel.makeValueSnak(constraintParameter, constraintStatus);
-        List<Snak> snakList1 = Collections.singletonList(snak);
-        SnakGroup snakGroup = Datamodel.makeSnakGroup(snakList1);
-        List<SnakGroup> snakGroupList = Collections.singletonList(snakGroup);
-        List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
+        List<Statement> statementList = constraintParameterStatementList(entityIdValue, new ArrayList<>());
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue, "Q21510857")).thenReturn(statementList);
+        when(fetcher.getConstraintsByType(propertyIdValue, MULTI_VALUE_CONSTRAINT_QID)).thenReturn(statementList);
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -62,18 +55,14 @@ public class MultiValueScrutinizerTest extends ScrutinizerTest {
     public void testNewItemTrigger() {
         ItemIdValue idA = TestingData.newIdA;
         ItemIdValue idB = TestingData.newIdB;
-        Snak mainSnakValue = Datamodel.makeValueSnak(propertyIdValue, valueSnak1);
+        Snak mainSnakValue = Datamodel.makeValueSnak(propertyIdValue, valueSnak);
         Statement statement = new StatementImpl("P1963", mainSnakValue, idA);
         ItemUpdate updateA = new ItemUpdateBuilder(idA).addStatement(TestingData.generateStatement(idA, idB)).addStatement(statement).build();
         ItemUpdate updateB = new ItemUpdateBuilder(idB).addStatement(TestingData.generateStatement(idB, idB)).build();
 
-        Snak snak = Datamodel.makeValueSnak(constraintParameter, constraintStatus);
-        List<Snak> snakList1 = Collections.singletonList(snak);
-        SnakGroup snakGroup = Datamodel.makeSnakGroup(snakList1);
-        List<SnakGroup> snakGroupList = Collections.singletonList(snakGroup);
-        List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
+        List<Statement> statementList = constraintParameterStatementList(entityIdValue, new ArrayList<>());
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue, "Q21510857")).thenReturn(statementList);
+        when(fetcher.getConstraintsByType(propertyIdValue, MULTI_VALUE_CONSTRAINT_QID)).thenReturn(statementList);
         setFetcher(fetcher);
 
         scrutinize(updateA, updateB);
@@ -84,18 +73,14 @@ public class MultiValueScrutinizerTest extends ScrutinizerTest {
     public void testExistingItemTrigger() {
         ItemIdValue idA = TestingData.existingId;
         ItemIdValue idB = TestingData.matchedId;
-        Snak mainSnakValue = Datamodel.makeValueSnak(propertyIdValue, valueSnak1);
+        Snak mainSnakValue = Datamodel.makeValueSnak(propertyIdValue, valueSnak);
         Statement statement = new StatementImpl("P1963", mainSnakValue, idA);
         ItemUpdate updateA = new ItemUpdateBuilder(idA).addStatement(TestingData.generateStatement(idA, idB)).addStatement(statement).build();
         ItemUpdate updateB = new ItemUpdateBuilder(idB).addStatement(TestingData.generateStatement(idB, idB)).build();
 
-        Snak snak = Datamodel.makeValueSnak(constraintParameter, constraintStatus);
-        List<Snak> snakList1 = Collections.singletonList(snak);
-        SnakGroup snakGroup = Datamodel.makeSnakGroup(snakList1);
-        List<SnakGroup> snakGroupList = Collections.singletonList(snakGroup);
-        List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
+        List<Statement> statementList = constraintParameterStatementList(entityIdValue, new ArrayList<>());
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue, "Q21510857")).thenReturn(statementList);
+        when(fetcher.getConstraintsByType(propertyIdValue, MULTI_VALUE_CONSTRAINT_QID)).thenReturn(statementList);
         setFetcher(fetcher);
 
         scrutinize(updateA, updateB);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
@@ -44,12 +44,16 @@ import java.util.stream.Collectors;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.openrefine.wikidata.qa.scrutinizers.QualifierCompatibilityScrutinizer.ALLOWED_QUALIFIERS_CONSTRAINT_PID;
+import static org.openrefine.wikidata.qa.scrutinizers.QualifierCompatibilityScrutinizer.ALLOWED_QUALIFIERS_CONSTRAINT_QID;
+import static org.openrefine.wikidata.qa.scrutinizers.QualifierCompatibilityScrutinizer.MANDATORY_QUALIFIERS_CONSTRAINT_PID;
+import static org.openrefine.wikidata.qa.scrutinizers.QualifierCompatibilityScrutinizer.MANDATORY_QUALIFIERS_CONSTRAINT_QID;
 
 public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerTest {
 
-    public static ItemIdValue allowedQualifierEntity = Datamodel.makeWikidataItemIdValue("Q21510851");
-    public static ItemIdValue mandatoryQualifierEntity = Datamodel.makeWikidataItemIdValue("Q21510856");
-    public static PropertyIdValue propertyParameterPID = Datamodel.makeWikidataPropertyIdValue("P2306");
+    public static ItemIdValue allowedQualifierEntity = Datamodel.makeWikidataItemIdValue(ALLOWED_QUALIFIERS_CONSTRAINT_QID);
+    public static ItemIdValue mandatoryQualifierEntity = Datamodel.makeWikidataItemIdValue(MANDATORY_QUALIFIERS_CONSTRAINT_QID);
+    public static PropertyIdValue propertyParameterPID = Datamodel.makeWikidataPropertyIdValue(ALLOWED_QUALIFIERS_CONSTRAINT_PID);
     public static PropertyIdValue propertyParameterValue = Datamodel.makeWikidataPropertyIdValue("P585");
 
     public static PropertyIdValue allowedPropertyIdValue = Datamodel.makeWikidataPropertyIdValue("P2196");
@@ -77,8 +81,8 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
         List<Statement> statementList = constraintParameterStatementList(allowedQualifierEntity, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(allowedPropertyIdValue, "Q21510851")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P2306")).thenReturn(Collections.singletonList(qualifierProperty));
+        when(fetcher.getConstraintsByType(allowedPropertyIdValue, ALLOWED_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, ALLOWED_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -99,8 +103,8 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
         List<Statement> statementList = constraintParameterStatementList(mandatoryQualifierEntity, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(mandatoryPropertyIdValue, "Q21510856")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P2306")).thenReturn(Collections.singletonList(qualifierProperty));
+        when(fetcher.getConstraintsByType(mandatoryPropertyIdValue, MANDATORY_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, MANDATORY_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -122,8 +126,8 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
         List<Statement> statementList = constraintParameterStatementList(allowedQualifierEntity, snakGroupList);
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(allowedPropertyIdValue, "Q21510851")).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, "P2306")).thenReturn(Collections.singletonList(qualifierProperty));
+        when(fetcher.getConstraintsByType(allowedPropertyIdValue, ALLOWED_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
+        when(fetcher.findValues(snakGroupList, ALLOWED_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QuantityScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QuantityScrutinizerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.openrefine.wikidata.qa.scrutinizers.QuantityScrutinizer.ALLOWED_UNITS_CONSTRAINT_PID;
 import static org.openrefine.wikidata.qa.scrutinizers.QuantityScrutinizer.ALLOWED_UNITS_CONSTRAINT_QID;
 import static org.openrefine.wikidata.qa.scrutinizers.QuantityScrutinizer.INTEGER_VALUED_CONSTRAINT_QID;
 import static org.openrefine.wikidata.qa.scrutinizers.QuantityScrutinizer.NO_BOUNDS_CONSTRAINT_QID;
@@ -55,7 +56,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest{
     public static ItemIdValue noBoundsEntity = Datamodel.makeWikidataItemIdValue(NO_BOUNDS_CONSTRAINT_QID);
     public static ItemIdValue integerValueEntity = Datamodel.makeWikidataItemIdValue(INTEGER_VALUED_CONSTRAINT_QID);
     public static ItemIdValue allowedUnitEntity = Datamodel.makeWikidataItemIdValue(ALLOWED_UNITS_CONSTRAINT_QID);
-    public static PropertyIdValue itemParameterPID = Datamodel.makeWikidataPropertyIdValue("P2305");
+    public static PropertyIdValue itemParameterPID = Datamodel.makeWikidataPropertyIdValue(ALLOWED_UNITS_CONSTRAINT_PID);
     public static Value allowedUnit = Datamodel.makeWikidataItemIdValue("Q5");
 
     @Override
@@ -211,7 +212,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest{
         List<Statement> constraintDefinitions = constraintParameterStatementList(allowedUnitEntity, constraintQualifiers);
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, ALLOWED_UNITS_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, "P2305")).thenReturn(Collections.singletonList(allowedUnit));
+        when(fetcher.findValues(constraintQualifiers, ALLOWED_UNITS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(allowedUnit));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -228,7 +229,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest{
         List<Statement> constraintDefinitions = constraintParameterStatementList(allowedUnitEntity, new ArrayList<>());
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, ALLOWED_UNITS_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(any(), eq("P2305"))).thenReturn(new ArrayList<>());
+        when(fetcher.findValues(any(), eq(ALLOWED_UNITS_CONSTRAINT_PID))).thenReturn(new ArrayList<>());
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -244,7 +245,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest{
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, ALLOWED_UNITS_CONSTRAINT_QID)).thenReturn(new ArrayList<>());
-        when(fetcher.findValues(any(), eq("P2305"))).thenReturn(new ArrayList<>());
+        when(fetcher.findValues(any(), eq(ALLOWED_UNITS_CONSTRAINT_PID))).thenReturn(new ArrayList<>());
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedPositionScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedPositionScrutinizerTest.java
@@ -46,18 +46,15 @@ import static org.mockito.Mockito.when;
 import static org.openrefine.wikidata.qa.scrutinizers.RestrictedPositionScrutinizer.SCOPE_CONSTRAINT_PID;
 import static org.openrefine.wikidata.qa.scrutinizers.RestrictedPositionScrutinizer.SCOPE_CONSTRAINT_QID;
 import static org.openrefine.wikidata.qa.scrutinizers.RestrictedPositionScrutinizer.SCOPE_CONSTRAINT_QUALIFIER_QID;
-import static org.openrefine.wikidata.qa.scrutinizers.RestrictedPositionScrutinizer.SCOPE_CONSTRAINT_REFERENCE_QID;
 import static org.openrefine.wikidata.qa.scrutinizers.RestrictedPositionScrutinizer.SCOPE_CONSTRAINT_VALUE_QID;
 
 public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
 
     public static PropertyIdValue propertyIdValue = Datamodel.makeWikidataPropertyIdValue("P22");
-    public static PropertyIdValue mainSnakPid = Datamodel.makeWikidataPropertyIdValue("P1234");
-    public static PropertyIdValue propertyScopeParameter = Datamodel.makeWikidataPropertyIdValue("P5314");
+    public static PropertyIdValue propertyScopeParameter = Datamodel.makeWikidataPropertyIdValue(SCOPE_CONSTRAINT_PID);
     public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_QID);
     public static ItemIdValue asMainSnak = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_VALUE_QID);
     public static ItemIdValue asQualifier = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_QUALIFIER_QID);
-    public static ItemIdValue asReference = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_REFERENCE_QID);
 
     @Override
     public EditScrutinizer getScrutinizer() {

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedValuesScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedValuesScrutinizerTest.java
@@ -34,7 +34,7 @@ public class RestrictedValuesScrutinizerTest extends SnakScrutinizerTest {
     public static ItemIdValue allowedValueEntity = Datamodel.makeWikidataItemIdValue(ALLOWED_VALUES_CONSTRAINT_QID);
     public static ItemIdValue disallowedValueEntity = Datamodel.makeWikidataItemIdValue(DISALLOWED_VALUES_CONSTRAINT_QID);
 
-    public static PropertyIdValue itemParameterPID = Datamodel.makeWikidataPropertyIdValue("P2305");
+    public static PropertyIdValue itemParameterPID = Datamodel.makeWikidataPropertyIdValue(ALLOWED_VALUES_CONSTRAINT_PID);
 
     @Override
     public EditScrutinizer getScrutinizer() {

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/SingleValueScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/SingleValueScrutinizerTest.java
@@ -33,15 +33,15 @@ import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.openrefine.wikidata.qa.scrutinizers.SingleValueScrutinizer.SINGLE_VALUE_CONSTRAINT_QID;
 
 public class SingleValueScrutinizerTest extends ScrutinizerTest {
 
@@ -49,9 +49,7 @@ public class SingleValueScrutinizerTest extends ScrutinizerTest {
     public static Value value1 = Datamodel.makeWikidataItemIdValue("Q6581072");
     public static Value value2 = Datamodel.makeWikidataItemIdValue("Q6581097");
 
-    public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue("Q19474404");
-    public static PropertyIdValue constraintException = Datamodel.makeWikidataPropertyIdValue("P2303");
-    public static Value exceptionValue = Datamodel.makeWikidataItemIdValue("Q7409772");
+    public static ItemIdValue entityIdValue = Datamodel.makeWikidataItemIdValue(SINGLE_VALUE_CONSTRAINT_QID);
 
     @Override
     public EditScrutinizer getScrutinizer() {
@@ -67,14 +65,10 @@ public class SingleValueScrutinizerTest extends ScrutinizerTest {
         Statement statement2 = new StatementImpl("P21", snak2, idA);
         ItemUpdate update = new ItemUpdateBuilder(idA).addStatement(statement1).addStatement(statement2).build();
 
-        Snak snak = Datamodel.makeValueSnak(constraintException, exceptionValue);
-        List<Snak> snakList = Collections.singletonList(snak);
-        SnakGroup snakGroup = Datamodel.makeSnakGroup(snakList);
-        List<SnakGroup> snakGroupList = Collections.singletonList(snakGroup);
-        List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
+        List<Statement> statementList = constraintParameterStatementList(entityIdValue, new ArrayList<>());
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue, "Q19474404")).thenReturn(statementList);
+        when(fetcher.getConstraintsByType(propertyIdValue, SINGLE_VALUE_CONSTRAINT_QID)).thenReturn(statementList);
         setFetcher(fetcher);
         scrutinize(update);
         assertWarningsRaised(SingleValueScrutinizer.type);
@@ -87,14 +81,10 @@ public class SingleValueScrutinizerTest extends ScrutinizerTest {
         Statement statement1 = new StatementImpl("P21", snak1, idA);
         ItemUpdate updateA = new ItemUpdateBuilder(idA).addStatement(statement1).build();
 
-        Snak snak = Datamodel.makeValueSnak(constraintException, exceptionValue);
-        List<Snak> snakList = Collections.singletonList(snak);
-        SnakGroup snakGroup = Datamodel.makeSnakGroup(snakList);
-        List<SnakGroup> snakGroupList = Collections.singletonList(snakGroup);
-        List<Statement> statementList = constraintParameterStatementList(entityIdValue, snakGroupList);
+        List<Statement> statementList = constraintParameterStatementList(entityIdValue, new ArrayList<>());
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
-        when(fetcher.getConstraintsByType(propertyIdValue, "Q19474404")).thenReturn(statementList);
+        when(fetcher.getConstraintsByType(propertyIdValue, SINGLE_VALUE_CONSTRAINT_QID)).thenReturn(statementList);
         setFetcher(fetcher);
         scrutinize(updateA);
         assertNoWarningRaised();


### PR DESCRIPTION
After the cleanup of MockconstraintFetcher, WikidataConstraintFetcher & ConstraintFetcher, replacing the hardcoded constraint IDs & property IDs with the values already defined in the corresponding scrutinizers to reuse in the test classes.