### PR TITLE
Fixed failing test edit all column / fill down

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/all-column/edit-columns.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/all-column/edit-columns.spec.js
@@ -51,11 +51,9 @@ describe(__filename, function () {
       ['01002', 'BUTTER,WHIPPED,WITH SALT', '', ''],
     ]);
   });
-  it('Ensure columns are filled down', function () {
-    cy.loadAndVisitProject('food.mini');
-    cy.columnActionClick('All', ['Edit columns', 'Blank down']);
 
-    cy.assertGridEquals([
+  it('Ensure columns are filled down', function () {
+    cy.loadAndVisitProject([
       ['NDB_No', 'Shrt_Desc', 'Water', 'Energ_Kcal'],
       ['01001', 'BUTTER,WITH SALT', '15.87', '717'],
       ['01002', 'BUTTER,WHIPPED,WITH SALT', '', ''],


### PR DESCRIPTION
Fixes and improve a test that was failing
@kushthedude the reason was that fill down, called from the "all" column is not editing columns all together, but one by one.
Hence, the grid re-render each time.

I noticed you're using food.small, and then apply some transforms to prepare the grid for initial testing conditions, it's actually best if you load a project from a json with the initial data you need to perform the test, so you don't need to prepare the grid for testing.