### PR TITLE
Temporary workaround set-env deprecation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,6 +34,8 @@ jobs:
 
     - name: Get the OpenRefine snapshot version
       run: echo ::set-env name=OR_VERSION::$(cat ./main/webapp/WEB-INF/classes/git.properties | jq -r '.["git.commit.id.describe"]')
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     - name: Generate dist files
       run: ./refine dist ${{ env.OR_VERSION }}
@@ -43,6 +45,7 @@ jobs:
       id: create_release
       run: echo ::set-env name=API_RELEASE::$(./.github/workflows/release_manager.sh)
       env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         OR_VERSION: ${{ env.OR_VERSION }}
         RELEASE_REPO_OWNER: OpenRefine
         RELEASE_REPO_TOKEN: ${{ secrets.RELEASE_REPO_TOKEN }}


### PR DESCRIPTION
This is an attempt to temporarily re-enable the `set-env` command, to make sure our CI stays green, before we figure out how to use the new system.

For #3341