### PR TITLE
Speed-up testing time for Cypress in CI/CD

### DIFF
--- a/docs/docs/technical-reference/functional-tests.md
+++ b/docs/docs/technical-reference/functional-tests.md
@@ -179,6 +179,8 @@ Cypress execution can be configured with environment variables, they can be decl
 Available variables are
 
 - OPENREFINE_URL, determine on which scheme://url:port to access OpenRefine, default to http://localhost:333
+- DISABLE_PROJECT_CLEANUP, If set to 1, projects will not be deleted after each run. Default to 0 to keep the OpenRefine instance clean
+
 
 Cypress contains [exaustive documentation](https://docs.cypress.io/guides/guides/environment-variables.html#Setting) about configuration, but here are two simple ways to configure the execution of the tests:
 

--- a/main/tests/cypress/cypress.json
+++ b/main/tests/cypress/cypress.json
@@ -7,7 +7,7 @@
   },
   "env": {
     "OPENREFINE_URL": "http://localhost:3333",
-    "DISABLE_PROJECT_CLEANUP": 1
+    "DISABLE_PROJECT_CLEANUP": 0
 
   }
 }

--- a/main/tests/cypress/cypress.json
+++ b/main/tests/cypress/cypress.json
@@ -6,6 +6,8 @@
     "openMode": 0
   },
   "env": {
-    "OPENREFINE_URL": "http://localhost:3333"
+    "OPENREFINE_URL": "http://localhost:3333",
+    "DISABLE_PROJECT_CLEANUP": 1
+
   }
 }

--- a/main/tests/cypress/cypress/support/index.js
+++ b/main/tests/cypress/cypress/support/index.js
@@ -33,7 +33,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  cy.cleanupProjects();
+  // DISABLE_PROJECT_CLEANUP is used to disable projects deletion
+  // Mostly used in CI/CD for performances
+  if(parseInt(Cypress.env('DISABLE_PROJECT_CLEANUP')) != 1){
+    cy.cleanupProjects();
+  }
 });
 
 before(() => {

--- a/refine
+++ b/refine
@@ -526,7 +526,7 @@ ui_tests() {
     # Cypress needs a unique group id
     # We're hashing the list of files to generate such Group Id
     CYPRESS_GROUP=$(echo $CYPRESS_BROWSER$CYPRESS_SPECS | shasum)
-    CYPRESS_RUN_CMD="yarn --cwd ./main/tests/cypress run cypress run --spec "$CYPRESS_SPECS" --browser $CYPRESS_BROWSER --group "$CYPRESS_GROUP" --headless --quiet --reporter list --env OPENREFINE_URL=http://$REFINE_HOST_INTERNAL:$REFINE_PORT"
+    CYPRESS_RUN_CMD="yarn --cwd ./main/tests/cypress run cypress run --spec "$CYPRESS_SPECS" --browser $CYPRESS_BROWSER --group "$CYPRESS_GROUP" --headless --quiet --reporter list --env DISABLE_PROJECT_CLEANUP=1,OPENREFINE_URL=http://$REFINE_HOST_INTERNAL:$REFINE_PORT"
     if [ "$CYPRESS_RECORD" = "1" ] ; then
         # if tests are recorded, project id is added to env vars, and --record flag is added to the cmd-line
         export CYPRESS_PROJECT_ID=$CYPRESS_PROJECT_ID


### PR DESCRIPTION
Added an environment variable to disable projects cleanup on CI/CD.
This way we save an extra API call after each test run.
It will also fix [a flaky scenario](https://dashboard.cypress.io/projects/s5du3k/runs/1369/test-results/7f66c317-4292-4347-a6de-eed8e0397d4a) where the delete token wasn't found