### PR TITLE
Only show candidates in range of best score facet settings (fixes #3673)

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -210,7 +210,7 @@ DataTableCellUI.prototype._render = function() {
             $('<span></span>').addClass("data-table-recon-score").text("(" + score + ")").appendTo(liSpan);
           };
 
-          bestScoreFacets = ui.browsingEngine.getJSON().facets.filter( facet => facet.expression == 'cell.recon.best.score' );
+          var bestScoreFacets = ui.browsingEngine.getJSON().facets.filter( facet => facet.expression == 'cell.recon.best.score' );
           for (var i = 0; i < candidates.length; i++) {
             var score = candidates[i].score;
             var renderIt = true;

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -210,8 +210,16 @@ DataTableCellUI.prototype._render = function() {
             $('<span></span>').addClass("data-table-recon-score").text("(" + score + ")").appendTo(liSpan);
           };
 
+          bestScoreFacets = ui.browsingEngine.getJSON().facets.filter( facet => facet.expression == 'cell.recon.best.score' );
           for (var i = 0; i < candidates.length; i++) {
-            renderCandidate(candidates[i], i);
+            var score = candidates[i].score;
+            var renderIt = true;
+            for ( var j = 0; j < bestScoreFacets.length; j++ ) {
+              if ((score < bestScoreFacets[j].from) || (score > bestScoreFacets[j].to))
+                renderIt = false;
+            }
+            if ( renderIt )
+              renderCandidate(candidates[i], i);
           }
         }
 


### PR DESCRIPTION
Fixes #3673

Changes proposed in this pull request:
- When using best candidate score facet, don't only limit which rows are shown, but limit which candidates are shown in those rows.
