### PR TITLE
Fix CLI setting for memory size (-m and /m)

### DIFF
--- a/refine
+++ b/refine
@@ -47,8 +47,7 @@ where [options] include:
      default: OS dependent
 
   -m <memory> max memory heap size to use
-     default: 1024M
-     Values less than 256M not allowed
+     default: 1400M
 
   -v <level> verbosity level [from low to high: error,warn,info,debug,trace]
      default: info
@@ -847,16 +846,8 @@ while [ $# -ne 0 ] ; do
     -i) shift; REFINE_INTERFACE="$1"; shift; continue;;
     -w) shift; REFINE_WEBAPP="$1"; shift; continue;;
     -d) shift; REFINE_DATA_DIR="$1"; shift; continue;;
-    -m) 
-      shift;
-      if [ $1 -le 256 ]
-      then
-        fail "Value of -m less than 256 not allowed";
-      else
-        REFINE_MEMORY="$1";
-        shift;
-        continue;
-      fi;;
+    -m) shift; REFINE_MEMORY="$1"; REFINE_MIN_MEMORY="$1"; shift; continue;;
+    -k) shift; REFINE_GOOGLE_API_KEY="$1"; shift; continue;;
     -v) shift; REFINE_VERBOSITY="$1"; shift; continue;;
     -x) shift; REFINE_EXTRA_OPTS="$1"; shift; continue;;
     --debug) shift; add_option '-Xdebug' '-Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n'; continue;;

--- a/refine.bat
+++ b/refine.bat
@@ -40,7 +40,7 @@ echo.
 echo  "/d" enable JVM debugging (on port 8000)
 echo.
 echo  "/m <memory>" max memory heap size to use
-echo     default: 1024M
+echo     default: 1400M
 echo.
 echo  "/x" enable JMX monitoring (for jconsole and friends)
 echo.
@@ -130,6 +130,7 @@ goto shift2loop
 
 :arg-m
 set REFINE_MEMORY=%2
+set REFINE_MIN_MEMORY=%2
 goto shift2loop
 
 :arg-d
@@ -155,7 +156,7 @@ set JAVA_OPTIONS=
 set OPTS=%OPTS% %JAVA_OPTIONS%
 
 if not "%REFINE_MEMORY%" == "" goto gotMemory
-set REFINE_MEMORY=1024M
+set REFINE_MEMORY=1400M
 if not "%REFINE_MIN_MEMORY%" == "" goto gotMemory
 set REFINE_MIN_MEMORY=256M
 


### PR DESCRIPTION
Fixes #4265.

Changes proposed in this pull request:
- Revert the faulty fix for #388.
- Let -m (on UNIX) and /m (on Windows) control both the initial heap size and the maximum one, so that we cannot run into the situation where the initial heap size is larger than the maximum one.
