### PR TITLE
Cleanup startup log on Linux

### DIFF
--- a/refine
+++ b/refine
@@ -623,9 +623,7 @@ run() {
     CLASSPATH="$REFINE_CLASSES_DIR${SEP}$REFINE_LIB_DIR/*"
 
     RUN_CMD=("$JAVA" -cp "$CLASSPATH" "${OPTS[@]}" "com.google.refine.Refine")
-    echo "${RUN_CMD[@]}"
 
-    echo "Starting OpenRefine at 'http://${REFINE_HOST_INTERNAL}:${REFINE_PORT}/'"
     echo ""
 
     if [ -z "$FORK" ] ; then
@@ -887,10 +885,12 @@ elif [ "$OS" = "linux" ] ; then
     freeRam=$(free -m | grep -oP '\d+' | head -n 1)
 fi
 
+echo "-------------------------------------------------------------------------------------------------"
 echo You have "$freeRam"M of free memory. 
 echo Your current configuration is set to use $REFINE_MEMORY of memory.
 echo OpenRefine can run better when given more memory. Read our FAQ on how to allocate more memory here:
-echo https://github.com/OpenRefine/OpenRefine/wiki/FAQ-Allocate-More-Memory
+echo https://docs.openrefine.org/manual/installing\#increasing-memory-allocation
+echo "-------------------------------------------------------------------------------------------------"
 
 if [ -z "$REFINE_MAX_FORM_CONTENT_SIZE" ] ; then
     REFINE_MAX_FORM_CONTENT_SIZE="1048576"


### PR DESCRIPTION
Closes #4375

Changes proposed in this pull request:
- remove printout of Java command in the logs
- update link to documentation about memory allocation
- add delimiters to the memory allocation message

Current result:
```
Using refine-dev.ini for configuration
-------------------------------------------------------------------------------------------------
You have 7630M of free memory.
Your current configuration is set to use 1400M of memory.
OpenRefine can run better when given more memory. Read our FAQ on how to allocate more memory here:
https://docs.openrefine.org/manual/installing#increasing-memory-allocation
-------------------------------------------------------------------------------------------------

18:48:04.668 [            refine_server] Starting Server bound to '127.0.0.1:3333' (0ms)
18:48:04.683 [            refine_server] refine.memory size: 1400M JVM Max heap: 1468006400 (15ms)
18:48:04.726 [            refine_server] Initializing context: '/' from '/home/antonin/ORmaster/main/webapp' (43ms)
18:48:04.779 [            refine_server] Starting autoreloading scanner...  (53ms)
18:48:06.215 [                   refine] Starting OpenRefine 3.6-SNAPSHOT [e003da8]... (1436ms)
18:48:06.216 [                   refine] initializing FileProjectManager with dir (1ms)
18:48:06.216 [                   refine] /home/antonin/.local/share/openrefine (0ms)
18:48:12.887 [                   refine] POST /command/core/load-language (6671ms)
18:48:12.928 [                   refine] GET /command/core/get-preference (41ms)
18:48:12.982 [                   refine] POST /command/core/load-language (54ms)
18:48:12.998 [                   refine] POST /command/core/load-language (16ms)
```
