### PR TITLE
fix: increase wait time for preview-table to update

### DIFF
--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -214,7 +214,7 @@ Cypress.Commands.add('waitForOrOperation', () => {
  */
 Cypress.Commands.add('typeExpression', (expression) => {
   cy.get('textarea.expression-preview-code').type(expression);
-  cy.wait(250); // eslint-disable-line
+  cy.wait(500); // eslint-disable-line
 });
 
 /**


### PR DESCRIPTION
Signed-off-by: kushthedude <kushthedude@gmail.com>

Fixes https://github.com/OpenRefine/OpenRefine/pull/3676#issuecomment-796982412

There have been more frequent failures for ui_tests due to less timeout in the update preview-table.

