### PR TITLE
Clarify refine.ini comments - fixes #3204

### DIFF
--- a/refine.ini
+++ b/refine.ini
@@ -10,11 +10,11 @@ no_proxy="localhost,127.0.0.1"
 #REFINE_HOST=127.0.0.1
 #REFINE_WEBAPP=main\webapp
 
-# Memory and max form size allocations
+# Maximum JVM heap (memory) and max form size allocations
 #REFINE_MAX_FORM_CONTENT_SIZE=1048576
 REFINE_MEMORY=1400M
 
-# Set initial java heap space (default: 256M) for better performance with large datasets
+# Initial (and minimum) size of Java heap
 REFINE_MIN_MEMORY=1400M
 
 # Some sample configurations. These have no defaults.
@@ -22,15 +22,13 @@ REFINE_MIN_MEMORY=1400M
 # Use a single JAVA_OPTIONS that includes any JVM options you need upon OpenRefine startup
 #JAVA_OPTIONS=-XX:+UseParallelGC -verbose:gc -Drefine.headless=true -Drefine.data_dir=C:\Users\user\AppData\Roaming\OpenRefine
 
-# Uncomment to increase autosave period to 60 mins (default: 5 minutes) for better performance of long-lasting transformations
+# Uncomment to increase autosave period to 60 mins (default: 5 minutes)
+# for better performance of long-lasting transformations (but increased risk of data loss)
 #REFINE_AUTOSAVE_PERIOD=60
 
-# OAuth credentials configurations for Google Data
-# Default OAuth credentials for Google Data have been embedded in the release version of OpenRefine
-# So if you are a user, you can just skip these configurations, but it's recommended to use your own credentials
-# If you are a developer, you'll need to acquire them by yourself
-# To get your own credentials, please see the wiki: https://github.com/OpenRefine/OpenRefine/wiki/Google-Extension
-# The wiki will guide you to get a client_id/client_secret pair
-# After getting the client_id and client_secret, put them below
+# Google Data OAuth configuration for developers
+# (NOTE: This are only needed for developers. Users of released versions can ignore this)
+# To get your credentials, please see the instructions on the wiki:
+#   https://github.com/OpenRefine/OpenRefine/wiki/Google-Extension
 #GDATA_CLIENT_ID=your_client_id
 #GDATA_CLIENT_SECRET=your_client_secret

--- a/refine.ini
+++ b/refine.ini
@@ -27,7 +27,7 @@ REFINE_MIN_MEMORY=1400M
 #REFINE_AUTOSAVE_PERIOD=60
 
 # Google Data OAuth configuration for developers
-# (NOTE: This are only needed for developers. Users of released versions can ignore this)
+# (NOTE: This is only needed for developers. Users of released versions can ignore this)
 # To get your credentials, please see the instructions on the wiki:
 #   https://github.com/OpenRefine/OpenRefine/wiki/Google-Extension
 #GDATA_CLIENT_ID=your_client_id


### PR DESCRIPTION
Fixes #3204 

Clarifies comments for:
- Google Data OAuth config
- JVM heap

NOTE: Our current JVM max heap settings are *lowering* the size computed for the default on my machine (4096 MB => 1400 MB), so we may just want to accept the defaults unless the user specifically wants to override them.