### PR TITLE
Improve exception reporting - refs #3145

### DIFF
--- a/main/src/com/google/refine/commands/Command.java
+++ b/main/src/com/google/refine/commands/Command.java
@@ -367,7 +367,7 @@ public abstract class Command {
         JsonGenerator writer = ParsingUtilities.mapper.getFactory().createGenerator(w);
         writer.writeStartObject();
         writer.writeStringField("code", "error");   
-        writer.writeStringField("message", e.getMessage());
+        writer.writeStringField("message", e.toString());
         writer.writeStringField("stack", sw.toString());
         writer.writeEndObject();
         writer.flush();


### PR DESCRIPTION
Partial fix for #3145 

- Include the exception name with the message returned to the user.

Still to do in a separate PR - redo error dialog so that stack trace is available (but hidden by default)
