### PR TITLE
Link to wiki page on first pull request

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ All developers including new distributions and plugin developers are invited to 
 
 ### How to submit PR's (pull requests), patches, and bug fixes
 
+- Read [Your first pull request](https://github.com/OpenRefine/OpenRefine/wiki/Your-first-pull-request)
 - Avoid merging master in your branch because it makes code review a lot harder.
 - If you want to keep your branch up to date with our master, it would be nicer if you could just rebase your branch instead. That would keep the history a lot cleaner.
 - Please avoid adding unrelated changes in the PR. Do a separate PR and rebase once they get merged can work really well.


### PR DESCRIPTION
These should be better integrated, but as a stopgap, just include the link