### PR TITLE
fix: unknown java 1.8 in build job action

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -122,11 +122,11 @@ jobs:
         restore-keys: |
             ${{ runner.os }}-maven-
 
-    - name: Set up JDK 1.8
+    - name: Set up Java 8
       uses: actions/setup-java@v2
       with:
         distribution: 'adopt'
-        java-version: 1.8
+        java-version: 8
 
     - name: Install genisoimage and jq
       run: sudo apt-get install genisoimage jq


### PR DESCRIPTION

Changes proposed in this pull request:
- CI was failing because java 1.8 is unknown for new java setup action

