### PR TITLE
Refactor HTTP code into common module & Improve Fetch URL  - fixes #3129

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -291,6 +291,11 @@
       <version>1.10.1</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <version>5.0.2</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.13</version>

--- a/main/src/com/google/refine/commands/recon/GuessTypesOfColumnCommand.java
+++ b/main/src/com/google/refine/commands/recon/GuessTypesOfColumnCommand.java
@@ -48,19 +48,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.http.Consts;
-import org.apache.http.NameValuePair;
-import org.apache.http.StatusLine;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.client.LaxRedirectStrategy;
-import org.apache.http.message.BasicNameValuePair;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -68,7 +55,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.refine.RefineServlet;
 import com.google.refine.commands.Command;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Column;
@@ -76,6 +62,7 @@ import com.google.refine.model.Project;
 import com.google.refine.model.ReconType;
 import com.google.refine.model.Row;
 import com.google.refine.model.recon.StandardReconConfig.ReconResult;
+import com.google.refine.util.HttpClient;
 import com.google.refine.util.ParsingUtilities;
 
 public class GuessTypesOfColumnCommand extends Command {
@@ -180,61 +167,38 @@ public class GuessTypesOfColumnCommand extends Command {
         }
         
         String queriesString = ParsingUtilities.defaultWriter.writeValueAsString(queryMap);
+        String responseString;
         try {
-            RequestConfig defaultRequestConfig = RequestConfig.custom()
-                    .setConnectTimeout(30 * 1000)
-                    .build();
+            responseString = postQueries(serviceUrl, queriesString);
+            ObjectNode o = ParsingUtilities.evaluateJsonStringToObjectNode(responseString);
 
-            HttpClientBuilder httpClientBuilder = HttpClients.custom()
-                    .setUserAgent(RefineServlet.getUserAgent())
-                    .setRedirectStrategy(new LaxRedirectStrategy())
-                    .setDefaultRequestConfig(defaultRequestConfig);
-            
-            CloseableHttpClient httpClient = httpClientBuilder.build();
-            HttpPost request = new HttpPost(serviceUrl);
-            List<NameValuePair> body = Collections.singletonList(
-                    new BasicNameValuePair("queries", queriesString));
-            request.setEntity(new UrlEncodedFormEntity(body, Consts.UTF_8));
-            
-            try (CloseableHttpResponse response = httpClient.execute(request)) {
-                StatusLine statusLine = response.getStatusLine();
-                if (statusLine.getStatusCode() >= 400) {
-                    throw new IOException("Failed  - code:" 
-                            + Integer.toString(statusLine.getStatusCode()) 
-                            + " message: " + statusLine.getReasonPhrase());
+            Iterator<JsonNode> iterator = o.iterator();
+            while (iterator.hasNext()) {
+                JsonNode o2 = iterator.next();
+                if (!(o2.has("result") && o2.get("result") instanceof ArrayNode)) {
+                    continue;
                 }
-                
-                String s = ParsingUtilities.inputStreamToString(response.getEntity().getContent());
-                ObjectNode o = ParsingUtilities.evaluateJsonStringToObjectNode(s);
 
-                Iterator<JsonNode> iterator = o.iterator();
-                while (iterator.hasNext()) {
-                    JsonNode o2 = iterator.next();
-                    if (!(o2.has("result") && o2.get("result") instanceof ArrayNode)) {
-                        continue;
-                    }
+                ArrayNode results = (ArrayNode) o2.get("result");
+                List<ReconResult> reconResults = ParsingUtilities.mapper.convertValue(results, new TypeReference<List<ReconResult>>() {});
+                int count = reconResults.size();
 
-                    ArrayNode results = (ArrayNode) o2.get("result");
-                    List<ReconResult> reconResults = ParsingUtilities.mapper.convertValue(results, new TypeReference<List<ReconResult>>() {});
-                    int count = reconResults.size();
+                for (int j = 0; j < count; j++) {
+                    ReconResult result = reconResults.get(j);
+                    double score = 1.0 / (1 + j); // score by each result's rank
 
-                    for (int j = 0; j < count; j++) {
-                        ReconResult result = reconResults.get(j);
-                        double score = 1.0 / (1 + j); // score by each result's rank
+                    List<ReconType> types = result.types;
+                    int typeCount = types.size();
 
-                        List<ReconType> types = result.types;
-                        int typeCount = types.size();
-
-                        for (int t = 0; t < typeCount; t++) {
-                        	ReconType type = types.get(t);
-                            double score2 = score * (typeCount - t) / typeCount;
-                            if (map.containsKey(type.id)) {
-                                TypeGroup tg = map.get(type.id);
-                                tg.score += score2;
-                                tg.count++;
-                            } else {
-                                map.put(type.id, new TypeGroup(type.id, type.name, score2));
-                            }
+                    for (int t = 0; t < typeCount; t++) {
+                        ReconType type = types.get(t);
+                        double score2 = score * (typeCount - t) / typeCount;
+                        if (map.containsKey(type.id)) {
+                            TypeGroup tg = map.get(type.id);
+                            tg.score += score2;
+                            tg.count++;
+                        } else {
+                            map.put(type.id, new TypeGroup(type.id, type.name, score2));
                         }
                     }
                 }
@@ -243,7 +207,7 @@ public class GuessTypesOfColumnCommand extends Command {
             logger.error("Failed to guess cell types for load\n" + queriesString, e);
             throw e;
         }
-        
+
         List<TypeGroup> types = new ArrayList<TypeGroup>(map.values());
         Collections.sort(types, new Comparator<TypeGroup>() {
             @Override
@@ -258,7 +222,12 @@ public class GuessTypesOfColumnCommand extends Command {
         
         return types;
     }
-    
+
+    private String postQueries(String serviceUrl, String queriesString) throws IOException {
+        HttpClient client = new HttpClient();
+        return client.postNameValue(serviceUrl, "queries", queriesString);
+    }
+
     static protected class TypeGroup {
         @JsonProperty("id")
         protected String id;

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -69,19 +69,13 @@ import org.apache.commons.fileupload.ProgressListener;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
 import org.apache.commons.fileupload.util.Streams;
-import org.apache.http.HttpEntity;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.entity.ContentType;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
-import org.apache.http.StatusLine;
+import org.apache.hc.client5.http.ClientProtocolException;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,10 +83,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.ProjectManager;
 import com.google.refine.ProjectMetadata;
-import com.google.refine.RefineServlet;
 import com.google.refine.importing.ImportingManager.Format;
 import com.google.refine.importing.UrlRewriter.Result;
 import com.google.refine.model.Project;
+import com.google.refine.util.HttpClient;
 import com.google.refine.util.JSONUtilities;
 import com.google.refine.util.ParsingUtilities;
 import java.util.stream.Collectors;
@@ -287,65 +281,56 @@ public class ImportingUtilities {
                     }
 
                     if ("http".equals(url.getProtocol()) || "https".equals(url.getProtocol())) {
-                        HttpClientBuilder clientbuilder = HttpClients.custom()
-                                .setUserAgent(RefineServlet.getUserAgent());
-//                                .setConnectionBackoffStrategy(ConnectionBackoffStrategy)
+                        final URL lastUrl = url;
+                        final HttpClientResponseHandler<String> responseHandler = new HttpClientResponseHandler<String>() {
 
-                        String userinfo = url.getUserInfo();
-                        // HTTPS only - no sending password in the clear over HTTP
-                        if ("https".equals(url.getProtocol()) && userinfo != null) {
-                            int s = userinfo.indexOf(':');
-                            if (s > 0) {
-                                String user = userinfo.substring(0, s);
-                                String pw = userinfo.substring(s + 1, userinfo.length());
-                                CredentialsProvider credsProvider = new BasicCredentialsProvider();
-                                credsProvider.setCredentials(new AuthScope(url.getHost(), 443),
-                                        new UsernamePasswordCredentials(user, pw));
-                                clientbuilder = clientbuilder.setDefaultCredentialsProvider(credsProvider);
-                            }
-                        }
+                            @Override
+                            public String handleResponse(final ClassicHttpResponse response) throws IOException {
+                                final int status = response.getCode();
+                                if (status >= HttpStatus.SC_SUCCESS && status < HttpStatus.SC_REDIRECTION) {
+                                    final HttpEntity entity = response.getEntity();
+                                    if (entity == null) {
+                                        throw new IOException("No content found in " + lastUrl.toExternalForm());
+                                    }
 
-                        CloseableHttpClient httpclient = clientbuilder.build();
-                        HttpGet httpGet = new HttpGet(url.toURI());
-                        CloseableHttpResponse response = httpclient.execute(httpGet);
+                                    try {
+                                    InputStream stream2 = entity.getContent();
 
-                        try {
-                            HttpEntity entity = response.getEntity();
-                            if (entity == null) {
-                                throw new Exception("No content found in " + url.toString());
-                            }
-                            StatusLine status = response.getStatusLine();
-                            int statusCode = response.getStatusLine().getStatusCode();
-                            if (statusCode >= 400) {
-                                String errorString = ParsingUtilities.inputStreamToString(entity.getContent());
-                                String message = String.format("HTTP error %d : %s | %s", statusCode,
-                                        status.getReasonPhrase(), errorString);
-                                throw new Exception(message);
-                            }
-                            InputStream stream2 = entity.getContent();
+                                    String mimeType = null;
+                                    String charset = null;
+                                    ContentType contentType = ContentType.parse(entity.getContentType());
+                                    if (contentType != null) {
+                                        mimeType = contentType.getMimeType();
+                                        Charset cs = contentType.getCharset();
+                                        if (cs != null) {
+                                            charset = cs.toString();
+                                        }
+                                    }
+                                    JSONUtilities.safePut(fileRecord, "declaredMimeType", mimeType);
+                                    JSONUtilities.safePut(fileRecord, "declaredEncoding", charset);
+                                    if (saveStream(stream2, lastUrl, rawDataDir, progress, update,
+                                            fileRecord, fileRecords,
+                                            entity.getContentLength())) {
+                                        return "saved"; // signal to increment archive count
+                                    }
 
-                            String mimeType = null;
-                            String charset = null;
-                            ContentType contentType = ContentType.get(entity);
-                            if (contentType != null) {
-                                mimeType = contentType.getMimeType();
-                                Charset cs = contentType.getCharset();
-                                if (cs != null) {
-                                    charset = cs.toString();
+                                    } catch (final IOException ex) {
+                                        throw new ClientProtocolException(ex);
+                                    }
+                                    return null;
+                                } else {
+                                    // String errorBody = EntityUtils.toString(response.getEntity());
+                                    throw new ClientProtocolException(String.format("HTTP error %d : %s for URL %s", status,
+                                            response.getReasonPhrase(), lastUrl.toExternalForm()));
                                 }
                             }
-                            JSONUtilities.safePut(fileRecord, "declaredMimeType", mimeType);
-                            JSONUtilities.safePut(fileRecord, "declaredEncoding", charset);
-                            if (saveStream(stream2, url, rawDataDir, progress, update,
-                                    fileRecord, fileRecords,
-                                    entity.getContentLength())) {
-                                archiveCount++;
-                            }
-                            downloadCount++;
-                            EntityUtils.consume(entity);
-                        } finally {
-                            httpGet.reset();
-                        }
+                        };
+
+                        HttpClient httpClient = new HttpClient();
+                        if (httpClient.getResponse(urlString, null, responseHandler) != null) {
+                            archiveCount++;
+                        };
+                        downloadCount++;
                     } else {
                         // Fallback handling for non HTTP connections (only FTP?)
                         URLConnection urlConnection = url.openConnection();
@@ -418,7 +403,7 @@ public class ImportingUtilities {
 
     private static boolean saveStream(InputStream stream, URL url, File rawDataDir, final Progress progress,
             final SavingUpdate update, ObjectNode fileRecord, ArrayNode fileRecords, long length)
-            throws IOException, Exception {
+            throws IOException {
         String localname = url.getPath();
         if (localname.isEmpty() || localname.endsWith("/")) {
             localname = localname + "temp";
@@ -436,7 +421,7 @@ public class ImportingUtilities {
         long actualLength = saveStreamToFile(stream, file, update);
         JSONUtilities.safePut(fileRecord, "size", actualLength);
         if (actualLength == 0) {
-            throw new Exception("No content found in " + url.toString());
+            throw new IOException("No content found in " + url.toString());
         } else if (length >= 0) {
             update.totalExpectedSize += (actualLength - length);
         } else {

--- a/main/src/com/google/refine/model/recon/ReconciledDataExtensionJob.java
+++ b/main/src/com/google/refine/model/recon/ReconciledDataExtensionJob.java
@@ -37,29 +37,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.model.recon;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.apache.http.Consts;
-import org.apache.http.NameValuePair;
-import org.apache.http.StatusLine;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.impl.client.LaxRedirectStrategy;
-import org.apache.http.message.BasicNameValuePair;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -69,13 +54,14 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.refine.RefineServlet;
 import com.google.refine.expr.functions.ToDate;
 import com.google.refine.model.ReconCandidate;
 import com.google.refine.model.ReconType;
+import com.google.refine.util.HttpClient;
 import com.google.refine.util.JSONUtilities;
 import com.google.refine.util.JsonViews;
 import com.google.refine.util.ParsingUtilities;
+
 
 public class ReconciledDataExtensionJob {
 
@@ -170,15 +156,23 @@ public class ReconciledDataExtensionJob {
     final public DataExtensionConfig extension;
     final public String              endpoint;
     final public List<ColumnInfo>    columns = new ArrayList<ColumnInfo>();
-    
+
     // not final: initialized lazily
-    private static CloseableHttpClient httpClient = null;
-    
+    private static HttpClient httpClient = null;
+
     public ReconciledDataExtensionJob(DataExtensionConfig obj, String endpoint) {
         this.extension = obj;
         this.endpoint = endpoint;
     }
-    
+
+    /**
+     * @todo Although the HTTP code has been unified, there may still be opportunity
+     * to refactor a higher level querying library out of this which could be shared
+     * with StandardReconConfig
+     *
+     * It may also be possible to extract a library to query reconciliation services
+     * which could be used outside of OpenRefine.
+     */
     public Map<String, ReconciledDataExtensionJob.DataExtension> extend(
         Set<String> ids,
         Map<String, ReconCandidate> reconCandidateMap
@@ -187,7 +181,7 @@ public class ReconciledDataExtensionJob {
         formulateQuery(ids, extension, writer);
 
         String query = writer.toString();
-        String response = performQuery(this.endpoint, query);
+        String response = postExtendQuery(this.endpoint, query);
 
         ObjectNode o = ParsingUtilities.mapper.readValue(response, ObjectNode.class);
 
@@ -218,46 +212,17 @@ public class ReconciledDataExtensionJob {
         return map;
     }
 
-    /**
-     * @todo this should be refactored to be unified with the HTTP querying code
-     * from StandardReconConfig. We should ideally extract a library to query
-     * reconciliation services and expose it as such for others to reuse.
-     */
-    
-    static protected String performQuery(String endpoint, String query) throws IOException {
-        HttpPost request = new HttpPost(endpoint);
-        List<NameValuePair> body = Collections.singletonList(
-                new BasicNameValuePair("extend", query));
-        request.setEntity(new UrlEncodedFormEntity(body, Consts.UTF_8));
-        
-        try (CloseableHttpResponse response = getHttpClient().execute(request)) {
-            StatusLine statusLine = response.getStatusLine();
-            if (statusLine.getStatusCode() >= 400) {
-                throw new IOException("Data extension query failed - code: "
-                        + Integer.toString(statusLine.getStatusCode())
-                        + " message: " + statusLine.getReasonPhrase());
-            } else {
-                return ParsingUtilities.inputStreamToString(response.getEntity().getContent());
-            }
-        }
+    static protected String postExtendQuery(String endpoint, String query) throws IOException {
+        return getHttpClient().postNameValue(endpoint, "extend", query);
     }
 
-    private static CloseableHttpClient getHttpClient() {
-        if (httpClient != null) {
-            return httpClient;
+    private static HttpClient getHttpClient() {
+        if (httpClient == null) {
+            httpClient = new HttpClient();
         }
-        RequestConfig defaultRequestConfig = RequestConfig.custom()
-                .setConnectTimeout(30 * 1000)
-                .build();
-
-        HttpClientBuilder httpClientBuilder = HttpClients.custom()
-                .setUserAgent(RefineServlet.getUserAgent())
-                .setRedirectStrategy(new LaxRedirectStrategy())
-                .setDefaultRequestConfig(defaultRequestConfig);
-        httpClient = httpClientBuilder.build();
         return httpClient;
     }
-    
+
     protected ReconciledDataExtensionJob.DataExtension collectResult(
         ObjectNode record,
         Map<String, ReconCandidate> reconCandidateMap

--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -125,6 +125,7 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
     private Header[] httpHeaders = new Header[0];
     final private RequestConfig defaultRequestConfig;
     private HttpClientBuilder httpClientBuilder;
+    private CloseableHttpClient httpclient;
 
     @JsonCreator
     public ColumnAdditionByFetchingURLsOperation(
@@ -217,7 +218,8 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
 
                     }
                 });
-                ;
+        httpclient = httpClientBuilder.build();
+
     }
 
     @JsonProperty("newColumnName")
@@ -417,7 +419,7 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
                 return null;
             }
 
-            try (CloseableHttpClient httpclient = httpClientBuilder.build();) { //HttpClients.createDefault()) {
+            try { //HttpClients.createDefault()) {
                 httpGet.setHeaders(httpHeaders);
                 httpGet.setConfig(defaultRequestConfig);
 

--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -430,13 +430,13 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
                     String reasonPhrase = response.getReasonPhrase();
                     int statusCode = response.getCode();
                     if (statusCode >= 400) { // We should never see 3xx since they get handled automatically
-                        throw new Exception(String.format("Got error %d : %s for URL %s", statusCode, reasonPhrase,
+                        throw new IOException(String.format("Got error %d : %s for URL %s", statusCode, reasonPhrase,
                                 httpGet.getRequestUri()));
                     }
 
                     HttpEntity entity = response.getEntity();
                     if (entity == null) {
-                        throw new Exception("No content found in " + httpGet.getRequestUri());
+                        throw new IOException("No content found in " + httpGet.getRequestUri());
                     }
 
                     String encoding = null;

--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -407,6 +407,12 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
                 CloseableHttpResponse response = null;
                 try {
                     response = httpclient.execute(httpGet);
+                    String reasonPhrase = response.getReasonPhrase();
+                    int statusCode = response.getCode();
+                    if (statusCode >= 400) { // We should never see 3xx since they get handled automatically
+                        throw new Exception(String.format("Got error %d : %s for URL %s", statusCode, reasonPhrase,
+                                httpGet.getRequestUri()));
+                    }
 
                     HttpEntity entity = response.getEntity();
                     if (entity == null) {

--- a/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
@@ -29,6 +29,7 @@ package com.google.refine.importing;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -98,8 +99,6 @@ public class ImportingUtilitiesTests extends ImporterTest {
     public void urlImporting() throws IOException {
 
         String RESPONSE_BODY = "{code:401,message:Unauthorised}";
-        String MESSAGE = String.format("HTTP error %d : %s | %s", 401,
-                "Client Error", RESPONSE_BODY);
 
         MockWebServer server = new MockWebServer();
         MockResponse mockResponse = new MockResponse();
@@ -108,6 +107,8 @@ public class ImportingUtilitiesTests extends ImporterTest {
         server.start();
         server.enqueue(mockResponse);
         HttpUrl url = server.url("/random");
+        String MESSAGE = String.format("HTTP error %d : %s for URL %s", 401,
+                "Client Error", url);
 
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
         StringBody stringBody = new StringBody(url.toString(), ContentType.MULTIPART_FORM_DATA);
@@ -145,9 +146,9 @@ public class ImportingUtilitiesTests extends ImporterTest {
                     return job.canceled;
                 }
             });
-            Assert.fail("No Exception was thrown");
+            fail("No Exception was thrown");
         } catch (Exception exception) {
-            Assert.assertEquals(MESSAGE, exception.getMessage());
+            assertEquals(exception.getMessage(), MESSAGE);
         } finally {
             server.close();
         }

--- a/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -91,7 +91,7 @@ public class StandardReconConfigTests extends RefineTest {
             return wordDistance(s1, s2);
         }
         
-        protected Recon createReconServiceResults(String text, ArrayNode resultsList, long historyEntryID) throws IOException {
+        protected Recon createReconServiceResults(String text, ArrayNode resultsList, long historyEntryID) {
         	return super.createReconServiceResults(text, resultsList, historyEntryID);
         }
     }

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -132,7 +132,7 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
         } catch (InterruptedException e) {
             Assert.fail("Test interrupted");
         }
-        Assert.assertFalse(process.isRunning());
+        Assert.assertFalse(process.isRunning(),"Process failed to complete within timeout " + timeout);
     }
 
     @Test
@@ -314,10 +314,10 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
 
             // Make sure that our Retry-After headers were obeyed (4*1 sec vs 4*100msec)
             long elapsed = System.currentTimeMillis() - start;
-            assertTrue(elapsed > 4000);
+            assertTrue(elapsed > 4000, "Retry-After retries didn't take long enough - elapsed = " + elapsed );
 
             // 1st row fails after 4 tries (3 retries), 2nd row tries twice and gets value
-            assertTrue(project.rows.get(0).getCellValue(1).toString().contains("Got error 429"));
+            assertTrue(project.rows.get(0).getCellValue(1).toString().contains("HTTP error 429"), "missing 429 error");
             assertEquals(project.rows.get(1).getCellValue(1).toString(), "success");
 
             server.shutdown();
@@ -362,12 +362,12 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
 
             // Make sure that our exponential back off is working
             long elapsed = System.currentTimeMillis() - start;
-            assertTrue(elapsed > 1600);
+            assertTrue(elapsed > 1600, "Exponential retries didn't take enough time - elapsed = " + elapsed);
 
             // 1st row fails after 4 tries (3 retries), 2nd row tries twice and gets value, 3rd row is hard error
-            assertTrue(project.rows.get(0).getCellValue(1).toString().contains("Got error 503"));
+            assertTrue(project.rows.get(0).getCellValue(1).toString().contains("HTTP error 503"), "Missing 503 error");
             assertEquals(project.rows.get(1).getCellValue(1).toString(), "success");
-            assertTrue(project.rows.get(2).getCellValue(1).toString().contains("Got error 404"));
+            assertTrue(project.rows.get(2).getCellValue(1).toString().contains("HTTP error 404"),"Missing 404 error");
 
             server.shutdown();
         }

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -272,5 +275,52 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
             server.shutdown();
         }
     }
+
+    @Test
+    public void testRetries() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.start();
+            HttpUrl url = server.url("/retries");
+
+            for (int i = 0; i < 2; i++) {
+                Row row = new Row(2);
+                row.setCell(0, new Cell("test" + (i + 1), null));
+                project.rows.add(row);
+            }
+
+            // Queue 4  error responses with 1 sec. Retry-After interval
+            for (int i = 0; i < 4; i++) {
+                server.enqueue(new MockResponse()
+                        .setHeader("Retry-After", 1)
+                        .setResponseCode(429)
+                        .setBody(Integer.toString(i,10)));
+            }
+
+            server.enqueue(new MockResponse().setBody("success"));
+
+            EngineDependentOperation op = new ColumnAdditionByFetchingURLsOperation(engine_config,
+                    "fruits",
+                    "\"" + url + "?city=\"+value",
+                    OnError.StoreError,
+                    "rand",
+                    1,
+                    100,
+                    false,
+                    null);
+
+            // 4 requests (3 retries @1 sec) + final response
+            long start = System.currentTimeMillis();
+            runAndWait(op, 3600);
+            // Make sure that our Retry-After headers were obeyed (3*1 sec vs 3*100msec)
+            long elapsed = System.currentTimeMillis() - start;
+            assertTrue(elapsed > 3000);
+
+            // Inspect rows - 1st row fails 3 retries, 2nd row retries twice and gets value
+            assertTrue(project.rows.get(0).getCellValue(1).toString().contains("Got error 429"));
+            assertEquals(project.rows.get(1).getCellValue(1).toString(), "success");
+            server.shutdown();
+        }
+    }
+
 
 }

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -358,7 +358,7 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
 
             // 6 requests (4 retries 200, 400, 800, 200 msec) + final response
             long start = System.currentTimeMillis();
-            runAndWait(op, 2000);
+            runAndWait(op, 2500);
 
             // Make sure that our exponential back off is working
             long elapsed = System.currentTimeMillis() - start;

--- a/main/tests/server/src/com/google/refine/operations/recon/ExtendDataOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ExtendDataOperationTests.java
@@ -38,9 +38,7 @@ import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,7 +47,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.commons.io.IOUtils;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
@@ -225,7 +222,6 @@ public class ExtendDataOperationTests extends RefineTest {
      * Test to fetch simple strings
      * @throws Exception 
      */
-    
     @BeforeMethod
     public void mockHttpCalls() throws Exception {
     	mockStatic(ReconciledDataExtensionJob.class);
@@ -236,9 +232,9 @@ public class ExtendDataOperationTests extends RefineTest {
 				return fakeHttpCall(invocation.getArgument(0), invocation.getArgument(1));
 			}
     	};
-    	PowerMockito.doAnswer(mockedResponse).when(ReconciledDataExtensionJob.class, "performQuery", anyString(), anyString());
+    	PowerMockito.doAnswer(mockedResponse).when(ReconciledDataExtensionJob.class, "postExtendQuery", anyString(), anyString());
     }
-    
+
     @AfterMethod
     public void cleanupHttpMocks() {
     	mockedResponses.clear();


### PR DESCRIPTION
Fixes #3129. 

Makes the following improvements to the Fetch URL code:
- switches to Apache [HTTP Client 5.0.2](https://www.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-5.0.x.txt) including support for HTTP/2 as well as automatic retries and other general improvements
- reuses HTTP client across requests for the entire operation rather than rebuilding it for every request to improve connection reuse and not pay connection setup cost every time (especially bad for HTTPS)
- honors Retry-After header (built-in support), but if none specified uses binary exponential backup (default is single retry at 1 sec.)
- computes interrequest delay using a request interceptor

~~Because the namespace was changed, the new client can coexist with the old client, but we should probably abstract this out into a reusable class that can be reused by project creation, reconciliation, etc.~~

I went ahead and split things out into their own reusable class and extended it to support POSTs as well as GETs so that it could be used for reconciliation too.