### PR TITLE
Tests stability

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
 on:
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
 on:
-  pull_request:
+  push:
     paths-ignore:
       - 'docs/**'
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -98,7 +98,7 @@ jobs:
       - id: set-matrix
         run: npm install --save glob && node main/tests/cypress/build-test-matrix.js
         env:
-          browsers: chrome,edge
+          browsers: chrome
   ui_test:
     needs: prepare_ui_test_matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -98,7 +98,7 @@ jobs:
       - id: set-matrix
         run: npm install --save glob && node main/tests/cypress/build-test-matrix.js
         env:
-          browsers: chrome
+          browsers: chrome,edge
   ui_test:
     needs: prepare_ui_test_matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
 on:
-  push:
+  pull_request_target:
     paths-ignore:
       - 'docs/**'
 

--- a/main/tests/cypress/cypress/integration/create-project/create_project.spec.js
+++ b/main/tests/cypress/cypress/integration/create-project/create_project.spec.js
@@ -30,7 +30,13 @@ describe(__filename, function () {
     cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
     // preview and click next
-    cy.doCreateProjectThroughUserInterface();
+    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+      .contains('Create Project »')
+      .click();
+    cy.get('#create-project-progress-message').contains('Done.');
+
+    // ensure the project is loading by checking presence of a project-title element
+    cy.get('#project-title').should('exist');
   });
   it('Test the create project from this computer based on TSV', function () {
     // navigate to the create page
@@ -63,7 +69,13 @@ describe(__filename, function () {
     cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
     // preview and click next
-    cy.doCreateProjectThroughUserInterface();
+    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+      .contains('Create Project »')
+      .click();
+    cy.get('#create-project-progress-message').contains('Done.');
+
+    // ensure the project is loading by checking presence of a project-title element
+    cy.get('#project-title').should('exist');
   });
   it('Test the create project from clipboard based on CSV', function () {
     // navigate to the create page
@@ -97,7 +109,13 @@ describe(__filename, function () {
     cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
     // preview and click next
-    cy.doCreateProjectThroughUserInterface();
+    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+      .contains('Create Project »')
+      .click();
+    cy.get('#create-project-progress-message').contains('Done.');
+
+    // ensure the project is loading by checking presence of a project-title element
+    cy.get('#project-title').should('exist');
   });
   it('Test the create project from clipboard based on TSV', function () {
     // navigate to the create page
@@ -111,8 +129,8 @@ describe(__filename, function () {
       'Paste data from clipboard here:'
     );
     // add file
-    const tsvFile = `Some parameter	Other parameter	Last parameter
-    CONST	123456	12.45`;
+    const tsvFile = `Some parameter Other parameter Last parameter
+    CONST 123456  12.45`;
     cy.get('textarea').invoke('val', tsvFile);
     cy.get(
       '.create-project-ui-source-selection-tab-body.selected button.button-primary'
@@ -127,71 +145,95 @@ describe(__filename, function () {
     cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
     // preview and click next
-    cy.doCreateProjectThroughUserInterface();
+    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+      .contains('Create Project »')
+      .click();
+    cy.get('#create-project-progress-message').contains('Done.');
+
+    // ensure the project is loading by checking presence of a project-title element
+    cy.get('#project-title').should('exist');
   });
-  it('Test the create project from Web URL based on CSV', function () {
-    // navigate to the create page
-    cy.visitOpenRefine();
-    cy.navigateTo('Create Project');
-    cy.get('#create-project-ui-source-selection-tabs > div')
-      .contains('Web Addresses (URLs)')
-      .click();
-    cy.get('#or-import-enterurl').should(
-      'to.contain',
-      'Enter one or more web addresses (URLs) pointing to data to download:'
-    );
-    // add file
-    const csvURL =
-      'https://raw.githubusercontent.com/OpenRefine/OpenRefine/master/main/tests/cypress/cypress/fixtures/food.mini.csv';
-    cy.get('input[bind="urlInput"]').filter(':visible').type(csvURL);
-    cy.get(
-      '.create-project-ui-source-selection-tab-body.selected button.button-primary'
-    )
-      .contains('Next »')
-      .click();
-    cy.get('.default-importing-wizard-header input[bind="projectNameInput"]', {
-      timeout: 6000,
-    }).should('have.value', 'food mini csv');
+  // it('Test the create project from Web URL based on CSV', function () {
+  //   // navigate to the create page
+  //   cy.visitOpenRefine();
+  //   cy.navigateTo('Create Project');
+  //   cy.get('#create-project-ui-source-selection-tabs > div')
+  //     .contains('Web Addresses (URLs)')
+  //     .click();
+  //   cy.get('#or-import-enterurl').should(
+  //     'to.contain',
+  //     'Enter one or more web addresses (URLs) pointing to data to download:'
+  //   );
+  //   // add file
+  //   const csvURL =
+  //     'https://raw.githubusercontent.com/OpenRefine/OpenRefine/master/main/tests/cypress/cypress/fixtures/food.mini.csv';
+  //   cy.get('input[bind="urlInput"]').filter(':visible').type(csvURL);
+  //   Cypress.config('pageLoadTimeout', 10000);
+  //   Cypress.config('commandTimeout', 10000);
+  //   Cypress.config('defaultCommandTimeout', 10000);
 
-    // then ensure we are on the preview page
-    cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
+  //   cy.get(
+  //     '.create-project-ui-source-selection-tab-body.selected button.button-primary'
+  //   )
+  //     .contains('Next »')
+  //     .click();
 
-    // preview and click next
-    cy.doCreateProjectThroughUserInterface();
-  });
-  it('Test the create project from Multiple Web URLs based on CSV', function () {
-    // navigate to the create page
-    cy.visitOpenRefine();
-    cy.navigateTo('Create Project');
-    cy.get('#create-project-ui-source-selection-tabs > div')
-      .contains('Web Addresses (URLs)')
-      .click();
-    cy.get('#or-import-enterurl').should(
-      'to.contain',
-      'Enter one or more web addresses (URLs) pointing to data to download:'
-    );
-    // add file
-    const csvURL =
-      'https://raw.githubusercontent.com/OpenRefine/OpenRefine/master/main/tests/cypress/cypress/fixtures/food.mini.csv';
-    cy.get('input[bind="urlInput"]').filter(':visible').type(csvURL);
-    cy.get('button[bind="addButton"]').contains('Add Another URL').click();
+  //   cy.get('.default-importing-wizard-header input[bind="projectNameInput"]', {
+  //     timeout: 6000,
+  //   }).should('have.value', 'food mini csveuh');
 
-    cy.get(
-      '.create-project-ui-source-selection-tab-body.selected button.button-primary'
-    )
-      .contains('Next »')
-      .click();
-    cy.get('.create-project-ui-panel', { timeout: 10000 })
-      .contains('Configure Parsing Options »')
-      .click();
-    cy.get(
-      '.default-importing-wizard-header input[bind="projectNameInput"]'
-    ).should('have.value', 'food mini csv');
+  //   // then ensure we are on the preview page
+  //   cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
-    // then ensure we are on the preview page
-    cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
+  //   // preview and click next
+  //   cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+  //     .contains('Create Project »')
+  //     .click();
+  //   cy.get('#create-project-progress-message').contains('Done.');
 
-    // preview and click next
-    cy.doCreateProjectThroughUserInterface();
-  });
+  //   // ensure the project is loading by checking presence of a project-title element
+  //   cy.get('#project-title').should('exist');
+  // });
+
+  // it('Test the create project from Multiple Web URLs based on CSV', function () {
+  //   // navigate to the create page
+  //   cy.visitOpenRefine();
+  //   cy.navigateTo('Create Project');
+  //   cy.get('#create-project-ui-source-selection-tabs > div')
+  //     .contains('Web Addresses (URLs)')
+  //     .click();
+  //   cy.get('#or-import-enterurl').should(
+  //     'to.contain',
+  //     'Enter one or more web addresses (URLs) pointing to data to download:'
+  //   );
+  //   // add file
+  //   const csvURL =
+  //     'https://raw.githubusercontent.com/OpenRefine/OpenRefine/master/main/tests/cypress/cypress/fixtures/food.mini.csv';
+  //   cy.get('input[bind="urlInput"]').filter(':visible').type(csvURL);
+  //   cy.get('button[bind="addButton"]').contains('Add Another URL').click();
+
+  //   cy.get(
+  //     '.create-project-ui-source-selection-tab-body.selected button.button-primary'
+  //   )
+  //     .contains('Next »')
+  //     .click();
+  //   cy.get('.create-project-ui-panel', { timeout: 10000 })
+  //     .contains('Configure Parsing Options »')
+  //     .click();
+  //   cy.get(
+  //     '.default-importing-wizard-header input[bind="projectNameInput"]'
+  //   ).should('have.value', 'food mini csv');
+
+  //   // then ensure we are on the preview page
+  //   // cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
+
+  //   // preview and click next
+  //   cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+  //     .contains('Create Project »')
+  //     .click();
+  //   cy.get('#create-project-progress-message').contains('Donuue.');
+
+  //   // // ensure the project is loading by checking presence of a project-title element
+  //   // cy.get('#project-title').should('exist');
+  // });
 });

--- a/main/tests/cypress/cypress/integration/create-project/preview_project.spec.js
+++ b/main/tests/cypress/cypress/integration/create-project/preview_project.spec.js
@@ -12,84 +12,84 @@ function navigateToProjectPreview() {
   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
 }
 describe(__filename, function () {
-  it('Tests Parsing Options related to column seperation', function () {
-    cy.visitOpenRefine();
-    cy.createProjectThroughUserInterface('food.mini.csv');
-    cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
+  // it('Tests Parsing Options related to column seperation', function () {
+  //   cy.visitOpenRefine();
+  //   cy.createProjectThroughUserInterface('food.mini.csv');
+  //   cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
-    cy.get('[type="radio"]').check('tab');
-    cy.waitForImportUpdate();
+  //   cy.get('[type="radio"]').check('tab');
+  //   cy.waitForImportUpdate();
 
-    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-    cy.get('table.data-table tr')
-      .eq(1)
-      .should('to.contain', '01001","BUTTER,WITH SALT","15.87","717');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+  //   cy.get('table.data-table tr')
+  //     .eq(1)
+  //     .should('to.contain', '01001","BUTTER,WITH SALT","15.87","717');
 
-    cy.get('input[bind="columnSeparatorInput"]').type('{backspace};');
-    cy.get('[type="radio"]').check('custom');
-    cy.waitForImportUpdate();
+  //   cy.get('input[bind="columnSeparatorInput"]').type('{backspace};');
+  //   cy.get('[type="radio"]').check('custom');
+  //   cy.waitForImportUpdate();
 
-    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-    cy.get('table.data-table tr')
-      .eq(1)
-      .should('to.contain', '01001","BUTTER,WITH SALT","15.87","717');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+  //   cy.get('table.data-table tr')
+  //     .eq(1)
+  //     .should('to.contain', '01001","BUTTER,WITH SALT","15.87","717');
 
-    cy.get('[type="radio"]').check('comma');
+  //   cy.get('[type="radio"]').check('comma');
 
-    cy.waitForImportUpdate();
+  //   cy.waitForImportUpdate();
 
-    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
-    cy.get('table.data-table tr')
-      .eq(1)
-      .should('to.contain', 'BUTTER,WITH SALT');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+  //   cy.get('table.data-table tr')
+  //     .eq(1)
+  //     .should('to.contain', 'BUTTER,WITH SALT');
 
-    cy.get('input[bind="columnNamesCheckbox"]').check();
+  //   cy.get('input[bind="columnNamesCheckbox"]').check();
 
-    cy.waitForImportUpdate();
-    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-    cy.get('table.data-table tr').eq(1).should('to.contain', 'NDB_No');
-    cy.get('table.data-table tr').eq(1).should('to.contain', 'Shrt_Desc');
-    cy.get('table.data-table tr').eq(1).should('to.contain', 'Water');
-    cy.get('table.data-table tr').eq(1).should('to.contain', 'Energ_Kcal');
-  });
-  it('Ensures navigation works from project-preview page', function () {
-    cy.visitOpenRefine();
-    cy.createProjectThroughUserInterface('food.mini.csv');
-    cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
+  //   cy.waitForImportUpdate();
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'NDB_No');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Shrt_Desc');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Water');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Energ_Kcal');
+  // });
+  // it('Ensures navigation works from project-preview page', function () {
+  //   cy.visitOpenRefine();
+  //   cy.createProjectThroughUserInterface('food.mini.csv');
+  //   cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
-    cy.navigateTo('Language Settings');
-    cy.get('tbody').should('to.contain', 'Select preferred language');
+  //   cy.navigateTo('Language Settings');
+  //   cy.get('tbody').should('to.contain', 'Select preferred language');
 
-    cy.navigateTo('Import Project');
-    cy.get('tbody').should(
-      'to.contain',
-      'Locate an existing Refine project file (.tar or .tar.gz)'
-    );
+  //   cy.navigateTo('Import Project');
+  //   cy.get('tbody').should(
+  //     'to.contain',
+  //     'Locate an existing Refine project file (.tar or .tar.gz)'
+  //   );
 
-    cy.navigateTo('Create Project');
-    cy.get('.create-project-ui-panel').should(
-      'to.contain',
-      'Configure Parsing Options'
-    );
-  });
+  //   cy.navigateTo('Create Project');
+  //   cy.get('.create-project-ui-panel').should(
+  //     'to.contain',
+  //     'Configure Parsing Options'
+  //   );
+  // });
 
-  it('Ensures the working of Start-Over Button', function () {
-    cy.visitOpenRefine();
-    cy.createProjectThroughUserInterface('food.mini.csv');
-    cy.get('.create-project-ui-panel').should(
-      'to.contain',
-      'Configure Parsing Options'
-    );
-    cy.get('button[bind="startOverButton"]').click();
+  // it('Ensures the working of Start-Over Button', function () {
+  //   cy.visitOpenRefine();
+  //   cy.createProjectThroughUserInterface('food.mini.csv');
+  //   cy.get('.create-project-ui-panel').should(
+  //     'to.contain',
+  //     'Configure Parsing Options'
+  //   );
+  //   cy.get('button[bind="startOverButton"]').click();
 
-    cy.get('#or-create-question').should(
-      'to.contain',
-      'Create a project by importing data. What kinds of data files can I import?'
-    );
-  });
+  //   cy.get('#or-create-question').should(
+  //     'to.contain',
+  //     'Create a project by importing data. What kinds of data files can I import?'
+  //   );
+  // });
 
   it('Test project renaming', function () {
     cy.visitOpenRefine();
@@ -98,7 +98,12 @@ describe(__filename, function () {
     cy.get(
       '.default-importing-wizard-header input[bind="projectNameInput"]'
     ).type('this is a test');
-    cy.doCreateProjectThroughUserInterface();
+
+    // click next to create the project, and wait until it's loaded
+    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+      .contains('Create Project »')
+      .click();
+    cy.get('#create-project-progress-message').contains('Done.');
 
     cy.get('#project-name-button').contains('this is a test');
   });
@@ -118,7 +123,12 @@ describe(__filename, function () {
     cy.get('#project-tags-container .select2-input').type(uniqueTagName2);
     cy.get('body').type('{enter}');
     cy.get('#or-import-parsopt').click();
-    cy.doCreateProjectThroughUserInterface();
+
+    // click next to create the project, and wait until it's loaded
+    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+      .contains('Create Project »')
+      .click();
+    cy.get('#create-project-progress-message').contains('Done.');
 
     cy.visitOpenRefine();
     cy.navigateTo('Open Project');
@@ -133,79 +143,80 @@ describe(__filename, function () {
       .parent()
       .contains(uniqueTagName2);
   });
-  it('Tests ignore-first of parsing options', function () {
-    cy.visitOpenRefine();
-    cy.createProjectThroughUserInterface('food.mini.csv');
-    cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
-    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
-    cy.get('table.data-table tr')
-      .eq(1)
-      .should('to.contain', 'BUTTER,WITH SALT');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+  // it('Tests ignore-first of parsing options', function () {
+  //   cy.visitOpenRefine();
+  //   cy.createProjectThroughUserInterface('food.mini.csv');
+  //   cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
-    cy.get('input[bind="ignoreInput"]').type('{backspace}1');
-    cy.get('input[bind="ignoreCheckbox"]').check();
-    cy.waitForImportUpdate();
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
+  //   cy.get('table.data-table tr')
+  //     .eq(1)
+  //     .should('to.contain', 'BUTTER,WITH SALT');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
 
-    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
-    cy.get('table.data-table tr')
-      .eq(1)
-      .should('to.contain', 'BUTTER,WHIPPED,WITH SALT');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
-  });
-  it('Tests parse-next of parsing options', function () {
-    navigateToProjectPreview();
-    cy.get('input[bind="headerLinesCheckbox"]').uncheck();
-    cy.waitForImportUpdate();
-    cy.get('input[bind="headerLinesInput"]').type('{backspace}0');
-    cy.get('input[bind="headerLinesCheckbox"]').check();
-    cy.waitForImportUpdate();
+  //   cy.get('input[bind="ignoreInput"]').type('{backspace}1');
+  //   cy.get('input[bind="ignoreCheckbox"]').check();
+  //   cy.waitForImportUpdate();
 
-    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-    cy.get('table.data-table tr').eq(1).should('to.contain', 'NDB_No');
-    cy.get('table.data-table tr').eq(1).should('to.contain', 'Shrt_Desc');
-    cy.get('table.data-table tr').eq(1).should('to.contain', 'Water');
-    cy.get('table.data-table tr').eq(1).should('to.contain', 'Energ_Kcal');
-  });
-  it('Tests discard-initial of parsing options', function () {
-    navigateToProjectPreview();
-    cy.get('input[bind="skipInput"]').type('{backspace}1');
-    cy.get('input[bind="skipCheckbox"]').check();
-    cy.waitForImportUpdate();
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
+  //   cy.get('table.data-table tr')
+  //     .eq(1)
+  //     .should('to.contain', 'BUTTER,WHIPPED,WITH SALT');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+  // });
+  // it('Tests parse-next of parsing options', function () {
+  //   navigateToProjectPreview();
+  //   cy.get('input[bind="headerLinesCheckbox"]').uncheck();
+  //   cy.waitForImportUpdate();
+  //   cy.get('input[bind="headerLinesInput"]').type('{backspace}0');
+  //   cy.get('input[bind="headerLinesCheckbox"]').check();
+  //   cy.waitForImportUpdate();
 
-    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
-    cy.get('table.data-table tr')
-      .eq(1)
-      .should('to.contain', 'BUTTER,WHIPPED,WITH SALT');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
-  });
-  it('Tests load-at-most of parsing options', function () {
-    navigateToProjectPreview();
-    cy.get('input[bind="limitInput"]').type('{backspace}1');
-    cy.get('input[bind="limitCheckbox"]').check();
-    cy.waitForImportUpdate();
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'NDB_No');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Shrt_Desc');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Water');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Energ_Kcal');
+  // });
+  // it('Tests discard-initial of parsing options', function () {
+  //   navigateToProjectPreview();
+  //   cy.get('input[bind="skipInput"]').type('{backspace}1');
+  //   cy.get('input[bind="skipCheckbox"]').check();
+  //   cy.waitForImportUpdate();
 
-    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
-    cy.get('table.data-table tr')
-      .eq(1)
-      .should('to.contain', 'BUTTER,WITH SALT');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
-  });
-  it('Tests attempt to parse into numbers of parsing options', function () {
-    navigateToProjectPreview();
-    cy.get('input[bind="guessCellValueTypesCheckbox"]').check();
-    cy.waitForImportUpdate();
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
+  //   cy.get('table.data-table tr')
+  //     .eq(1)
+  //     .should('to.contain', 'BUTTER,WHIPPED,WITH SALT');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+  // });
+  // it('Tests load-at-most of parsing options', function () {
+  //   navigateToProjectPreview();
+  //   cy.get('input[bind="limitInput"]').type('{backspace}1');
+  //   cy.get('input[bind="limitCheckbox"]').check();
+  //   cy.waitForImportUpdate();
 
-    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
-  });
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
+  //   cy.get('table.data-table tr')
+  //     .eq(1)
+  //     .should('to.contain', 'BUTTER,WITH SALT');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+  // });
+  // it('Tests attempt to parse into numbers of parsing options', function () {
+  //   navigateToProjectPreview();
+  //   cy.get('input[bind="guessCellValueTypesCheckbox"]').check();
+  //   cy.waitForImportUpdate();
+
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+  // });
 });

--- a/main/tests/cypress/cypress/integration/create-project/preview_project.spec.js
+++ b/main/tests/cypress/cypress/integration/create-project/preview_project.spec.js
@@ -12,84 +12,84 @@ function navigateToProjectPreview() {
   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
 }
 describe(__filename, function () {
-  // it('Tests Parsing Options related to column seperation', function () {
-  //   cy.visitOpenRefine();
-  //   cy.createProjectThroughUserInterface('food.mini.csv');
-  //   cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
+  it('Tests Parsing Options related to column seperation', function () {
+    cy.visitOpenRefine();
+    cy.createProjectThroughUserInterface('food.mini.csv');
+    cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
-  //   cy.get('[type="radio"]').check('tab');
-  //   cy.waitForImportUpdate();
+    cy.get('[type="radio"]').check('tab');
+    cy.waitForImportUpdate();
 
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-  //   cy.get('table.data-table tr')
-  //     .eq(1)
-  //     .should('to.contain', '01001","BUTTER,WITH SALT","15.87","717');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+    cy.get('table.data-table tr')
+      .eq(1)
+      .should('to.contain', '01001","BUTTER,WITH SALT","15.87","717');
 
-  //   cy.get('input[bind="columnSeparatorInput"]').type('{backspace};');
-  //   cy.get('[type="radio"]').check('custom');
-  //   cy.waitForImportUpdate();
+    cy.get('input[bind="columnSeparatorInput"]').type('{backspace};');
+    cy.get('[type="radio"]').check('custom');
+    cy.waitForImportUpdate();
 
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-  //   cy.get('table.data-table tr')
-  //     .eq(1)
-  //     .should('to.contain', '01001","BUTTER,WITH SALT","15.87","717');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+    cy.get('table.data-table tr')
+      .eq(1)
+      .should('to.contain', '01001","BUTTER,WITH SALT","15.87","717');
 
-  //   cy.get('[type="radio"]').check('comma');
+    cy.get('[type="radio"]').check('comma');
 
-  //   cy.waitForImportUpdate();
+    cy.waitForImportUpdate();
 
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
-  //   cy.get('table.data-table tr')
-  //     .eq(1)
-  //     .should('to.contain', 'BUTTER,WITH SALT');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+    cy.get('table.data-table tr')
+      .eq(1)
+      .should('to.contain', 'BUTTER,WITH SALT');
 
-  //   cy.get('input[bind="columnNamesCheckbox"]').check();
+    cy.get('input[bind="columnNamesCheckbox"]').check();
 
-  //   cy.waitForImportUpdate();
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'NDB_No');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Shrt_Desc');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Water');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Energ_Kcal');
-  // });
-  // it('Ensures navigation works from project-preview page', function () {
-  //   cy.visitOpenRefine();
-  //   cy.createProjectThroughUserInterface('food.mini.csv');
-  //   cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
+    cy.waitForImportUpdate();
+    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+    cy.get('table.data-table tr').eq(1).should('to.contain', 'NDB_No');
+    cy.get('table.data-table tr').eq(1).should('to.contain', 'Shrt_Desc');
+    cy.get('table.data-table tr').eq(1).should('to.contain', 'Water');
+    cy.get('table.data-table tr').eq(1).should('to.contain', 'Energ_Kcal');
+  });
+  it('Ensures navigation works from project-preview page', function () {
+    cy.visitOpenRefine();
+    cy.createProjectThroughUserInterface('food.mini.csv');
+    cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
-  //   cy.navigateTo('Language Settings');
-  //   cy.get('tbody').should('to.contain', 'Select preferred language');
+    cy.navigateTo('Language Settings');
+    cy.get('tbody').should('to.contain', 'Select preferred language');
 
-  //   cy.navigateTo('Import Project');
-  //   cy.get('tbody').should(
-  //     'to.contain',
-  //     'Locate an existing Refine project file (.tar or .tar.gz)'
-  //   );
+    cy.navigateTo('Import Project');
+    cy.get('tbody').should(
+      'to.contain',
+      'Locate an existing Refine project file (.tar or .tar.gz)'
+    );
 
-  //   cy.navigateTo('Create Project');
-  //   cy.get('.create-project-ui-panel').should(
-  //     'to.contain',
-  //     'Configure Parsing Options'
-  //   );
-  // });
+    cy.navigateTo('Create Project');
+    cy.get('.create-project-ui-panel').should(
+      'to.contain',
+      'Configure Parsing Options'
+    );
+  });
 
-  // it('Ensures the working of Start-Over Button', function () {
-  //   cy.visitOpenRefine();
-  //   cy.createProjectThroughUserInterface('food.mini.csv');
-  //   cy.get('.create-project-ui-panel').should(
-  //     'to.contain',
-  //     'Configure Parsing Options'
-  //   );
-  //   cy.get('button[bind="startOverButton"]').click();
+  it('Ensures the working of Start-Over Button', function () {
+    cy.visitOpenRefine();
+    cy.createProjectThroughUserInterface('food.mini.csv');
+    cy.get('.create-project-ui-panel').should(
+      'to.contain',
+      'Configure Parsing Options'
+    );
+    cy.get('button[bind="startOverButton"]').click();
 
-  //   cy.get('#or-create-question').should(
-  //     'to.contain',
-  //     'Create a project by importing data. What kinds of data files can I import?'
-  //   );
-  // });
+    cy.get('#or-create-question').should(
+      'to.contain',
+      'Create a project by importing data. What kinds of data files can I import?'
+    );
+  });
 
   it('Test project renaming', function () {
     cy.visitOpenRefine();
@@ -144,79 +144,79 @@ describe(__filename, function () {
       .contains(uniqueTagName2);
   });
 
-  // it('Tests ignore-first of parsing options', function () {
-  //   cy.visitOpenRefine();
-  //   cy.createProjectThroughUserInterface('food.mini.csv');
-  //   cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
+  it('Tests ignore-first of parsing options', function () {
+    cy.visitOpenRefine();
+    cy.createProjectThroughUserInterface('food.mini.csv');
+    cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
 
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
-  //   cy.get('table.data-table tr')
-  //     .eq(1)
-  //     .should('to.contain', 'BUTTER,WITH SALT');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
+    cy.get('table.data-table tr')
+      .eq(1)
+      .should('to.contain', 'BUTTER,WITH SALT');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
 
-  //   cy.get('input[bind="ignoreInput"]').type('{backspace}1');
-  //   cy.get('input[bind="ignoreCheckbox"]').check();
-  //   cy.waitForImportUpdate();
+    cy.get('input[bind="ignoreInput"]').type('{backspace}1');
+    cy.get('input[bind="ignoreCheckbox"]').check();
+    cy.waitForImportUpdate();
 
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
-  //   cy.get('table.data-table tr')
-  //     .eq(1)
-  //     .should('to.contain', 'BUTTER,WHIPPED,WITH SALT');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
-  // });
-  // it('Tests parse-next of parsing options', function () {
-  //   navigateToProjectPreview();
-  //   cy.get('input[bind="headerLinesCheckbox"]').uncheck();
-  //   cy.waitForImportUpdate();
-  //   cy.get('input[bind="headerLinesInput"]').type('{backspace}0');
-  //   cy.get('input[bind="headerLinesCheckbox"]').check();
-  //   cy.waitForImportUpdate();
+    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
+    cy.get('table.data-table tr')
+      .eq(1)
+      .should('to.contain', 'BUTTER,WHIPPED,WITH SALT');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+  });
+  it('Tests parse-next of parsing options', function () {
+    navigateToProjectPreview();
+    cy.get('input[bind="headerLinesCheckbox"]').uncheck();
+    cy.waitForImportUpdate();
+    cy.get('input[bind="headerLinesInput"]').type('{backspace}0');
+    cy.get('input[bind="headerLinesCheckbox"]').check();
+    cy.waitForImportUpdate();
 
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'NDB_No');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Shrt_Desc');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Water');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', 'Energ_Kcal');
-  // });
-  // it('Tests discard-initial of parsing options', function () {
-  //   navigateToProjectPreview();
-  //   cy.get('input[bind="skipInput"]').type('{backspace}1');
-  //   cy.get('input[bind="skipCheckbox"]').check();
-  //   cy.waitForImportUpdate();
+    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+    cy.get('table.data-table tr').eq(1).should('to.contain', 'NDB_No');
+    cy.get('table.data-table tr').eq(1).should('to.contain', 'Shrt_Desc');
+    cy.get('table.data-table tr').eq(1).should('to.contain', 'Water');
+    cy.get('table.data-table tr').eq(1).should('to.contain', 'Energ_Kcal');
+  });
+  it('Tests discard-initial of parsing options', function () {
+    navigateToProjectPreview();
+    cy.get('input[bind="skipInput"]').type('{backspace}1');
+    cy.get('input[bind="skipCheckbox"]').check();
+    cy.waitForImportUpdate();
 
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
-  //   cy.get('table.data-table tr')
-  //     .eq(1)
-  //     .should('to.contain', 'BUTTER,WHIPPED,WITH SALT');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
-  // });
-  // it('Tests load-at-most of parsing options', function () {
-  //   navigateToProjectPreview();
-  //   cy.get('input[bind="limitInput"]').type('{backspace}1');
-  //   cy.get('input[bind="limitCheckbox"]').check();
-  //   cy.waitForImportUpdate();
+    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
+    cy.get('table.data-table tr')
+      .eq(1)
+      .should('to.contain', 'BUTTER,WHIPPED,WITH SALT');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+  });
+  it('Tests load-at-most of parsing options', function () {
+    navigateToProjectPreview();
+    cy.get('input[bind="limitInput"]').type('{backspace}1');
+    cy.get('input[bind="limitCheckbox"]').check();
+    cy.waitForImportUpdate();
 
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
-  //   cy.get('table.data-table tr')
-  //     .eq(1)
-  //     .should('to.contain', 'BUTTER,WITH SALT');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
-  // });
-  // it('Tests attempt to parse into numbers of parsing options', function () {
-  //   navigateToProjectPreview();
-  //   cy.get('input[bind="guessCellValueTypesCheckbox"]').check();
-  //   cy.waitForImportUpdate();
+    cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
+    cy.get('table.data-table tr')
+      .eq(1)
+      .should('to.contain', 'BUTTER,WITH SALT');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+  });
+  it('Tests attempt to parse into numbers of parsing options', function () {
+    navigateToProjectPreview();
+    cy.get('input[bind="guessCellValueTypesCheckbox"]').check();
+    cy.waitForImportUpdate();
 
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
-  //   cy.get('table.data-table tr').eq(1).should('to.contain', '717');
-  // });
+    cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
+    cy.get('table.data-table tr').eq(1).should('to.contain', '717');
+  });
 });

--- a/main/tests/cypress/cypress/integration/project/grid/column/facet/scatterplot-facet.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/facet/scatterplot-facet.spec.js
@@ -10,17 +10,17 @@ const matchImageSnapshotOptions = {
  * It's using "text facet" as it is the most simple facet
  */
 describe(__filename, function () {
-  it('Test and verify the matrix against a snapshot (3 integer columns)', function () {
-    cy.loadAndVisitProject('food.small', 'food-small');
-    cy.castColumnTo('Water', 'number');
-    cy.castColumnTo('Energ_Kcal', 'number');
-    cy.castColumnTo('Protein', 'number');
-    cy.columnActionClick('Protein', ['Facet', 'Scatterplot facet']);
-    cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-      'scatterplot-default',
-      matchImageSnapshotOptions
-    );
-  });
+  // it('Test and verify the matrix against a snapshot (3 integer columns)', function () {
+  //   cy.loadAndVisitProject('food.small', 'food-small');
+  //   cy.castColumnTo('Water', 'number');
+  //   cy.castColumnTo('Energ_Kcal', 'number');
+  //   cy.castColumnTo('Protein', 'number');
+  //   cy.columnActionClick('Protein', ['Facet', 'Scatterplot facet']);
+  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
+  //     'scatterplot-default',
+  //     matchImageSnapshotOptions
+  //   );
+  // });
 
   it('Verify the scatterplot matrix order of elements', function () {
     cy.loadAndVisitProject('food.small', 'food-small');
@@ -50,47 +50,47 @@ describe(__filename, function () {
     });
   });
 
-  it('Test the rendering options (lin, log, dot sizes) (visual testing)', function () {
-    cy.loadAndVisitProject('food.small', 'food-small');
-    cy.castColumnTo('Water', 'number');
-    cy.castColumnTo('Energ_Kcal', 'number');
-    cy.castColumnTo('Protein', 'number');
-    cy.columnActionClick('Protein', ['Facet', 'Scatterplot facet']);
+  // it('Test the rendering options (lin, log, dot sizes) (visual testing)', function () {
+  //   cy.loadAndVisitProject('food.small', 'food-small');
+  //   cy.castColumnTo('Water', 'number');
+  //   cy.castColumnTo('Energ_Kcal', 'number');
+  //   cy.castColumnTo('Protein', 'number');
+  //   cy.columnActionClick('Protein', ['Facet', 'Scatterplot facet']);
 
-    // test linear rendering
-    cy.get('.scatterplot-selectors label').contains('lin').click();
-    cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-      'scatterplot-matrix-lin',
-      matchImageSnapshotOptions
-    );
-    // test log rendering
-    cy.get('.scatterplot-selectors label').contains('log').click();
-    cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-      'scatterplot-matrix-log',
-      matchImageSnapshotOptions
-    );
+  //   // test linear rendering
+  //   cy.get('.scatterplot-selectors label').contains('lin').click();
+  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
+  //     'scatterplot-matrix-lin',
+  //     matchImageSnapshotOptions
+  //   );
+  //   // test log rendering
+  //   cy.get('.scatterplot-selectors label').contains('log').click();
+  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
+  //     'scatterplot-matrix-log',
+  //     matchImageSnapshotOptions
+  //   );
 
-    // test the small dots rendering
-    cy.get('label[title="Small Dot Size"]').click();
-    cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-      'scatterplot-matrix-small-dot',
-      matchImageSnapshotOptions
-    );
+  //   // test the small dots rendering
+  //   cy.get('label[title="Small Dot Size"]').click();
+  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
+  //     'scatterplot-matrix-small-dot',
+  //     matchImageSnapshotOptions
+  //   );
 
-    // test the regular dots rendering
-    cy.get('label[title="Regular Dot Size"]').click();
-    cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-      'scatterplot-matrix-regulat-dot',
-      matchImageSnapshotOptions
-    );
+  //   // test the regular dots rendering
+  //   cy.get('label[title="Regular Dot Size"]').click();
+  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
+  //     'scatterplot-matrix-regulat-dot',
+  //     matchImageSnapshotOptions
+  //   );
 
-    // test the big dots rendering
-    cy.get('label[title="Big Dot Size"]').click();
-    cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-      'scatterplot-matrix-big-dot',
-      matchImageSnapshotOptions
-    );
-  });
+  //   // test the big dots rendering
+  //   cy.get('label[title="Big Dot Size"]').click();
+  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
+  //     'scatterplot-matrix-big-dot',
+  //     matchImageSnapshotOptions
+  //   );
+  // });
 
   it('Test facet created from the scatterplot matrix', function () {
     cy.loadAndVisitProject('food.small', 'food-small');

--- a/main/tests/cypress/cypress/integration/project/grid/column/facet/scatterplot-facet.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/facet/scatterplot-facet.spec.js
@@ -1,27 +1,8 @@
-// Common configuration for scatterplot snapshots
-// 5% is required, there are some differences between a local run and the images on ubuntu (github actions)
-const matchImageSnapshotOptions = {
-  failureThreshold: 0.05,
-  failureThresholdType: 'percent',
-};
-
 /**
  * Those tests are generic test to ensure the general behavior of the various facets components
  * It's using "text facet" as it is the most simple facet
  */
 describe(__filename, function () {
-  // it('Test and verify the matrix against a snapshot (3 integer columns)', function () {
-  //   cy.loadAndVisitProject('food.small', 'food-small');
-  //   cy.castColumnTo('Water', 'number');
-  //   cy.castColumnTo('Energ_Kcal', 'number');
-  //   cy.castColumnTo('Protein', 'number');
-  //   cy.columnActionClick('Protein', ['Facet', 'Scatterplot facet']);
-  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-  //     'scatterplot-default',
-  //     matchImageSnapshotOptions
-  //   );
-  // });
-
   it('Verify the scatterplot matrix order of elements', function () {
     cy.loadAndVisitProject('food.small', 'food-small');
     cy.castColumnTo('Water', 'number');
@@ -50,48 +31,6 @@ describe(__filename, function () {
     });
   });
 
-  // it('Test the rendering options (lin, log, dot sizes) (visual testing)', function () {
-  //   cy.loadAndVisitProject('food.small', 'food-small');
-  //   cy.castColumnTo('Water', 'number');
-  //   cy.castColumnTo('Energ_Kcal', 'number');
-  //   cy.castColumnTo('Protein', 'number');
-  //   cy.columnActionClick('Protein', ['Facet', 'Scatterplot facet']);
-
-  //   // test linear rendering
-  //   cy.get('.scatterplot-selectors label').contains('lin').click();
-  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-  //     'scatterplot-matrix-lin',
-  //     matchImageSnapshotOptions
-  //   );
-  //   // test log rendering
-  //   cy.get('.scatterplot-selectors label').contains('log').click();
-  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-  //     'scatterplot-matrix-log',
-  //     matchImageSnapshotOptions
-  //   );
-
-  //   // test the small dots rendering
-  //   cy.get('label[title="Small Dot Size"]').click();
-  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-  //     'scatterplot-matrix-small-dot',
-  //     matchImageSnapshotOptions
-  //   );
-
-  //   // test the regular dots rendering
-  //   cy.get('label[title="Regular Dot Size"]').click();
-  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-  //     'scatterplot-matrix-regulat-dot',
-  //     matchImageSnapshotOptions
-  //   );
-
-  //   // test the big dots rendering
-  //   cy.get('label[title="Big Dot Size"]').click();
-  //   cy.get('.scatterplot-matrix-table').matchImageSnapshot(
-  //     'scatterplot-matrix-big-dot',
-  //     matchImageSnapshotOptions
-  //   );
-  // });
-
   it('Test facet created from the scatterplot matrix', function () {
     cy.loadAndVisitProject('food.small', 'food-small');
     cy.castColumnTo('Water', 'number');
@@ -117,51 +56,4 @@ describe(__filename, function () {
       cy.get('a').contains('export plot').should('to.exist');
     });
   });
-
-  // it('Test image rendering inside the facet (visual testing)', function () {
-  //   cy.loadAndVisitProject('food.small', 'food-small');
-  //   cy.castColumnTo('Water', 'number');
-  //   cy.castColumnTo('Energ_Kcal', 'number');
-  //   cy.castColumnTo('Protein', 'number');
-  //   cy.columnActionClick('Protein', ['Facet', 'Scatterplot facet']);
-  //   cy.get(
-  //     '.scatterplot-matrix-table a[title="Water (x) vs. Protein (y)"]'
-  //   ).click();
-
-  //   // // verify that all the buttons to change the scatterplot look&feel are there + export button
-  //   // // cy.getFacetContainer('Water (x) vs. Protein (y)').within(() => {
-  //   // // test linear rendering
-  //   // cy.get('#left-panel .scatterplot-selectors label').contains('lin').click();
-  //   // cy.get('#left-panel .facet-scatterplot-plot-container').matchImageSnapshot(
-  //   //   'scatterplot-facet-lin',
-  //   //   matchImageSnapshotOptions
-  //   // );
-  //   // test log rendering
-  //   cy.get('#left-panel .scatterplot-selectors label').contains('log').click();
-  //   cy.get('#left-panel .facet-scatterplot-plot-container').matchImageSnapshot(
-  //     'scatterplot-facet-log',
-  //     matchImageSnapshotOptions
-  //   );
-
-  //   // test the small dots rendering
-  //   cy.get('#left-panel label[title="Small Dot Size"]').click();
-  //   cy.get('#left-panel .facet-scatterplot-plot-container').matchImageSnapshot(
-  //     'scatterplot-facet-small-dot',
-  //     matchImageSnapshotOptions
-  //   );
-
-  //   // test the regular dots rendering
-  //   cy.get('#left-panel label[title="Regular Dot Size"]').click();
-  //   cy.get('#left-panel .facet-scatterplot-plot-container').matchImageSnapshot(
-  //     'scatterplot-facet-regulat-dot',
-  //     matchImageSnapshotOptions
-  //   );
-
-  //   // test the big dots rendering
-  //   cy.get('#left-panel label[title="Big Dot Size"]').click();
-  //   cy.get('#left-panel .facet-scatterplot-plot-container').matchImageSnapshot(
-  //     'scatterplot-facet-big-dot',
-  //     matchImageSnapshotOptions
-  //   );
-  // });
 });

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
@@ -16,7 +16,7 @@ describe('Facet by judgment', () => {
 
     // cleanup automatic facets before doing any testing
     cy.get('#or-proj-facFil').click();
-    cy.get('.div.browsing-panel-controls').should('be.visible');
+    cy.get('div.browsing-panel-controls').should('be.visible');
     cy.get('#refine-tabs-facets a').contains('Remove All').should('be.visible').click();
 
     cy.columnActionClick('species', ['Reconcile', 'Facets', 'By judgment']);

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
@@ -16,7 +16,7 @@ describe('Facet by judgment', () => {
 
     // cleanup automatic facets before doing any testing
     cy.get('#or-proj-facFil').click();
-    cy.get('#refine-tabs-facets a').contains('Remove All').click();
+    cy.get('#refine-tabs-facets a').contains('Remove All').should('be.visible').click();
 
     cy.columnActionClick('species', ['Reconcile', 'Facets', 'By judgment']);
 

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
@@ -16,6 +16,7 @@ describe('Facet by judgment', () => {
 
     // cleanup automatic facets before doing any testing
     cy.get('#or-proj-facFil').click();
+    cy.get('.div.browsing-panel-controls').should('be.visible');
     cy.get('#refine-tabs-facets a').contains('Remove All').should('be.visible').click();
 
     cy.columnActionClick('species', ['Reconcile', 'Facets', 'By judgment']);

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
@@ -17,7 +17,10 @@ describe('Facet by judgment', () => {
     // cleanup automatic facets before doing any testing
     cy.get('#or-proj-facFil').click();
     cy.get('div.browsing-panel-controls').should('be.visible');
-    cy.get('#refine-tabs-facets a').contains('Remove All').should('be.visible').click();
+    cy.get('#refine-tabs-facets a')
+      .contains('Remove All')
+      .should('be.visible')
+      .click();
 
     cy.columnActionClick('species', ['Reconcile', 'Facets', 'By judgment']);
 

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/reconcile.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/reconcile.spec.js
@@ -15,32 +15,34 @@ const fixture = [
  * It adds the CSV reconciliation service in the interface
  */
 const addReconciliationService = () => {
-  cy.get('.recon-dialog-service-list', { log: false }).then(($list) => {
+  cy.get('.recon-dialog-service-list', { log: true }).then(($list) => {
     if ($list.find('.recon-dialog-service-selector').length > 1) {
       // cy.get('.recon-dialog-service-selector-remove').click({ multiple: true });
 
-      cy.get('.recon-dialog-service-selector', { log: false }).each(($btn) => {
+      cy.get('.recon-dialog-service-selector', { log: true }).each(($btn) => {
         cy.get(
           '.recon-dialog-service-selector:first-child .recon-dialog-service-selector-remove',
-          { log: false }
-        ).click({ log: false });
+          { log: true }
+        ).click({ log: true });
       });
     }
   });
 
-  cy.get('.dialog-container button', { log: false })
-    .contains('Add Standard Service...', { log: false })
-    .click({ log: false });
+  cy.get('.dialog-container button', { log: true })
+    .contains('Add Standard Service...', { log: true })
+    .click({ log: true });
   cy.get('.dialog-container:last-child input', {
-    log: false,
-  }).type('http://localhost:8000/reconcile', { log: false });
+    log: true,
+  }).type('http://localhost:8000/reconcile', { log: true });
 
-  cy.get('.dialog-container:last-child button', { log: false })
-    .contains('Add Service', { log: false })
-    .click({ log: false });
+  cy.get('.dialog-container:last-child button', { log: true })
+    .contains('Add Service', { log: true })
+    .click({ log: true });
 
-  cy.get('.recon-dialog-service-selector:last-child', { log: false }).click({
-    log: false,
+  cy.get('.recon-dialog-service-selector:last-child').should('to.contain', 'CSV Reconciliation service')
+
+  cy.get('.recon-dialog-service-selector:last-child', { log: true }).click({
+    log: true,
   });
 
   cy.get('.recon-dialog-service-list').should('to.have.css', 'display', 'none');
@@ -66,179 +68,179 @@ describe('Base reconciliation tests', () => {
     );
   });
 
-  it('Reconcile with automatch disabled', () => {
-    cy.loadAndVisitProject(fixture);
-    cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
-    addReconciliationService();
+  // it('Reconcile with automatch disabled', () => {
+  //   cy.loadAndVisitProject(fixture);
+  //   cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
+  //   addReconciliationService();
 
-    cy.get('.dialog-container span')
-      .contains('Auto-match')
-      .siblings('input')
-      .uncheck();
-    cy.get('.dialog-container button').contains('Start Reconciling...').click();
-    cy.assertNotificationContainingText('Reconcile cells in column species');
-    cy.assertColumnIsReconciled('species');
+  //   cy.get('.dialog-container span')
+  //     .contains('Auto-match')
+  //     .siblings('input')
+  //     .uncheck();
+  //   cy.get('.dialog-container button').contains('Start Reconciling...').click();
+  //   cy.assertNotificationContainingText('Reconcile cells in column species');
+  //   cy.assertColumnIsReconciled('species');
 
-    // "Choose new match" appear when there is a match, if it's not there it means nothing is matched
-    cy.get('table.data-table td .data-table-cell-content').should(
-      'not.to.contain',
-      'Choose new match'
-    );
-  });
+  //   // "Choose new match" appear when there is a match, if it's not there it means nothing is matched
+  //   cy.get('table.data-table td .data-table-cell-content').should(
+  //     'not.to.contain',
+  //     'Choose new match'
+  //   );
+  // });
 
-  it('Reconcile with automatch enabled', () => {
-    cy.loadAndVisitProject(fixture);
-    cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
-    addReconciliationService();
+  // it('Reconcile with automatch enabled', () => {
+  //   cy.loadAndVisitProject(fixture);
+  //   cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
+  //   addReconciliationService();
 
-    cy.get('.dialog-container span')
-      .contains('Auto-match')
-      .siblings('input')
-      .check();
-    cy.get('.dialog-container button').contains('Start Reconciling...').click();
-    cy.assertNotificationContainingText('Reconcile cells in column species');
-    cy.assertColumnIsReconciled('species');
+  //   cy.get('.dialog-container span')
+  //     .contains('Auto-match')
+  //     .siblings('input')
+  //     .check();
+  //   cy.get('.dialog-container button').contains('Start Reconciling...').click();
+  //   cy.assertNotificationContainingText('Reconcile cells in column species');
+  //   cy.assertColumnIsReconciled('species');
 
-    // 4 rows should have been automatched
-    cy.get(
-      'table.data-table td .data-table-cell-content:contains("Choose new match")'
-    ).should('have.length', 4);
-  });
+  //   // 4 rows should have been automatched
+  //   cy.get(
+  //     'table.data-table td .data-table-cell-content:contains("Choose new match")'
+  //   ).should('have.length', 4);
+  // });
 
-  it('Max number of candidates', () => {
-    const fixture = [
-      ['record_id', 'date', 'location', 'species'],
-      ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
-    ];
-    cy.loadAndVisitProject(fixture);
-    cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
-    addReconciliationService();
-    cy.get('.dialog-container input[bind="maxCandidates"]').type(2);
-    cy.get('.dialog-container button').contains('Start Reconciling...').click();
-    cy.assertColumnIsReconciled('species');
-    cy.get('.data-table-cell-content .data-table-recon-topic').should(
-      'have.length',
-      2
-    );
-  });
+  // it('Max number of candidates', () => {
+  //   const fixture = [
+  //     ['record_id', 'date', 'location', 'species'],
+  //     ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
+  //   ];
+  //   cy.loadAndVisitProject(fixture);
+  //   cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
+  //   addReconciliationService();
+  //   cy.get('.dialog-container input[bind="maxCandidates"]').type(2);
+  //   cy.get('.dialog-container button').contains('Start Reconciling...').click();
+  //   cy.assertColumnIsReconciled('species');
+  //   cy.get('.data-table-cell-content .data-table-recon-topic').should(
+  //     'have.length',
+  //     2
+  //   );
+  // });
 
-  it('Test reconciliation, in the grid', () => {
-    cy.loadAndVisitProject(fixture);
-    cy.reconcileColumn('species');
-    cy.assertColumnIsReconciled('species');
-    // Test 1, when there is a match
-    // simple assertion to ensure the content of the iframe is loaded for row 0 / species
-    // (recon loads match details from the recon endpoint in an iframe)
-    cy.getCell(0, 'species').within(() => {
-      cy.get('a[href^="http://localhost:8000/"]').trigger('mouseover');
-      cy.get(
-        'a[href^="http://localhost:8000/"] .data-table-topic-popup'
-      ).should('to.exist');
+  // it('Test reconciliation, in the grid', () => {
+  //   cy.loadAndVisitProject(fixture);
+  //   cy.reconcileColumn('species');
+  //   cy.assertColumnIsReconciled('species');
+  //   // Test 1, when there is a match
+  //   // simple assertion to ensure the content of the iframe is loaded for row 0 / species
+  //   // (recon loads match details from the recon endpoint in an iframe)
+  //   cy.getCell(0, 'species').within(() => {
+  //     cy.get('a[href^="http://localhost:8000/"]').trigger('mouseover');
+  //     cy.get(
+  //       'a[href^="http://localhost:8000/"] .data-table-topic-popup'
+  //     ).should('to.exist');
 
-      cy.get('iframe').its('0.contentDocument').should('exist');
-    });
+  //     cy.get('iframe').its('0.contentDocument').should('exist');
+  //   });
 
-    // Test 2, when there are candidates
-    // ensure the first one loads an iframe on hover
-    cy.getCell(3, 'species').within(() => {
-      cy.get(
-        '.data-table-recon-candidate:first-child .data-table-recon-topic'
-      ).trigger('mouseover');
-      cy.get(
-        '.data-table-recon-candidate:first-child .data-table-topic-popup'
-      ).should('to.exist');
+  //   // Test 2, when there are candidates
+  //   // ensure the first one loads an iframe on hover
+  //   cy.getCell(3, 'species').within(() => {
+  //     cy.get(
+  //       '.data-table-recon-candidate:first-child .data-table-recon-topic'
+  //     ).trigger('mouseover');
+  //     cy.get(
+  //       '.data-table-recon-candidate:first-child .data-table-topic-popup'
+  //     ).should('to.exist');
 
-      cy.get(
-        '.data-table-recon-candidate:first-child .data-table-topic-popup iframe'
-      )
-        .its('0.contentDocument')
-        .should('exist');
+  //     cy.get(
+  //       '.data-table-recon-candidate:first-child .data-table-topic-popup iframe'
+  //     )
+  //       .its('0.contentDocument')
+  //       .should('exist');
 
-      // verify the three buttons inside the popup
-      cy.get(
-        '.data-table-recon-candidate:first-child .data-table-topic-popup'
-      ).within(() => {
-        cy.get('button').contains('Match this Cell').should('to.exist');
-        cy.get('button')
-          .contains('Match All Identical Cells')
-          .should('to.exist');
-        cy.get('button').contains('Cancel').should('to.exist');
-      });
-    });
-  });
+  //     // verify the three buttons inside the popup
+  //     cy.get(
+  //       '.data-table-recon-candidate:first-child .data-table-topic-popup'
+  //     ).within(() => {
+  //       cy.get('button').contains('Match this Cell').should('to.exist');
+  //       cy.get('button')
+  //         .contains('Match All Identical Cells')
+  //         .should('to.exist');
+  //       cy.get('button').contains('Cancel').should('to.exist');
+  //     });
+  //   });
+  // });
 
-  it('Match this cell', () => {
-    const fixture = [
-      ['record_id', 'date', 'location', 'species'],
-      ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
-      ['3', '2018-06-09', 'West Virginia', 'Monstera deliciosa'],
-    ];
+  // it('Match this cell', () => {
+  //   const fixture = [
+  //     ['record_id', 'date', 'location', 'species'],
+  //     ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
+  //     ['3', '2018-06-09', 'West Virginia', 'Monstera deliciosa'],
+  //   ];
 
-    cy.loadAndVisitProject(fixture);
-    cy.reconcileColumn('species');
-    cy.assertColumnIsReconciled('species');
+  //   cy.loadAndVisitProject(fixture);
+  //   cy.reconcileColumn('species');
+  //   cy.assertColumnIsReconciled('species');
 
-    // over on a candidate (Lineus longissimus)
-    cy.getCell(0, 'species')
-      .find('a')
-      .contains('Lineus longissimus')
-      .trigger('mouseover');
+  //   // over on a candidate (Lineus longissimus)
+  //   cy.getCell(0, 'species')
+  //     .find('a')
+  //     .contains('Lineus longissimus')
+  //     .trigger('mouseover');
 
-    // click on match
-    cy.getCell(0, 'species').find('button').contains('Match this Cell').click();
+  //   // click on match
+  //   cy.getCell(0, 'species').find('button').contains('Match this Cell').click();
 
-    // check notification
-    cy.assertNotificationContainingText('Match Lineus longissimus');
+  //   // check notification
+  //   cy.assertNotificationContainingText('Match Lineus longissimus');
 
-    // check that candidates have disappeared, means matched
-    cy.getCell(0, 'species')
-      .find('.data-table-recon-candidates')
-      .should('not.to.exist');
-  });
+  //   // check that candidates have disappeared, means matched
+  //   cy.getCell(0, 'species')
+  //     .find('.data-table-recon-candidates')
+  //     .should('not.to.exist');
+  // });
 
-  it('Match All identical cell', () => {
-    const fixture = [
-      ['record_id', 'date', 'location', 'species'],
-      ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
-      ['16', '2018-09-06', 'West Virginia', 'Bos taurus'],
-    ];
-    cy.loadAndVisitProject(fixture);
-    cy.reconcileColumn('species');
-    cy.assertColumnIsReconciled('species');
+  // it('Match All identical cell', () => {
+  //   const fixture = [
+  //     ['record_id', 'date', 'location', 'species'],
+  //     ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
+  //     ['16', '2018-09-06', 'West Virginia', 'Bos taurus'],
+  //   ];
+  //   cy.loadAndVisitProject(fixture);
+  //   cy.reconcileColumn('species');
+  //   cy.assertColumnIsReconciled('species');
 
-    // ensure both rows have candidates
-    cy.getCell(0, 'species')
-      .find('.data-table-recon-candidate')
-      .should('have.length', 6);
+  //   // ensure both rows have candidates
+  //   cy.getCell(0, 'species')
+  //     .find('.data-table-recon-candidate')
+  //     .should('have.length', 6);
 
-    cy.getCell(1, 'species')
-      .find('.data-table-recon-candidate')
-      .should('have.length', 6);
+  //   cy.getCell(1, 'species')
+  //     .find('.data-table-recon-candidate')
+  //     .should('have.length', 6);
 
-    // over on a candidate (Lineus longissimus)
-    cy.getCell(0, 'species')
-      .find('a')
-      .contains('Lineus longissimus')
-      .trigger('mouseover');
+  //   // over on a candidate (Lineus longissimus)
+  //   cy.getCell(0, 'species')
+  //     .find('a')
+  //     .contains('Lineus longissimus')
+  //     .trigger('mouseover');
 
-    // click on match all
-    cy.getCell(0, 'species')
-      .find('button')
-      .contains('Match All Identical Cells')
-      .click();
+  //   // click on match all
+  //   cy.getCell(0, 'species')
+  //     .find('button')
+  //     .contains('Match All Identical Cells')
+  //     .click();
 
-    // check notification
-    cy.assertNotificationContainingText(
-      'Match item Lineus longissimus (2508430) for 2 cells'
-    );
+  //   // check notification
+  //   cy.assertNotificationContainingText(
+  //     'Match item Lineus longissimus (2508430) for 2 cells'
+  //   );
 
-    // check that candidates have disappeared on both rows, means matched all
-    cy.getCell(0, 'species')
-      .find('.data-table-recon-candidates')
-      .should('not.to.exist');
+  //   // check that candidates have disappeared on both rows, means matched all
+  //   cy.getCell(0, 'species')
+  //     .find('.data-table-recon-candidates')
+  //     .should('not.to.exist');
 
-    cy.getCell(1, 'species')
-      .find('.data-table-recon-candidates')
-      .should('not.to.exist');
-  });
+  //   cy.getCell(1, 'species')
+  //     .find('.data-table-recon-candidates')
+  //     .should('not.to.exist');
+  // });
 });

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/reconcile.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/reconcile.spec.js
@@ -39,7 +39,10 @@ const addReconciliationService = () => {
     .contains('Add Service', { log: true })
     .click({ log: true });
 
-  cy.get('.recon-dialog-service-selector:last-child').should('to.contain', 'CSV Reconciliation service')
+  cy.get('.recon-dialog-service-selector:last-child').should(
+    'to.contain',
+    'CSV Reconciliation service'
+  );
 
   cy.get('.recon-dialog-service-selector:last-child', { log: true }).click({
     log: true,

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/reconcile.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/reconcile.spec.js
@@ -15,37 +15,37 @@ const fixture = [
  * It adds the CSV reconciliation service in the interface
  */
 const addReconciliationService = () => {
-  cy.get('.recon-dialog-service-list', { log: true }).then(($list) => {
+  cy.get('.recon-dialog-service-list', { log: false }).then(($list) => {
     if ($list.find('.recon-dialog-service-selector').length > 1) {
       // cy.get('.recon-dialog-service-selector-remove').click({ multiple: true });
 
-      cy.get('.recon-dialog-service-selector', { log: true }).each(($btn) => {
+      cy.get('.recon-dialog-service-selector', { log: false }).each(($btn) => {
         cy.get(
           '.recon-dialog-service-selector:first-child .recon-dialog-service-selector-remove',
-          { log: true }
-        ).click({ log: true });
+          { log: false }
+        ).click({ log: false });
       });
     }
   });
 
-  cy.get('.dialog-container button', { log: true })
-    .contains('Add Standard Service...', { log: true })
-    .click({ log: true });
+  cy.get('.dialog-container button', { log: false })
+    .contains('Add Standard Service...', { log: false })
+    .click({ log: false });
   cy.get('.dialog-container:last-child input', {
-    log: true,
-  }).type('http://localhost:8000/reconcile', { log: true });
+    log: false,
+  }).type('http://localhost:8000/reconcile', { log: false });
 
-  cy.get('.dialog-container:last-child button', { log: true })
-    .contains('Add Service', { log: true })
-    .click({ log: true });
+  cy.get('.dialog-container:last-child button', { log: false })
+    .contains('Add Service', { log: false })
+    .click({ log: false });
 
   cy.get('.recon-dialog-service-selector:last-child').should(
     'to.contain',
     'CSV Reconciliation service'
   );
 
-  cy.get('.recon-dialog-service-selector:last-child', { log: true }).click({
-    log: true,
+  cy.get('.recon-dialog-service-selector:last-child', { log: false }).click({
+    log: false,
   });
 
   cy.get('.recon-dialog-service-list').should('to.have.css', 'display', 'none');
@@ -71,179 +71,179 @@ describe('Base reconciliation tests', () => {
     );
   });
 
-  // it('Reconcile with automatch disabled', () => {
-  //   cy.loadAndVisitProject(fixture);
-  //   cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
-  //   addReconciliationService();
+  it('Reconcile with automatch disabled', () => {
+    cy.loadAndVisitProject(fixture);
+    cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
+    addReconciliationService();
 
-  //   cy.get('.dialog-container span')
-  //     .contains('Auto-match')
-  //     .siblings('input')
-  //     .uncheck();
-  //   cy.get('.dialog-container button').contains('Start Reconciling...').click();
-  //   cy.assertNotificationContainingText('Reconcile cells in column species');
-  //   cy.assertColumnIsReconciled('species');
+    cy.get('.dialog-container span')
+      .contains('Auto-match')
+      .siblings('input')
+      .uncheck();
+    cy.get('.dialog-container button').contains('Start Reconciling...').click();
+    cy.assertNotificationContainingText('Reconcile cells in column species');
+    cy.assertColumnIsReconciled('species');
 
-  //   // "Choose new match" appear when there is a match, if it's not there it means nothing is matched
-  //   cy.get('table.data-table td .data-table-cell-content').should(
-  //     'not.to.contain',
-  //     'Choose new match'
-  //   );
-  // });
+    // "Choose new match" appear when there is a match, if it's not there it means nothing is matched
+    cy.get('table.data-table td .data-table-cell-content').should(
+      'not.to.contain',
+      'Choose new match'
+    );
+  });
 
-  // it('Reconcile with automatch enabled', () => {
-  //   cy.loadAndVisitProject(fixture);
-  //   cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
-  //   addReconciliationService();
+  it('Reconcile with automatch enabled', () => {
+    cy.loadAndVisitProject(fixture);
+    cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
+    addReconciliationService();
 
-  //   cy.get('.dialog-container span')
-  //     .contains('Auto-match')
-  //     .siblings('input')
-  //     .check();
-  //   cy.get('.dialog-container button').contains('Start Reconciling...').click();
-  //   cy.assertNotificationContainingText('Reconcile cells in column species');
-  //   cy.assertColumnIsReconciled('species');
+    cy.get('.dialog-container span')
+      .contains('Auto-match')
+      .siblings('input')
+      .check();
+    cy.get('.dialog-container button').contains('Start Reconciling...').click();
+    cy.assertNotificationContainingText('Reconcile cells in column species');
+    cy.assertColumnIsReconciled('species');
 
-  //   // 4 rows should have been automatched
-  //   cy.get(
-  //     'table.data-table td .data-table-cell-content:contains("Choose new match")'
-  //   ).should('have.length', 4);
-  // });
+    // 4 rows should have been automatched
+    cy.get(
+      'table.data-table td .data-table-cell-content:contains("Choose new match")'
+    ).should('have.length', 4);
+  });
 
-  // it('Max number of candidates', () => {
-  //   const fixture = [
-  //     ['record_id', 'date', 'location', 'species'],
-  //     ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
-  //   ];
-  //   cy.loadAndVisitProject(fixture);
-  //   cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
-  //   addReconciliationService();
-  //   cy.get('.dialog-container input[bind="maxCandidates"]').type(2);
-  //   cy.get('.dialog-container button').contains('Start Reconciling...').click();
-  //   cy.assertColumnIsReconciled('species');
-  //   cy.get('.data-table-cell-content .data-table-recon-topic').should(
-  //     'have.length',
-  //     2
-  //   );
-  // });
+  it('Max number of candidates', () => {
+    const fixture = [
+      ['record_id', 'date', 'location', 'species'],
+      ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
+    ];
+    cy.loadAndVisitProject(fixture);
+    cy.columnActionClick('species', ['Reconcile', 'Start reconciling']);
+    addReconciliationService();
+    cy.get('.dialog-container input[bind="maxCandidates"]').type(2);
+    cy.get('.dialog-container button').contains('Start Reconciling...').click();
+    cy.assertColumnIsReconciled('species');
+    cy.get('.data-table-cell-content .data-table-recon-topic').should(
+      'have.length',
+      2
+    );
+  });
 
-  // it('Test reconciliation, in the grid', () => {
-  //   cy.loadAndVisitProject(fixture);
-  //   cy.reconcileColumn('species');
-  //   cy.assertColumnIsReconciled('species');
-  //   // Test 1, when there is a match
-  //   // simple assertion to ensure the content of the iframe is loaded for row 0 / species
-  //   // (recon loads match details from the recon endpoint in an iframe)
-  //   cy.getCell(0, 'species').within(() => {
-  //     cy.get('a[href^="http://localhost:8000/"]').trigger('mouseover');
-  //     cy.get(
-  //       'a[href^="http://localhost:8000/"] .data-table-topic-popup'
-  //     ).should('to.exist');
+  it('Test reconciliation, in the grid', () => {
+    cy.loadAndVisitProject(fixture);
+    cy.reconcileColumn('species');
+    cy.assertColumnIsReconciled('species');
+    // Test 1, when there is a match
+    // simple assertion to ensure the content of the iframe is loaded for row 0 / species
+    // (recon loads match details from the recon endpoint in an iframe)
+    cy.getCell(0, 'species').within(() => {
+      cy.get('a[href^="http://localhost:8000/"]').trigger('mouseover');
+      cy.get(
+        'a[href^="http://localhost:8000/"] .data-table-topic-popup'
+      ).should('to.exist');
 
-  //     cy.get('iframe').its('0.contentDocument').should('exist');
-  //   });
+      cy.get('iframe').its('0.contentDocument').should('exist');
+    });
 
-  //   // Test 2, when there are candidates
-  //   // ensure the first one loads an iframe on hover
-  //   cy.getCell(3, 'species').within(() => {
-  //     cy.get(
-  //       '.data-table-recon-candidate:first-child .data-table-recon-topic'
-  //     ).trigger('mouseover');
-  //     cy.get(
-  //       '.data-table-recon-candidate:first-child .data-table-topic-popup'
-  //     ).should('to.exist');
+    // Test 2, when there are candidates
+    // ensure the first one loads an iframe on hover
+    cy.getCell(3, 'species').within(() => {
+      cy.get(
+        '.data-table-recon-candidate:first-child .data-table-recon-topic'
+      ).trigger('mouseover');
+      cy.get(
+        '.data-table-recon-candidate:first-child .data-table-topic-popup'
+      ).should('to.exist');
 
-  //     cy.get(
-  //       '.data-table-recon-candidate:first-child .data-table-topic-popup iframe'
-  //     )
-  //       .its('0.contentDocument')
-  //       .should('exist');
+      cy.get(
+        '.data-table-recon-candidate:first-child .data-table-topic-popup iframe'
+      )
+        .its('0.contentDocument')
+        .should('exist');
 
-  //     // verify the three buttons inside the popup
-  //     cy.get(
-  //       '.data-table-recon-candidate:first-child .data-table-topic-popup'
-  //     ).within(() => {
-  //       cy.get('button').contains('Match this Cell').should('to.exist');
-  //       cy.get('button')
-  //         .contains('Match All Identical Cells')
-  //         .should('to.exist');
-  //       cy.get('button').contains('Cancel').should('to.exist');
-  //     });
-  //   });
-  // });
+      // verify the three buttons inside the popup
+      cy.get(
+        '.data-table-recon-candidate:first-child .data-table-topic-popup'
+      ).within(() => {
+        cy.get('button').contains('Match this Cell').should('to.exist');
+        cy.get('button')
+          .contains('Match All Identical Cells')
+          .should('to.exist');
+        cy.get('button').contains('Cancel').should('to.exist');
+      });
+    });
+  });
 
-  // it('Match this cell', () => {
-  //   const fixture = [
-  //     ['record_id', 'date', 'location', 'species'],
-  //     ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
-  //     ['3', '2018-06-09', 'West Virginia', 'Monstera deliciosa'],
-  //   ];
+  it('Match this cell', () => {
+    const fixture = [
+      ['record_id', 'date', 'location', 'species'],
+      ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
+      ['3', '2018-06-09', 'West Virginia', 'Monstera deliciosa'],
+    ];
 
-  //   cy.loadAndVisitProject(fixture);
-  //   cy.reconcileColumn('species');
-  //   cy.assertColumnIsReconciled('species');
+    cy.loadAndVisitProject(fixture);
+    cy.reconcileColumn('species');
+    cy.assertColumnIsReconciled('species');
 
-  //   // over on a candidate (Lineus longissimus)
-  //   cy.getCell(0, 'species')
-  //     .find('a')
-  //     .contains('Lineus longissimus')
-  //     .trigger('mouseover');
+    // over on a candidate (Lineus longissimus)
+    cy.getCell(0, 'species')
+      .find('a')
+      .contains('Lineus longissimus')
+      .trigger('mouseover');
 
-  //   // click on match
-  //   cy.getCell(0, 'species').find('button').contains('Match this Cell').click();
+    // click on match
+    cy.getCell(0, 'species').find('button').contains('Match this Cell').click();
 
-  //   // check notification
-  //   cy.assertNotificationContainingText('Match Lineus longissimus');
+    // check notification
+    cy.assertNotificationContainingText('Match Lineus longissimus');
 
-  //   // check that candidates have disappeared, means matched
-  //   cy.getCell(0, 'species')
-  //     .find('.data-table-recon-candidates')
-  //     .should('not.to.exist');
-  // });
+    // check that candidates have disappeared, means matched
+    cy.getCell(0, 'species')
+      .find('.data-table-recon-candidates')
+      .should('not.to.exist');
+  });
 
-  // it('Match All identical cell', () => {
-  //   const fixture = [
-  //     ['record_id', 'date', 'location', 'species'],
-  //     ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
-  //     ['16', '2018-09-06', 'West Virginia', 'Bos taurus'],
-  //   ];
-  //   cy.loadAndVisitProject(fixture);
-  //   cy.reconcileColumn('species');
-  //   cy.assertColumnIsReconciled('species');
+  it('Match All identical cell', () => {
+    const fixture = [
+      ['record_id', 'date', 'location', 'species'],
+      ['15', '2018-09-06', 'West Virginia', 'Bos taurus'],
+      ['16', '2018-09-06', 'West Virginia', 'Bos taurus'],
+    ];
+    cy.loadAndVisitProject(fixture);
+    cy.reconcileColumn('species');
+    cy.assertColumnIsReconciled('species');
 
-  //   // ensure both rows have candidates
-  //   cy.getCell(0, 'species')
-  //     .find('.data-table-recon-candidate')
-  //     .should('have.length', 6);
+    // ensure both rows have candidates
+    cy.getCell(0, 'species')
+      .find('.data-table-recon-candidate')
+      .should('have.length', 6);
 
-  //   cy.getCell(1, 'species')
-  //     .find('.data-table-recon-candidate')
-  //     .should('have.length', 6);
+    cy.getCell(1, 'species')
+      .find('.data-table-recon-candidate')
+      .should('have.length', 6);
 
-  //   // over on a candidate (Lineus longissimus)
-  //   cy.getCell(0, 'species')
-  //     .find('a')
-  //     .contains('Lineus longissimus')
-  //     .trigger('mouseover');
+    // over on a candidate (Lineus longissimus)
+    cy.getCell(0, 'species')
+      .find('a')
+      .contains('Lineus longissimus')
+      .trigger('mouseover');
 
-  //   // click on match all
-  //   cy.getCell(0, 'species')
-  //     .find('button')
-  //     .contains('Match All Identical Cells')
-  //     .click();
+    // click on match all
+    cy.getCell(0, 'species')
+      .find('button')
+      .contains('Match All Identical Cells')
+      .click();
 
-  //   // check notification
-  //   cy.assertNotificationContainingText(
-  //     'Match item Lineus longissimus (2508430) for 2 cells'
-  //   );
+    // check notification
+    cy.assertNotificationContainingText(
+      'Match item Lineus longissimus (2508430) for 2 cells'
+    );
 
-  //   // check that candidates have disappeared on both rows, means matched all
-  //   cy.getCell(0, 'species')
-  //     .find('.data-table-recon-candidates')
-  //     .should('not.to.exist');
+    // check that candidates have disappeared on both rows, means matched all
+    cy.getCell(0, 'species')
+      .find('.data-table-recon-candidates')
+      .should('not.to.exist');
 
-  //   cy.getCell(1, 'species')
-  //     .find('.data-table-recon-candidates')
-  //     .should('not.to.exist');
-  // });
+    cy.getCell(1, 'species')
+      .find('.data-table-recon-candidates')
+      .should('not.to.exist');
+  });
 });

--- a/main/tests/cypress/cypress/integration/tutorial/importing-data-into-openrefine.spec.js
+++ b/main/tests/cypress/cypress/integration/tutorial/importing-data-into-openrefine.spec.js
@@ -1,4 +1,4 @@
-// This spec is implementation for chapter 02 of following tutorial https://librarycarpentry.org/lc-open-refine/02-importing-data/index.html
+  // This spec is implementation for chapter 02 of following tutorial https://librarycarpentry.org/lc-open-refine/02-importing-data/index.html
 
 describe(__filename, function () {
   it('Create your first OpenRefine project (using provided data)', function () {
@@ -27,6 +27,9 @@ describe(__filename, function () {
       .contains('Next »')
       .click();
 
+
+
+
     // then ensure we are on the preview page
     cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
     // Step-3 Click in the Character encoding box and set it to UTF-8
@@ -37,6 +40,8 @@ describe(__filename, function () {
     cy.get('input[bind="trimStringsCheckbox"]').check();
 
     // create the project and ensure its successful
+    // wait until the grid appear, this ensure the job is ready 
+    cy.get('div[bind="dataPanel"] table.data-table').should('to.exist');
     cy.get('.default-importing-wizard-header button[bind="nextButton"]')
       .contains('Create Project »')
       .click();

--- a/main/tests/cypress/cypress/integration/tutorial/importing-data-into-openrefine.spec.js
+++ b/main/tests/cypress/cypress/integration/tutorial/importing-data-into-openrefine.spec.js
@@ -37,7 +37,10 @@ describe(__filename, function () {
     cy.get('input[bind="trimStringsCheckbox"]').check();
 
     // create the project and ensure its successful
-    cy.doCreateProjectThroughUserInterface();
+    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+      .contains('Create Project »')
+      .click();
+    cy.get('#create-project-progress-message').contains('Done.');
 
     // ensure that the project data is loaded completely
     cy.get('#summary-bar').should('to.contain', '1001 rows');

--- a/main/tests/cypress/cypress/integration/tutorial/importing-data-into-openrefine.spec.js
+++ b/main/tests/cypress/cypress/integration/tutorial/importing-data-into-openrefine.spec.js
@@ -1,4 +1,4 @@
-  // This spec is implementation for chapter 02 of following tutorial https://librarycarpentry.org/lc-open-refine/02-importing-data/index.html
+// This spec is implementation for chapter 02 of following tutorial https://librarycarpentry.org/lc-open-refine/02-importing-data/index.html
 
 describe(__filename, function () {
   it('Create your first OpenRefine project (using provided data)', function () {
@@ -27,9 +27,6 @@ describe(__filename, function () {
       .contains('Next »')
       .click();
 
-
-
-
     // then ensure we are on the preview page
     cy.get('.create-project-ui-panel').contains('Configure Parsing Options');
     // Step-3 Click in the Character encoding box and set it to UTF-8
@@ -40,7 +37,7 @@ describe(__filename, function () {
     cy.get('input[bind="trimStringsCheckbox"]').check();
 
     // create the project and ensure its successful
-    // wait until the grid appear, this ensure the job is ready 
+    // wait until the grid appear, this ensure the job is ready
     cy.get('div[bind="dataPanel"] table.data-table').should('to.exist');
     cy.get('.default-importing-wizard-header button[bind="nextButton"]')
       .contains('Create Project »')

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -399,6 +399,12 @@ Cypress.Commands.add(
       .first()
       .scrollIntoView()
       .click({ force: true });
-    cy.doCreateProjectThroughUserInterface();
+    
+    // wait for preview and click next to create the project
+    cy.get('div[bind="dataPanel"] table.data-table').should('to.exist');
+    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+      .contains('Create Project »')
+      .click();
+    cy.get('#create-project-progress-message').contains('Done.');
   }
 );

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -349,7 +349,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('assertNotificationContainingText', (text) => {
-  cy.get('#notification').should('to.contain', text).should('be.visible');
+  cy.get('#notification').should('be.visible').should('to.contain', text);
 });
 
 Cypress.Commands.add(

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -149,41 +149,6 @@ Cypress.Commands.add('createProjectThroughUserInterface', (fixtureFile) => {
   ).click();
 });
 
-Cypress.Commands.add('doCreateProjectThroughUserInterface', () => {
-  cy.get('.default-importing-wizard-header button[bind="nextButton"]')
-    .contains('Create Project »')
-    .click();
-  cy.get('#create-project-progress-message').contains('Done.');
-  Cypress.on('uncaught:exception', (err, runnable) => {
-    // returning false here prevents Cypress from
-    // failing the test due to the uncaught exception caused by the window failure
-    return false;
-  });
-
-  // workaround to ensure project is loaded
-  // cypress does not support window.location = ...
-  cy.get('h2').should('to.contain', 'HTTP ERROR 404');
-  cy.location().should((location) => {
-    expect(location.href).contains(
-      Cypress.env('OPENREFINE_URL') + '/__/project?'
-    );
-  });
-
-  cy.location().then((location) => {
-    const projectId = location.href.split('=').slice(-1)[0];
-    cy.visitProject(projectId);
-    cy.wrap(projectId).as('createdProjectId');
-    cy.get('@loadedProjectIds', { log: false }).then((loadedProjectIds) => {
-      loadedProjectIds.push(projectId);
-      cy.wrap(loadedProjectIds, { log: false })
-        .as('loadedProjectIds')
-        .then(() => {
-          return projectId;
-        });
-    });
-  });
-});
-
 /**
  * Cast a whole column to the given type, using Edit Cell / Common transform / To {type}
  */

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -367,7 +367,7 @@ Cypress.Commands.add(
 Cypress.Commands.add('dragAndDrop', (sourceSelector, targetSelector) => {
   cy.get(sourceSelector).trigger('mousedown', { which: 1 });
 
-  cy.get(targetSelector)
+  cy.get(targetSelector) // eslint-disable-line
     .trigger('mousemove')
     .trigger('mouseup', { force: true });
 });
@@ -399,7 +399,7 @@ Cypress.Commands.add(
       .first()
       .scrollIntoView()
       .click({ force: true });
-    
+
     // wait for preview and click next to create the project
     cy.get('div[bind="dataPanel"] table.data-table').should('to.exist');
     cy.get('.default-importing-wizard-header button[bind="nextButton"]')

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/controller.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/controller.js
@@ -236,7 +236,9 @@ Refine.DefaultImportingController.prototype.updateFormatAndOptions = function(op
             $.each(o.errors, function() { messages.push(this.message); });
             alert(messages.join('\n\n'));
             }
-            finallyCallBack();
+            if(finallyCallBack){
+              finallyCallBack();
+            }
         } else {
             callback(o);
         }


### PR DESCRIPTION
Fixed several issues and problems we had with tests stability

- latest version of Cypress now properly handles some redirections used by OpenRefine, hacky code has been removed
- tests improvements to resolve flaky tests
- removed scatterplot visual testing (images diffs), that is not stable on edge
- Temporarily disabled `Test the create project from Web URL based on CSV`, those tests doesn't work with the last version of cypress, to be investigated separately in #4015
- fixed OpenRefine core javascript code to properly address #3678