### PR TITLE
Fix Google extension authentication flow.

### DIFF
--- a/extensions/gdata/module/MOD-INF/controller.js
+++ b/extensions/gdata/module/MOD-INF/controller.js
@@ -105,6 +105,9 @@ function process(path, request, response) {
     context.state = request.getParameter("state");
     
     (function() {
+      if (Packages.com.google.refine.extension.gdata.TokenCookie.getToken(request) !== null) {
+          return;
+      }
       var tokenAndExpiresInSeconds =  Packages.com.google.refine.extension.gdata.GoogleAPIExtension.getTokenFromCode(module,request);
       if (tokenAndExpiresInSeconds) {
         var tokenInfo = tokenAndExpiresInSeconds.split(",");


### PR DESCRIPTION
This prevents consecutive requests to the /authorized endpoint from requesting authorization multiple times to Google (only the first time succeeds).

Closes #3991.