### PR TITLE
Narrow permissiveness for fields on null & catch more GREL syntax errors

### DIFF
--- a/main/src/com/google/refine/grel/Parser.java
+++ b/main/src/com/google/refine/grel/Parser.java
@@ -111,6 +111,10 @@ public class Parser {
     protected Evaluable parseSubExpression() throws ParsingException {
         Evaluable sub = parseTerm();
 
+        if (_token != null && _token.type != TokenType.Operator && _token.type != TokenType.Delimiter) {
+            throw makeException("Expecting an operator or delimiter here");
+        }
+
         while (_token != null &&
                 _token.type == TokenType.Operator &&
                 "+-".indexOf(_token.text) >= 0) {
@@ -133,6 +137,10 @@ public class Parser {
      */
     protected Evaluable parseTerm() throws ParsingException {
         Evaluable factor = parseFactor();
+
+        if (_token != null && _token.type != TokenType.Operator && _token.type != TokenType.Delimiter) {
+            throw makeException("Expecting an operator or delimiter here");
+        }
 
         while (_token != null &&
                 _token.type == TokenType.Operator &&
@@ -248,7 +256,9 @@ public class Parser {
         }
 
         while (_token != null) {
-            if (_token.type == TokenType.Operator && _token.text.equals(".")) {
+            if (_token.type == TokenType.Error) {
+                throw makeException("Parse error");
+            } else if (_token.type == TokenType.Operator && _token.text.equals(".")) {
                 next(false); // swallow .
 
                 if (_token == null || _token.type != TokenType.Identifier) {

--- a/main/src/com/google/refine/grel/Scanner.java
+++ b/main/src/com/google/refine/grel/Scanner.java
@@ -134,7 +134,8 @@ public class Scanner {
                 _index++;
             }
 
-            if (_index < _limit && (c == '.' || c == 'e')) {
+            if (_index + 1 < _limit && (c == '.' /* || c == 'e'*/)
+                    && Character.isDigit(_text.charAt(_index + 1))) {
                 double value2 = value;
                 if (c == '.') {
                     _index++;
@@ -145,11 +146,10 @@ public class Scanner {
                         division *= 10;
                         _index++;
                     }
-
                     value2 /= division;
+                } else if (c == 'e') {
+                    // TODO: support scientific notation
                 }
-
-                // TODO: support exponent e notation
 
                 return new NumberToken(
                     start,

--- a/main/src/com/google/refine/grel/ast/FieldAccessorExpr.java
+++ b/main/src/com/google/refine/grel/ast/FieldAccessorExpr.java
@@ -37,6 +37,7 @@ import java.util.Properties;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.HasFields;
@@ -62,14 +63,17 @@ public class FieldAccessorExpr implements Evaluable {
         if (ExpressionUtils.isError(o)) {
             return o; // bubble the error up
         } else if (o == null) {
-            return null;
+            if ("value".equals(_fieldName)) {
+                return null;
+            }
+            return new EvalError("Cannot retrieve field from null");
         } else if (o instanceof HasFields) {
             return ((HasFields) o).getField(_fieldName, bindings);
         } else if (o instanceof ObjectNode) {
-        	JsonNode value = ((ObjectNode) o).get(_fieldName);
-        	return JsonValueConverter.convert(value);
+            JsonNode value = ((ObjectNode) o).get(_fieldName);
+            return JsonValueConverter.convert(value);
         } else {
-            return null;
+            return new EvalError("No accessible fields available");
         }
     }
 

--- a/main/src/com/google/refine/grel/ast/OperatorCallExpr.java
+++ b/main/src/com/google/refine/grel/ast/OperatorCallExpr.java
@@ -35,6 +35,7 @@ package com.google.refine.grel.ast;
 
 import java.util.Properties;
 
+import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 
@@ -138,7 +139,7 @@ public class OperatorCallExpr implements Evaluable {
                 }
             }
         }
-        return null;
+        return new EvalError("Unrecognized operator: " + _op);
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -72,6 +72,7 @@ import com.google.refine.model.Column;
 import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
+import com.google.refine.util.StringUtils;
 import com.google.refine.util.TestUtils;
 
 import edu.mit.simile.butterfly.ButterflyModule;
@@ -347,7 +348,9 @@ public class RefineTest extends PowerMockTestCase {
     throws ParsingException {
         Evaluable eval = MetaParser.parse("grel:" + test[0]);
         Object result = eval.evaluate(bindings);
-        Assert.assertEquals(result.toString(), test[1], "Wrong result for expression: " + test[0]);
+        if (result != test[1]) { // special case null
+            Assert.assertEquals(StringUtils.toString(result), test[1], "Wrong result for expression: " + test[0]);
+        }
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/expr/functions/GetTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/GetTests.java
@@ -26,10 +26,11 @@
  ******************************************************************************/
 package com.google.refine.expr.functions;
 
+import static org.testng.Assert.assertNull;
+
 import java.util.Properties;
 
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
@@ -67,16 +68,48 @@ public class GetTests extends RefineTest {
     }
 
     @Test
+    public void testGetFieldFromNull() throws ParsingException {
+        String test[] = { "null.get('value')", null };
+        parseEval(bindings, test);
+        String test2[] = { "get(null,'value')", null };
+        parseEval(bindings, test2);
+        String test3[] = { "get(null,'foo')", null }; // FIXME: should be an error
+        parseEval(bindings, test3);
+    }
+
+    @Test
+    public void testGetSubstring() throws ParsingException {
+        String test[] = { "'abc'.get(2)", "c" };
+        parseEval(bindings, test);
+        String test2[] = { "get('abcd', 1, 3)", "bc" };
+        parseEval(bindings, test2);
+        String test3[] = { "get('abcd', 1, 10)", "bcd" };
+        parseEval(bindings, test3);
+        String test4[] = { "get(null, 2)", null }; // FIXME: should be an error?
+        parseEval(bindings, test4);
+    }
+
+    @Test
+    public void testGetArraySlice() throws ParsingException {
+        String test[] = { "[1,2,3].get(2)", "3" };
+        parseEval(bindings, test);
+        String test2[] = { "get([1,2,3,4], 1, 3)", "[2, 3]" };
+        parseEval(bindings, test2);
+        String test3[] = { "get([1,2,3,4], 1, 10)", "[2, 3, 4]" };
+        parseEval(bindings, test3);
+    }
+
+    @Test
     public void testGetJsonFieldExists() throws ParsingException {
-        String test[] = { "\"[{\\\"one\\\": \\\"1\\\"}]\".parseJson()[0].one", "1" };
+        String test[] = { "\"[{\\\"one\\\": \\\"1\\\"}]\".parseJson()[0].get('one')", "1" };
         parseEval(bindings, test);
     }
 
     @Test
     public void testGetJsonFieldAbsent() throws ParsingException {
-        String test =  "\"[{\\\"one\\\": \\\"1\\\"}]\".parseJson()[0].two";
+        String test =  "\"[{\\\"one\\\": \\\"1\\\"}]\".parseJson()[0].get('two')";
         Evaluable eval = MetaParser.parse("grel:" + test);
-        Assert.assertNull(eval.evaluate(bindings));
+        assertNull(eval.evaluate(bindings));
     }
 
 }

--- a/main/tests/server/src/com/google/refine/grel/FunctionTests.java
+++ b/main/tests/server/src/com/google/refine/grel/FunctionTests.java
@@ -109,7 +109,7 @@ public class FunctionTests extends RefineTest {
         Set<String> valid0args = new HashSet<>(Arrays.asList("now")); // valid 0-arg returns datetype
         // Not sure which, if any, of these are intended, but fixing them may break existing scripts
         Set<String> returnsNull = new HashSet<>(Arrays.asList("chomp", "contains", "escape", "unescape", "exp",
-                "fingerprint", "get", "jsonize", "parseJson", "partition", "pow", "rpartition",
+                "fingerprint", "jsonize", "parseJson", "partition", "pow", "rpartition",
                 "slice", "substring", // synonyms for Slice
                 "unicode", "unicodeType"
                 ));
@@ -132,7 +132,7 @@ public class FunctionTests extends RefineTest {
     void testTooManyArgs() {
         // Not sure which, if any, of these are intended, but fixing them may break existing scripts
         Set<String> returnsNull = new HashSet<>(Arrays.asList("chomp", "contains", "coalesce", "escape", "unescape",
-                "exp", "fingerprint", "get", "now", "parseJson", "partition", "pow", "rpartition",
+                "exp", "fingerprint", "now", "parseJson", "partition", "pow", "rpartition",
                 "slice", "substring", // synonyms for Slice
                 "unicode", "unicodeType"
                 ));

--- a/main/tests/server/src/com/google/refine/grel/GrelTests.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTests.java
@@ -168,6 +168,19 @@ public class GrelTests extends RefineTest {
     }
 
     @Test
+    public void testGetJsonFieldExists() throws ParsingException {
+        String test[] = { "\"[{\\\"one\\\": \\\"1\\\"}]\".parseJson()[0].one", "1" };
+        parseEval(bindings, test);
+    }
+
+    @Test
+    public void testGetJsonFieldAbsent() throws ParsingException {
+        String test =  "\"[{\\\"one\\\": \\\"1\\\"}]\".parseJson()[0].two";
+        Evaluable eval = MetaParser.parse("grel:" + test);
+        Assert.assertNull(eval.evaluate(bindings));
+    }
+
+    @Test
     public void testJoinJsonArray() throws ParsingException {
         String test[] = { "\"{\\\"values\\\":[\\\"one\\\",\\\"two\\\",\\\"three\\\"]}\".parseJson().values.join(\",\")", "one,two,three" };
         parseEval(bindings, test);

--- a/main/tests/server/src/com/google/refine/grel/GrelTests.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTests.java
@@ -33,10 +33,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.grel;
 
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
 import java.util.Properties;
 
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
@@ -91,7 +94,7 @@ public class GrelTests extends RefineTest {
                 // Test succeeded
                 continue;
             }
-            Assert.fail("Expression failed to generate parse syntax error: " + test);
+            fail("Expression failed to generate parse syntax error: " + test);
         }
     }
 
@@ -105,9 +108,9 @@ public class GrelTests extends RefineTest {
             try {
                 Evaluable eval = MetaParser.parse("grel:" + test);
                 Object result = eval.evaluate(bindings);
-                Assert.assertTrue(result instanceof EvalError );
+                assertTrue(result instanceof EvalError );
             } catch (ParsingException e) {
-                Assert.fail("Unexpected parse failure: " + test);                
+                fail("Unexpected parse failure: " + test);
             }
         }
     }
@@ -177,7 +180,7 @@ public class GrelTests extends RefineTest {
     public void testGetJsonFieldAbsent() throws ParsingException {
         String test =  "\"[{\\\"one\\\": \\\"1\\\"}]\".parseJson()[0].two";
         Evaluable eval = MetaParser.parse("grel:" + test);
-        Assert.assertNull(eval.evaluate(bindings));
+        assertNull(eval.evaluate(bindings));
     }
 
     @Test
@@ -188,23 +191,25 @@ public class GrelTests extends RefineTest {
 
     @Test
     public void testGetFieldFromNull() throws ParsingException {
-        String test =  "null.value";
+        String test =  "null.value"; // special case evaluates to null
         Evaluable eval = MetaParser.parse("grel:" + test);
-        Assert.assertNull(eval.evaluate(bindings));
+        assertNull(eval.evaluate(bindings));
+        Evaluable eval2 = MetaParser.parse("grel:null.foo"); // all others error
+        assertTrue(eval2.evaluate(bindings) instanceof EvalError);
     }
-    
+
     // to demonstrate bug fixing for #1204
     @Test
     public void testCrossFunctionEval() {
-            String test = "cross(\"Mary\", \"My Address Book\", \"friend\")";
-            
-            try {
-                Evaluable eval = MetaParser.parse("grel:" + test);
-                Object result = eval.evaluate(bindings);
-                Assert.assertTrue(result instanceof EvalError );
-            } catch (ParsingException e) {
-                Assert.fail("Unexpected parse failure for cross function: " + test);                
-            }
+        String test = "cross(\"Mary\", \"My Address Book\", \"friend\")";
+
+        try {
+            Evaluable eval = MetaParser.parse("grel:" + test);
+            Object result = eval.evaluate(bindings);
+            assertTrue(result instanceof EvalError );
+        } catch (ParsingException e) {
+            fail("Unexpected parse failure for cross function: " + test);
+        }
     }
 
 }

--- a/main/tests/server/src/com/google/refine/grel/GrelTests.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTests.java
@@ -88,7 +88,7 @@ public class GrelTests extends RefineTest {
                 "2^3",
                 "1 2",
                 "'a' 'b'",
-                "1e3" // TODO: error until scientific notation implementation done
+                "1e3", // TODO: error until scientific notation implementation done
                 };
         for (String test : tests) {
             try{
@@ -106,6 +106,8 @@ public class GrelTests extends RefineTest {
         String tests[] = {
                 "1=1",
                 "value.datePart()",
+                "[1['a','b','c']]", // issue #2507
+                "value.endsWith(\"ROAD\")))))*&(&#37;!#(&)", // issue #169
                 };
         for (String test : tests) {
             try {

--- a/main/tests/server/src/com/google/refine/grel/GrelTests.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTests.java
@@ -85,7 +85,10 @@ public class GrelTests extends RefineTest {
                 "",
                 "1-1-",
                 "2**3",
-//                "2^3" // TODO: Should this generate an error?
+                "2^3",
+                "1 2",
+                "'a' 'b'",
+                "1e3" // TODO: error until scientific notation implementation done
                 };
         for (String test : tests) {
             try{
@@ -101,7 +104,7 @@ public class GrelTests extends RefineTest {
     @Test
     public void testEvalError() {
         String tests[] = {
-//                "1=1", // TODO: Throws NullPointerException
+                "1=1",
                 "value.datePart()",
                 };
         for (String test : tests) {
@@ -124,7 +127,8 @@ public class GrelTests extends RefineTest {
                 { "1-1-1", "-1" }, 
                 { "1-2-3", "-4" }, 
                 { "1-(2-3)", "2" }, 
-                { "2*3", "6" }, 
+                { "2*3", "6" },
+                { "2.0*3", "6.0" },
                 { "3%2", "1" }, 
                 { "3/2", "1" },
                 { "3.0/2", "1.5" }, 
@@ -136,7 +140,8 @@ public class GrelTests extends RefineTest {
                 { "1>=1", "true" }, 
                 { "1<=2", "true" }, 
                 { "2<=2", "true" }, 
-                { "3<=2", "false" }, 
+                { "3<=2", "false" },
+//                { "1e3", "1000" }, // TODO: scientific notation has only a placeholder so far
 //                { "", "" }, 
         };
         for (String[] test : tests) {
@@ -183,6 +188,7 @@ public class GrelTests extends RefineTest {
         assertNull(eval.evaluate(bindings));
     }
 
+    // TODO: This seems like it's actually a join() test
     @Test
     public void testJoinJsonArray() throws ParsingException {
         String test[] = { "\"{\\\"values\\\":[\\\"one\\\",\\\"two\\\",\\\"three\\\"]}\".parseJson().values.join(\",\")", "one,two,three" };
@@ -196,6 +202,20 @@ public class GrelTests extends RefineTest {
         assertNull(eval.evaluate(bindings));
         Evaluable eval2 = MetaParser.parse("grel:null.foo"); // all others error
         assertTrue(eval2.evaluate(bindings) instanceof EvalError);
+    }
+
+    @Test
+    public void testGetFieldFromBadType() throws ParsingException {
+        String test =  "1.foo";
+        Evaluable eval = MetaParser.parse("grel:" + test);
+        assertTrue(eval.evaluate(bindings) instanceof EvalError);
+        String test1 =  "1.1.foo";
+        Evaluable eval1 = MetaParser.parse("grel:" + test1);
+        assertTrue(eval1.evaluate(bindings) instanceof EvalError);
+        Evaluable eval2 = MetaParser.parse("grel:[1,2].value");
+        assertTrue(eval2.evaluate(bindings) instanceof EvalError);
+        Evaluable eval3 = MetaParser.parse("grel:'foo'.value");
+        assertTrue(eval3.evaluate(bindings) instanceof EvalError);
     }
 
     // to demonstrate bug fixing for #1204


### PR DESCRIPTION
Fixes #169.  Fixes #2507. refs #1036

This change retains `null.value` as a special case which returns `null` but restores previous behavior of evaluating to an error for other field names (e.g. `null.foo`) as well as attempts to access fields on objects that don't support it (e.g. `[1,2].foo`).

Adding tests for the latter piece led to a bit of an odyssey fixing parser errors which were silently ignored (1.foo, 1.1.foo, etc).
Also enabled some commented out GREL tests which failed (both due to exceptions and to silently ignoring errors).

Errors which were silently ignored before, but which will now error include:
- two adjacent numbers or strings without an intervening operator or delimiter (`1 1` or `'a' 'b'`)
- unsupported operators like assignment (`=`) or exponentiation (`^`)
- scientific notation (`1e3`)
- malformed numbers (`1.xyz` would be interpreted as 1 with the rest thrown away)

Also added tests for `get()`, including coverage for the example in #2507, and moved the dot notation tests back to `GrelTests` where they belong (I incorrectly moved them recently). The parameter checking in `get` needed tightening up to fix #2507, but I left the majority of the unusual behavior (e.g. floating point array indices) unchanged and just added tests which match the current behavior.

Finally, added a test case for #169 (which had already been fixed by the above changes)