### PR TITLE
Use OSSRH snapshot repository to host snapshot releases.

### DIFF
--- a/.github/workflows/release_manager.sh
+++ b/.github/workflows/release_manager.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-
-# Build Release Message
-API_JSON=$(printf '{"tag_name": "%s","target_commitish": "master","name": "OpenRefine snapshot %s","body": "This is a snapshot of the development version of OpenRefine, made on %s.\\n\\nThis contains the latest new features and bug fixes, but might not have been tested as thoroughly as official releases.\\n\\nMake sure you [back up your workspace](https://docs.openrefine.org/manual/installing#back-up-your-data) to avoid data loss and report any issues found with this version on [the mailing list](https://groups.google.com/forum/#!forum/openrefine).","draft": false,"prerelease": true}' ${OR_VERSION} ${OR_VERSION} "$(date -u +"%c")" )
-
-# Create Release
-echo $( curl --silent -H "Authorization: token ${RELEASE_REPO_TOKEN}" --data "${API_JSON}" "https://api.github.com/repos/${RELEASE_REPO_OWNER}/OpenRefine-snapshot-releases/releases" | jq -r '.upload_url' )

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -137,6 +137,8 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: 11
+        server-username: OSSRH_USER
+        server-password: OSSRH_PASS
 
     - name: Install genisoimage and jq
       run: sudo apt-get install genisoimage jq
@@ -170,63 +172,7 @@ jobs:
     - name: Generate dist files
       run: ./refine dist ${{ env.OR_VERSION }}
 
-    - name: Create Release
-      if: github.repository == 'OpenRefine/OpenRefine'
-      id: create_release
-      run: echo ::set-env name=API_RELEASE::$(./.github/workflows/release_manager.sh)
-      env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-        OR_VERSION: ${{ env.OR_VERSION }}
-        RELEASE_REPO_OWNER: OpenRefine
-        RELEASE_REPO_TOKEN: ${{ secrets.RELEASE_REPO_TOKEN }}
+    - name: Upload snapshot releases to OSSRH
+      run: mvn deploy -DskipTests=true
 
