### PR TITLE
Fix links on Manual Introduction page.

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -12,14 +12,14 @@ This manual is designed to comprehensively walk through every aspect of setting 
 This documentation platform provides a separate version of the user manual for each version of OpenRefine (from 3.4.1 onwards) - if you're looking for a later version than 3.4.1, please select the correct version from the dropdown menu in the top bar of this page. 
 -->
 
-This user manual starts with instructions for [installing or upgrading OpenRefine on Windows, Mac, and Linux computers](installing). It then walks you through [the interface and how to run OpenRefine](running#jvm-preferences) from a program or command line, with or without setting custom preferences and modifications.
+This user manual starts with instructions for [installing or upgrading OpenRefine on Windows, Mac, and Linux computers](manual/installing). It then walks you through [the interface and how to run OpenRefine](manual/running#jvm-preferences) from a program or command line, with or without setting custom preferences and modifications.
 
-The manual then teaches you how to [start a project](starting) by importing an existing dataset. We work through how to [view and learn about your data](exploring) using facets, filters, and sorting. 
+The manual then teaches you how to [start a project](manual/starting) by importing an existing dataset. We work through how to [view and learn about your data](manual/exploring) using facets, filters, and sorting. 
 
-Then we launch into [transforming that data permanently](transforming) through common and custom transformations, clustering, pulling data from the web, [reconciling](reconciling), and [writing expressions](expressions). 
+Then we launch into [transforming that data permanently](manual/transforming) through common and custom transformations, clustering, pulling data from the web, [reconciling](manual/reconciling), and [writing expressions](manual/expressions). 
 
-Finally we discuss what to do with your improved dataset, whether [exporting](exporting) it to a file or uploading statements to Wikidata. 
+Finally we discuss what to do with your improved dataset, whether [exporting](manual/exporting) it to a file or uploading statements to Wikidata. 
 
-If you're stuck on any aspect and can't find an answer in the manual, try the [Troubleshooting page](troubleshooting) for links to various places to find help. 
+If you're stuck on any aspect and can't find an answer in the manual, try the [Troubleshooting page](manual/troubleshooting) for links to various places to find help. 
 
 If you are new and want to learn how to use OpenRefine using an example dataset, you may wish to start with a user-contributed tutorial from our [recommendations list](https://github.com/OpenRefine/OpenRefine/wiki/External-Resources).


### PR DESCRIPTION
This documentation PR fixes links which currently 404 on the Introduction page by adding `manual/` to the path of the relevant links.