### PR TITLE
Fix ToDate test failure & inefficiency - fixes #3026

### DIFF
--- a/main/src/com/google/refine/expr/functions/ToDate.java
+++ b/main/src/com/google/refine/expr/functions/ToDate.java
@@ -37,8 +37,8 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -167,9 +167,9 @@ public class ToDate implements Function {
             return date;
         } else {
             try {
-                return javax.xml.bind.DatatypeConverter.parseDateTime(o1).getTime().toInstant()
-                		.plusSeconds(ZonedDateTime.now().getOffset().getTotalSeconds())
-                		.atOffset(ZoneOffset.of("Z"));
+                Calendar parsedDate = javax.xml.bind.DatatypeConverter.parseDateTime(o1);
+                int offsetMillis = parsedDate.getTimeZone().getOffset(parsedDate.getTimeInMillis());
+                return parsedDate.toInstant().plusMillis(offsetMillis).atOffset(ZoneOffset.of("Z"));
             } catch (IllegalArgumentException e2) {
                 return null;
             }

--- a/main/src/com/google/refine/util/ParsingUtilities.java
+++ b/main/src/com/google/refine/util/ParsingUtilities.java
@@ -182,7 +182,7 @@ public class ParsingUtilities {
     static public String localDateToString(LocalDateTime d) {
       OffsetDateTime odt = OffsetDateTime.of(d,
                 OffsetDateTime.now().getOffset());
-      
+      // FIXME: A LocalDate has no timezone, by definition.
       return odt.withOffsetSameInstant(ZoneOffset.of("Z")).format(ISO8601);
     }
 

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/ToFromConversionTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/ToFromConversionTests.java
@@ -141,6 +141,7 @@ public class ToFromConversionTests extends RefineTest {
       Assert.assertTrue(invoke("toDate", "") instanceof EvalError);
       Assert.assertTrue(invoke("toDate", 1.0) instanceof EvalError);
       Assert.assertTrue(invoke("toDate", "2012-03-01", "xxx") instanceof EvalError); // bad format string
+      Assert.assertTrue(invoke("toDate", "2012-03-01", 1L) instanceof EvalError); // non-string format arg
       Assert.assertTrue(invoke("toDate", "P1M") instanceof EvalError); // Durations aren't supported
 
       Assert.assertTrue(invoke("toDate", "2012-03-01") instanceof OffsetDateTime);

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/ToFromConversionTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/ToFromConversionTests.java
@@ -133,56 +133,61 @@ public class ToFromConversionTests extends RefineTest {
     
     @Test
     public void testToDate() throws CalendarParserException {
-        // Inject a fixed non-UTC timezone
-        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        try {
+            // Inject a fixed non-UTC timezone
+            TimeZone.setDefault(TimeZone.getTimeZone("JST"));
 
-      Assert.assertTrue(invoke("toDate") instanceof EvalError);
-      Assert.assertTrue(invoke("toDate", (Object) null) instanceof EvalError);
-      Assert.assertTrue(invoke("toDate", "") instanceof EvalError);
-      Assert.assertTrue(invoke("toDate", 1.0) instanceof EvalError);
-      Assert.assertTrue(invoke("toDate", "2012-03-01", "xxx") instanceof EvalError); // bad format string
-      Assert.assertTrue(invoke("toDate", "2012-03-01", 1L) instanceof EvalError); // non-string format arg
-      Assert.assertTrue(invoke("toDate", "P1M") instanceof EvalError); // Durations aren't supported
+            Assert.assertTrue(invoke("toDate") instanceof EvalError);
+            Assert.assertTrue(invoke("toDate", (Object) null) instanceof EvalError);
+            Assert.assertTrue(invoke("toDate", "") instanceof EvalError);
+            Assert.assertTrue(invoke("toDate", 1.0) instanceof EvalError);
+            Assert.assertTrue(invoke("toDate", "2012-03-01", "xxx") instanceof EvalError); // bad format string
+            Assert.assertTrue(invoke("toDate", "2012-03-01", 1L) instanceof EvalError); // non-string format arg
+            Assert.assertTrue(invoke("toDate", "P1M") instanceof EvalError); // Durations aren't supported
 
-      Assert.assertTrue(invoke("toDate", "2012-03-01") instanceof OffsetDateTime);
-      Assert.assertEquals(invoke("toDate", "2012-03-01"),CalendarParser.parseAsOffsetDateTime("2012-03-01"));
-      //parse as 'month first' date with and without explicit 'true' parameter
-      Assert.assertEquals(invoke("toDate", "01/03/2012"),CalendarParser.parseAsOffsetDateTime("2012-01-03"));
-      Assert.assertEquals(invoke("toDate", "01/03/2012",true),CalendarParser.parseAsOffsetDateTime("2012-01-03"));
-      //parse as 'month first' date with 'false' parameter
-      Assert.assertEquals(invoke("toDate", "01/03/2012",false),CalendarParser.parseAsOffsetDateTime("2012-03-01"));
-      //parse as 'month first' date without 'false' parameter but with format specified
-      Assert.assertEquals(invoke("toDate", "01/03/2012","dd/MM/yyyy"),CalendarParser.parseAsOffsetDateTime("2012-03-01"));
-      Assert.assertEquals(invoke("toDate", "2012-03-01","yyyy-MM-dd"),CalendarParser.parseAsOffsetDateTime("2012-03-01"));
-      //Two digit year
-      Assert.assertEquals(invoke("toDate", "02-02-01"),CalendarParser.parseAsOffsetDateTime("2001-02-02"));
-      // Multiple format strings should get tried sequentially until one succeeds or all are exhausted
-      Assert.assertEquals(invoke("toDate", "2012-03-01","MMM","yyyy-MM-dd"), CalendarParser.parseAsOffsetDateTime("2012-03-01"));
-      
-      // Boolean argument combined with Multiple format strings 
-      Assert.assertEquals(invoke("toDate", "01/03/2012",false, "MMM","yyyy-MM-dd","MM/dd/yyyy"), CalendarParser.parseAsOffsetDateTime("2012-03-01"));
-      
-      // First string can be a locale identifier instead of a format string
-      Assert.assertEquals(invoke("toDate", "2013-06-01","zh"), CalendarParser.parseAsOffsetDateTime("2013-06-01"));
-      Assert.assertEquals(invoke("toDate", "01-六月-2013","zh","dd-MMM-yyyy"), CalendarParser.parseAsOffsetDateTime("2013-06-01"));
-      Assert.assertEquals(invoke("toDate", "01-六月-2013", "zh-CN", "dd-MMM-yyyy"), CalendarParser.parseAsOffsetDateTime("2013-06-01"));
-      Assert.assertEquals(invoke("toDate", "01-六月-2013", "zh", "MMM-dd-yyyy", "dd-MMM-yyyy"), CalendarParser.parseAsOffsetDateTime("2013-06-01"));
+            Assert.assertTrue(invoke("toDate", "2012-03-01") instanceof OffsetDateTime);
+            Assert.assertEquals(invoke("toDate", "2012-03-01"),CalendarParser.parseAsOffsetDateTime("2012-03-01"));
+            //parse as 'month first' date with and without explicit 'true' parameter
+            Assert.assertEquals(invoke("toDate", "01/03/2012"),CalendarParser.parseAsOffsetDateTime("2012-01-03"));
+            Assert.assertEquals(invoke("toDate", "01/03/2012",true),CalendarParser.parseAsOffsetDateTime("2012-01-03"));
+            //parse as 'month first' date with 'false' parameter
+            Assert.assertEquals(invoke("toDate", "01/03/2012",false),CalendarParser.parseAsOffsetDateTime("2012-03-01"));
+            //parse as 'month first' date without 'false' parameter but with format specified
+            Assert.assertEquals(invoke("toDate", "01/03/2012","dd/MM/yyyy"),CalendarParser.parseAsOffsetDateTime("2012-03-01"));
+            Assert.assertEquals(invoke("toDate", "2012-03-01","yyyy-MM-dd"),CalendarParser.parseAsOffsetDateTime("2012-03-01"));
+            //Two digit year
+            Assert.assertEquals(invoke("toDate", "02-02-01"),CalendarParser.parseAsOffsetDateTime("2001-02-02"));
+            // Multiple format strings should get tried sequentially until one succeeds or all are exhausted
+            Assert.assertEquals(invoke("toDate", "2012-03-01","MMM","yyyy-MM-dd"), CalendarParser.parseAsOffsetDateTime("2012-03-01"));
 
-      // If a long, convert to string
-      Assert.assertEquals(invoke("toDate", (long) 2012), invoke("toDate", "2012-01-01"));
+            // Boolean argument combined with Multiple format strings 
+            Assert.assertEquals(invoke("toDate", "01/03/2012",false, "MMM","yyyy-MM-dd","MM/dd/yyyy"), CalendarParser.parseAsOffsetDateTime("2012-03-01"));
 
-      // If already a date, leave it alone
-      Assert.assertEquals(invoke("toDate", CalendarParser.parseAsOffsetDateTime("2012-03-01")),CalendarParser.parseAsOffsetDateTime("2012-03-01"));
+            // First string can be a locale identifier instead of a format string
+            Assert.assertEquals(invoke("toDate", "2013-06-01","zh"), CalendarParser.parseAsOffsetDateTime("2013-06-01"));
+            Assert.assertEquals(invoke("toDate", "01-六月-2013","zh","dd-MMM-yyyy"), CalendarParser.parseAsOffsetDateTime("2013-06-01"));
+            Assert.assertEquals(invoke("toDate", "01-六月-2013", "zh-CN", "dd-MMM-yyyy"), CalendarParser.parseAsOffsetDateTime("2013-06-01"));
+            Assert.assertEquals(invoke("toDate", "01-六月-2013", "zh", "MMM-dd-yyyy", "dd-MMM-yyyy"), CalendarParser.parseAsOffsetDateTime("2013-06-01"));
 
-      // FIXME: Date/times without timezone info were interpreted as local up until May 2018 at which point they switch to UTC
-//      Assert.assertEquals(invoke("toDate", "2013-06-01T13:12:11"), CalendarParser.parseAsOffsetDateTime("2013-06-01 13:12:11"));
+            // If a long, convert to string
+            Assert.assertEquals(invoke("toDate", (long) 2012), invoke("toDate", "2012-01-01"));
 
-      // These match current behavior, but would fail with the historic (pre-2018) behavior
-      Assert.assertEquals(invoke("toDate", "2013-06-01T13:12:11Z"), CalendarParser.parseAsOffsetDateTime("2013-06-01 13:12:11"));
-      Assert.assertEquals(invoke("toDate", "2013-06-01Z"), CalendarParser.parseAsOffsetDateTime("2013-06-01"));
+            // If already a date, leave it alone
+            Assert.assertEquals(invoke("toDate", CalendarParser.parseAsOffsetDateTime("2012-03-01")),CalendarParser.parseAsOffsetDateTime("2012-03-01"));
 
-      // TODO: more tests for datetimes with timezones and/or offsets
-//       Assert.assertEquals(invoke("toDate", "2013-06-01T13:12:11+06:00"), CalendarParser.parseAsOffsetDateTime("2013-06-01 13:12:11"));
+            // FIXME: Date/times without timezone info were interpreted as local up until May 2018 at which point they switch to UTC
+            //      Assert.assertEquals(invoke("toDate", "2013-06-01T13:12:11"), CalendarParser.parseAsOffsetDateTime("2013-06-01 13:12:11"));
+
+            // These match current behavior, but would fail with the historic (pre-2018) behavior
+            Assert.assertEquals(invoke("toDate", "2013-06-01T13:12:11Z"), CalendarParser.parseAsOffsetDateTime("2013-06-01 13:12:11"));
+            Assert.assertEquals(invoke("toDate", "2013-06-01Z"), CalendarParser.parseAsOffsetDateTime("2013-06-01"));
+
+            // TODO: more tests for datetimes with timezones and/or offsets
+            //       Assert.assertEquals(invoke("toDate", "2013-06-01T13:12:11+06:00"), CalendarParser.parseAsOffsetDateTime("2013-06-01 13:12:11"));
+        } finally {
+            TimeZone.setDefault(originalTimeZone);
+        }
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/ToFromConversionTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/ToFromConversionTests.java
@@ -35,6 +35,7 @@ package com.google.refine.expr.functions.strings;
 
 import java.time.OffsetDateTime;
 import java.util.Properties;
+import java.util.TimeZone;
 
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -49,7 +50,6 @@ import com.google.refine.expr.util.CalendarParser;
 import com.google.refine.expr.util.CalendarParserException;
 import com.google.refine.grel.ControlFunctionRegistry;
 import com.google.refine.grel.Function;
-import com.google.refine.util.ParsingUtilities;
 
 
 /**
@@ -135,6 +135,9 @@ public class ToFromConversionTests extends RefineTest {
     
     @Test
     public void testToDate() throws CalendarParserException {
+        // Inject a fixed non-UTC timezone
+        TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+
       Assert.assertTrue(invoke("toDate") instanceof EvalError);
       Assert.assertTrue(invoke("toDate", (Object) null) instanceof EvalError);
       Assert.assertTrue(invoke("toDate", "") instanceof EvalError);

--- a/main/tests/server/src/com/google/refine/io/ProjectMetadataTests.java
+++ b/main/tests/server/src/com/google/refine/io/ProjectMetadataTests.java
@@ -41,10 +41,10 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.refine.ProjectMetadata;
 
 public class ProjectMetadataTests {
-	  
+
     private String jsonSaveMode = null;
     private String jsonNonSaveMode = null;
-    
+
     @BeforeSuite
     public void setUpJson() throws IOException {
     	InputStream f = ProjectMetadataTests.class.getClassLoader().getResourceAsStream("example_project_metadata.json");
@@ -59,16 +59,17 @@ public class ProjectMetadataTests {
         TestUtils.isSerializedTo(metadata, jsonNonSaveMode);
         TestUtils.isSerializedTo(metadata, jsonSaveMode, true);
 	}
-	
-	@Test
-	public void serializeProjectMetadataInDifferentTimezone() throws JsonParseException, JsonMappingException, IOException {
-    	TimeZone.setDefault(TimeZone.getTimeZone("JST"));
-    	try {
-	        ProjectMetadata metadata = ParsingUtilities.mapper.readValue(jsonSaveMode, ProjectMetadata.class);
-	        TestUtils.isSerializedTo(metadata, jsonNonSaveMode);
-	        TestUtils.isSerializedTo(metadata, jsonSaveMode, true);
-    	} finally {
-    		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-    	}
-	}
+
+    @Test
+    public void serializeProjectMetadataInDifferentTimezone() throws JsonParseException, JsonMappingException, IOException {
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("JST"));
+            ProjectMetadata metadata = ParsingUtilities.mapper.readValue(jsonSaveMode, ProjectMetadata.class);
+            TestUtils.isSerializedTo(metadata, jsonNonSaveMode);
+            TestUtils.isSerializedTo(metadata, jsonSaveMode, true);
+        } finally {
+            TimeZone.setDefault(originalTimeZone);
+        }
+    }
 }

--- a/main/tests/server/src/com/google/refine/util/ParsingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/util/ParsingUtilitiesTests.java
@@ -33,7 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.util;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.zip.GZIPOutputStream;
 
 import java.time.OffsetDateTime;
@@ -49,7 +51,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
-import com.google.refine.util.ParsingUtilities;
+
 
 public class ParsingUtilitiesTests extends RefineTest {
     
@@ -92,24 +94,26 @@ public class ParsingUtilitiesTests extends RefineTest {
         Assert.assertEquals(2017, ParsingUtilities.stringToLocalDate("2017-04-03T08:09:43.123Z").getYear());
         Assert.assertEquals(2017, ParsingUtilities.stringToLocalDate("2017-04-03T08:09:43+00:00").getYear());
     }
-    
+
     /**
      * Converting between string and local time must be reversible, no matter the timezone.
      */
     @Test
     public void stringToLocalDateNonUTC() {
-    	TimeZone.setDefault(TimeZone.getTimeZone("JST"));
-    	try {
-    		Assert.assertEquals(ParsingUtilities.stringToLocalDate("2001-08-12T00:00:00Z").getHour(), 9);
-    		Assert.assertEquals(ParsingUtilities.localDateToString(
-    				ParsingUtilities.stringToLocalDate("2001-08-12T00:00:00Z")),
-    				"2001-08-12T00:00:00Z");
-    		
-    	} finally {
-    		TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-    	}
+        TimeZone originalTimeZone = TimeZone.getDefault();
+        try {
+            TimeZone.setDefault(TimeZone.getTimeZone("JST"));
+            Assert.assertEquals(ParsingUtilities.stringToLocalDate("2001-08-12T00:00:00Z").getHour(), 9);
+            // TODO: This doesn't really make sense since a LocalDate, by definition, doesn't have timezone info
+            Assert.assertEquals(ParsingUtilities.localDateToString(
+                    ParsingUtilities.stringToLocalDate("2001-08-12T00:00:00Z")),
+                    "2001-08-12T00:00:00Z");
+
+        } finally {
+            TimeZone.setDefault(originalTimeZone);
+        }
     }
-    
+
     @Test
     public void parseProjectModifiedBeforeJDK8() {
         String modified = "2014-01-15T21:46:25Z";


### PR DESCRIPTION
Fixes #3026. 

- Use `Instant.truncate(DAYS)` instead of homebrew offset calculation.
- Fix handling of unknown language code as first format string. It was creating 160 copies of it and trying to convert (unsuccessfully) with them all.

The unknown language code used to return an `EvalError` but that behavior was changed and the test that covered it was disabled. Presumably this was intentional, but I'm not sure why. 
@ostephens do you know why?