### PR TITLE
Add .factorypath and others to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ open-refine.log
 .vscode
 .metadata # Eclipse plugins specific
 
+# Locally stored "Eclipse launch configurations"
+*.launch
+
 .idea
 *.iml
 
@@ -55,3 +58,12 @@ apache-maven-*-bin.tar.gz
 
 # Ignore refine-dev.ini
 refine-dev.ini
+
+# Java annotation processor (APT)
+.factorypath
+
+# Code Recommenders
+.recommenders/
+
+# STS (Spring Tool Suite)
+.springBeans


### PR DESCRIPTION
.factorypath file gets added as a changed file in source control depending on the IDE you are using (I use VS Code).
Added a few other exclusions that my previous team used to add to our Java projects.