### PR TITLE
Mention UniversalLanguageSelector requirement

### DIFF
--- a/docs/docs/manual/wikibase/configuration.md
+++ b/docs/docs/manual/wikibase/configuration.md
@@ -19,7 +19,7 @@ To let your users contribute to your Wikibase instance with OpenRefine, you will
 
 ### Requirements {#requirements}
 
-To work with OpenRefine, your Wikibase instance needs an associated reconciliation service. For instance you can use [a Python wrapper](https://github.com/wetneb/openrefine-wikibase) for this.
+To work with OpenRefine, your Wikibase instance needs an associated reconciliation service. For instance you can use [a Python wrapper](https://github.com/wetneb/openrefine-wikibase) for this. Also, in addition to Wikibase, the [UniversalLanguageSelector extension](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:UniversalLanguageSelector) should be installed.
 
 
 ### The format of the manifest {#the-format-of-the-manifest}

--- a/docs/versioned_docs/version-3.5/manual/wikibase/configuration.md
+++ b/docs/versioned_docs/version-3.5/manual/wikibase/configuration.md
@@ -19,7 +19,7 @@ To let your users contribute to your Wikibase instance with OpenRefine, you will
 
 ### Requirements {#requirements}
 
-To work with OpenRefine, your Wikibase instance needs an associated reconciliation service. For instance you can use [a Python wrapper](https://github.com/wetneb/openrefine-wikibase) for this.
+To work with OpenRefine, your Wikibase instance needs an associated reconciliation service. For instance you can use [a Python wrapper](https://github.com/wetneb/openrefine-wikibase) for this. Also, in addition to Wikibase, the [UniversalLanguageSelector extension](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:UniversalLanguageSelector) should be installed.
 
 
 ### The format of the manifest {#the-format-of-the-manifest}


### PR DESCRIPTION
ULS provides the [`languagesearch` API](https://www.mediawiki.org/wiki/Special:MyLanguage/API:Languagesearch) used to select term languages.

Changes proposed in this pull request:
- Add ULS to the 3.5 docs
- (no other docs because IIUC arbitrary Wikibase support is new in 3.5)
