### PR TITLE
Remove trailing slashes in doc pages URLs to fix links.

### DIFF
--- a/docs/docs/technical-reference/reconciliation-api.md
+++ b/docs/docs/technical-reference/reconciliation-api.md
@@ -6,7 +6,7 @@ sidebar_label: Reconciliation API
 
 _This page is kept for the record. [A cleaner version of this specification](https://reconciliation-api.github.io/specs/0.1/) was written by the [W3C Entity Reconciliation Community Group](https://www.w3.org/community/reconciliation/), which has been formed to improve and promote this API. Join the community group to get involved!_
 
-_This is a technical description of the mechanisms behind the reconciliation system in OpenRefine. For usage instructions, see [Reconciliation](Reconciliation)._
+_This is a technical description of the mechanisms behind the reconciliation system in OpenRefine. For usage instructions, see [Reconciliation](/manual/reconciling)._
 
 ## Introduction
 

--- a/docs/docs/technical-reference/writing-extensions.md
+++ b/docs/docs/technical-reference/writing-extensions.md
@@ -103,7 +103,7 @@ The `init()` function in `controller.js` allows the extension to register variou
 
 The Extensions are loaded by the Butterfly framework. Butterfly refers to these as 'modules'. [The location of modules is set in the `main/webapp/butterfly.properties` file](https://github.com/OpenRefine/OpenRefine/blob/master/main/webapp/WEB-INF/butterfly.properties#L27). Butterfly simply descends into each of those paths and looks for any `MOD-INF` directories.
 
-For more information, see [Extension Points](Extension-Points).
+For more information, see [Extension Points](https://github.com/OpenRefine/OpenRefine/wiki/Extension-Points).
 
 ## Extension points
 
@@ -222,7 +222,7 @@ Your command will then be accessible at [http://127.0.0.1:3333/command/my-extens
 
 ### Server-side: Operations
 
-Most commands change the project's data. Most of them do so by creating abstract operations. See the Changes, History, Processes, and Operations section of the [Server Side Architecture](Server-side+Architecture) document.
+Most commands change the project's data. Most of them do so by creating abstract operations. See the Changes, History, Processes, and Operations section of the [Server Side Architecture](https://github.com/OpenRefine/OpenRefine/wiki/Server-Side-Architecture) document.
 
 You can register an operation **class** in the `init` function as follows:
 

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   onBrokenLinks: 'error',
+  onBrokenMarkdownLinks: 'error',
   title: 'OpenRefine',
   tagline: 'A power tool for working with messy data.',
   url: 'https://docs.openrefine.org/',
@@ -106,5 +107,12 @@ module.exports = {
         },
       },
     ],
+  ],
+  scripts: [
+    {
+      src: '/js/fix-location.js',
+      async: false,
+      defer: false,
+    },
   ],
 };

--- a/docs/static/js/fix-location.js
+++ b/docs/static/js/fix-location.js
@@ -4,5 +4,5 @@
  * https://github.com/facebook/docusaurus/issues/2394#issuecomment-630638096
  */
 if (window && window.location && window.location.pathname.endsWith('/') && window.location.pathname !== '/') {
-  window.history.replaceState('', '', window.location.pathname.substr(0, window.location.pathname.length - 1))
+  window.history.replaceState('', '', window.location.pathname.substr(0, window.location.pathname.length - 1) + window.location.hash)
 }

--- a/docs/static/js/fix-location.js
+++ b/docs/static/js/fix-location.js
@@ -1,0 +1,8 @@
+/*
+ * when trailing slashes are added to URLs, this breaks internal links.
+ * This is a fix for this issue taken from:
+ * https://github.com/facebook/docusaurus/issues/2394#issuecomment-630638096
+ */
+if (window && window.location && window.location.pathname.endsWith('/') && window.location.pathname !== '/') {
+  window.history.replaceState('', '', window.location.pathname.substr(0, window.location.pathname.length - 1))
+}


### PR DESCRIPTION
Closes #3819 by adding some JS code to remove trailing slashes at the end of documentation URLs.