### PR TITLE
Added confirm dialog for starred expression remove links #501

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -244,6 +244,7 @@
     "core-dialogs/sql-exporter": "SQL Exporter",
     "core-dialogs/custom-tab-exp": "Custom Tabular Exporter",
     "core-dialogs/select-columns-dialog": "Select columns",
+    "core-dialogs/unstar-expression": "Unstar Expression?",
     "core-dialogs/content": "Content",
     "core-dialogs/download": "Download",
     "core-dialogs/upload": "Upload",

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -244,7 +244,7 @@
     "core-dialogs/sql-exporter": "SQL Exporter",
     "core-dialogs/custom-tab-exp": "Custom Tabular Exporter",
     "core-dialogs/select-columns-dialog": "Select columns",
-    "core-dialogs/unstar-expression": "Unstar Expression?",
+    "core-dialogs/unstar-expression": "Unstar expression?",
     "core-dialogs/content": "Content",
     "core-dialogs/download": "Download",
     "core-dialogs/upload": "Upload",

--- a/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
@@ -352,7 +352,7 @@ ExpressionPreviewDialog.Widget.prototype._renderStarredExpressions = function(da
         $('<a href="javascript:{}">'+$.i18n('core-dialogs/remove')+'</a>').appendTo(tr.insertCell(0)).click(function() {
             var removeExpression = DialogSystem.createDialog();
                 removeExpression.width("250px");
-            var removeExpressionHead = $('<div></div>').addClass("dialog-header").text($.i18n('core-dialogs/remove') + " " + $.i18n('core-dialogs/expression') + "?")
+            var removeExpressionHead = $('<div></div>').addClass("dialog-header").text($.i18n('core-dialogs/unstar-expression'))
                 .appendTo(removeExpression);
             var removeExpressionFooter = $('<div></div>').addClass("dialog-footer").appendTo(removeExpression);
 

--- a/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
@@ -350,15 +350,30 @@ ExpressionPreviewDialog.Widget.prototype._renderStarredExpressions = function(da
         var o = Scripting.parse(entry.code);
         
         $('<a href="javascript:{}">'+$.i18n('core-dialogs/remove')+'</a>').appendTo(tr.insertCell(0)).click(function() {
-            Refine.postCSRF(
-                "command/core/toggle-starred-expression",
-                { expression: entry.code, returnList: true },
-                function(data) {
-                    self._renderStarredExpressions(data);
-                    self._renderExpressionHistoryTab();
-                },
-                "json"
-            );
+            var removeExpression = DialogSystem.createDialog();
+                removeExpression.width("250px");
+            var removeExpressionHead = $('<div></div>').addClass("dialog-header").text($.i18n('core-dialogs/remove') + " " + $.i18n('core-dialogs/expression') + "?")
+                .appendTo(removeExpression);
+            var removeExpressionFooter = $('<div></div>').addClass("dialog-footer").appendTo(removeExpression);
+
+            $('<button class="button"></button>').html($.i18n('core-buttons/ok')).click(function() {
+                Refine.postCSRF(
+                    "command/core/toggle-starred-expression",
+                    { expression: entry.code, returnList: true },
+                    function(data) {
+                        self._renderStarredExpressions(data);
+                        self._renderExpressionHistoryTab();
+                    },
+                    "json"
+                );
+                DialogSystem.dismissUntil(1);
+            }).appendTo(removeExpressionFooter);
+
+            $('<button class="button" style="float:right;"></button>').text($.i18n('core-buttons/cancel')).click(function() {
+                DialogSystem.dismissUntil(1);
+            }).appendTo(removeExpressionFooter);
+
+            this._level = DialogSystem.showDialog(removeExpression);
         });
         
         $('<a href="javascript:{}">Reuse</a>').appendTo(tr.insertCell(1)).click(function() {

--- a/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
@@ -366,11 +366,11 @@ ExpressionPreviewDialog.Widget.prototype._renderStarredExpressions = function(da
                     },
                     "json"
                 );
-                DialogSystem.dismissUntil(1);
+                DialogSystem.dismissUntil(DialogSystem._layers.length - 1);
             }).appendTo(removeExpressionFooter);
 
             $('<button class="button" style="float:right;"></button>').text($.i18n('core-buttons/cancel')).click(function() {
-                DialogSystem.dismissUntil(1);
+                DialogSystem.dismissUntil(DialogSystem._layers.length - 1);
             }).appendTo(removeExpressionFooter);
 
             this._level = DialogSystem.showDialog(removeExpression);


### PR DESCRIPTION
Fixes #501 

Used the built in dialog system to create the small popup asking for confirmation.
Chose the 'Remove Expression?' and the 'OK' and 'Cancel' for the text as they were already in the translation files.