### PR TITLE
fix internal link

### DIFF
--- a/docs/docs/manual/grelfunctions.md
+++ b/docs/docs/manual/grelfunctions.md
@@ -52,7 +52,7 @@ You can use toString() to convert numbers to strings with rounding, using an [op
 |0.15|0|
 |100.0|100|
 
-You can also convert dates to strings, using date parsing syntax built in to OpenRefine (see [the toDate() function for details](#todateo-boolean-month_first--format1-format2--)). For example,  `value.toString("MMM-dd-yyyy")` would convert the date value [2024-10-15T00:00:00Z] to “Oct-15-2024”.
+You can also convert dates to strings, using date parsing syntax built into OpenRefine (see [the toDate() function for details](#todateo-b-monthfirst-s-format1-s-format2-)). For example, `value.toString("MMM-dd-yyyy")` would convert the date value [2024-10-15T00:00:00Z] to “Oct-15-2024”.
 
 Note: In OpenRefine, using toString() on a null cell outputs the string “null”.
 


### PR DESCRIPTION
Old link would not lead to any section in live documentation.

Changes proposed in this pull request:
- fix internal link
- remove superfluous space
- "in to" -> "into"
