### PR TITLE
Improve documentation of Java compatibility.

### DIFF
--- a/docs/docs/manual/installing.md
+++ b/docs/docs/manual/installing.md
@@ -20,7 +20,7 @@ OpenRefine is designed to work with **Windows**, **Mac**, and **Linux** operatin
 
 If you install and start OpenRefine on a Windows computer without Java, it will automatically open up a browser window to the [Java downloads page](https://java.com/en/download/), and you can simply follow the instructions there.
 
-We recommend you [download](https://java.com/en/download/) and install Java before proceeding with the OpenRefine installation. Please note that OpenRefine works with Java 14 but not Java 16 or later versions, hopefully this will be fixed in the 3.5 final release (see issue [#4106](https://github.com/OpenRefine/OpenRefine/issues/4106)).
+We recommend you [download](https://java.com/en/download/) and install Java before proceeding with the OpenRefine installation. Please note that OpenRefine works with Java 8 to Java 15 but not Java 16 or later versions.
 
 #### Compatible browser {#compatible-browser}
 

--- a/docs/versioned_docs/version-3.4/manual/installing.md
+++ b/docs/versioned_docs/version-3.4/manual/installing.md
@@ -20,7 +20,7 @@ OpenRefine is designed to work with **Windows**, **Mac**, and **Linux** operatin
 
 If you install and start OpenRefine on a Windows computer without Java, it will automatically open up a browser window to the [Java downloads page](https://java.com/en/download/), and you can simply follow the instructions there.
 
-We recommend you [download](https://java.com/en/download/) and install Java before proceeding with the OpenRefine installation. Please note that OpenRefine works with Java 14 but not Java 16 or later versions, hopefully this will be fixed in the 3.5 final release (see issue [#4106](https://github.com/OpenRefine/OpenRefine/issues/4106)).
+We recommend you [download](https://java.com/en/download/) and install Java before proceeding with the OpenRefine installation. Please note that OpenRefine works with Java 8 to Java 15 but not Java 16 or later versions.
 
 #### Compatible browser {#compatible-browser}
 


### PR DESCRIPTION
Changes proposed in this pull request:
- make it more explicit which versions of Java we are compatible with
- remove link to issue with expectation of release (since we will not add support for Java 16 in 3.5)

