### PR TITLE
Wiki create process test

### DIFF
--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/operations/PerformWikibaseEditsOperationTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/operations/PerformWikibaseEditsOperationTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertEquals;
 import java.io.LineNumberReader;
 import java.util.Properties;
 
+import com.google.refine.process.Process;
 import org.openrefine.wikidata.testing.TestingData;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -57,8 +58,6 @@ public class PerformWikibaseEditsOperationTest extends OperationTest {
         return TestingData.jsonFromFile("operations/perform-edits.json");
     }
 
-
-    
     @Test(expectedExceptions=IllegalArgumentException.class)
     public void testConstructor() {
         new PerformWikibaseEditsOperation(EngineConfig.reconstruct("{}"), "", 5, "");
@@ -66,9 +65,9 @@ public class PerformWikibaseEditsOperationTest extends OperationTest {
 
     @Test
     public void testCreateProcess() throws Exception{
-        PerformWikibaseEditsOperation p = new PerformWikibaseEditsOperation(EngineConfig.reconstruct("{}"), "test", 5, "");
+        PerformWikibaseEditsOperation operation = new PerformWikibaseEditsOperation(EngineConfig.reconstruct("{}"), "test", 5, "");
         project.rows.get(0).cells.set(0, TestingData.makeNewItemCell(1234L, "new item"));
-        p.createProcess(project, new Properties());
+        Process process = operation.createProcess(project, new Properties());
     }
 
     @Test
@@ -91,8 +90,4 @@ public class PerformWikibaseEditsOperationTest extends OperationTest {
 
         assertEquals(changeString, saveChange(change));
     }
-
-
-
-
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/operations/PerformWikibaseEditsOperationTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/operations/PerformWikibaseEditsOperationTest.java
@@ -26,6 +26,7 @@ package org.openrefine.wikidata.operations;
 import static org.testng.Assert.assertEquals;
 
 import java.io.LineNumberReader;
+import java.util.Properties;
 
 import org.openrefine.wikidata.testing.TestingData;
 import org.testng.annotations.BeforeMethod;
@@ -55,10 +56,19 @@ public class PerformWikibaseEditsOperationTest extends OperationTest {
             throws Exception {
         return TestingData.jsonFromFile("operations/perform-edits.json");
     }
+
+
     
     @Test(expectedExceptions=IllegalArgumentException.class)
     public void testConstructor() {
         new PerformWikibaseEditsOperation(EngineConfig.reconstruct("{}"), "", 5, "");
+    }
+
+    @Test
+    public void testCreateProcess() throws Exception{
+        PerformWikibaseEditsOperation p = new PerformWikibaseEditsOperation(EngineConfig.reconstruct("{}"), "test", 5, "");
+        project.rows.get(0).cells.set(0, TestingData.makeNewItemCell(1234L, "new item"));
+        p.createProcess(project, new Properties());
     }
 
     @Test
@@ -81,5 +91,8 @@ public class PerformWikibaseEditsOperationTest extends OperationTest {
 
         assertEquals(changeString, saveChange(change));
     }
+
+
+
 
 }


### PR DESCRIPTION
Noticing that there are no test cases for the "PerformEditsProcess" class in the wiki extension, I try to create a simple test case to test the constructor of "PerformEditsProcess" by calling the "createProcess" method in PerformWikibaseEditsOperation. I plan to further test the process with threading simulation if this approach is acceptable. 

Changes proposed in this pull request:
add "testCreateProcess" method in PerformWikibaseEditsOperationTest.java
