### PR TITLE
Restore log levels after Jetty update

### DIFF
--- a/main/src/log4j.properties
+++ b/main/src/log4j.properties
@@ -1,4 +1,6 @@
 log4j.rootLogger=INFO, console
+log4j.logger.org.eclipse.log=WARN
+log4j.logger.org.eclipse.jetty=ERROR
 log4j.logger.org.apache.http.headers=WARN
 log4j.logger.org.apache.http.impl=WARN
 log4j.logger.org.apache.http.client=WARN
@@ -10,3 +12,4 @@ log4j.appender.console.layout=com.google.refine.logging.IndentingLayout
 log4j.logger.butterfly=ERROR
 log4j.logger.refine=INFO
 log4j.logger.FileProjectManager=WARN
+

--- a/main/src/log4j.properties
+++ b/main/src/log4j.properties
@@ -6,3 +6,7 @@ log4j.logger.velocity=WARN
 
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=com.google.refine.logging.IndentingLayout
+
+log4j.logger.butterfly=ERROR
+log4j.logger.refine=INFO
+log4j.logger.FileProjectManager=WARN

--- a/server/src/log4j.properties
+++ b/server/src/log4j.properties
@@ -1,8 +1,0 @@
-log4j.rootLogger=INFO, console
-log4j.logger.org.eclipse.log=WARN
-log4j.logger.org.eclipse.jetty=ERROR
-log4j.logger.velocity=WARN
-
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=com.google.util.logging.IndentingLayout
-

--- a/server/src/log4j.properties
+++ b/server/src/log4j.properties
@@ -1,11 +1,8 @@
 log4j.rootLogger=INFO, console
-log4j.logger.org.mortbay.log=WARN
-log4j.logger.org.mortbay.jetty=ERROR
+log4j.logger.org.eclipse.log=WARN
+log4j.logger.org.eclipse.jetty=ERROR
 log4j.logger.velocity=WARN
 
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=com.google.util.logging.IndentingLayout
 
-log4j.logger.butterfly=ERROR
-log4j.logger.refine=INFO
-log4j.logger.FileProjectManager=WARN


### PR DESCRIPTION
Fixes #3782.

For some reason the logging levels are now taken from the `log4j.properties` file in the `main` module, not the `server` one. Not sure why. Anyway, this restores the previous log levels, which makes the output less verbose.
