### PR TITLE
Move findValues method to EditScrtuinzer

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/ConstraintFetcher.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/ConstraintFetcher.java
@@ -24,9 +24,7 @@
 package org.openrefine.wikidata.qa;
 
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.Value;
 
 import java.util.List;
 
@@ -48,16 +46,5 @@ public interface ConstraintFetcher {
      * @return the list of matching constraint statements
      */
     List<Statement> getConstraintsByType(PropertyIdValue pid, String qid);
-
-    /**
-     * Returns the values of a given property in qualifiers
-     *
-     * @param groups
-     *            the qualifiers
-     * @param pid
-     *            the property to filter on
-     * @return
-     */
-    List<Value> findValues(List<SnakGroup> groups, String pid);
 
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/WikidataConstraintFetcher.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/WikidataConstraintFetcher.java
@@ -27,12 +27,10 @@ import org.openrefine.wikidata.utils.EntityCache;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
 import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-import org.wikidata.wdtk.datamodel.interfaces.Value;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -116,27 +114,6 @@ public class WikidataConstraintFetcher implements ConstraintFetcher {
         } else {
             return new ArrayList<Statement>();
         }
-    }
-
-    /**
-     * Returns the values of a given property in qualifiers
-     * 
-     * @param groups
-     *            the qualifiers
-     * @param pid
-     *            the property to filter on
-     * @return
-     */
-    @Override
-    public List<Value> findValues(List<SnakGroup> groups, String pid) {
-        List<Value> results = new ArrayList<>();
-        for (SnakGroup group : groups) {
-            if (group.getProperty().getId().equals(pid)) {
-                for (Snak snak : group.getSnaks())
-                    results.add(snak.getValue());
-            }
-        }
-        return results;
     }
 
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/DifferenceWithinRangeScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/DifferenceWithinRangeScrutinizer.java
@@ -23,9 +23,9 @@ public class DifferenceWithinRangeScrutinizer extends EditScrutinizer {
         DifferenceWithinRangeConstraint(Statement statement) {
             List<SnakGroup> specs = statement.getClaim().getQualifiers();
             if (specs != null) {
-                List<Value> lowerValueProperty = _fetcher.findValues(specs, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_PID);
-                List<Value> minValue = _fetcher.findValues(specs, MINIMUM_VALUE_PID);
-                List<Value> maxValue = _fetcher.findValues(specs, MAXIMUM_VALUE_PID);
+                List<Value> lowerValueProperty = findValues(specs, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_PID);
+                List<Value> minValue = findValues(specs, MINIMUM_VALUE_PID);
+                List<Value> maxValue = findValues(specs, MAXIMUM_VALUE_PID);
                 if (!lowerValueProperty.isEmpty()) {
                     lowerPropertyIdValue = (PropertyIdValue) lowerValueProperty.get(0);
                 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/EditScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/EditScrutinizer.java
@@ -28,6 +28,12 @@ import org.openrefine.wikidata.qa.QAWarning;
 import org.openrefine.wikidata.qa.QAWarning.Severity;
 import org.openrefine.wikidata.qa.QAWarningStore;
 import org.openrefine.wikidata.updates.ItemUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.Snak;
+import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
+import org.wikidata.wdtk.datamodel.interfaces.Value;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Inspects an edit batch and emits warnings.
@@ -124,5 +130,25 @@ public abstract class EditScrutinizer {
      */
     protected void critical(String type) {
         addIssue(type, null, QAWarning.Severity.CRITICAL, 1);
+    }
+
+    /**
+     * Returns the values of a given property in qualifiers
+     *
+     * @param groups
+     *            the qualifiers
+     * @param pid
+     *            the property to filter on
+     * @return
+     */
+    protected List<Value> findValues(List<SnakGroup> groups, String pid) {
+        List<Value> results = new ArrayList<>();
+        for (SnakGroup group : groups) {
+            if (group.getProperty().getId().equals(pid)) {
+                for (Snak snak : group.getSnaks())
+                    results.add(snak.getValue());
+            }
+        }
+        return results;
     }
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/EntityTypeScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/EntityTypeScrutinizer.java
@@ -26,7 +26,7 @@ public class EntityTypeScrutinizer extends SnakScrutinizer {
             List<SnakGroup> constraint = statementList.get(0).getClaim().getQualifiers();
             boolean isUsable = true;
             if (constraint != null) {
-                isUsable = _fetcher.findValues(constraint, ALLOWED_ENTITY_TYPES_PID).contains(
+                isUsable = findValues(constraint, ALLOWED_ENTITY_TYPES_PID).contains(
                         Datamodel.makeWikidataItemIdValue(ALLOWED_ITEM_TYPE_QID));
             }
             if (!isUsable) {

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/FormatScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/FormatScrutinizer.java
@@ -60,7 +60,7 @@ public class FormatScrutinizer extends SnakScrutinizer {
         FormatConstraint(Statement statement) {
             List<SnakGroup> constraint = statement.getClaim().getQualifiers();
             if (constraint != null) {
-                List<Value> regexes = _fetcher.findValues(constraint, FORMAT_REGEX_PID);
+                List<Value> regexes = findValues(constraint, FORMAT_REGEX_PID);
                 if (!regexes.isEmpty()) {
                     regularExpressionFormat = ((StringValue) regexes.get(0)).getString();
                 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstraintScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstraintScrutinizer.java
@@ -58,7 +58,7 @@ public class InverseConstraintScrutinizer extends StatementScrutinizer {
             List<SnakGroup> specs = statement.getClaim().getQualifiers();
 
             if (specs != null) {
-                List<Value> inverses = _fetcher.findValues(specs, INVERSE_PROPERTY_PID);
+                List<Value> inverses = findValues(specs, INVERSE_PROPERTY_PID);
                 if (!inverses.isEmpty()) {
                     propertyParameterValue = (PropertyIdValue) inverses.get(0);
                 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/QualifierCompatibilityScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/QualifierCompatibilityScrutinizer.java
@@ -59,7 +59,7 @@ public class QualifierCompatibilityScrutinizer extends StatementScrutinizer {
             allowedProperties = new HashSet<>();
             List<SnakGroup> specs = statement.getClaim().getQualifiers();
             if (specs != null) {
-                List<Value> properties = _fetcher.findValues(specs, ALLOWED_QUALIFIERS_CONSTRAINT_PID);
+                List<Value> properties = findValues(specs, ALLOWED_QUALIFIERS_CONSTRAINT_PID);
                 allowedProperties = properties.stream()
                         .filter(e -> e != null)
                         .map(e -> (PropertyIdValue) e)
@@ -75,7 +75,7 @@ public class QualifierCompatibilityScrutinizer extends StatementScrutinizer {
             mandatoryProperties = new HashSet<>();
             List<SnakGroup> specs = statement.getClaim().getQualifiers();
             if (specs != null) {
-                List<Value> properties = _fetcher.findValues(specs, MANDATORY_QUALIFIERS_CONSTRAINT_PID);
+                List<Value> properties = findValues(specs, MANDATORY_QUALIFIERS_CONSTRAINT_PID);
                 mandatoryProperties = properties.stream()
                         .filter(e -> e != null)
                         .map(e -> (PropertyIdValue) e)

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/QuantityScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/QuantityScrutinizer.java
@@ -38,7 +38,7 @@ public class QuantityScrutinizer extends SnakScrutinizer {
         AllowedUnitsConstraint(Statement statement) {
             List<SnakGroup> specs = statement.getClaim().getQualifiers();
             if (specs != null) {
-                List<Value> properties = _fetcher.findValues(specs, ALLOWED_UNITS_CONSTRAINT_PID);
+                List<Value> properties = findValues(specs, ALLOWED_UNITS_CONSTRAINT_PID);
                 allowedUnits = properties.stream()
                         .map(e -> e == null ? null : (ItemIdValue) e)
                         .collect(Collectors.toSet());

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedPositionScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedPositionScrutinizer.java
@@ -57,7 +57,7 @@ public class RestrictedPositionScrutinizer extends StatementScrutinizer {
                 ItemIdValue targetValue = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_VALUE_QID);
                 ItemIdValue targetQualifier = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_QUALIFIER_QID);
                 ItemIdValue targetReference = Datamodel.makeWikidataItemIdValue(SCOPE_CONSTRAINT_REFERENCE_QID);
-                List<Value> snakValues = _fetcher.findValues(specs, SCOPE_CONSTRAINT_PID);
+                List<Value> snakValues = findValues(specs, SCOPE_CONSTRAINT_PID);
                 isAllowedAsValue = snakValues.contains(targetValue);
                 isAllowedAsQualifier = snakValues.contains(targetQualifier);
                 isAllowedAsReference =  snakValues.contains(targetReference);

--- a/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedValuesScrutinizer.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedValuesScrutinizer.java
@@ -27,7 +27,7 @@ public class RestrictedValuesScrutinizer extends SnakScrutinizer {
         AllowedValueConstraint(Statement statement) {
             List<SnakGroup> specs = statement.getClaim().getQualifiers();
             if (specs != null) {
-                List<Value> properties = _fetcher.findValues(specs, ALLOWED_VALUES_CONSTRAINT_PID);
+                List<Value> properties = findValues(specs, ALLOWED_VALUES_CONSTRAINT_PID);
                 allowedValues = properties.stream().collect(Collectors.toSet());
             }
         }
@@ -38,7 +38,7 @@ public class RestrictedValuesScrutinizer extends SnakScrutinizer {
         DisallowedValueConstraint(Statement statement) {
             List<SnakGroup> specs = statement.getClaim().getQualifiers();
             if (specs != null) {
-                List<Value> properties = _fetcher.findValues(specs, DISALLOWED_VALUES_CONSTRAINT_PID);
+                List<Value> properties = findValues(specs, DISALLOWED_VALUES_CONSTRAINT_PID);
                 disallowedValues = properties.stream().collect(Collectors.toSet());
             }
         }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/DifferenceWithinScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/DifferenceWithinScrutinizerTest.java
@@ -18,7 +18,6 @@ import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
 import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
 
 import java.math.BigDecimal;
-import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.Mockito.mock;
@@ -64,9 +63,6 @@ public class DifferenceWithinScrutinizerTest extends ScrutinizerTest{
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(upperBoundPid, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_PID)).thenReturn(Collections.singletonList(lowerBoundPid));
-        when(fetcher.findValues(constraintQualifiers, MINIMUM_VALUE_PID)).thenReturn(Collections.singletonList(minValue));
-        when(fetcher.findValues(constraintQualifiers, MAXIMUM_VALUE_PID)).thenReturn(Collections.singletonList(maxValue));
         setFetcher(fetcher);
 
         scrutinize(updateA);
@@ -92,9 +88,6 @@ public class DifferenceWithinScrutinizerTest extends ScrutinizerTest{
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(upperBoundPid, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, DIFFERENCE_WITHIN_RANGE_CONSTRAINT_PID)).thenReturn(Collections.singletonList(lowerBoundPid));
-        when(fetcher.findValues(constraintQualifiers, MINIMUM_VALUE_PID)).thenReturn(Collections.singletonList(minValue));
-        when(fetcher.findValues(constraintQualifiers, MAXIMUM_VALUE_PID)).thenReturn(Collections.singletonList(maxValue));
         setFetcher(fetcher);
 
         scrutinize(updateA);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/EntityTypeScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/EntityTypeScrutinizerTest.java
@@ -58,11 +58,10 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue,ALLOWED_ENTITY_TYPES_QID)).thenReturn(statementList);
-//        when(fetcher.findValues(snakGroupList, ALLOWED_ENTITY_TYPES_PID)).thenReturn(Collections.singletonList(allowedValue));
         setFetcher(fetcher);
 
         scrutinize(update);
-        assertNoWarningRaised();
+//        assertNoWarningRaised();
     }
 
     @Test
@@ -82,7 +81,6 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue,ALLOWED_ENTITY_TYPES_QID)).thenReturn(statementList);
-//        when(fetcher.findValues(snakGroupList, ALLOWED_ENTITY_TYPES_PID)).thenReturn(Collections.singletonList(itemValue));
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/EntityTypeScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/EntityTypeScrutinizerTest.java
@@ -58,7 +58,7 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue,ALLOWED_ENTITY_TYPES_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, ALLOWED_ENTITY_TYPES_PID)).thenReturn(Collections.singletonList(allowedValue));
+//        when(fetcher.findValues(snakGroupList, ALLOWED_ENTITY_TYPES_PID)).thenReturn(Collections.singletonList(allowedValue));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -82,7 +82,7 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue,ALLOWED_ENTITY_TYPES_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, ALLOWED_ENTITY_TYPES_PID)).thenReturn(Collections.singletonList(itemValue));
+//        when(fetcher.findValues(snakGroupList, ALLOWED_ENTITY_TYPES_PID)).thenReturn(Collections.singletonList(itemValue));
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/EntityTypeScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/EntityTypeScrutinizerTest.java
@@ -50,7 +50,7 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
 
         ItemUpdate update = new ItemUpdateBuilder(idA).addStatement(statement).build();
 
-        Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, itemValue);
+        Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, allowedValue);
         List<Snak> qualifierSnakList = Collections.singletonList(qualifierSnak);
         SnakGroup qualifierSnakGroup = Datamodel.makeSnakGroup(qualifierSnakList);
         List<SnakGroup> snakGroupList = Collections.singletonList(qualifierSnakGroup);
@@ -61,7 +61,7 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
         setFetcher(fetcher);
 
         scrutinize(update);
-//        assertNoWarningRaised();
+        assertNoWarningRaised();
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/FormatScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/FormatScrutinizerTest.java
@@ -79,7 +79,6 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, FORMAT_CONSTRAINT_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, FORMAT_REGEX_PID)).thenReturn(Collections.singletonList(regularExpressionFormat));
         setFetcher(fetcher);
         scrutinize(updateA);
         assertWarningsRaised(FormatScrutinizer.type);
@@ -100,7 +99,6 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, FORMAT_CONSTRAINT_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, FORMAT_REGEX_PID)).thenReturn(Collections.singletonList(regularExpressionFormat));
         setFetcher(fetcher);
         scrutinize(updateA);
         assertNoWarningRaised();
@@ -121,7 +119,6 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, FORMAT_CONSTRAINT_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, FORMAT_REGEX_PID)).thenReturn(Collections.singletonList(regularExpressionFormat));
         setFetcher(fetcher);
         scrutinize(updateA);
         assertWarningsRaised(FormatScrutinizer.type);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstaintScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstaintScrutinizerTest.java
@@ -77,7 +77,7 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyId, INVERSE_CONSTRAINT_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(inversePropertyID));
+//        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(inversePropertyID));
         setFetcher(fetcher);
         scrutinize(update);
         assertWarningsRaised(InverseConstraintScrutinizer.type);
@@ -98,7 +98,7 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(symmetricPropertyID, SYMMETRIC_CONSTRAINT_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(symmetricPropertyID));
+//        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(symmetricPropertyID));
         setFetcher(fetcher);
         scrutinize(update);
         assertWarningsRaised(InverseConstraintScrutinizer.type);
@@ -119,7 +119,7 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyId, INVERSE_CONSTRAINT_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(inversePropertyID));
+//        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(inversePropertyID));
         setFetcher(fetcher);
         scrutinize(update);
         assertNoWarningRaised();

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstaintScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstaintScrutinizerTest.java
@@ -77,10 +77,9 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyId, INVERSE_CONSTRAINT_QID)).thenReturn(statementList);
-//        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(inversePropertyID));
         setFetcher(fetcher);
-        scrutinize(update);
-        assertWarningsRaised(InverseConstraintScrutinizer.type);
+//        scrutinize(update);
+//        assertWarningsRaised(InverseConstraintScrutinizer.type);
     }
 
     @Test
@@ -98,7 +97,6 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(symmetricPropertyID, SYMMETRIC_CONSTRAINT_QID)).thenReturn(statementList);
-//        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(symmetricPropertyID));
         setFetcher(fetcher);
         scrutinize(update);
         assertWarningsRaised(InverseConstraintScrutinizer.type);
@@ -119,7 +117,6 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyId, INVERSE_CONSTRAINT_QID)).thenReturn(statementList);
-//        when(fetcher.findValues(snakGroupList, INVERSE_PROPERTY_PID)).thenReturn(Collections.singletonList(inversePropertyID));
         setFetcher(fetcher);
         scrutinize(update);
         assertNoWarningRaised();

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstaintScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/InverseConstaintScrutinizerTest.java
@@ -69,7 +69,7 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
         Statement statement = new StatementImpl("P25", mainSnak, idA);
         ItemUpdate update = new ItemUpdateBuilder(idA).addStatement(statement).build();
 
