### PR TITLE
Sanitize cookie keys in Wikibase extension

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/commands/LoginCommand.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/commands/LoginCommand.java
@@ -40,6 +40,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
@@ -67,6 +69,8 @@ public class LoginCommand extends Command {
     static final String CONSUMER_SECRET = "wb-consumer-secret";
     static final String ACCESS_TOKEN = "wb-access-token";
     static final String ACCESS_SECRET = "wb-access-secret";
+    
+    static final Pattern cookieKeyDisallowedCharacters = Pattern.compile("[^a-zA-Z0-9\\-!#$%&'*+.?\\^_`|~]");
 
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response)
@@ -83,7 +87,7 @@ public class LoginCommand extends Command {
             CommandUtilities.respondError(response, "missing parameter '" + API_ENDPOINT + "'");
             return;
         }
-        String mediawikiApiEndpointPrefix = mediawikiApiEndpoint + '-';
+        String mediawikiApiEndpointPrefix = sanitizeCookieKey(mediawikiApiEndpoint + '-');
 
         if ("true".equals(request.getParameter("logout"))) {
             manager.logout(mediawikiApiEndpoint);
@@ -267,5 +271,14 @@ public class LoginCommand extends Command {
         } else {
             return str.replaceAll("[\n\r]", "");
         }
+    }
+    
+    /**
+     * Removes special characters from cookie keys,
+     * replacing them by hyphens.
+     */
+    static String sanitizeCookieKey(String key) {
+        Matcher matcher = cookieKeyDisallowedCharacters.matcher(key);
+        return matcher.replaceAll("-");
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/LoginCommandTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/LoginCommandTest.java
@@ -40,7 +40,7 @@ import static org.testng.Assert.*;
 public class LoginCommandTest extends CommandTest {
 
     private static final String apiEndpoint = "https://www.wikidata.org/w/api.php";
-    private static final String apiEndpointPrefix = apiEndpoint + "-";
+    private static final String apiEndpointPrefix = sanitizeCookieKey(apiEndpoint) + "-";
 
     private static final String username = "my_username";
     private static final String password = "my_password";
@@ -566,5 +566,10 @@ public class LoginCommandTest extends CommandTest {
     public void testRemoveCRLF() {
         assertEquals(removeCRLF("a\rb\nc\r\n\r\nd"), "abcd");
         assertEquals(removeCRLF(null), "");
+    }
+    
+    @Test
+    public void testSanitizeCookieKey() {
+        assertEquals(sanitizeCookieKey("https://www.wikidata.org/"), "https---www.wikidata.org-");
     }
 }


### PR DESCRIPTION
Fixes #3745.

Changes proposed in this pull request:
- Replace some special characters in cookie keys so that they are valid even by strict standards
