### PR TITLE
Faster rendering of rows and cells

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -90,7 +90,7 @@ DataTableCellUI.prototype._render = function() {
   } else if (!("r" in cell) || !cell.r) {
     if (typeof cell.v !== "string" || "t" in cell) {
       if (typeof cell.v == "number") {
-        divContent.addClass("data-table-cell-content-numeric");
+        divContent.classList.add('data-table-cell-content-numeric');
       }
       var nonstringSpan = document.createElement('span');
       nonstringSpan.className = 'data-table-value-nonstring';
@@ -108,17 +108,18 @@ DataTableCellUI.prototype._render = function() {
       divContent.appendChild(span);
     }
   } else {
+    var divContentRecon = $(divContent);
     var r = cell.r;
     var service = (r.service) ? ReconciliationManager.getServiceFromUrl(r.service) : null;
 
     if (r.j == "new") {
-      $('<span>').text(cell.v).appendTo(divContent);
-      $('<span>').addClass("data-table-recon-new").text("new").appendTo(divContent);
+      $('<span>').text(cell.v).appendTo(divContentRecon);
+      $('<span>').addClass("data-table-recon-new").text("new").appendTo(divContentRecon);
 
       $('<a href="javascript:{}"></a>')
       .text($.i18n('core-views/choose-match'))
       .addClass("data-table-recon-action")
-      .appendTo(divContent).click(function(evt) {
+      .appendTo(divContentRecon).click(function(evt) {
         self._doRematch();
       });
     } else if (r.j == "matched" && "m" in r && r.m !== null) {
@@ -126,7 +127,7 @@ DataTableCellUI.prototype._render = function() {
       var a = $('<a></a>')
       .text(match.name)
       .attr("target", "_blank")
-      .appendTo(divContent);
+      .appendTo(divContentRecon);
 
       if (service && (service.view) && (service.view.url)) {
         a.attr("href", encodeURI(service.view.url.replace("{{id}}", match.id)));
@@ -136,19 +137,19 @@ DataTableCellUI.prototype._render = function() {
         self._previewOnHover(service, match, a, a, false);
       }
 
-      $('<span> </span>').appendTo(divContent);
+      $('<span> </span>').appendTo(divContentRecon);
       $('<a href="javascript:{}"></a>')
       .text($.i18n('core-views/choose-match'))
       .addClass("data-table-recon-action")
-      .appendTo(divContent)
+      .appendTo(divContentRecon)
       .click(function(evt) {
         self._doRematch();
       });
     } else {
-      $('<span>').text(cell.v).appendTo(divContent);
+      $('<span>').text(cell.v).appendTo(divContentRecon);
 
       if (this._dataTableView._showRecon) {
-        var ul = $('<div></div>').addClass("data-table-recon-candidates").appendTo(divContent);
+        var ul = $('<div></div>').addClass("data-table-recon-candidates").appendTo(divContentRecon);
         if ("c" in r && r.c.length > 0) {
           var candidates = r.c;
           var renderCandidate = function(candidate, index) {
@@ -226,7 +227,7 @@ DataTableCellUI.prototype._render = function() {
           addSuggest = true;
         }
 
-        var extraChoices = $('<div>').addClass("data-table-recon-extra").appendTo(divContent);
+        var extraChoices = $('<div>').addClass("data-table-recon-extra").appendTo(divContentRecon);
         if (addSuggest) {
           $('<a href="javascript:{}"></a>')
           .click(function(evt) {

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -62,43 +62,50 @@ DataTableCellUI.prototype._render = function() {
   var self = this;
   var cell = this._cell;
 
-  var divContent = $('<div/>')
-  .addClass("data-table-cell-content");
+  var divContent = document.createElement('div');
+  divContent.className = 'data-table-cell-content';
 
-  var editLink = $('<a href="javascript:{}">&nbsp;</a>')
-  .addClass("data-table-cell-edit")
-  .attr("title", $.i18n('core-views/edit-cell'))
-  .appendTo(divContent)
-  .click(function() { self._startEdit(this); });
+  var editLink = document.createElement('a');
+  editLink.className = 'data-table-cell-edit';
+  editLink.setAttribute('title', $.i18n('core-views/edit-cell'));
+  editLink.href = 'javascript:{}';
+  divContent.appendChild(editLink).appendChild(document.createTextNode('\u00A0'));
+  editLink.addEventListener('click', function() { self._startEdit(this); });
 
   $(this._td).empty()
   .unbind()
-  .mouseenter(function() { editLink.css("visibility", "visible"); })
-  .mouseleave(function() { editLink.css("visibility", "hidden"); });
+  .mouseenter(function() { editLink.style.visibility = "visible" })
+  .mouseleave(function() { editLink.style.visibility = "hidden" });
 
   if (!cell || ("v" in cell && cell.v === null)) {
-    $('<span>').addClass("data-table-null").html('null').appendTo(divContent);
+    var nullSpan = document.createElement('span');
+    nullSpan.className = 'data-table-null';
+    nullSpan.innerHTML = 'null';
+    divContent.appendChild(nullSpan);
   } else if ("e" in cell) {
-    $('<span>').addClass("data-table-error").text(cell.e).appendTo(divContent);
+    var errorSpan = document.createElement('span');
+    errorSpan.className = 'data-table-error';
+    errorSpan.textContent = cell.e;
+    divContent.appendChild(errorSpan);
   } else if (!("r" in cell) || !cell.r) {
     if (typeof cell.v !== "string" || "t" in cell) {
       if (typeof cell.v == "number") {
         divContent.addClass("data-table-cell-content-numeric");
       }
-      $('<span>')
-      .addClass("data-table-value-nonstring")
-      .text(cell.v)
-      .appendTo(divContent);
+      var nonstringSpan = document.createElement('span');
+      nonstringSpan.className = 'data-table-value-nonstring';
+      nonstringSpan.textContent = cell.v;
+      divContent.appendChild(nonstringSpan);
     } else if (URL.looksLikeUrl(cell.v)) {
-      $('<a>')
-      .text(cell.v)
-      .attr("href", cell.v)
-      .attr("target", "_blank")
-      .appendTo(divContent);
+      var url = document.createElement('a');
+      url.textContent = cell.v;
+      url.setAttribute('href', cell.v);
+      url.setAttribute('target', '_blank');
+      divContent.appendChild(url);
     } else {
-      $('<span>')
-      .text(cell.v)
-      .appendTo(divContent);
+      var span = document.createElement('span');
+      span.textContent = cell.v;
+      divContent.appendChild(span);
     }
   } else {
     var r = cell.r;
@@ -233,7 +240,7 @@ DataTableCellUI.prototype._render = function() {
     }
   }
 
-  divContent.appendTo(this._td);
+  this._td.appendChild(divContent);
 };
 
 DataTableCellUI.prototype._doRematch = function() {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -417,8 +417,9 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
         "json"
       );
     });
-
-    var tdFlag = tr.insertCell(tr.cells.length);    var flag = document.createElement('a');
+    
+    var tdFlag = tr.insertCell(tr.cells.length);
+    var flag = document.createElement('a');
     flag.classList.add(row.flagged ? "data-table-flag-on" : "data-table-flag-off");
     flag.href = "javascript:{}";
     tdFlag.appendChild(flag).appendChild(document.createTextNode('\u00A0'));
@@ -443,12 +444,18 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     if (theProject.rowModel.mode == "record-based") {
       if ("j" in row) {
         $(tr).addClass("record");
-        $('<div></div>').html((row.j + 1) + ".").appendTo(tdIndex);
+        var div = document.createElement('div');
+        div.innerHTML = (row.j + 1) + '.';
+        tdIndex.appendChild(div);
       } else {
-        $('<div></div>').html("&nbsp;").appendTo(tdIndex);
+        var div = document.createElement('div');
+        div.innerHTML = '\u00A0';
+        tdIndex.appendChild(div);
       }
     } else {
-      $('<div></div>').html((row.i + 1) + ".").appendTo(tdIndex);
+      var div = document.createElement('div');
+      div.innerHTML = (row.i + 1) + '.';
+      tdIndex.appendChild(div);
     }
 
     $(tr).addClass(even ? "even" : "odd");

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -397,11 +397,12 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     $(tr).empty();
     var cells = row.cells;
     var tdStar = tr.insertCell(tr.cells.length);
-    var star = $('<a href="javascript:{}">&nbsp;</a>')
-    .addClass(row.starred ? "data-table-star-on" : "data-table-star-off")
-    .appendTo(tdStar)
-    .click(function() {
-      var newStarred = !row.starred;
+    var star = document.createElement('a');
+    star.href = "javascript:{}";
+    star.classList.add(row.starred ? "data-table-star-on" : "data-table-star-off");
+    tdStar.appendChild(star).appendChild(document.createTextNode('\u00A0'));
+    star.addEventListener('click', function() {
+    var newStarred = !row.starred;
       Refine.postCoreProcess(
         "annotate-one-row",
         { row: row.i, starred: newStarred },
@@ -416,12 +417,12 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
         "json"
       );
     });
-    
-    var tdFlag = tr.insertCell(tr.cells.length);
-    var flag = $('<a href="javascript:{}">&nbsp;</a>')
-    .addClass(row.flagged ? "data-table-flag-on" : "data-table-flag-off")
-    .appendTo(tdFlag)
-    .click(function() {
+
+    var tdFlag = tr.insertCell(tr.cells.length);    var flag = document.createElement('a');
+    flag.classList.add(row.flagged ? "data-table-flag-on" : "data-table-flag-off");
+    flag.href = "javascript:{}";
+    tdFlag.appendChild(flag).appendChild(document.createTextNode('\u00A0'));
+    flag.addEventListener('click', function() {
       var newFlagged = !row.flagged;
       Refine.postCoreProcess(
         "annotate-one-row",

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -400,7 +400,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     var star = document.createElement('a');
     star.href = "javascript:{}";
     star.classList.add(row.starred ? "data-table-star-on" : "data-table-star-off");
-    tdStar.appendChild(star).appendChild(document.createTextNode('\u00A0'));
+    tdStar.appendChild(star).appendChild(document.createTextNode('\u00A0')); // NBSP
     star.addEventListener('click', function() {
     var newStarred = !row.starred;
       Refine.postCoreProcess(


### PR DESCRIPTION
The rendering functions for rows and cells use jQuery which causes a greater overhead. Replacing it (in cases where it isn't necessary) by javascript speeds up the functions tremendously. 

The comparison below is across 10 rows and 15 columns. The difference increases with greater number of rows and columns.

## Before
<img width="495" alt="2020-07-22 (4)" src="https://user-images.githubusercontent.com/52909743/88102994-0bc66e80-cbbe-11ea-9864-702be3c7b8a3.png">

## After
<img width="496" alt="2020-07-22 (2)" src="https://user-images.githubusercontent.com/52909743/88103007-1123b900-cbbe-11ea-9138-09710fbdc4d6.png">

