### PR TITLE
Make sure POST requests are retried even when connections are closed.

### DIFF
--- a/main/src/com/google/refine/util/HttpClient.java
+++ b/main/src/com/google/refine/util/HttpClient.java
@@ -210,5 +210,13 @@ public class HttpClient {
             }
             return interval;
         }
+        
+        /**
+         * Even our POST requests should be retried, they are deemed idempotent
+         */
+        @Override
+        public boolean handleAsIdempotent(final HttpRequest request) {
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Closes #3664.

By default, the Apache HTTP client does not retry POST requests in when basic network errors happen (such as a closed connection) because those requests are not deemed idempotent (so retrying them might generate a side effect on the server twice). But for reconciliation they are idempotent, so they should be retried.

It would be good to make this parameter configurable: if we add support for POST requests in the URL fetching operation, for instance, we could want to have a different behaviour there (not retrying by default). But I am a bit worried by the parameters we are gathering in the constructor of HttpClient, we should probably already introduce a builder class here.

The underlying issue is that the Apache HTTP client tries to reuse connections (which is useful) without checking before if the connection is still open (which is bad). There could be other workarounds like this:
https://williamsbdev.com/posts/no-http-response-exceptions/
The performance overhead of that solution is not so bad (10ms is negligible compared to the time most recon services will take to answer recon batches) but it feels a bit hacky to me. But it could also be a useful addition.

My solution covers other cases (connection closed after the request was initiated, for instance, which is definitely useful when requests take a long time to complete).