-    - name: Upload Release Asset Windows
-      id: upload-release-asset-win
-      if: github.repository == 'OpenRefine/OpenRefine'
-      uses: actions/upload-release-asset@v1.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_REPO_TOKEN }}
-      with:
-        upload_url: ${{ env.API_RELEASE }}
-        asset_path: ./packaging/target/openrefine-win-${{ env.OR_VERSION }}.zip
-        asset_name: openrefine-win-${{ env.OR_VERSION }}.zip
-        asset_content_type: application/zip
-
-    - name: Upload Release Asset Linux
-      id: upload-release-asset-linux
-      if: github.repository == 'OpenRefine/OpenRefine'
-      uses: actions/upload-release-asset@v1.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_REPO_TOKEN }}
-      with:
-        upload_url: ${{ env.API_RELEASE }}
-        asset_path: ./packaging/target/openrefine-linux-${{ env.OR_VERSION }}.tar.gz
-        asset_name: openrefine-linux-${{ env.OR_VERSION }}.tar.gz
-        asset_content_type: application/tar+gzip
-
-    - name: Upload Release Asset Mac
-      id: upload-release-asset-mac
-      if: github.repository == 'OpenRefine/OpenRefine'
-      uses: actions/upload-release-asset@v1.0.2
-      env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_REPO_TOKEN }}
-      with:
-        upload_url: ${{ env.API_RELEASE }}
-        asset_path: ./packaging/target/openrefine-mac-${{ env.OR_VERSION }}.dmg
-        asset_name: openrefine-mac-${{ env.OR_VERSION }}.dmg
-        asset_content_type: application/x-apple-diskimage
-
-    - name: Delete older releases
-      id: delete-older-releases
-      if: github.repository == 'OpenRefine/OpenRefine'
-      uses: dev-drprasad/delete-older-releases@v0.2.0
-      with:
-        repo: OpenRefine/OpenRefine-snapshot-releases
-        # Specifies number of latest releases (sorted by created_at) to keep. Pass 0 if you want to delete all releases
-        keep_latest: 10
-        # Specifies whether to delete tags associated to older releases or not.
-        # Older tags without any associated releases will not be deleted
-        delete_tags: true  
-      env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_REPO_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ the web. All from a web browser and the comfort and privacy of your own computer
 
 * [OpenRefine Releases](https://github.com/OpenRefine/OpenRefine/releases)
 
+## Snapshot releases
+
+Latest development version, packaged for:
+* [Linux](https://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=org.openrefine&a=openrefine&v=3.6-SNAPSHOT&c=linux&p=tar.gz)
+* [Windows](https://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=org.openrefine&a=openrefine&v=3.6-SNAPSHOT&c=mac&p=dmg)
+* [MacOS](https://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=org.openrefine&a=openrefine&v=3.6-SNAPSHOT&c=win&p=zip)
+
 ## Run from source
 
 If you have cloned this repository to your computer, you can run OpenRefine with:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ before_test:
     copy packaging\test_pom.xml packaging\pom.xml
 - cmd: |-
     mvn process-resources
-    mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+    mvn package -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 test_script:
 - cmd: echo Running test_script...

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -148,6 +148,14 @@
             <skipTests>true</skipTests>
           </configuration>
         </plugin>
+       <plugin>
+	 <groupId>org.apache.maven.plugins</groupId>
+	 <artifactId>maven-deploy-plugin</artifactId>
+	 <version>${maven-deploy-plugin.version}</version>
+	 <configuration>
+	   <skip>true</skip>
+	 </configuration>
+       </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -87,6 +87,14 @@
            </filesets>
          </configuration>
        </plugin>
+       <plugin>
+	 <groupId>org.apache.maven.plugins</groupId>
+	 <artifactId>maven-deploy-plugin</artifactId>
+	 <version>${maven-deploy-plugin.version}</version>
+	 <configuration>
+	   <skip>true</skip>
+	 </configuration>
+       </plugin>
      </plugins>
    </build>
 </project>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -369,6 +369,14 @@
             </execution>
           </executions>
         </plugin>
+         <plugin>
+	   <groupId>org.apache.maven.plugins</groupId>
+	   <artifactId>maven-deploy-plugin</artifactId>
+	   <version>${maven-deploy-plugin.version}</version>
+	   <configuration>
+	    <skip>true</skip>
+	  </configuration>
+         </plugin>
     	</plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
+    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
   </properties>
 
 
@@ -125,24 +126,6 @@
     <resources>
     </resources>
     <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-	<version>${build-helper-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <phase>generate-sources</phase>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <configuration>
-              <sources>
-                <source>server/src</source>
-              </sources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -261,6 +244,77 @@
           </sourceDirectories>
         </configuration>
        </plugin>
+       <plugin>
+	  <groupId>org.codehaus.mojo</groupId>
+	  <artifactId>build-helper-maven-plugin</artifactId>
+	  <version>${build-helper-maven-plugin.version}</version>
+	  <inherited>false</inherited>
+	  <executions>
+	    <!-- Attach tar.gz artifact for linux -->
+	    <execution>
+		<id>attach-linux</id>
+		<phase>package</phase>
+		<goals>
+		    <goal>attach-artifact</goal>
+		</goals>
+		<configuration>
+		    <artifacts>
+			<artifact>
+			    <file>packaging/target/${project.build.finalName}-linux-${project.version}.tar.gz</file>
+			    <type>tar.gz</type>
+			    <classifier>linux</classifier>
+			</artifact>
+		    </artifacts>
+		</configuration>
+	    </execution>
+	    
+	    <!-- Attach the zip file for windows -->
+	    <execution>
+		<id>attach-win</id>
+		<phase>package</phase>
+		<goals>
+		    <goal>attach-artifact</goal>
+		</goals>
+		<configuration>
+		    <skipAttach>${skipCreateExe}</skipAttach>
+		    <artifacts>
+			<artifact>
+			    <file>packaging/target/${project.build.finalName}-win-${project.version}.zip</file>
+			    <type>zip</type>
+			    <classifier>win</classifier>
+			</artifact>
+		    </artifacts>
+		</configuration>
+	    </execution>
+	    
+	    <!-- Attach the final DMG for MacOS -->
+	    <execution>
+		<id>attach-dmg</id>
+		<phase>package</phase>
+		<goals>
+		    <goal>attach-artifact</goal>
+		</goals>
+		<configuration>
+		    <artifacts>
+			<artifact>
+		            <file>packaging/target/${project.build.finalName}-mac-${project.version}.dmg</file>
+			    <type>dmg</type>
+			    <classifier>mac</classifier>
+			</artifact>
+		    </artifacts>
+		</configuration>
+	      </execution>
+	    </executions>
+          </plugin>
+
+       <plugin>
+	 <groupId>org.apache.maven.plugins</groupId>
+	 <artifactId>maven-deploy-plugin</artifactId>
+	 <version>${maven-deploy-plugin.version}</version>
+	 <configuration>
+            <deployAtEnd>true</deployAtEnd>
+	 </configuration>
+       </plugin>
     </plugins>
   </build>
 
@@ -284,4 +338,12 @@
     </repository>
   </repositories>
 
+  <!-- Locations of the artifacts published -->
+  <distributionManagement>
+     <snapshotRepository>
+       <id>ossrh</id>
+       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+     </snapshotRepository>
+  </distributionManagement>
+ 
 </project>


### PR DESCRIPTION
Closes #4346.

Changes proposed in this pull request:
- integrate snapshot uploading into the Maven build process (for the standard `deploy` goal)
- remove scripts to upload to GitHub releases

This might need merging before it can be tested.
