### PR TITLE
Create FUNDING.yml to have Sponsor button for repo

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: OpenRefine


### PR DESCRIPTION
As per GitHub Support, the only other thing left to do is also publish the FUNDING.yml file that links to the Organization itself to our OpenRefine repo so that folks visiting the repository directly will also see the Sponsor button.

>Jack (GitHub Support)
>Sep 1, 2020, 5:51 PM UTC
>
> Hi Thad,
> 
> I ran this by our Sponsors product team, and they said that the link I shared https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository should have the correct information to add the Sponsors button to a repo. If you have any specific suggestions on how to improve it, we're definitely open to hearing how it can be improved or less confusing.
> 
> They said:
> 
> If they want the Sponsor button to show up in the OpenRefine/OpenRefine repo, then they will need to add a FUNDING.yml file under the .github/ directory on the default branch. The funding file should look something like:
> 
>     github: OpenRefine
> 
> I hope this helps, but if we can further clarify, please let us know.
> 
> Best,
> Jack