### PR TITLE
Support export filenames with non-ASCII chars.  (fixes #3724)

### DIFF
--- a/main/src/com/google/refine/commands/project/ExportRowsCommand.java
+++ b/main/src/com/google/refine/commands/project/ExportRowsCommand.java
@@ -58,6 +58,7 @@ import com.google.refine.exporters.StreamExporter;
 import com.google.refine.exporters.WriterExporter;
 import com.google.refine.exporters.sql.SqlExporterException;
 import com.google.refine.model.Project;
+import com.google.common.net.PercentEscaper;
 
 public class ExportRowsCommand extends Command {
     private  static final Logger logger = LoggerFactory.getLogger("ExportRowsCommand");
@@ -105,7 +106,9 @@ public class ExportRowsCommand extends Command {
             if (!"true".equals(preview)) {
                 String path = request.getPathInfo();
                 String filename = path.substring(path.lastIndexOf('/') + 1);
-                response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+                PercentEscaper escaper = new PercentEscaper("", false);
+                filename = escaper.escape(filename);
+                response.setHeader("Content-Disposition", "attachment; filename=" +filename+"; filename*=utf-8' '" + filename);
             }
             
             if (exporter instanceof WriterExporter) {


### PR DESCRIPTION
Fixes #3724 

Changes proposed in this pull request:
- Support non-ASCII characters in export filenames

Tested on a Mac.  Follows [RFC6266](https://tools.ietf.org/html/rfc6266).