-        Snak qualifierSnak = Datamodel.makeValueSnak(propertyParameter, inverseEntityIdValue);
+        Snak qualifierSnak = Datamodel.makeValueSnak(propertyParameter, inversePropertyID);
         List<Snak> qualifierSnakList = Collections.singletonList(qualifierSnak);
         SnakGroup qualifierSnakGroup = Datamodel.makeSnakGroup(qualifierSnakList);
         List<SnakGroup> snakGroupList = Collections.singletonList(qualifierSnakGroup);
@@ -78,8 +78,8 @@ public class InverseConstaintScrutinizerTest extends StatementScrutinizerTest {
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyId, INVERSE_CONSTRAINT_QID)).thenReturn(statementList);
         setFetcher(fetcher);
-//        scrutinize(update);
-//        assertWarningsRaised(InverseConstraintScrutinizer.type);
+        scrutinize(update);
+        assertWarningsRaised(InverseConstraintScrutinizer.type);
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
@@ -81,7 +81,6 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(allowedPropertyIdValue, ALLOWED_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
-//        when(fetcher.findValues(snakGroupList, ALLOWED_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -103,7 +102,6 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(mandatoryPropertyIdValue, MANDATORY_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
-//        when(fetcher.findValues(snakGroupList, MANDATORY_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -126,7 +124,6 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(allowedPropertyIdValue, ALLOWED_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
-//        when(fetcher.findValues(snakGroupList, ALLOWED_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
@@ -81,6 +81,7 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(allowedPropertyIdValue, ALLOWED_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
+//        when(fetcher.findValues(snakGroupList, ALLOWED_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -102,6 +103,7 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(mandatoryPropertyIdValue, MANDATORY_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
+//        when(fetcher.findValues(snakGroupList, MANDATORY_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -124,6 +126,7 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(allowedPropertyIdValue, ALLOWED_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
+//        when(fetcher.findValues(snakGroupList, ALLOWED_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
@@ -46,7 +46,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openrefine.wikidata.qa.scrutinizers.QualifierCompatibilityScrutinizer.ALLOWED_QUALIFIERS_CONSTRAINT_PID;
 import static org.openrefine.wikidata.qa.scrutinizers.QualifierCompatibilityScrutinizer.ALLOWED_QUALIFIERS_CONSTRAINT_QID;
-import static org.openrefine.wikidata.qa.scrutinizers.QualifierCompatibilityScrutinizer.MANDATORY_QUALIFIERS_CONSTRAINT_PID;
 import static org.openrefine.wikidata.qa.scrutinizers.QualifierCompatibilityScrutinizer.MANDATORY_QUALIFIERS_CONSTRAINT_QID;
 
 public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerTest {
@@ -82,7 +81,6 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(allowedPropertyIdValue, ALLOWED_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, ALLOWED_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -104,7 +102,6 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(mandatoryPropertyIdValue, MANDATORY_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, MANDATORY_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -127,7 +124,6 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(allowedPropertyIdValue, ALLOWED_QUALIFIERS_CONSTRAINT_QID)).thenReturn(statementList);
-        when(fetcher.findValues(snakGroupList, ALLOWED_QUALIFIERS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(qualifierProperty));
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QuantityScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/QuantityScrutinizerTest.java
@@ -20,8 +20,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openrefine.wikidata.qa.scrutinizers.QuantityScrutinizer.ALLOWED_UNITS_CONSTRAINT_PID;
@@ -212,7 +210,6 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest{
         List<Statement> constraintDefinitions = constraintParameterStatementList(allowedUnitEntity, constraintQualifiers);
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, ALLOWED_UNITS_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, ALLOWED_UNITS_CONSTRAINT_PID)).thenReturn(Collections.singletonList(allowedUnit));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -229,7 +226,6 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest{
         List<Statement> constraintDefinitions = constraintParameterStatementList(allowedUnitEntity, new ArrayList<>());
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, ALLOWED_UNITS_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(any(), eq(ALLOWED_UNITS_CONSTRAINT_PID))).thenReturn(new ArrayList<>());
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -245,7 +241,6 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest{
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, ALLOWED_UNITS_CONSTRAINT_QID)).thenReturn(new ArrayList<>());
-        when(fetcher.findValues(any(), eq(ALLOWED_UNITS_CONSTRAINT_PID))).thenReturn(new ArrayList<>());
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedPositionScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedPositionScrutinizerTest.java
@@ -73,7 +73,6 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, constraintQualifiers);
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, SCOPE_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, SCOPE_CONSTRAINT_PID)).thenReturn(Collections.singletonList(asQualifier));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -92,7 +91,6 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, constraintQualifiers);
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, SCOPE_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, SCOPE_CONSTRAINT_PID)).thenReturn(Collections.singletonList(asMainSnak));
         setFetcher(fetcher);
 
         scrutinize(update);
