### PR TITLE
Update Wikidata Toolkit to 0.12.0

### DIFF
--- a/extensions/wikidata/pom.xml
+++ b/extensions/wikidata/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <powermock.version>2.0.9</powermock.version>
-    <wdtk.version>0.12.0-SNAPSHOT</wdtk.version>
+    <wdtk.version>0.12.0</wdtk.version>
   </properties>
 
   <build>
@@ -127,7 +127,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.openrefine.dependencies.wdtk</groupId>
+      <groupId>org.wikidata.wdtk</groupId>
       <artifactId>wdtk-wikibaseapi</artifactId>
       <version>${wdtk.version}</version>
     </dependency>
@@ -137,12 +137,12 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openrefine.dependencies.wdtk</groupId>
+      <groupId>org.wikidata.wdtk</groupId>
       <artifactId>wdtk-datamodel</artifactId>
       <version>${wdtk.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openrefine.dependencies.wdtk</groupId>
+      <groupId>org.wikidata.wdtk</groupId>
       <artifactId>wdtk-util</artifactId>
       <version>${wdtk.version}</version>
     </dependency>


### PR DESCRIPTION
This update is done manually rather than via dependabot because we were previously using an unofficial snapshot of this library.
