### PR TITLE
Fix help link for date formats

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/custom-tabular-exporter-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/custom-tabular-exporter-dialog.html
@@ -59,7 +59,7 @@
                 <td width="1%"><input type="radio" name="custom-tabular-exporter-date" value="custom" id="$custom-exporter-date-custom" /></td>
                 <td colspan="3">
                   <label for="$custom-exporter-date-custom" bind="or_dialog_custom"></label> <input size="35" class="lightweight" bind="dateCustomInput" />
-                  <a href="" target="_blank" bind="or_dialog_help"></a>
+                  <a href="https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html" target="_blank" bind="or_dialog_help"></a>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
added link to <a> element for help on available date formats.
Fixes #3362 