### PR TITLE
Adjust the menuItem class to avoid colliding borders

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -72,8 +72,8 @@
     display: inline-block;
     border: 2px solid #4dc6e1;
     border-radius: var(--ifm-code-border-radius);
-    margin: 0;
-    padding: 1px var(--ifm-code-padding-horizontal);
+    margin: 1px 0px;
+    padding: 0px 4px;
   }
 
   .markdown img {


### PR DESCRIPTION
As suggested by @ostephens orally, this attemps to shrink the blue boxes around menu items:

**Before:**
![image](https://user-images.githubusercontent.com/309908/104628097-21fa4680-5698-11eb-9f83-08eed1698157.png)
**After:**
![image](https://user-images.githubusercontent.com/309908/104627987-faa37980-5697-11eb-89ae-f7a704dee586.png)
