### PR TITLE
Importer refactoring cleanup

### DIFF
--- a/main/src/com/google/refine/importers/FixedWidthImporter.java
+++ b/main/src/com/google/refine/importers/FixedWidthImporter.java
@@ -132,7 +132,7 @@ public class FixedWidthImporter extends TabularImportingParserBase {
             }
         };
         
-        TabularImportingParserBase.readTable(project, metadata, job, dataReader, fileSource, limit, options, exceptions);
+        TabularImportingParserBase.readTable(project, job, dataReader, limit, options, exceptions);
     }
     
     /**

--- a/main/src/com/google/refine/importers/LineBasedImporter.java
+++ b/main/src/com/google/refine/importers/LineBasedImporter.java
@@ -129,6 +129,6 @@ public class LineBasedImporter extends TabularImportingParserBase {
             }
         };
         
-        TabularImportingParserBase.readTable(project, metadata, job, dataReader, fileSource, limit, options, exceptions);
+        TabularImportingParserBase.readTable(project, job, dataReader, limit, options, exceptions);
     }
 }

--- a/main/src/com/google/refine/importers/SeparatorBasedImporter.java
+++ b/main/src/com/google/refine/importers/SeparatorBasedImporter.java
@@ -157,7 +157,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
             }
         };
         
-        TabularImportingParserBase.readTable(project, metadata, job, dataReader, fileSource, limit, options, exceptions);
+        TabularImportingParserBase.readTable(project, job, dataReader, limit, options, exceptions);
     }
     
     static protected ArrayList<Object> getCells(String line, CSVParser parser, LineNumberReader lnReader)

--- a/main/src/com/google/refine/importers/TabularImportingParserBase.java
+++ b/main/src/com/google/refine/importers/TabularImportingParserBase.java
@@ -75,13 +75,36 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
     protected TabularImportingParserBase(boolean useInputStream) {
         super(useInputStream);
     }
+
+    /**
+     * @param project
+     * @param metadata
+     * @param job
+     * @param reader
+     * @param fileSource
+     * @param limit
+     * @param options
+     * @param exceptions
+     * @deprecated 2020-07-23 Use {@link TabularImportingParserBase#readTable(Project, ImportingJob, TableDataReader, int, ObjectNode, List)}
+     */
+    @Deprecated
+    static public void readTable(
+            Project project,
+            ProjectMetadata metadata,
+            ImportingJob job,
+            TableDataReader reader,
+            String fileSource,
+            int limit,
+            ObjectNode options,
+            List<Exception> exceptions
+        ) {
+        readTable(project, job, reader, limit, options, exceptions);
+    }
     
     static public void readTable(
         Project project,
-        ProjectMetadata metadata,
         ImportingJob job,
         TableDataReader reader,
-        String fileSource,
         int limit,
         ObjectNode options,
         List<Exception> exceptions

--- a/main/src/com/google/refine/importers/WikitextImporter.java
+++ b/main/src/com/google/refine/importers/WikitextImporter.java
@@ -749,7 +749,7 @@ public class WikitextImporter extends TabularImportingParserBase {
                 // TODO this does not seem to do anything - maybe we need to pass it to OpenRefine in some other way?
             }
 
-            TabularImportingParserBase.readTable(project, metadata, job, dataReader, fileSource, limit, options, exceptions);
+            TabularImportingParserBase.readTable(project, job, dataReader, limit, options, exceptions);
             
             // Add reconciliation statistics
             if (dataReader.columnReconciled != null) {

--- a/main/src/com/google/refine/importers/tree/ImportParameters.java
+++ b/main/src/com/google/refine/importers/tree/ImportParameters.java
@@ -27,34 +27,30 @@
 package com.google.refine.importers.tree;
 
 
+/**
+ * @deprecated 2020-07-23 Use the method signatures which take individual parameters instead of this
+ */
+@Deprecated
 public class ImportParameters {
     protected boolean trimStrings;
     protected boolean storeEmptyStrings;
     protected boolean guessDataType;
     protected boolean includeFileSources = false;
     protected String fileSource = null;
-    // TODO: What is the compatibility impact of including new fields
-    protected boolean includeArchiveFileName = false;
-    protected String archiveFileName = null;
 
+    @Deprecated
     public ImportParameters(boolean trimStrings, boolean storeEmptyStrings, boolean guessCellValueTypes,
-            boolean includeFileSources, String fileSource, boolean includeArchiveFileName, String archiveFileName) {
+            boolean includeFileSources, String fileSource) {
         this.trimStrings = trimStrings;
         this.storeEmptyStrings = storeEmptyStrings;
         this.guessDataType = guessCellValueTypes;
         this.includeFileSources = includeFileSources;
         this.fileSource = fileSource;
-        this.includeArchiveFileName = includeArchiveFileName;
-        this.archiveFileName = archiveFileName;
     }
 
-    public ImportParameters(boolean trimStrings, boolean storeEmptyStrings, boolean guessCellValueTypes,
-            boolean includeFileSources, String fileSource) {
-        this(trimStrings, storeEmptyStrings, guessCellValueTypes, includeFileSources, fileSource, false, "");
-    }
-    
+    @Deprecated
     public ImportParameters(boolean trimStrings, boolean storeEmptyStrings, boolean guessCellValueTypes) {
         this(trimStrings, storeEmptyStrings, guessCellValueTypes, false, "");
     }
-    
+
 }

--- a/main/src/com/google/refine/importers/tree/TreeImportingParserBase.java
+++ b/main/src/com/google/refine/importers/tree/TreeImportingParserBase.java
@@ -210,12 +210,10 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
         boolean trimStrings = JSONUtilities.getBoolean(options, "trimStrings", true);
         boolean storeEmptyStrings = JSONUtilities.getBoolean(options, "storeEmptyStrings", false);
         boolean guessCellValueTypes = JSONUtilities.getBoolean(options, "guessCellValueTypes", true);
-        boolean includeFileSources = JSONUtilities.getBoolean(options, "includeFileSources", false);
 
         try {
             XmlImportUtilities.importTreeData(treeParser, project, recordPath, rootColumnGroup, limit2,
-                    new ImportParameters(trimStrings, storeEmptyStrings, guessCellValueTypes, includeFileSources,
-                            fileSource));
+                    trimStrings, storeEmptyStrings, guessCellValueTypes);
         } catch (Exception e){
             exceptions.add(e);
         }

--- a/main/tests/server/src/com/google/refine/importers/XmlImportUtilitiesStub.java
+++ b/main/tests/server/src/com/google/refine/importers/XmlImportUtilitiesStub.java
@@ -49,31 +49,50 @@ public class XmlImportUtilitiesStub extends XmlImportUtilities {
         return super.detectRecordElement(parser, tag);
     }
 
-    public void ProcessSubRecordWrapper(Project project, TreeReader parser, ImportColumnGroup columnGroup,
+    @Deprecated
+    public void processSubRecordWrapper(Project project, TreeReader parser, ImportColumnGroup columnGroup,
             ImportRecord record, int level, ImportParameters parameter)
             throws Exception {
         super.processSubRecord(project, parser, columnGroup, record, level, parameter);
     }
 
+    @Deprecated
     public void findRecordWrapper(Project project, TreeReader parser, String[] recordPath, int pathIndex,
-            ImportColumnGroup rootColumnGroup, boolean trimStrings, boolean storeEmptyStrings, boolean guessDataType)
+            ImportColumnGroup rootColumnGroup, int limit, ImportParameters parameters)
             throws Exception {
-        super.findRecord(project, parser, recordPath, pathIndex, rootColumnGroup, -1, 
-                new ImportParameters(trimStrings, storeEmptyStrings, guessDataType));
+        super.findRecord(project, parser, recordPath, pathIndex, rootColumnGroup, limit, parameters);
     }
+
+
+    public void findRecordWrapper(Project project, TreeReader parser, String[] recordPath, int pathIndex,
+            ImportColumnGroup rootColumnGroup, int limit, boolean trimStrings, boolean storeEmptyStrings,
+            boolean guessDataType) throws Exception {
+        super.findRecord(project, parser, recordPath, pathIndex, rootColumnGroup, limit, trimStrings, storeEmptyStrings,
+                guessDataType);
+    }
+
+    @Deprecated
+    public void processRecordWrapper(Project project, TreeReader parser, ImportColumnGroup rootColumnGroup,
+            ImportParameters parameters)
+            throws Exception {
+        super.processRecord(project, parser, rootColumnGroup, parameters);
+    }
+
 
     public void processRecordWrapper(Project project, TreeReader parser, ImportColumnGroup rootColumnGroup,
             boolean trimStrings, boolean storeEmptyStrings, boolean guessDataType)
             throws Exception {
-        super.processRecord(project, parser, rootColumnGroup, 
-                new ImportParameters(trimStrings, storeEmptyStrings, guessDataType));
-    }    
+        super.processRecord(project, parser, rootColumnGroup, trimStrings, storeEmptyStrings, guessDataType);
+    }
 
