### PR TITLE
Add Java runtime name & version to About page - fixes #3240

### DIFF
--- a/main/src/com/google/refine/commands/GetVersionCommand.java
+++ b/main/src/com/google/refine/commands/GetVersionCommand.java
@@ -44,17 +44,26 @@ import com.google.refine.RefineServlet;
 
 public class GetVersionCommand extends Command {
 
-	protected class VersionResponse {
-		@JsonProperty("version")
-		public String version = RefineServlet.VERSION;
-		@JsonProperty("revision")
-		public String revision = RefineServlet.REVISION;
-		@JsonProperty("full_version")
-		public String full_version = RefineServlet.FULL_VERSION;
-		@JsonProperty("full_name")
-		public String full_name = RefineServlet.FULLNAME;
-	}
-    
+    protected class VersionResponse {
+        @JsonProperty("version")
+        public String version = RefineServlet.VERSION;
+        @JsonProperty("revision")
+        public String revision = RefineServlet.REVISION;
+        @JsonProperty("full_version")
+        public String full_version = RefineServlet.FULL_VERSION;
+        @JsonProperty("full_name")
+        public String full_name = RefineServlet.FULLNAME;
+        @JsonProperty("java_vm_name")
+        public String java_vm_name = System.getProperty("java.vm.name", "?");
+        @JsonProperty("java_vm_version")
+        public String java_vm_version = System.getProperty("java.vm.version", "?");
+        @JsonProperty("java_runtime_name")
+        public String java_runtime_name = System.getProperty("java.runtime.name", "?");
+        @JsonProperty("java_runtime_version")
+        // public String java_runtime_version = Runtime.getRuntime().version(); // Java 9 or later
+        public String java_runtime_version = System.getProperty("java.runtime.version", "?");
+    }
+
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         respondJSON(response, new VersionResponse());

--- a/main/webapp/modules/core/about.html
+++ b/main/webapp/modules/core/about.html
@@ -54,18 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <script type="text/javascript" src="externals/languages/fi.js"></script>
     <script type="text/javascript" src="externals/languages/ru.js"></script>
     <script type="text/javascript" src="scripts/index.js"></script>
-    <script>
-      $(function() {
-        if (OpenRefineVersion && OpenRefineVersion.version) {
-          if (OpenRefineVersion.version != "$VERSION") {
-            $("#openrefine-version").text($.i18n("core-index/version", OpenRefineVersion.version + " [" + OpenRefineVersion.revision + "]"));
-          }
-          else {
-            $("#openrefine-version").text($.i18n("core-index/version", "[HEAD]"));
-          }
-        }
-      });
-    </script>
+
   </head>
   <body>
     <div id="header">
@@ -74,7 +63,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
     <div id="body-info">
       <h1>About OpenRefine</h1>
+      <!-- The following two IDs must match those in index.vt/index.js -->
       <h2 id="openrefine-version"></h2>
+      <h3 id="java-runtime-version"></h3>
       
       <p>
         OpenRefine is a power tool for working with messy data. Use it to improve data consistency,
@@ -135,7 +126,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <h2>OpenRefine License</h2>
             
 <pre class="license">
-Copyright 2010-2012, Google Inc. and contributors
+Copyright 2010-2020, Google Inc. and contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/main/webapp/modules/core/scripts/index.js
+++ b/main/webapp/modules/core/scripts/index.js
@@ -134,6 +134,7 @@ $(function() {
           OpenRefineVersion = data;
 
           $("#openrefine-version").text($.i18n('core-index/version', OpenRefineVersion.full_version));
+          $("#java-runtime-version").text(OpenRefineVersion.java_runtime_name + " " + OpenRefineVersion.java_runtime_version);
 
             $.getJSON("https://api.github.com/repos/openrefine/openrefine/releases/latest",
              function( data ) {

--- a/main/webapp/modules/core/styles/index.less
+++ b/main/webapp/modules/core/styles/index.less
@@ -76,7 +76,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   font-size: 1.3em;
   position: absolute;
   bottom: 0;
-  left: 0;
+  left: -5px;
   width: 100%;
   text-align: center;
   }


### PR DESCRIPTION
Fixes #3240. 

- Adds Java runtime name and version to the GetVersionCommand
- Displays the returned information on the About page. 
- Removes non-functional (and confusing!) embedded in the HTML on the About page.

Also minor cosmetic fixup to lower left corner of home page to visually center elements.