@@ -130,7 +128,6 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, constraintQualifiers);
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, SCOPE_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, SCOPE_CONSTRAINT_PID)).thenReturn(Collections.singletonList(asMainSnak));
         setFetcher(fetcher);
 
         scrutinize(update);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedValuesScrutinizerTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/qa/scrutinizers/RestrictedValuesScrutinizerTest.java
@@ -12,7 +12,6 @@ import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -21,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.openrefine.wikidata.qa.scrutinizers.RestrictedValuesScrutinizer.ALLOWED_VALUES_CONSTRAINT_PID;
 import static org.openrefine.wikidata.qa.scrutinizers.RestrictedValuesScrutinizer.ALLOWED_VALUES_CONSTRAINT_QID;
-import static org.openrefine.wikidata.qa.scrutinizers.RestrictedValuesScrutinizer.DISALLOWED_VALUES_CONSTRAINT_PID;
 import static org.openrefine.wikidata.qa.scrutinizers.RestrictedValuesScrutinizer.DISALLOWED_VALUES_CONSTRAINT_QID;
 
 public class RestrictedValuesScrutinizerTest extends SnakScrutinizerTest {
@@ -64,7 +62,6 @@ public class RestrictedValuesScrutinizerTest extends SnakScrutinizerTest {
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(allowedPropertyIdValue, ALLOWED_VALUES_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
         when(fetcher.getConstraintsByType(allowedPropertyIdValue, DISALLOWED_VALUES_CONSTRAINT_QID)).thenReturn(new ArrayList<>());
-        when(fetcher.findValues(constraintQualifiers, ALLOWED_VALUES_CONSTRAINT_PID)).thenReturn(Collections.singletonList(allowedValue));
         setFetcher(fetcher);
 
         scrutinize(statement);
@@ -82,7 +79,6 @@ public class RestrictedValuesScrutinizerTest extends SnakScrutinizerTest {
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(allowedPropertyIdValue, ALLOWED_VALUES_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
         when(fetcher.getConstraintsByType(allowedPropertyIdValue, DISALLOWED_VALUES_CONSTRAINT_QID)).thenReturn(new ArrayList<>());
-        when(fetcher.findValues(constraintQualifiers, ALLOWED_VALUES_CONSTRAINT_PID)).thenReturn(Collections.singletonList(allowedValue));
         setFetcher(fetcher);
 
         scrutinize(statement);
@@ -100,7 +96,6 @@ public class RestrictedValuesScrutinizerTest extends SnakScrutinizerTest {
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(disallowedPropertyIdValue, ALLOWED_VALUES_CONSTRAINT_QID)).thenReturn(new ArrayList<>());
         when(fetcher.getConstraintsByType(disallowedPropertyIdValue, DISALLOWED_VALUES_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, DISALLOWED_VALUES_CONSTRAINT_PID)).thenReturn(Collections.singletonList(disallowedValue));
         setFetcher(fetcher);
 
         scrutinize(statement);
@@ -118,7 +113,6 @@ public class RestrictedValuesScrutinizerTest extends SnakScrutinizerTest {
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(disallowedPropertyIdValue, ALLOWED_VALUES_CONSTRAINT_QID)).thenReturn(new ArrayList<>());
         when(fetcher.getConstraintsByType(disallowedPropertyIdValue, DISALLOWED_VALUES_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
-        when(fetcher.findValues(constraintQualifiers, DISALLOWED_VALUES_CONSTRAINT_PID)).thenReturn(Collections.singletonList(disallowedValue));
         setFetcher(fetcher);
 
         scrutinize(statement);


### PR DESCRIPTION
As findValues method is not concerned with fetching, therefore moving it to EditScrtuinizer as suggested by @afkbrb in his [comment](https://github.com/OpenRefine/OpenRefine/pull/2925#issuecomment-658496080)