### PR TITLE
Make it possible to view more than 50 rows

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -186,7 +186,7 @@ DataTableView.prototype._renderPagingControls = function(pageSizeControls, pagin
   }
 
   $('<span>'+$.i18n('core-views/show')+': </span>').appendTo(pageSizeControls);
-  var sizes = [ 5, 10, 25, 50 ];
+  var sizes = [ 5, 10, 25, 100, 500, 1000 ];
   var renderPageSize = function(index) {
     var pageSize = sizes[index];
     var a = $('<a href="javascript:{}"></a>')


### PR DESCRIPTION
Adding the options 100, 500, 1000.

**Motivation**

I have in my own OpenRefine had these options for a while and I have found that it saves scrolling and context switching time when one needs to manually go through large amounts of data, by making sure one does not need to scroll up to access the pagination navigation.

**Notes**

I have tested the performance of this on two computers and I don't think even the 1000 option will be problematic on most modern computers.

The only past issue on the subject I'm aware of is #3087 