### PR TITLE
Prevent snapshot release when only docs push

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '!docs/**'
 
 jobs:
   ui_tests:


### PR DESCRIPTION
I "think" this small change is the right way to prevent unnecessary snapshot release workflow run such as this one:
https://github.com/OpenRefine/OpenRefine/actions/runs/515619980
when the only files changed were in the /docs folders in a PR that was merged into master branch.

Example from: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-positive-and-negative-patterns-1