### PR TITLE
Solves issues #1940 : SQL exporter doesn't create compliant column names  and #2716 : Review / improve multinational characters support in SQL exporter

### DIFF
--- a/extensions/database/src/com/google/refine/extension/database/pgsql/PgSQLDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/pgsql/PgSQLDatabaseService.java
@@ -47,6 +47,7 @@ import com.google.refine.extension.database.SQLType;
 import com.google.refine.extension.database.model.DatabaseColumn;
 import com.google.refine.extension.database.model.DatabaseInfo;
 import com.google.refine.extension.database.model.DatabaseRow;
+import com.google.refine.exporters.sql.SqlCreateBuilder;
 
 public class PgSQLDatabaseService extends DatabaseService {
     private static final Logger logger = LoggerFactory.getLogger("PgSQLDatabaseService");
@@ -135,6 +136,7 @@ public class PgSQLDatabaseService extends DatabaseService {
                 int dbMinorVersion = metadata.getDatabaseMinorVersion();
                 String dbProductVersion = metadata.getDatabaseProductVersion();
                 String dbProductName = metadata.getDatabaseProductName();
+                SqlCreateBuilder.dbType=dbProductName;
                 DatabaseInfo dbInfo = new DatabaseInfo();
                 dbInfo.setDatabaseMajorVersion(dbMajorVersion);
                 dbInfo.setDatabaseMinorVersion(dbMinorVersion);

--- a/main/src/com/google/refine/exporters/sql/SqlCreateBuilder.java
+++ b/main/src/com/google/refine/exporters/sql/SqlCreateBuilder.java
@@ -45,6 +45,7 @@ public class SqlCreateBuilder {
     private String table;
     private List<String> columns;
     private JsonNode options;
+    public static String dbType="";
 
 
     public SqlCreateBuilder(String table, List<String> columns, JsonNode sqlOptions) {
@@ -82,13 +83,21 @@ public class SqlCreateBuilder {
       
                 
                 if (name != null) {
-                    if(trimColNames) {
+                	if(trimColNames) {
                         String trimmedCol = name.replaceAll("\\s", "");
-                        createSB.append( trimmedCol + " ");
-                    }else{
-                        createSB.append(name + " ");
-                    }
-                   
+                        if(dbType.equals("PostgreSQL")) {
+                    	       createSB.append("\"" +trimmedCol.replaceAll("'","''")+ "\" ");
+                    	   }else {
+                    		   createSB.append("`"+trimmedCol+"`" + " ");
+                    	   }
+                     }else{
+                     	if(dbType.equals("PostgreSQL")) {
+                     	    createSB.append("\"" +name.replaceAll("'","''")+ "\" ");
+                     	}else {
+                     		createSB.append("`"+name+"` ");	
+                     	}
+                     }
+                	
                     if (type.equals(SqlData.SQL_TYPE_VARCHAR)) {
                         if (size.isEmpty()) {
                             size = "255";

--- a/main/src/com/google/refine/exporters/sql/SqlInsertBuilder.java
+++ b/main/src/com/google/refine/exporters/sql/SqlInsertBuilder.java
@@ -179,9 +179,19 @@ public class SqlInsertBuilder {
         }
 
         boolean trimColNames = options == null ? false : JSONUtilities.getBoolean(options, "trimColumnNames", false);
-        String colNamesWithSep = columns.stream().map(col -> col.replaceAll("\\s", "")).collect(Collectors.joining(","));
+        String colNamesWithSep;
+        if(SqlCreateBuilder.dbType.equals("PostgreSQL")) {
+        	colNamesWithSep = columns.stream().map(col -> col.replaceAll("\\s", "")).map(col->col.replaceAll("'", "''")).collect(Collectors.joining("\",\""));	
+        }else {
+        	colNamesWithSep = columns.stream().map(col -> col.replaceAll("\\s", "")).collect(Collectors.joining("`,`"));
+        }
+        
         if(!trimColNames) {
-           colNamesWithSep = columns.stream().collect(Collectors.joining(","));  
+        	if(SqlCreateBuilder.dbType.equals("PostgreSQL")) {
+        		colNamesWithSep = columns.stream().map(col->col.replaceAll("'", "''")).collect(Collectors.joining("\",\"")); 
+            }else {
+            	colNamesWithSep = columns.stream().collect(Collectors.joining("`,`")); 
+            } 
         }
 
         String valuesString = values.toString();
@@ -191,7 +201,11 @@ public class SqlInsertBuilder {
 
         sql.append("INSERT INTO ").append(table);
         sql.append(" (");
-        sql.append(colNamesWithSep);
+        if(SqlCreateBuilder.dbType.equals("PostgreSQL")) {
+        	sql.append("\""+colNamesWithSep +"\""); 
+        }else {
+        	sql.append("`"+colNamesWithSep +"`"); 
+        } 
         sql.append(") VALUES ").append("\n");
         sql.append(valuesString);
         


### PR DESCRIPTION
Fixes #{1940} and #{2716}

Changes proposed in this pull request:
- Changed SqlInsertBuilder, SqlCreateBuilder and PgSQLDatabaseService to add quotes based on the type of database chosen by user in order to allow flexible column names.
- 
- 