-    public void addCellWrapper(Project project, ImportColumnGroup columnGroup, ImportRecord record, String columnLocalName, Serializable value, int commonStartingRowIndex) {
+    public void addCellWrapper(Project project, ImportColumnGroup columnGroup, ImportRecord record,
+            String columnLocalName, Serializable value, int commonStartingRowIndex) {
         super.addCell(project, columnGroup, record, columnLocalName, value);
     }
 
-    public void addCellWrapper(Project project, ImportColumnGroup columnGroup, ImportRecord record, String columnLocalName, String text, int commonStartingRowIndex, boolean trimStrings, boolean storeEmptyStrings) {
+    public void addCellWrapper(Project project, ImportColumnGroup columnGroup, ImportRecord record,
+            String columnLocalName, String text, int commonStartingRowIndex, boolean trimStrings,
+            boolean storeEmptyStrings) {
         super.addCell(project, columnGroup, record, columnLocalName, text, trimStrings, storeEmptyStrings);
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/XmlImportUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/XmlImportUtilitiesTests.java
@@ -49,7 +49,6 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
-import com.google.refine.importers.JsonImporter;
 import com.google.refine.importers.JsonImporter.JSONTreeReader;
 import com.google.refine.importers.XmlImporter.XmlParser;
 import com.google.refine.importers.tree.ImportColumn;
@@ -211,6 +210,33 @@ public class XmlImportUtilitiesTests extends RefineTest {
         String[] recordPath = new String[]{"library","book"};
         try {
             XmlImportUtilitiesStub.importTreeData(createXmlParser(), project, recordPath, columnGroup, -1,
+                    false, true, false);
+        } catch (Exception e){
+            Assert.fail();
+        }
+
+        assertProjectCreated(project, 0, 6);
+
+        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
+
+        Assert.assertEquals(columnGroup.subgroups.size(), 1);
+        Assert.assertNotNull(columnGroup.subgroups.get("book"));
+        Assert.assertEquals(columnGroup.subgroups.get("book").subgroups.size(), 3);
+        Assert.assertNotNull(columnGroup.subgroups.get("book").subgroups.get("author"));
+        Assert.assertNotNull(columnGroup.subgroups.get("book").subgroups.get("title"));
+        Assert.assertNotNull(columnGroup.subgroups.get("book").subgroups.get("publish_date"));
+    }
+    
+    /**
+     * Test of deprecated method which can go away when it does
+     */
+    @Test
+    public void importTreeDataXmlTestDeprecated(){
+        loadSampleXml();
+
+        String[] recordPath = new String[]{"library","book"};
+        try {
+            XmlImportUtilitiesStub.importTreeData(createXmlParser(), project, recordPath, columnGroup, -1,
                     new ImportParameters(false, true, false));
         } catch (Exception e){
             Assert.fail();
@@ -230,6 +256,39 @@ public class XmlImportUtilitiesTests extends RefineTest {
 
     @Test
     public void importXmlWithVaryingStructureTest(){
+        loadData(XmlImporterTests.getSampleWithVaryingStructure());
+
+        String[] recordPath = new String[]{"library", "book"};
+        try {
+            XmlImportUtilitiesStub.importTreeData(createXmlParser(), project, recordPath, columnGroup, -1,
+                    false, true, false);
+        } catch (Exception e){
+            Assert.fail();
+        }
+
+        assertProjectCreated(project, 0, 6);
+        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
+        Assert.assertEquals(project.rows.get(5).cells.size(), 5);
+
+        Assert.assertEquals(columnGroup.subgroups.size(), 1);
+        Assert.assertEquals(columnGroup.name, "");
+        ImportColumnGroup book = columnGroup.subgroups.get("book");
+        Assert.assertNotNull(book);
+        Assert.assertEquals(book.columns.size(), 1);
+        Assert.assertEquals(book.subgroups.size(), 4);
+        Assert.assertNotNull(book.subgroups.get("author"));
+        Assert.assertEquals(book.subgroups.get("author").columns.size(), 1);
+        Assert.assertNotNull(book.subgroups.get("title"));
+        Assert.assertNotNull(book.subgroups.get("publish_date"));
+        Assert.assertNotNull(book.subgroups.get("genre"));
+    }
+
+
+    /**
+     * Test using deprecated method which can go away when it does
+     */
+    @Test
+    public void importXmlWithVaryingStructureTestDeprecated(){
         loadData(XmlImporterTests.getSampleWithVaryingStructure());
 
         String[] recordPath = new String[]{"library", "book"};
@@ -290,7 +349,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
         int pathIndex = 0;
 
         try {
-            SUT.findRecordWrapper(project, parser, recordPath, pathIndex, columnGroup,
+            SUT.findRecordWrapper(project, parser, recordPath, pathIndex, columnGroup, -1,
                     false, false, false);
         } catch (Exception e) {
             Assert.fail();
@@ -301,6 +360,32 @@ public class XmlImportUtilitiesTests extends RefineTest {
         Assert.assertEquals(project.rows.get(0).cells.size(), 4);
         //TODO
     }
+
+    /**
+     * Test of deprecated wrapper method which can go away when it does
+     */
+    @Test
+    public void findRecordTestXmlDeprecated(){
+        loadSampleXml();
+        createXmlParser();
+        ParserSkip();
+
+        String[] recordPath = new String[]{"library","book"};
+        int pathIndex = 0;
+
+        try {
+            SUT.findRecordWrapper(project, parser, recordPath, pathIndex, columnGroup, -1,
+                    new ImportParameters(false, false, false));
+        } catch (Exception e) {
+            Assert.fail();
+        }
+
+        assertProjectCreated(project, 0, 6);
+
+        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
+        //TODO
+    }
+
 
     @Test
     public void processRecordTestXml(){
@@ -378,7 +463,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
         ParserSkip();
 
         try {
-            SUT.ProcessSubRecordWrapper(project, parser, columnGroup, record,0, 
+            SUT.processSubRecordWrapper(project, parser, columnGroup, record,0, 
                     new ImportParameters(false, false, false));
         } catch (Exception e) {
             Assert.fail();


### PR DESCRIPTION
Refs #2963. Followup to #2978. This tidies up a few loose ends from the importer refactoring:
- reverts the archive file name changes to ImportParameters and marks the entire class as deprecated since it was just introduced at the beginning of all this silliness
- removes unused parameters from `TabularImportingParserBase.readTable()` to make it easier to figure out what's used where and marks the old method signature as deprecated
- ditto for `XmlImportUtilities.importTreeData()` and some related methods in that class. Switch them back from using `ImportParameters` and having to guess which of its members they depended on to using specific parameters.
- removes duplicate fileSource and archiveFileName setting code from `XmlImportUtilities`. Likely not a functional problem, but a performance and code duplication issue.
- lowercased method name `XmlImporterUtiltilitiesStub.ProcessSubRecordWrapper()`
- doubled up tests for things that had new forms to test both the old and new forms
