### PR TITLE
Support BCE dates in Wikibase upload

### DIFF
--- a/extensions/wikidata/module/scripts/schema-alignment.js
+++ b/extensions/wikidata/module/scripts/schema-alignment.js
@@ -1021,7 +1021,7 @@ SchemaAlignment._initField = function(inputContainer, mode, initialValue, change
       changedCallback();
     });
 
-    SchemaAlignment.setupStringInputValidation(input, /^((\d{4}(-[0-1]\d(-[0-3]\d)?)?)|TODAY)$/);
+    SchemaAlignment.setupStringInputValidation(input, /^(([\-]?\d{4}(-[0-1]\d(-[0-3]\d)?)?)|TODAY)$/);
    } else if (mode === "globe-coordinate") {
      input.attr("placeholder", "lat,lon");
      var propagateValue = function(val) {

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
@@ -108,11 +108,6 @@ public class WbDateConstant implements WbExpression<TimeValue> {
         String calendarIri = TimeValue.CM_GREGORIAN_PRO; // Gregorian calendar is assumed by default
         
         String trimmedDatestamp = datestamp.trim();
-
-        if(trimmedDatestamp.startsWith("-")){
-            trimmedDatestamp = trimmedDatestamp.replace("-", "");
-            bceFlag = true;
-        }
         
         if("TODAY".equals(trimmedDatestamp)) {
 	        Calendar calendar = Calendar.getInstance();
@@ -123,7 +118,11 @@ public class WbDateConstant implements WbExpression<TimeValue> {
 	    			(byte)0, (byte)0, (byte)0, (byte)11, 0,0,0, TimeValue.CM_GREGORIAN_PRO);
 	    	return todaysDate;
         }
-        
+
+        if(trimmedDatestamp.startsWith("-")){
+            trimmedDatestamp = trimmedDatestamp.substring(1);
+            bceFlag = true;
+        }
     	
         for (Entry<SimpleDateFormat, Integer> entry : acceptedFormats.entrySet()) {
             ParsePosition position = new ParsePosition(0);

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
@@ -104,7 +104,7 @@ public class WbDateConstant implements WbExpression<TimeValue> {
         Date bestDate = null;
         int precision = 0; // default precision (will be overridden if successfully parsed)
         int maxLength = 0; // the maximum length parsed
-        Boolean bceFlag = false; // judge whether this is a BCE year
+        boolean bceFlag = false; // judge whether this is a BCE year
         String calendarIri = TimeValue.CM_GREGORIAN_PRO; // Gregorian calendar is assumed by default
         
         String trimmedDatestamp = datestamp.trim();

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
@@ -104,9 +104,15 @@ public class WbDateConstant implements WbExpression<TimeValue> {
         Date bestDate = null;
         int precision = 0; // default precision (will be overridden if successfully parsed)
         int maxLength = 0; // the maximum length parsed
+        Boolean bceFlag = false; // judge whether this is a BCE year
         String calendarIri = TimeValue.CM_GREGORIAN_PRO; // Gregorian calendar is assumed by default
         
         String trimmedDatestamp = datestamp.trim();
+
+        if(trimmedDatestamp.startsWith("-")){
+            trimmedDatestamp = trimmedDatestamp.replace("-", "");
+            bceFlag = true;
+        }
         
         if("TODAY".equals(trimmedDatestamp)) {
 	        Calendar calendar = Calendar.getInstance();
@@ -155,7 +161,10 @@ public class WbDateConstant implements WbExpression<TimeValue> {
             Calendar calendar = Calendar.getInstance();
             calendar = Calendar.getInstance();
             calendar.setTime(bestDate);
-            return Datamodel.makeTimeValue(calendar.get(Calendar.YEAR), (byte) (calendar.get(Calendar.MONTH) + 1), 
+            long year = calendar.get(Calendar.YEAR);
+            if(bceFlag)
+                year = -1*year;
+            return Datamodel.makeTimeValue(year, (byte) (calendar.get(Calendar.MONTH) + 1),
                     (byte) calendar.get(Calendar.DAY_OF_MONTH), (byte) calendar.get(Calendar.HOUR_OF_DAY),
                     (byte) calendar.get(Calendar.MINUTE), (byte) calendar.get(Calendar.SECOND), (byte) precision, 0, 0,
                     0, calendarIri);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
@@ -92,7 +92,7 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
                 TimeValue.CM_GREGORIAN_PRO), secondz);
 
         evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
-                TimeValue.CM_GREGORIAN_PRO), BCEwhitespace);
+                TimeValue.CM_GREGORIAN_PRO), whitespace);
         
         evaluatesTo(Datamodel.makeTimeValue(1320, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), julianDecade);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
@@ -47,7 +47,21 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
     private WbDateConstant julianYear = new WbDateConstant("1324_Q1985786");
     private WbDateConstant julianDecade = new WbDateConstant("1320D_Q1985786");
 
-    private WbDateConstant BCE = new WbDateConstant("-1100");
+    private WbDateConstant BCEmillenium = new WbDateConstant("-1001M");
+    private WbDateConstant BCEcentury = new WbDateConstant("-1701C");
+    private WbDateConstant BCEdecade = new WbDateConstant("-1990D");
+    private WbDateConstant BCEyear = new WbDateConstant("-2018");
+    private WbDateConstant BCEmonth = new WbDateConstant("-2018-02");
+    private WbDateConstant BCEday = new WbDateConstant("-2018-02-27");
+    private WbDateConstant BCEwhitespace = new WbDateConstant("   -2018-02-27  ");
+    private WbDateConstant BCEsecond = new WbDateConstant("-2017-01-03T04:12:45");
+    private WbDateConstant BCEsecondz = new WbDateConstant("-2017-01-03T04:12:45Z");
+
+    private WbDateConstant BCEjulianDay = new WbDateConstant("-1324-02-27_Q1985786");
+    private WbDateConstant BCEjulianMonth = new WbDateConstant("-1324-02_Q1985786");
+    private WbDateConstant BCEjulianYear = new WbDateConstant("-1324_Q1985786");
+    private WbDateConstant BCEjulianDecade = new WbDateConstant("-1320D_Q1985786");
+
     
     @Test
     public void testSerialize() {
@@ -78,7 +92,7 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
                 TimeValue.CM_GREGORIAN_PRO), secondz);
 
         evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
-                TimeValue.CM_GREGORIAN_PRO), whitespace);
+                TimeValue.CM_GREGORIAN_PRO), BCEwhitespace);
         
         evaluatesTo(Datamodel.makeTimeValue(1320, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), julianDecade);
