### PR TITLE
Add separator to zip slip check - fixes #3043

### DIFF
--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -458,13 +458,13 @@ public class ImportingUtilities {
             name = name.substring(0, q);
         }
         
-        File file = new File(dir, name);     
+        File file = new File(dir, name);
         // For CVE-2018-19859, issue #1840
-        if (!file.toPath().normalize().startsWith(dir.toPath().normalize())) {
-        	throw new IllegalArgumentException("Zip archives with files escaping their root directory are not allowed.");
+        if (!file.toPath().normalize().startsWith(dir.toPath().normalize() + File.separator)) {
+            throw new IllegalArgumentException("Zip archives with files escaping their root directory are not allowed.");
         }
         
-        int dot = name.indexOf('.');
+        int dot = name.lastIndexOf('.');
         String prefix = dot < 0 ? name : name.substring(0, dot);
         String suffix = dot < 0 ? "" : name.substring(dot);
         int index = 2;


### PR DESCRIPTION
Also split filename suffix at last dot in case of filenames with multiple dots.

Fixes #3043 