### PR TITLE
Add border radius to left/right panel

### DIFF
--- a/main/webapp/modules/core/styles/project.less
+++ b/main/webapp/modules/core/styles/project.less
@@ -76,9 +76,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   position: fixed;
   overflow: hidden;
   padding: 0px;
-  padding-top: @padding_tight;
+  padding-top: 0px;
   font-size: 1.3em;
   background: @chrome_secondary;  
+  border-top-right-radius: 7px;
   }
   
 #left-panel  .ui-tabs .ui-tabs-panel {
@@ -94,6 +95,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   padding: 0px;
   padding-left: @padding_tight;
   background: @chrome_primary;
+  border-top-left-radius: 7px;
   }
 
 #tool-panel {


### PR DESCRIPTION
- Adds curvature to top-right corner of left-panel, and top-left corner of right-panel which highlights separation more to show the collapsible nature with new hide panel button. 
![image](https://user-images.githubusercontent.com/986438/124837324-3d108980-df4a-11eb-8872-45913cc072ca.png)

- removes unnecessary padding to better align left and right panel top edges visually.
![image](https://user-images.githubusercontent.com/986438/124837811-36cedd00-df4b-11eb-97f9-59b562ceacaf.png)
