### PR TITLE
Fix warning about license during packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
   </organization>
   <licenses>
     <license>
-      <name>BSD 3-Clause "New" or "Revised" License</name>
-      <url>https://github.com/OpenRefine/OpenRefine/blob/master/LICENSE.txt</url>
+      <name>BSD-3-Clause</name>
+      <url>https://raw.githubusercontent.com/OpenRefine/OpenRefine/master/LICENSE.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>


### PR DESCRIPTION
Fix license download warning during packaging
- Updates `<name>` tag to a SPDX identifier https://spdx.org/licenses/ as recommended by https://maven.apache.org/pom.html#licenses
- Updates `<url>` tag to use raw content for easier preview with tools