### PR TITLE
Update code of conduct committee members

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,9 +55,14 @@ a project may be further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at foundation@openrefine.org. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
+reported by contacting the Code of Conduct Committee at code-of-conduct@openrefine.org.
+The committee consists of:
+* Lozanna Rossenova
+* Chris Erdmann
+* Jessica Hardwicke
+
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The code of conduct is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 


### PR DESCRIPTION
We asked the steering committee to help with forming a code of conduct committee for the project.

The idea is that this committee should be formed of project members who are unlikely to be involved in any dispute directly, because they are not involved in the day-to-day development. By listing their names explicitly in the CoC document we are making it more likely that people actually reach out to them if there is any issue (otherwise they could hold back, thinking that the person they have a problem with could be in the committee too).