### PR TITLE
fix broken jdatapath dependency not found

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -175,7 +175,7 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.codeberry.jdatapath</groupId>
+      <groupId>org.openrefine.dependencies</groupId>
       <artifactId>jdatapath</artifactId>
       <version>alpha2</version>
     </dependency>


### PR DESCRIPTION
On the `new-architecture` branch, I couldn't find the old codeberry groupId but see on Maven Central that we have it contained in the `org.openrefine.dependencies` for now, so let's update that pom to make the clean/build seamless for folks like me wanting to help test later.