### PR TITLE
Update to vicino 1.2 and drop transitive dependencies - fixes #2959

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -268,7 +268,7 @@
     <dependency>
       <groupId>org.openrefine.dependencies</groupId>
       <artifactId>vicino</artifactId>
-      <version>1.1</version>
+      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>oauth.signpost</groupId>
@@ -334,16 +334,6 @@
       <groupId>com.metaweb</groupId>
       <artifactId>lessen</artifactId>
       <version>1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.openrefine.dependencies</groupId>
-      <artifactId>secondstring</artifactId>
-      <version>20100303</version>
-    </dependency>
-    <dependency>
-      <groupId>org.openrefine.dependencies</groupId>
-      <artifactId>arithcode</artifactId>
-      <version>1.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Bump to vicino 1.2 with bug fix and real POM.

Drop dependencies on secondstring and arithcode which are just transitive dependencies from simile-vicino, now that it has a
proper POM. Fixes #2959.