### PR TITLE
Fix date parsing to avoid offsets due to DST.

### DIFF
--- a/main/src/com/google/refine/util/ParsingUtilities.java
+++ b/main/src/com/google/refine/util/ParsingUtilities.java
@@ -99,7 +99,7 @@ public class ParsingUtilities {
     public static final ObjectWriter defaultWriter = mapper.writerWithView(JsonViews.NonSaveMode.class).with(defaultFilters);
 
     public static final DateTimeFormatter ISO8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
-    private static final ZoneOffset defaultTimeOffset = OffsetDateTime.now().getOffset();
+    private static final ZoneId defaultZone = ZoneId.systemDefault();
                 
     static public Properties parseUrlParameters(HttpServletRequest request) {
         Properties options = new Properties();
@@ -248,26 +248,26 @@ public class ParsingUtilities {
 
     /**
      * Converts an old-style Java Date to an OffsetDateTime,
-     * assuming the date is represented in the current default system timezone
+     * assuming the date is represented in the current default system zone
      * (which is what you get if the date was parsed using `Calendar.getDefault()`).
      * 
      * @param date
      * @return
      */
     public static OffsetDateTime toDate(Date date) {
-        return date.toInstant().atOffset(defaultTimeOffset);
+        return date.toInstant().atZone(defaultZone).toOffsetDateTime();
     }
 
     /**
      * Converts an old-style Java Calendar to an OffsetDateTime,
-     * assuming the date is represented in the current default system timezone
+     * assuming the date is represented in the current default system zone
      * (which is what you get if the date was parsed using `Calendar.getDefault()`).
      * 
      * @param date
      * @return
      */
     public static OffsetDateTime toDate(Calendar date) {
-        return date.toInstant().atOffset(defaultTimeOffset);
+        return date.toInstant().atZone(defaultZone).toOffsetDateTime();
     }
 
 	public static ObjectNode evaluateJsonStringToObjectNode(String optionsString) {


### PR DESCRIPTION
This pull request comes without tests because there is no clean way
to set the system timezone in a Java unit test:
https://stackoverflow.com/questions/23466218/setting-timezone-for-maven-unit-tests-on-java-8

The problem came from the fact that we were interpreting all dates with the current
zone *offset*, which varies during the year depending on DST, meaning that during the winter
we would interpret summer dates in a winter timezone, which does not make sense.
This changes the date conversion mechanism to only rely on the current zone, making sure
the correct offset is used depending on the value of the converted date.

Fixes #4294.
