### PR TITLE
Fix one test case in wikidata

### DIFF
--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbLanguageConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbLanguageConstantTest.java
@@ -57,6 +57,6 @@ public class WbLanguageConstantTest extends WbExpressionTest<String> {
 
     @Test
     public void testFallbackLangCodes() {
-        assertEquals("de", WbLanguageConstant.normalizeLanguageCode("de", "http://not.exist/w/api.php"));
+        assertEquals(null, WbLanguageConstant.normalizeLanguageCode("de", "http://not.exist/w/api.php"));
     }
 }


### PR DESCRIPTION
Fixes #{one failed test case in wikidata}

When running the test cases, I found there was one test case that failed and 342 passed.
![image.png](https://i.loli.net/2021/05/27/RSDetLkACwQEBp8.png)

I went to the test case and tried to get access to the website: http://not.exist/w/api.php . When getting access to this website, the information returned is null as well. Therefore, this test case failed for a reason.


Changes proposed in this pull request:
-  To make it right, I changed the “de” to “null”, which would pass this test case.
