### PR TITLE
thadguidry-patch-refine-bat

### DIFF
--- a/refine.bat
+++ b/refine.bat
@@ -115,6 +115,8 @@ if ""%1"" == ""/m"" goto arg-m
 if ""%1"" == ""/x"" goto arg-x
 goto endArgumentParsing
 
+rem --- Set Arguments ----------------------------------------------
+
 :arg-p
 set REFINE_PORT=%2
 goto shift2loop


### PR DESCRIPTION
Fixes refine.bat label missing error during batch file parsing
