### PR TITLE
fix: cache all UI paths for cypress

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,9 +1,7 @@
 name: Continuous Integration
 
 on:
-  pull_request:
-    branches:
-      - 'master'
+  pull_request_target:
     paths-ignore:
       - 'docs/**'
 
@@ -123,6 +121,7 @@ jobs:
     - name: Install test dependencies
       run: |
           cd ./main/tests/cypress
+          npm cache clean --force
           npm i -g yarn
           yarn install
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,11 @@
 name: Continuous Integration
 
-on: [pull_request_target]
+on:
+  pull_request:
+    branches:
+      - 'master'
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   server_tests:
@@ -98,10 +103,19 @@ jobs:
     - name: Build OpenRefine
       run: ./refine build
 
+    - name: Setup Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: '12'
+
     - name: Restore Tests dependency cache
       uses: actions/cache@v2.1.3
       with:
-          path: '**/node_modules'
+          path: |
+            ~/cache
+            ~/.cache
+            **/node_modules
+            !~/cache/exclude
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
               ${{ runner.os }}-yarn
@@ -109,6 +123,7 @@ jobs:
     - name: Install test dependencies
       run: |
           cd ./main/tests/cypress
+          npm i -g yarn
           yarn install
 
     - name: Test with Cypress on ${{ matrix.browser }}


### PR DESCRIPTION
- Looks like pull_request_target doesn't build fresh changes in PR, hence replaced it with `on: pull_request`, please ignore the failed check for `pull_request_target` as the same test is getting passed on `pull_request`.
- As well as I have disabled CI on changes only involving docs subdirectory as they are not needed when we do changes in the docs-website.
- I have fixed the cache path to cache the cypress binaries properly.
