### PR TITLE
Show left panel when a facet is created

### DIFF
--- a/main/webapp/modules/core/scripts/facets/facet.js
+++ b/main/webapp/modules/core/scripts/facets/facet.js
@@ -37,6 +37,8 @@ class Facet {
   	this._config = config;
   	this._options = options || {};
   	this._minimizeState = false;
+  	
+  	Refine.showLeftPanel();
   };
 
   _minimize() {

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -182,6 +182,11 @@ Refine._showHideLeftPanel = function() {
   resizeAll();
 };
 
+Refine.showLeftPanel = function() {
+  $('div#body').removeClass("hide-left-panel");
+  resizeAll();
+};
+
 Refine.setTitle = function(status) {
   var title = theProject.metadata.name + " - OpenRefine";
   if (status) {


### PR DESCRIPTION
Fixes #2891

Added the Refine.showLeftPanel() function.

Changes proposed in this pull request:
When a facet is created, make sure the left panel is being shown.