### PR TITLE
Attempt to fix flaky integration tests

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/column/edit-column/add_columns_based_on_this_column.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/edit-column/add_columns_based_on_this_column.spec.js
@@ -12,7 +12,7 @@ describe(__filename, function () {
     cy.typeExpression('value.toLowercase()');
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'
-    ).contains('butter,with salt');
+    ).should('to.contain', 'butter,with salt');
     cy.confirmDialogPanel();
 
     cy.assertCellEquals(0, 'Test_GREL_toLower', 'butter,with salt');
@@ -32,7 +32,7 @@ describe(__filename, function () {
     cy.typeExpression('return value.lower()');
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'
-    ).contains('butter,with salt');
+    ).should('to.contain', 'butter,with salt');
     cy.confirmDialogPanel();
 
     cy.assertCellEquals(0, 'Test_Python_toLower', 'butter,with salt');
@@ -52,7 +52,7 @@ describe(__filename, function () {
     cy.typeExpression('(.. value (toLowerCase) )');
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'
-    ).contains('butter,with salt');
+    ).should('to.contain', 'butter,with salt');
     cy.confirmDialogPanel();
 
     cy.assertCellEquals(0, 'Test_Clojure_toLower', 'butter,with salt');

--- a/main/tests/cypress/cypress/integration/project/undo_redo/apply.spec.js
+++ b/main/tests/cypress/cypress/integration/project/undo_redo/apply.spec.js
@@ -2,7 +2,7 @@ describe(__filename, function () {
   it('Apply a JSON', function () {
     cy.loadAndVisitProject('food.mini');
 
-    cy.get('#or-proj-undoRedo').click();
+    cy.get('#or-proj-undoRedo').should('to.exist').should('be.visible').click();
     cy.get('#refine-tabs-history .history-panel-controls')
       .contains('Apply')
       .click();

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -286,6 +286,9 @@ Cypress.Commands.add(
   (fixture, projectName = Date.now()) => {
     cy.loadProject(fixture, projectName).then((projectId) => {
       cy.visit(Cypress.env('OPENREFINE_URL') + '/project?project=' + projectId);
+
+      cy.get('#left-panel', { log: false }).should('be.visible');
+      cy.get('#right-panel', { log: false }).should('be.visible');
     });
   }
 );


### PR DESCRIPTION
This PR is an attempt to fix some tests that are flaky.

- apply.spec.js
- add_columns_based_on_this_colum.spec.js

Also added some assertions to ensure OpenRefine is properly loaded in method `loadAndVisitProject`, I believe that should also help to lower the flakyness rate