### PR TITLE
Update openrefine-api.md

### DIFF
--- a/docs/docs/technical-reference/openrefine-api.md
+++ b/docs/docs/technical-reference/openrefine-api.md
@@ -17,7 +17,7 @@ multipart form-data:
       'project-file' : file contents
       'project-name' : project name
       'format' : format of data in project-file (e.g. 'text/line-based/*sv') [optional]
-      'options' : json object containing options relevant to the file format [optional]. However for JSON input file this parameter is [Mandatory]
+      'options' : json object containing options relevant to the file format [optional - however, some importers may have required options, such as `recordPath` for the JSON & XML importers].
 
 The formats supported will depend on the version of OpenRefine you are using and any Extensions you have installed. The common formats include:
 

--- a/docs/docs/technical-reference/openrefine-api.md
+++ b/docs/docs/technical-reference/openrefine-api.md
@@ -17,7 +17,7 @@ multipart form-data:
       'project-file' : file contents
       'project-name' : project name
       'format' : format of data in project-file (e.g. 'text/line-based/*sv') [optional]
-      'options' : json object containing options relevant to the file format [optional]
+      'options' : json object containing options relevant to the file format [optional]. However for JSON input file this parameter is [Mandatory]
 
 The formats supported will depend on the version of OpenRefine you are using and any Extensions you have installed. The common formats include:
 
@@ -159,9 +159,14 @@ On success returns JSON response
 
 > **Command:** _POST /command/core/export-rows_
 
-      'project' : project id
-      'engine' : JSON string... (e.g. '{"facets":[],"mode":"row-based"}')
+In the parameter
+
+      'project' : project id      
       'format' : format... (e.g 'tsv', 'csv')
+
+In the form data
+
+      'engine' : JSON string... (e.g. '{"facets":[],"mode":"row-based"}')
       
 Returns exported row data in the specified format. The formats supported will depend on the version of OpenRefine you are using and any Extensions you have installed. The common formats include:
 


### PR DESCRIPTION
Documentations for `Create project` and `Export rows` API calls are modified. When creating a project based on `json input file` it seems like `options` parameter is mandatory. For `Export rows` call both '`project` and `format` parameters should be provided as a request parameters  