### PR TITLE
Add Google API key - fixes #3604

### DIFF
--- a/extensions/gdata/module/scripts/index/gdata-source-ui.js
+++ b/extensions/gdata/module/scripts/index/gdata-source-ui.js
@@ -83,13 +83,7 @@ Refine.GDataSourceUI.prototype.attachUI = function(body) {
       } else {
         doc.type = 'table';
       }
-      
-      if (GdataExtension.isAuthorized()) {
-          self._controller.startImportingDocument(doc);     
-      } else {
-          var fn = self._controller.startImportingDocument;
-          GdataExtension.showAuthorizationDialog(fn.bind(self._controller, doc));
-      }
+      self._controller.startImportingDocument(doc);
     }
   });
    

--- a/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
@@ -25,6 +25,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.drive.Drive;
 import com.google.api.services.drive.DriveScopes;
 import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.SheetsRequestInitializer;
 import com.google.api.services.sheets.v4.SheetsScopes;
 import com.google.refine.ProjectManager;
 import com.google.refine.preference.PreferenceStore;
@@ -33,10 +34,13 @@ import edu.mit.simile.butterfly.ButterflyModule;
 
 abstract public class GoogleAPIExtension {
     protected static final String SERVICE_APP_NAME = "OpenRefine-Google-Service";
-    // We can set the second param to a default client_id for release version
+
+    // For a production release, the second parameter (default value) can be set
+    // for the following three properties (client_id, client_secret, and API key) to
+    // the production values from the Google API console
     private static final String CLIENT_ID = System.getProperty("ext.gdata.clientid", "");
-    // We can set the second param to a default client_secret for release version
     private static final String CLIENT_SECRET = System.getProperty("ext.gdata.clientsecret", "");
+    private static final String API_KEY = System.getProperty("ext.gdata.apikey", "");
     
     /** Global instance of the HTTP transport. */
     protected static final HttpTransport HTTP_TRANSPORT = new NetHttpTransport();
@@ -157,19 +161,28 @@ abstract public class GoogleAPIExtension {
      * @throws IOException
      */
     public static Sheets getSheetsService(String token) throws IOException {
-        Credential credential =  new Credential.Builder(null).build().setAccessToken(token);
+        final Credential credential;
+        if (token != null) {
+            credential =  new Credential.Builder(null).build().setAccessToken(token);
+        } else {
+            credential = null;
+        }
         int connectTimeout = getConnectTimeout();
         int readTimeout = getReadTimeout();
         
-        return new Sheets.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential).setHttpRequestInitializer(new HttpRequestInitializer() {
-            @Override
-            public void initialize(HttpRequest httpRequest) throws IOException {
-                credential.initialize(httpRequest);
-                httpRequest.setConnectTimeout(connectTimeout);  
-                httpRequest.setReadTimeout(readTimeout);  // 3 minutes read timeout
-            }
-        })
-          .setApplicationName(SERVICE_APP_NAME).build();
+        return new Sheets.Builder(HTTP_TRANSPORT, JSON_FACTORY, credential)
+                .setApplicationName(SERVICE_APP_NAME)
+                .setSheetsRequestInitializer(new SheetsRequestInitializer(API_KEY))
+                .setHttpRequestInitializer(new HttpRequestInitializer() {
+                    @Override
+                    public void initialize(HttpRequest httpRequest) throws IOException {
+                        if (credential != null) {
+                            credential.initialize(httpRequest);
+                        }
+                        httpRequest.setConnectTimeout(connectTimeout);
+                        httpRequest.setReadTimeout(readTimeout);
+                    }
+                }).build();
     }
 
     private static int getConnectTimeout() {

--- a/refine
+++ b/refine
@@ -944,7 +944,9 @@ add_option "-Dpython.cachedir=$HOME/.local/share/google/refine/cachedir"
 
 if [ ! -z "$GDATA_CLIENT_ID" ] ; then
     if [ ! -z "$GDATA_CLIENT_SECRET" ] ; then
-        add_option "-Dext.gdata.clientid=$GDATA_CLIENT_ID" "-Dext.gdata.clientsecret=$GDATA_CLIENT_SECRET"
+        if [ ! -z "$GDATA_API_KEY" ] ; then
+            add_option "-Dext.gdata.clientid=$GDATA_CLIENT_ID" "-Dext.gdata.clientsecret=$GDATA_CLIENT_SECRET" "-Dext.gdata.apikey=$GDATA_API_KEY"
+        fi
     fi
 fi
 

--- a/refine.bat
+++ b/refine.bat
@@ -185,7 +185,8 @@ set REFINE_LIB_DIR=server\target\lib
 
 if "%GDATA_CLIENT_ID%" == "" goto skipGDataCredentials
 if "%GDATA_CLIENT_SECRET%" == "" goto skipGDataCredentials
-set OPTS=%OPTS% -Dext.gdata.clientid=%GDATA_CLIENT_ID% -Dext.gdata.clientsecret=%GDATA_CLIENT_SECRET%
+if "%GDATA_API_KEY%" == "" goto skipGDataCredentials
+set OPTS=%OPTS% -Dext.gdata.clientid=%GDATA_CLIENT_ID% -Dext.gdata.clientsecret=%GDATA_CLIENT_SECRET% -Dext.gdata.apikey=%GDATA_API_KEY%
 :skipGDataCredentials
 
 rem ----- Respond to the action ----------------------------------------------------------

--- a/refine.ini
+++ b/refine.ini
@@ -32,3 +32,4 @@ REFINE_MIN_MEMORY=1400M
 #   https://github.com/OpenRefine/OpenRefine/wiki/Google-Extension
 #GDATA_CLIENT_ID=your_client_id
 #GDATA_CLIENT_SECRET=your_client_secret
+#GDATA_API_KEY=your API key


### PR DESCRIPTION
Fixes #3604.

Enables access to public data in Google Sheets/Drive. API key must be sent if OAuth token isn't.