### PR TITLE
Adds useful Clojure dependencies

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -355,7 +355,26 @@
       <artifactId>juniversalchardet</artifactId>
       <version>2.3.2</version>
     </dependency>
-
+    <dependency>
+      <groupId>clojure.java-time</groupId>
+      <artifactId>clojure.java-time</artifactId>
+      <version>0.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>tick</groupId>
+      <artifactId>tick</artifactId>
+      <version>0.4.26-alpha</version>
+    </dependency>
+    <dependency>
+      <groupId>funcool</groupId>
+      <artifactId>cuerdas</artifactId>
+      <version>2020.03.26-3</version>
+    </dependency>
+    <dependency>
+      <groupId>kixi</groupId>
+      <artifactId>stats</artifactId>
+      <version>0.5.4</version>
+    </dependency>
     <!-- test dependencies -->
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,10 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>clojars.org</id>
+      <url>https://repo.clojars.org</url>
+    </repository>
   </repositories>
 
 </project>


### PR DESCRIPTION
- Adds clojure.java-time for convenience working with Java 8 Date-Time from Clojure
- Adds tick for advanced date-time manipulation
- Adds cuerdas for String manipulation (similar to GREL functions in Clojure)
- Adds kixi.stats for statistical sampling and transducing

But **what I really want** is somehow to not even bake these Clojure dependencies into OpenRefine's dependencies but instead allow dynamic Clojure dependencies via a `deps.edn` file and whenever I restart OpenRefine it will have pulled down those dependencies?  Or perhaps it can work without restarting OpenRefine, and it downloads the dependencies and adds them to the classpath automatically.

Details: https://clojure.org/guides/deps_and_cli
