### PR TITLE
Exclude duplicate dependency from odftoolkit.

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -270,6 +270,15 @@
       <groupId>org.odftoolkit</groupId>
       <artifactId>odfdom-java</artifactId>
       <version>0.9.0-RC1</version>
+      <!-- workaround for https://github.com/tdf/odftoolkit/issues/131 
+         can be removed as soon as this library is updated to a newer version with
+         https://github.com/tdf/odftoolkit/pull/132 in it. -->
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.openrefine.dependencies</groupId>


### PR DESCRIPTION
Closes #4296.

Changes proposed in this pull request:
- temporary workaround by manually excluding a dependency. Fix has been proposed upstream: https://github.com/tdf/odftoolkit/pull/132
