### PR TITLE
feat: introduce dependabot for cypress suite

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@
 
 version: 2
 updates:
+# For openrefine java deps
 - package-ecosystem: maven
   directory: "/"
   schedule:
@@ -13,11 +14,18 @@ updates:
     versions:
     - "> 1.4.12"
     - "< 2"
+# For documentation website
 - package-ecosystem: "npm" # For Yarn
+  directory: "docs/"
+  schedule:
+    interval: "daily"
+# For github actions
+- package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "daily"
-- package-ecosystem: "github-actions"
-  directory: "/"
+# For cypress test_suite
+- package-ecosystem: "npm"
+  directory: "main/tests/cypress"
   schedule:
     interval: "daily"

--- a/main/tests/cypress/yarn.lock
+++ b/main/tests/cypress/yarn.lock
@@ -377,10 +377,10 @@ cypress-wait-until@^1.7.1:
   resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-1.7.1.tgz#3789cd18affdbb848e3cfc1f918353c7ba1de6f8"
   integrity sha512-8DL5IsBTbAxBjfYgCzdbohPq/bY+IKc63fxtso1C8RWhLnQkZbVESyaclNr76jyxfId6uyzX8+Xnt0ZwaXNtkA==
 
-cypress@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.0.0.tgz#57050773c61e8fe1e5c9871cc034c616fcacded9"
-  integrity sha512-A/w9S15xGxX5UVeAQZacKBqaA0Uqlae9e5WMrehehAdFiLOZj08IgSVZOV8YqA9OH9Z0iBOnmsEkK3NNj43VrA==
+cypress@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.0.1.tgz#86857ca2f527c3723575737deab42fd8f2a209df"
+  integrity sha512-3xtQZ0YM65soLgKQUgn2wg2IbWsM6A2yBg6L4RF31mZHr5LNKdO2/9sgiwxEVMKu2C2m6+IQ75zHP41kZP5rPg==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"


### PR DESCRIPTION
Signed-off-by: Kush Trivedi <kushthedude@gmail.com>

fixes #3444 

- Fixes the wrong dependabot config for website_deps
- Introduces dependabot for cypress
- Bumps cypress to 6.0.2