### PR TITLE
Fix wikibase date export format

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
@@ -124,8 +124,6 @@ public class WbDateConstant implements WbExpression<TimeValue> {
             bceFlag = true;
         }
 
-        int segment = trimmedDatestamp.split("-").length;  // judge whether the precision is smaller than year, month or day
-
         for (Entry<SimpleDateFormat, Integer> entry : acceptedFormats.entrySet()) {
             ParsePosition position = new ParsePosition(0);
             Date date = entry.getKey().parse(trimmedDatestamp, position);
@@ -163,8 +161,8 @@ public class WbDateConstant implements WbExpression<TimeValue> {
             calendar = Calendar.getInstance();
             calendar.setTime(bestDate);
             long year = calendar.get(Calendar.YEAR);
-            int month = segment > 1 ? calendar.get(Calendar.MONTH) + 1: 0;
-            int day_of_month = segment > 2 ? calendar.get(Calendar.DAY_OF_MONTH) : 0;
+            int month = precision < 10 ? 0 : calendar.get(Calendar.MONTH) + 1;
+            int day_of_month = precision < 11 ? 0 : calendar.get(Calendar.DAY_OF_MONTH);
             if(bceFlag)
                 year = -1*year;
             return Datamodel.makeTimeValue(year, (byte) month,

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java
@@ -123,7 +123,9 @@ public class WbDateConstant implements WbExpression<TimeValue> {
             trimmedDatestamp = trimmedDatestamp.substring(1);
             bceFlag = true;
         }
-    	
+
+        int segment = trimmedDatestamp.split("-").length;  // judge whether the precision is smaller than year, month or day
+
         for (Entry<SimpleDateFormat, Integer> entry : acceptedFormats.entrySet()) {
             ParsePosition position = new ParsePosition(0);
             Date date = entry.getKey().parse(trimmedDatestamp, position);
@@ -161,10 +163,12 @@ public class WbDateConstant implements WbExpression<TimeValue> {
             calendar = Calendar.getInstance();
             calendar.setTime(bestDate);
             long year = calendar.get(Calendar.YEAR);
+            int month = segment > 1 ? calendar.get(Calendar.MONTH) + 1: 0;
+            int day_of_month = segment > 2 ? calendar.get(Calendar.DAY_OF_MONTH) : 0;
             if(bceFlag)
                 year = -1*year;
-            return Datamodel.makeTimeValue(year, (byte) (calendar.get(Calendar.MONTH) + 1),
-                    (byte) calendar.get(Calendar.DAY_OF_MONTH), (byte) calendar.get(Calendar.HOUR_OF_DAY),
+            return Datamodel.makeTimeValue(year, (byte) month,
+                    (byte) day_of_month, (byte) calendar.get(Calendar.HOUR_OF_DAY),
                     (byte) calendar.get(Calendar.MINUTE), (byte) calendar.get(Calendar.SECOND), (byte) precision, 0, 0,
                     0, calendarIri);
         }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/exporters/QuickStatementsExporterTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/exporters/QuickStatementsExporterTest.java
@@ -71,7 +71,6 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         StringWriter writer = new StringWriter();
         Properties properties = new Properties();
         exporter.export(project, properties, engine, writer);
-        System.out.println(TestingData.inceptionWithNewQS);
         assertEquals(TestingData.inceptionWithNewQS, writer.toString());
     }
 

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/exporters/QuickStatementsExporterTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/exporters/QuickStatementsExporterTest.java
@@ -71,6 +71,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         StringWriter writer = new StringWriter();
         Properties properties = new Properties();
         exporter.export(project, properties, engine, writer);
+        System.out.println(TestingData.inceptionWithNewQS);
         assertEquals(TestingData.inceptionWithNewQS, writer.toString());
     }
 

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
@@ -74,15 +74,15 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
     @Test
     public void testEvaluate() {
         
-        evaluatesTo(Datamodel.makeTimeValue(1001, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 6, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(1001, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 6, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), millenium);
-        evaluatesTo(Datamodel.makeTimeValue(1701, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 7, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(1701, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 7, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), century);
-        evaluatesTo(Datamodel.makeTimeValue(1990, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(1990, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), decade);
-        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), year);
-        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), month);
         evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), day);
@@ -94,11 +94,11 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
         evaluatesTo(Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), whitespace);
         
