### PR TITLE
Follow-up fix for facet panel resizing when using permalinks to restore facets

### DIFF
--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -184,6 +184,7 @@ Refine._showHideLeftPanel = function() {
 
 Refine.showLeftPanel = function() {
   $('div#body').removeClass("hide-left-panel");
+  if(ui.browsingEngine == undefined || ui.browsingEngine.resize == undefined) return;
   resizeAll();
 };
 


### PR DESCRIPTION
Fixes #2891

Changes proposed in this pull request:
- If loaded thru a permalink, the new facets will not try to resize the display that is not yet loaded (and though crashes).

This fix a bug introduced in code merged to master yesterday.

Regards,
   Antoine