### PR TITLE
Update odftoolkit to 0.9.0

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -261,6 +261,18 @@
       <groupId>org.odftoolkit</groupId>
       <artifactId>odfdom-java</artifactId>
       <version>0.9.0</version>
+      <!-- workaround for https://github.com/tdf/odftoolkit/issues/131,
+	 which is unfortunately still not solved after
+         https://github.com/tdf/odftoolkit/pull/132
+	 because xml-apis remains an indirect dependency of this library
+	 through xercesImpl.
+      -->
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.openrefine.dependencies</groupId>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -260,16 +260,7 @@
     <dependency>
       <groupId>org.odftoolkit</groupId>
       <artifactId>odfdom-java</artifactId>
-      <version>0.9.0-RC1</version>
-      <!-- workaround for https://github.com/tdf/odftoolkit/issues/131 
-         can be removed as soon as this library is updated to a newer version with
-         https://github.com/tdf/odftoolkit/pull/132 in it. -->
-      <exclusions>
-        <exclusion>
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>0.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.openrefine.dependencies</groupId>


### PR DESCRIPTION
(No issue number)

Updates to this new version which does not depend on a vulnerable version of Apache Jena anymore.
