### PR TITLE
Check for errors on Guess Types query - fixes #3173

### DIFF
--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -52,24 +52,28 @@ ReconStandardServicePanel.prototype._guessTypes = function(f) {
     }),
     null, 
     function(data) {
-      self._types = data.types;
+      if (data.code && data.code === 'ok') {
+        self._types = data.types;
 
-      if (self._types.length === 0 && "defaultTypes" in self._service) {
-        var defaultTypes = {};
-        $.each(self._service.defaultTypes, function() {
-          defaultTypes[this.id] = this.name;
-        });
-        $.each(self._types, function() {
-          delete defaultTypes[typeof this == "string" ? this : this.id];
-        });
-        for (var id in defaultTypes) {
-          if (defaultTypes.hasOwnProperty(id)) {
-            self._types.push({
-              id: id,
-              name: defaultTypes[id].name
-            });
+        if (self._types.length === 0 && "defaultTypes" in self._service) {
+          var defaultTypes = {};
+          $.each(self._service.defaultTypes, function() {
+            defaultTypes[this.id] = this.name;
+          });
+          $.each(self._types, function() {
+            delete defaultTypes[typeof this == "string" ? this : this.id];
+          });
+          for (var id in defaultTypes) {
+            if (defaultTypes.hasOwnProperty(id)) {
+              self._types.push({
+                id: id,
+                name: defaultTypes[id].name
+              });
+            }
           }
         }
+      } else {
+        alert('Guess Types query failed ' + data.code + ' : ' + data.message);
       }
 
       dismissBusy();


### PR DESCRIPTION
Fixes #3173. Don't assume that the query always succeeds.
Error reporting is rudimentary (alert), but better than nothing, which is what we had before.

In addition to the originally reported error, this will also catch 403 Forbidden codes which will become more common as reconciliation services implement authentication