### PR TITLE
test: Added tests for transpose functionalities, #3426

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/column/transpose/cell_accross_columns.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/transpose/cell_accross_columns.spec.js
@@ -47,10 +47,10 @@ describe(__filename, function () {
       .type('Address');
 
     cy.confirmDialogPanel();
+    cy.waitForOrOperation();
     cy.assertNotificationContainingText(
       'Transpose cells in columns starting with Street'
     );
-    cy.waitForOrOperation();
 
     cy.assertGridEquals([
       ['Name', 'Address'],
@@ -70,7 +70,7 @@ describe(__filename, function () {
   /**
    * https://docs.openrefine.org/manual/transposing/#two-columns
    */
-  it('Transpose cells across columns into rows (Two column)', function () {
+  it('Transpose cells across columns into rows (Two columns)', function () {
     const fixture = [
       ['Name', 'Street', 'City', 'State/Province', 'Country', 'Postal code'],
 
@@ -101,10 +101,10 @@ describe(__filename, function () {
     );
 
     cy.confirmDialogPanel();
+    cy.waitForOrOperation();
     cy.assertNotificationContainingText(
       'Transpose cells in columns starting with Street'
     );
-    cy.waitForOrOperation();
 
     cy.assertGridEquals([
       ['Name', 'Address part', 'Address'],

--- a/main/tests/cypress/cypress/integration/project/grid/column/transpose/cell_accross_columns.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/transpose/cell_accross_columns.spec.js
@@ -1,0 +1,122 @@
+/**
+ * The following scenarios are inspired by the official OpenRefine documentation
+ * https://docs.openrefine.org/manual/transposing/
+ */
+describe(__filename, function () {
+  /**
+   * https://docs.openrefine.org/manual/transposing/#one-column
+   */
+  it('Transpose cells across columns into rows (One column)', function () {
+    const fixture = [
+      ['Name', 'Street', 'City', 'State/Province', 'Country', 'Postal code'],
+
+      ['Jacques Cousteau', '23 quai de Conti', 'Paris', '', 'France', '75270'],
+      [
+        'Emmy Noether',
+        '010 N Merion Avenue',
+        'Bryn Mawr',
+        'Pennsylvania',
+        'USA',
+        '19010',
+      ],
+    ];
+    cy.loadAndVisitProject(fixture);
+
+    cy.columnActionClick('Street', [
+      'Transpose',
+      'Transpose cells across columns into rows...',
+    ]);
+
+    cy.get('.dialog-container select[bind="fromColumnSelect"]').select(
+      'Street'
+    );
+    cy.get('.dialog-container select[bind="toColumnSelect"]').select(
+      '(last column)'
+    );
+
+    // add the column name and "test" string to each transposed cell
+    cy.get('label')
+      .contains("prepend the original column's name to each cell")
+      .click();
+    cy.get('input[bind="separatorInput"]').type(' test ');
+    cy.get('.dialog-container label').contains('One column').click();
+    cy.get('.dialog-container label')
+      .contains('One column')
+      .parent()
+      .find('input')
+      .type('Address');
+
+    cy.confirmDialogPanel();
+    cy.assertNotificationContainingText(
+      'Transpose cells in columns starting with Street'
+    );
+    cy.waitForOrOperation();
+
+    cy.assertGridEquals([
+      ['Name', 'Address'],
+      ['Jacques Cousteau', 'Street: test 23 quai de Conti'],
+      ['', 'City: test Paris'],
+      ['', 'Country: test France'],
+      ['', 'Postal code: test 75270'],
+
+      ['Emmy Noether', 'Street: test 010 N Merion Avenue'],
+      ['', 'City: test Bryn Mawr'],
+      ['', 'State/Province: test Pennsylvania'],
+      ['', 'Country: test USA'],
+      ['', 'Postal code: test 19010'],
+    ]);
+  });
+
+  /**
+   * https://docs.openrefine.org/manual/transposing/#two-columns
+   */
+  it('Transpose cells across columns into rows (Two column)', function () {
+    const fixture = [
+      ['Name', 'Street', 'City', 'State/Province', 'Country', 'Postal code'],
+
+      ['Jacques Cousteau', '23 quai de Conti', 'Paris', '', 'France', '75270'],
+      [
+        'Emmy Noether',
+        '010 N Merion Avenue',
+        'Bryn Mawr',
+        'Pennsylvania',
+        'USA',
+        '19010',
+      ],
+    ];
+    cy.loadAndVisitProject(fixture);
+
+    cy.columnActionClick('Street', [
+      'Transpose',
+      'Transpose cells across columns into rows...',
+    ]);
+
+    cy.get('.dialog-container label').contains('Two new columns').click();
+
+    cy.get('.dialog-container input[bind="keyColumnNameInput"]').type(
+      'Address part'
+    );
+    cy.get('.dialog-container input[bind="valueColumnNameInput"]').type(
+      'Address'
+    );
+
+    cy.confirmDialogPanel();
+    cy.assertNotificationContainingText(
+      'Transpose cells in columns starting with Street'
+    );
+    cy.waitForOrOperation();
+
+    cy.assertGridEquals([
+      ['Name', 'Address part', 'Address'],
+      ['Jacques Cousteau', 'Street', '23 quai de Conti'],
+      ['', 'City', 'Paris'],
+      ['', 'Country', 'France'],
+      ['', 'Postal code', '75270'],
+      ['Emmy Noether', 'Street', '010 N Merion Avenue'],
+      ['', 'City', 'Bryn Mawr'],
+      ['', 'State/Province', 'Pennsylvania'],
+      ['', 'Country', 'USA'],
+      ['', 'Postal code', '19010'],
+    ]);
+  });
+});

--- a/main/tests/cypress/cypress/integration/project/grid/column/transpose/cells_in_rows.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/transpose/cells_in_rows.spec.js
@@ -1,0 +1,43 @@
+/**
+ * The following scenarios are inspired by the official OpenRefine documentation
+ * https://docs.openrefine.org/manual/transposing/
+ */
+describe(__filename, function () {
+  /**
+   * https://docs.openrefine.org/manual/transposing/#transpose-cells-in-rows-into-columns
+   */
+  it('Transpose cells in rows into columns', function () {
+    const fixture = [
+      ['Employee'],
+      ['Employee: Karen Chiu'],
+      ['Job title: Senior analyst'],
+      ['Office: New York'],
+      ['Employee: Joe Khoury'],
+      ['Job title: Junior analyst'],
+      ['Office: Beirut'],
+      ['Employee: Samantha Martinez'],
+      ['Job title: CTO'],
+      ['Office: Tokyo'],
+    ];
+    cy.loadAndVisitProject(fixture);
+
+    // the number of columns is prompted with an alert
+    // need to mock it
+    cy.window().then(($win) => {
+      cy.stub($win, 'prompt').returns('3');
+    });
+
+    cy.columnActionClick('Employee', [
+      'Transpose',
+      'Transpose cells in rows into columns...',
+    ]);
+
+    const expected = [
+      ['Employee 1', 'Employee 2', 'Employee 3'],
+      ['Employee: Karen Chiu', 'Job title: Senior analyst', 'Office: New York'],
+      ['Employee: Joe Khoury', 'Job title: Junior analyst', 'Office: Beirut'],
+      ['Employee: Samantha Martinez', 'Job title: CTO', 'Office: Tokyo'],
+    ];
+    cy.assertGridEquals(expected);
+  });
+});

--- a/main/tests/cypress/cypress/integration/project/grid/column/transpose/columnize.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/transpose/columnize.spec.js
@@ -27,7 +27,9 @@ describe(__filename, function () {
     cy.get('select[bind="keyColumnSelect"]').select('Field');
     cy.get('select[bind="valueColumnSelect"]').select('Data');
     cy.get('select[bind="noteColumnSelect"]').select('Source');
+
     cy.confirmDialogPanel();
+    cy.waitForOrOperation();
     cy.assertNotificationContainingText(
       'Columnize by key column Field and value column Data with note column Source'
     );
@@ -62,7 +64,9 @@ describe(__filename, function () {
     ]);
     cy.get('select[bind="keyColumnSelect"]').select('Field');
     cy.get('select[bind="valueColumnSelect"]').select('Data');
+
     cy.confirmDialogPanel();
+    cy.waitForOrOperation();
     cy.assertNotificationContainingText(
       'Columnize by key column Field and value column Data'
     );

--- a/main/tests/cypress/cypress/integration/project/grid/column/transpose/columnize.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/transpose/columnize.spec.js
@@ -1,0 +1,77 @@
+/**
+ * The following scenarios are inspired by the official OpenRefine documentation
+ * https://docs.openrefine.org/manual/transposing/
+ */
+describe(__filename, function () {
+  /**
+   * https://docs.openrefine.org/manual/transposing/#columnize-by-keyvalue-columns
+   * and https://docs.openrefine.org/manual/transposing/#notes-column
+   */
+  it('Columnize by key/value columns', function () {
+    const fixture = [
+      ['Field', 'Data', 'Source'],
+
+      ['Name', 'Galanthus nivalis', 'IUCN'],
+      ['Color', 'White', 'Contributed by Martha'],
+      ['IUCN ID', '162168', ''],
+      ['Name', 'Narcissus cyclamineus', 'Legacy'],
+      ['Color', 'Yellow', '2009 survey'],
+      ['IUCN ID', '161899', ''],
+    ];
+    cy.loadAndVisitProject(fixture);
+
+    cy.columnActionClick('Field', [
+      'Transpose',
+      'Columnize by key/value columns...',
+    ]);
+    cy.get('select[bind="keyColumnSelect"]').select('Field');
+    cy.get('select[bind="valueColumnSelect"]').select('Data');
+    cy.get('select[bind="noteColumnSelect"]').select('Source');
+    cy.confirmDialogPanel();
+    cy.assertNotificationContainingText(
+      'Columnize by key column Field and value column Data with note column Source'
+    );
+
+    const expected = [
+      ['Name', 'Color', 'IUCN ID', 'Source : Name', 'Source : Color'],
+      ['Galanthus nivalis', 'White', '162168', 'IUCN', 'Contributed by Martha'],
+      ['Narcissus cyclamineus', 'Yellow', '161899', 'Legacy', '2009 survey'],
+    ];
+    cy.assertGridEquals(expected);
+  });
+
+  /**
+   * https://docs.openrefine.org/manual/transposing/#extra-columns
+   * Extra column Wikidata ID must be preserved
+   */
+  it('Columnize by key/value columns + Extra columns', function () {
+    const fixture = [
+      ['Field', 'Data', 'Wikidata ID'],
+      ['Name', 'Galanthus nivalis', 'Q109995'],
+      ['Color', 'White', 'Q109995'],
+      ['IUCN ID', '162168', 'Q109995'],
+      ['Name', 'Narcissus cyclamineus', 'Q1727024'],
+      ['Color', 'Yellow', 'Q1727024'],
+      ['IUCN ID', '161899', 'Q1727024'],
+    ];
+    cy.loadAndVisitProject(fixture);
+
+    cy.columnActionClick('Field', [
+      'Transpose',
+      'Columnize by key/value columns...',
+    ]);
+    cy.get('select[bind="keyColumnSelect"]').select('Field');
+    cy.get('select[bind="valueColumnSelect"]').select('Data');
+    cy.confirmDialogPanel();
+    cy.assertNotificationContainingText(
+      'Columnize by key column Field and value column Data'
+    );
+
+    const expected = [
+      ['Wikidata ID', 'Name', 'Color', 'IUCN ID'],
+      ['Q109995', 'Galanthus nivalis', 'White', '162168'],
+      ['Q1727024', 'Narcissus cyclamineus', 'Yellow', '161899'],
+    ];
+    cy.assertGridEquals(expected);
+  });
+});


### PR DESCRIPTION
Added tests for the transpose functionalities of OR
Basically, it follows [tutorials found on the doc](https://docs.openrefine.org/manual/transposing/)

Does this needs to be improved ?
Any missing or critical points that are not covered by the present tests ?

@kushthedude please have a look at the new command available, `cy.assertGridEquals`, it let us test the whole grid in one single assertion