### PR TITLE
Have LGTM ignore external libraries for quality checks

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -3,6 +3,10 @@ extraction:
     index:
       build_command:
       - mvn clean test-compile
+  javascript:
+    index:
+      exclude:
+        - main/webapp/modules/core/externals
 
 queries:
   - exclude: java/insecure-cookie


### PR DESCRIPTION
Currently LGTM is reporting alerts on problems found/fixed in external Javascript libraries which are included in our source tree. We don't control these, so this is just noise.

This PR changes the LGTM config to ignore external libraries. It has been successfully tested as part of #3087.
