### PR TITLE
Fix for issue #3330 grel phonetic-function

### DIFF
--- a/main/src/com/google/refine/expr/functions/strings/Phonetic.java
+++ b/main/src/com/google/refine/expr/functions/strings/Phonetic.java
@@ -72,7 +72,10 @@ public class Phonetic implements Function {
                     return new EvalError(ControlFunctionRegistry.getFunctionName(this)
                             + " expects a string for the second argument");
                 }
-            }
+            } else {
+                return new EvalError(ControlFunctionRegistry.getFunctionName(this)
+                        + " expects a string for the second argument.Make sure to pass the argument in proper string format");
+                }     
         }
         if (args.length < 3) {
             if ("doublemetaphone".equalsIgnoreCase(encoding)) {

--- a/main/src/com/google/refine/expr/functions/strings/Phonetic.java
+++ b/main/src/com/google/refine/expr/functions/strings/Phonetic.java
@@ -75,7 +75,7 @@ public class Phonetic implements Function {
             } else {
                 return new EvalError(ControlFunctionRegistry.getFunctionName(this)
                         + " expects a string for the second argument, the phonetic encoding to use.");
-                }     
+            }     
         }
         if (args.length < 3) {
             if ("doublemetaphone".equalsIgnoreCase(encoding)) {

--- a/main/src/com/google/refine/expr/functions/strings/Phonetic.java
+++ b/main/src/com/google/refine/expr/functions/strings/Phonetic.java
@@ -74,7 +74,7 @@ public class Phonetic implements Function {
                 }
             } else {
                 return new EvalError(ControlFunctionRegistry.getFunctionName(this)
-                        + " expects a string for the second argument.Make sure to pass the argument in proper string format");
+                        + " expects a string for the second argument, the phonetic encoding to use.");
                 }     
         }
         if (args.length < 3) {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/PhoneticTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/PhoneticTests.java
@@ -25,16 +25,25 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 package com.google.refine.expr.functions.strings;
-
+import org.testng.Assert;
 import org.testng.annotations.Test;
-
+import com.google.refine.RefineTest;
 import com.google.refine.util.TestUtils;
 
-public class PhoneticTests {
+public class PhoneticTests extends RefineTest {
     @Test
     public void serializePhonetic() {
         String json = "{\"description\":\"Returns the a phonetic encoding of s (optionally indicating which encoding to use')\",\"params\":\"string s, string encoding (optional, defaults to 'metaphone3')\",\"returns\":\"string\"}";
         TestUtils.isSerializedTo(new Phonetic(), json);
+    }
+    
+    @Test
+    public void testtoPhoneticInvalidParams() {
+	Assert.assertTrue(invoke("phonetic") instanceof EvalError);                            //if no arguments are provided
+	Assert.assertTrue(invoke("phonetic",(Object[])null) instanceof EvalError);             //if first argument(value) is null
+	Assert.assertTrue(invoke("phonetic","one",(Object[])null) instanceof EvalError);       //if second argument(encoding type) is null
+	Assert.assertTrue(invoke("phonetic","one","other") instanceof EvalError);              //if second argument(encoding type) is not a valid encoding type
+	Assert.assertTrue(invoke("phonetic","one","metaphone3","three") instanceof EvalError); //if more than 2 arguments are provided
     }
 }
 

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/PhoneticTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/PhoneticTests.java
@@ -29,6 +29,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.google.refine.RefineTest;
 import com.google.refine.util.TestUtils;
+import com.google.refine.expr.EvalError;
 
 public class PhoneticTests extends RefineTest {
     @Test


### PR DESCRIPTION
Fix:
There is one test case missing in the file in the phonetic.java due to which it fails to validate the second argument when it is not string or number and hence falls back to default behaviour of considering "metaphone3" as its second argument.
Adding a if-else case for checking second argument solves the issue.