### PR TITLE
Update info on Docs README about Next version

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,14 @@ yarn
 yarn start
 ```
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
+This command starts a local development server and opens up a browser window. Usually at the URL http://localhost:3000
+Most changes are reflected live without having to restart the server.
+
+### Next version of OpenRefine docs
+If you wish to work on the next version of docs for OpenRefine (`master` branch) then you will need to:
+1. Git checkout our `master` branch
+1. Edit files under `docs/docs/`
+2. Preview changes with the URL kept pointing to http://localhost:3000/next which will automatically show changes live with yarn after you save a file.
 
 ### Build
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,8 +32,8 @@ Most changes are reflected live without having to restart the server.
 ### Next version of OpenRefine docs
 If you wish to work on the next version of docs for OpenRefine (`master` branch) then you will need to:
 1. Git checkout our `master` branch
-1. Edit files under `docs/docs/`
-2. Preview changes with the URL kept pointing to http://localhost:3000/next which will automatically show changes live with yarn after you save a file.
+2. Edit files under `docs/docs/`
+3. Preview changes with the URL kept pointing to http://localhost:3000/next which will automatically show changes live with yarn after you save a file.
 
 ### Build
 


### PR DESCRIPTION
@wetneb Does this look OK?  I just tested and seems that this is how we can actually work and see the "next version" of docs and we didn't really document this anywhere as far as I can tell.  So this README section is a good place?

Fixes #{issue number here}

Changes proposed in this pull request:
- Update Docs README about Next version
- 
- 
