### PR TITLE
Pressing "Enter" in the project name field at the preview stage will now create the project

### DIFF
--- a/main/webapp/modules/core/scripts/index/default-importing-controller/parsing-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/parsing-panel.js
@@ -49,6 +49,11 @@ Refine.DefaultImportingController.prototype._showParsingPanel = function(hasFile
   this._parsingPanelElmts.nextButton.click(function() {
     self._createProject();
   });
+  this._parsingPanelElmts.projectNameInput.keydown(function(e) {
+    if(e.keyCode==13){
+      self._createProject();
+    }
+  });
   if (hasFileSelection) {
     this._parsingPanelElmts.previousButton.click(function() {
       self._createProjectUI.showCustomPanel(self._fileSelectionPanel);


### PR DESCRIPTION
This does not use the submit event, because there is no `<form>` in it

#3137 

![test](https://user-images.githubusercontent.com/57166588/106376751-1c5c6a80-63d3-11eb-8e44-7df8b7923784.gif)
