### PR TITLE
Make sure size of recon preview pop-up is set before positioning

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -495,8 +495,8 @@ DataTableCellUI.prototype._previewCandidateTopic = function(candidate, elmt, pre
     return; // no preview service available
   }
 
-  MenuSystem.positionMenuLeftRight(fakeMenu, $(elmt));
   fakeMenu.appendTo(elmt);
+  MenuSystem.positionMenuLeftRight(fakeMenu, $(elmt));
 
   var dismissMenu = function() {
      fakeMenu.remove();


### PR DESCRIPTION
Fixes #3028

Changes proposed in this pull request:
- Create the pop-up before positioning it so that size can be considered in order to not overflow the window.

