### PR TITLE
Add Dockerfile for easier exploration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM maven:3.6.3-openjdk-8
+
+COPY . /refine
+RUN apt-get update -y \
+    && apt-get install -y curl \
+    && /refine/refine build
+EXPOSE 3333
+WORKDIR /refine
+ENTRYPOINT ["/refine/refine", "-i", "0.0.0.0", "run"]


### PR DESCRIPTION
Hi all,

when trying out OpenRefine on my machine, I didn't want to install Java so I wrote a little Dockerfile. Full disclosure: I'm not an expert on Docker and thus the file might not even follow best practices. The reason I am opening this PR is to start a discussion. I'm happy to add documentation, make changes, or even close the PR alltogether if you think it's a bad idea.

With this change, a user would be able to get their own version of OpenRefine running simply through

```bash
docker build -t openrefine:v1 .
docker run -d -it -p3333:3333 openrefine:v1
```

and then point their browser to `http://localhost:3333`.

I can imagine this might be useful to people who don't live in the Java ecosystem but want to give OpenRefine a try anyway. Let me know what you think :) 

Cheers,
Kevin