### PR TITLE
Refactor editor api for existing Items

### DIFF
--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/editing/EditBatchProcessorTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/editing/EditBatchProcessorTest.java
@@ -152,9 +152,12 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         verify(fetcher, times(1)).getEntityDocuments(toQids(firstBatch));
         verify(fetcher, times(1)).getEntityDocuments(toQids(secondBatch));
         for (ItemDocument doc : fullBatch) {
-            verify(editor, times(1)).updateTermsStatements(doc, Collections.emptyList(),
-                    Collections.singletonList(description), Collections.emptyList(), Collections.emptyList(),
-                    Collections.emptyList(), Collections.emptyList(), summary, tags);
+            verify(editor, times(1)).editEntityDocument(Datamodel.makeItemUpdate(doc.getEntityId(),
+                    doc.getRevisionId(), Datamodel.makeTermUpdate(Collections.emptyList(), Collections.emptyList()),
+                    Datamodel.makeTermUpdate(Collections.singletonList(description), Collections.emptyList()),
+                    Collections.emptyMap(),
+                    Datamodel.makeStatementUpdate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
+                    Collections.emptyList(), Collections.emptyList()), false, summary, tags);
         }
     }
 


### PR DESCRIPTION
Fixes #4268

Changes proposed in this pull request:
- Factor out deprecated editor api in `EditBatchProcessor` for existing Item updates
- Update `EditBatchProcessorTest` class