### PR TITLE
Fixed sample extension pom.xml

### DIFF
--- a/extensions/sample/pom.xml
+++ b/extensions/sample/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.openrefine</groupId>
   <artifactId>sample</artifactId>
   <packaging>jar</packaging>
-  <version>3.0-SNAPSHOT</version>
+  <version>3.6-SNAPSHOT</version>
 
   <name>OpenRefine - Sample extension</name>
   <description>Example extension provided for demonstration purposes</description>


### PR DESCRIPTION
hey,

the sample extension does not compile because of the main maven dependency

```
cd extensions/sample
mvn compile

..
 Could not resolve dependencies for project org.openrefine:sample:jar:3.0-SNAPSHOT: org.openrefine:main:jar:3.0-SNAPSHOT was not found in https://oss.sonatype.org/content/repositories/snapshots/ during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of snapshots has elapsed or updates are forced
```

This PR should address it

