### PR TITLE
fixed options to add to run OpenRefine in headless mode

### DIFF
--- a/refine
+++ b/refine
@@ -511,7 +511,7 @@ ui_test() {
 
     REFINE_DATA_DIR="${TMPDIR:=/tmp}/openrefine-tests"
     
-    add_option "-Drefine.headless=true"
+    add_option "-x refine.headless=true"
     add_option "-Drefine.autoreload=false"
     add_option "-Dbutterfly.autoreload=false"
     
@@ -658,7 +658,7 @@ broker_run() {
     fi
 
     add_option "-Drefine.webapp=broker/core"
-    add_option "-Drefine.headless=true"
+    add_option "-x refine.headless=true"
 
     add_option "-Drefine.port=$REFINE_PORT"
     add_option "-Drefine.host=0.0.0.0"


### PR DESCRIPTION
Fixes #{3818}

Changes proposed in this pull request:
- modified the option to add to run OpenRefine in headless mode from -Drefine.headless=true to -x refine.headless=true in refine folder.
- 
- 