@@ -92,8 +106,34 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
 
     @Test
     public void testEvaluateBCE() {
-        evaluatesTo(Datamodel.makeTimeValue(-1100, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
-                TimeValue.CM_GREGORIAN_PRO), BCE);
+        evaluatesTo(Datamodel.makeTimeValue(-1001, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 6, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), BCEmillenium);
+        evaluatesTo(Datamodel.makeTimeValue(-1701, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 7, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), BCEcentury);
+        evaluatesTo(Datamodel.makeTimeValue(-1990, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), BCEdecade);
+        evaluatesTo(Datamodel.makeTimeValue(-2018, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), BCEyear);
+        evaluatesTo(Datamodel.makeTimeValue(-2018, (byte) 2, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), BCEmonth);
+        evaluatesTo(Datamodel.makeTimeValue(-2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), BCEday);
+        evaluatesTo(Datamodel.makeTimeValue(-2017, (byte) 1, (byte) 3, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), BCEsecond);
+        evaluatesTo(Datamodel.makeTimeValue(-2017, (byte) 1, (byte) 3, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), BCEsecondz);
+
+        evaluatesTo(Datamodel.makeTimeValue(-2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), BCEwhitespace);
+
+        evaluatesTo(Datamodel.makeTimeValue(-1320, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
+                TimeValue.CM_JULIAN_PRO), BCEjulianDecade);
+        evaluatesTo(Datamodel.makeTimeValue(-1324, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
+                TimeValue.CM_JULIAN_PRO), BCEjulianYear);
+        evaluatesTo(Datamodel.makeTimeValue(-1324, (byte) 2, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
+                TimeValue.CM_JULIAN_PRO), BCEjulianMonth);
+        evaluatesTo(Datamodel.makeTimeValue(-1324, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
+                TimeValue.CM_JULIAN_PRO), BCEjulianDay);
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
@@ -47,6 +47,7 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
     private WbDateConstant julianYear = new WbDateConstant("1324_Q1985786");
     private WbDateConstant julianDecade = new WbDateConstant("1320D_Q1985786");
 
+    private WbDateConstant BCE = new WbDateConstant("-1100");
     
     @Test
     public void testSerialize() {
@@ -88,7 +89,13 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
         evaluatesTo(Datamodel.makeTimeValue(1324, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), julianDay);
     }
-    
+
+    @Test
+    public void testEvaluateBCE() {
+        evaluatesTo(Datamodel.makeTimeValue(-1100, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
+                TimeValue.CM_GREGORIAN_PRO), BCE);
+    }
+
     @Test
     public void testToday() {
     	Calendar calendar = Calendar.getInstance();


### PR DESCRIPTION
Fixes #{3816}

Changes proposed in this pull request:
- one test for BCE year added in WbDateConstantTest.java
- make change in method parse() of WbDateConstant.java to support BCE year(for example, regard a BCE year -1100
- as 1100 when call other read-only methods and finally change the year from positive 1100 to -1100 when return the TimeValue for parse())
- 