-        evaluatesTo(Datamodel.makeTimeValue(1320, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(1320, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), julianDecade);
-        evaluatesTo(Datamodel.makeTimeValue(1324, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(1324, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), julianYear);
-        evaluatesTo(Datamodel.makeTimeValue(1324, (byte) 2, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(1324, (byte) 2, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), julianMonth);
         evaluatesTo(Datamodel.makeTimeValue(1324, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), julianDay);
@@ -106,15 +106,15 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
 
     @Test
     public void testEvaluateBCE() {
-        evaluatesTo(Datamodel.makeTimeValue(-1001, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 6, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(-1001, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 6, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), BCEmillenium);
-        evaluatesTo(Datamodel.makeTimeValue(-1701, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 7, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(-1701, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 7, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), BCEcentury);
-        evaluatesTo(Datamodel.makeTimeValue(-1990, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(-1990, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), BCEdecade);
-        evaluatesTo(Datamodel.makeTimeValue(-2018, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(-2018, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), BCEyear);
-        evaluatesTo(Datamodel.makeTimeValue(-2018, (byte) 2, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(-2018, (byte) 2, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), BCEmonth);
         evaluatesTo(Datamodel.makeTimeValue(-2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), BCEday);
@@ -126,11 +126,11 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
         evaluatesTo(Datamodel.makeTimeValue(-2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
                 TimeValue.CM_GREGORIAN_PRO), BCEwhitespace);
 
-        evaluatesTo(Datamodel.makeTimeValue(-1320, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(-1320, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 8, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), BCEjulianDecade);
-        evaluatesTo(Datamodel.makeTimeValue(-1324, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(-1324, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 9, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), BCEjulianYear);
-        evaluatesTo(Datamodel.makeTimeValue(-1324, (byte) 2, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
+        evaluatesTo(Datamodel.makeTimeValue(-1324, (byte) 2, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 10, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), BCEjulianMonth);
         evaluatesTo(Datamodel.makeTimeValue(-1324, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11, 0, 0, 0,
                 TimeValue.CM_JULIAN_PRO), BCEjulianDay);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateVariableTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateVariableTest.java
@@ -32,7 +32,7 @@ import com.google.refine.model.Cell;
 
 public class WbDateVariableTest extends WbVariableTest<TimeValue> {
 
-    private TimeValue year = Datamodel.makeTimeValue(2018, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9,
+    private TimeValue year = Datamodel.makeTimeValue(2018, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 9,
             0, 0, 0, TimeValue.CM_GREGORIAN_PRO);
     private TimeValue day = Datamodel.makeTimeValue(2018, (byte) 2, (byte) 27, (byte) 0, (byte) 0, (byte) 0, (byte) 11,
             0, 0, 0,  TimeValue.CM_GREGORIAN_PRO);

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WikibaseSchemaTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WikibaseSchemaTest.java
@@ -58,9 +58,9 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
 
     private ItemIdValue qid1 = Datamodel.makeWikidataItemIdValue("Q1377");
     private ItemIdValue qid2 = Datamodel.makeWikidataItemIdValue("Q865528");
-    private TimeValue date1 = Datamodel.makeTimeValue(1919, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9,
+    private TimeValue date1 = Datamodel.makeTimeValue(1919, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 9,
             (byte) 0, (byte) 0, (byte) 0, TimeValue.CM_GREGORIAN_PRO);
-    private TimeValue date2 = Datamodel.makeTimeValue(1965, (byte) 1, (byte) 1, (byte) 0, (byte) 0, (byte) 0, (byte) 9,
+    private TimeValue date2 = Datamodel.makeTimeValue(1965, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 0, (byte) 9,
             (byte) 0, (byte) 0, (byte) 0, TimeValue.CM_GREGORIAN_PRO);
     private StringValue url = Datamodel.makeStringValue("http://www.ljubljana-slovenia.com/university-ljubljana");
     private PropertyIdValue inceptionPid = Datamodel.makeWikidataPropertyIdValue("P571");
@@ -158,6 +158,7 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
         List<ItemUpdate> expected = new ArrayList<>();
         ItemUpdate update1 = new ItemUpdateBuilder(qid1).addStatement(statement1).build();
         expected.add(update1);
+        System.out.println(expected);
         assertEquals(expected, updates);
     }
 

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WikibaseSchemaTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WikibaseSchemaTest.java
@@ -158,7 +158,6 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
         List<ItemUpdate> expected = new ArrayList<>();
         ItemUpdate update1 = new ItemUpdateBuilder(qid1).addStatement(statement1).build();
         expected.add(update1);
-        System.out.println(expected);
         assertEquals(expected, updates);
     }
 

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/testing/TestingData.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/testing/TestingData.java
@@ -52,10 +52,10 @@ public class TestingData {
     public static final String inceptionWithNewCsv = "subject,inception,reference\n"
             + "Q1377,1919,http://www.ljubljana-slovenia.com/university-ljubljana\n" + "Q865528,1965,\n"
             + "new uni,2016,http://new-uni.com/";
-    public static final String inceptionWithNewQS = "Q1377\tP571\t+1919-01-01T00:00:00Z/9"
+    public static final String inceptionWithNewQS = "Q1377\tP571\t+1919-00-00T00:00:00Z/9"
             + "\tS854\t\"http://www.ljubljana-slovenia.com/university-ljubljana\""
-            + "\tS813\t+2018-02-28T00:00:00Z/11\n" + "Q865528\tP571\t+1965-01-01T00:00:00Z/9"
-            + "\tS813\t+2018-02-28T00:00:00Z/11\n" + "CREATE\n" + "LAST\tP571\t+2016-01-01T00:00:00Z/9"
+            + "\tS813\t+2018-02-28T00:00:00Z/11\n" + "Q865528\tP571\t+1965-00-00T00:00:00Z/9"
+            + "\tS813\t+2018-02-28T00:00:00Z/11\n" + "CREATE\n" + "LAST\tP571\t+2016-00-00T00:00:00Z/9"
             + "\tS854\t\"http://new-uni.com/\"" + "\tS813\t+2018-02-28T00:00:00Z/11\n";
 
     public static ItemIdValue newIdA = makeNewItemIdValue(1234L, "new item A");


### PR DESCRIPTION
Fixes #3694

Changes proposed in this pull request:
- Adjust "extensions/wikidata/src/org/openrefine/wikidata/schema/WbDateConstant.java" and add a variable "segment" to judge whether the date has a precision smaller than year, month or day
- Adjust "extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java" accordingly to test correctness.
- Note that the basic classes such as "Date" and "Calendar" are not modified since the authority is not assigned and I also think there isn't necessity to modify them because time like "1883-00-00T00:00:00Z" is actually not a real valid date.
