### PR TITLE
Add updated chat URL for Web and Mobile clients support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Contact us
 ----------
 * [Mailing List](https://groups.google.com/forum/#!forum/openrefine)
 * [Twitter](http://www.twitter.com/openrefine)
-* [Matrix/Element Gitter bridge (mobile friendly)](https://matrix.to/#/#OpenRefine_OpenRefine:gitter.im)
 * [Gitter](https://gitter.im/OpenRefine/OpenRefine)
+* [Matrix (bridged from Gitter)](https://matrix.to/#/#OpenRefine_OpenRefine:gitter.im)
 
 Licensing and legal issues
 --------------------------

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Contact us
 ----------
 * [Mailing List](https://groups.google.com/forum/#!forum/openrefine)
 * [Twitter](http://www.twitter.com/openrefine)
-* [Matrix/Element/Gitter chat](https://matrix.to/#/#OpenRefine_OpenRefine:gitter.im)
+* [Matrix/Element Gitter bridge (mobile friendly)](https://matrix.to/#/#OpenRefine_OpenRefine:gitter.im)
+* [Gitter](https://gitter.im/OpenRefine/OpenRefine)
 
 Licensing and legal issues
 --------------------------

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Contact us
 ----------
 * [Mailing List](https://groups.google.com/forum/#!forum/openrefine)
 * [Twitter](http://www.twitter.com/openrefine)
+* [Matrix/Element/Gitter chat](https://matrix.to/#/#OpenRefine_OpenRefine:gitter.im)
 
 Licensing and legal issues
 --------------------------


### PR DESCRIPTION
In December 2020, mobile clients can no longer connect to OpenRefine room for Gitter since the mobile clients are now deprecated.  Also since [Gitlab has sold Gitter and now officially has now moved to the Matrix.org Foundation (London)](https://matrix.org/blog/2020/09/30/welcoming-gitter-to-matrix) and they now have an updated bridge for our room.

![image](https://user-images.githubusercontent.com/986438/105920452-07f82680-5ffd-11eb-8bc6-846c64a75d31.png)

I spoke with Gitter support (Matrix) and they provided the new URL.  Which even shows up when using iOS app or Web via Element.io  We just need to provide this for easy onboarding for users.
https://matrix.to/#/#OpenRefine_OpenRefine:gitter.im

So I think we need to update this in our README.md