### PR TITLE
Migrate out of PowerMock for the Wikidata extension

### DIFF
--- a/extensions/wikidata/pom.xml
+++ b/extensions/wikidata/pom.xml
@@ -15,7 +15,6 @@
   </parent>
 
   <properties>
-    <powermock.version>2.0.9</powermock.version>
     <wdtk.version>0.12.1-SNAPSHOT</wdtk.version>
   </properties>
 
@@ -121,17 +120,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-testng</artifactId>
-      <version>${powermock.version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
-     </dependency>
-     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>${powermock.version}</version>
-      <scope>test</scope>
-     </dependency>
+    </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>

--- a/extensions/wikidata/src/org/openrefine/wikidata/commands/ConnectionManager.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/commands/ConnectionManager.java
@@ -165,7 +165,7 @@ public class ConnectionManager {
     /**
      * For testability.
      */
-    static BasicApiConnection convertToBasicApiConnection(Map<String, Object> map) throws JsonProcessingException {
+    BasicApiConnection convertToBasicApiConnection(Map<String, Object> map) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         String json = mapper.writeValueAsString(map);
         return mapper.readValue(json, BasicApiConnection.class);

--- a/extensions/wikidata/src/org/openrefine/wikidata/commands/LoginCommand.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/commands/LoginCommand.java
@@ -71,6 +71,8 @@ public class LoginCommand extends Command {
     static final String ACCESS_SECRET = "wb-access-secret";
     
     static final Pattern cookieKeyDisallowedCharacters = Pattern.compile("[^a-zA-Z0-9\\-!#$%&'*+.?\\^_`|~]");
+    
+    protected ConnectionManager manager = null;
 
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response)
@@ -80,7 +82,9 @@ public class LoginCommand extends Command {
             return;
         }
 
-        ConnectionManager manager = ConnectionManager.getInstance();
+        if (manager == null) {
+        	manager = ConnectionManager.getInstance();
+        }
 
         String mediawikiApiEndpoint = removeCRLF(request.getParameter(API_ENDPOINT));
         if (isBlank(mediawikiApiEndpoint)) {
@@ -188,7 +192,6 @@ public class LoginCommand extends Command {
             return;
         }
 
-        ConnectionManager manager = ConnectionManager.getInstance();
         Map<String, Object> jsonResponse = new HashMap<>();
         if (manager.isLoggedIn(mediawikiApiEndpoint)) {
             jsonResponse.put("logged_in", manager.isLoggedIn(mediawikiApiEndpoint));
@@ -281,4 +284,8 @@ public class LoginCommand extends Command {
         Matcher matcher = cookieKeyDisallowedCharacters.matcher(key);
         return matcher.replaceAll("-");
     }
+
+	protected void setConnectionManager(ConnectionManager connectionManager) {
+		this.manager = connectionManager;
+	}
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/utils/EntityCache.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/utils/EntityCache.java
@@ -85,6 +85,12 @@ public class EntityCache {
         return cache.apply(id.getId());
     }
 
+    /**
+     * Get an entity cache for a given Wikibase instance.
+     * @param siteIri
+     * @param mediaWikiApiEndpoint
+     * @return
+     */
     public static EntityCache getEntityCache(String siteIri, String mediaWikiApiEndpoint) {
         EntityCache entityCache = entityCacheMap.get(siteIri);
         if (entityCache == null) {
@@ -92,6 +98,15 @@ public class EntityCache {
             entityCacheMap.put(siteIri, entityCache);
         }
         return entityCache;
+    }
+    
+    /**
+     * Provided for testability.
+     * @param siteIri
+     * @param cache
+     */
+    public static void setEntityCache(String siteIri, EntityCache cache) {
+    	entityCacheMap.put(siteIri, cache);
     }
 
     public List<EntityDocument> getMultipleDocuments(List<EntityIdValue> entityIds) throws ExecutionException {
@@ -102,4 +117,8 @@ public class EntityCache {
     public static EntityDocument getEntityDocument(String entityPrefix, String mediaWikiApiEndpoint, EntityIdValue id) {
         return getEntityCache(entityPrefix, mediaWikiApiEndpoint).get(id);
     }
+
+	public static void removeEntityCache(String siteIri) {
+		entityCacheMap.remove(siteIri);
+	}
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/ConnectionManagerTests.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/ConnectionManagerTests.java
@@ -1,0 +1,78 @@
+package org.openrefine.wikidata.commands;
+
+public class ConnectionManagerTests {
+	/**
+	 * 
+	 * TODO the following tests were written for LoginCommand but actually test ConnectionManager.
+	 * They should be rewritten to directly test this class.
+	 * 
+	 
+    @Test
+    public void testLogoutFailedBecauseCredentialsExpired() throws Exception {
+        // if our credentials expire and we try to log out,
+        // we should consider that the logout succeeded.
+        // Workaround for https://github.com/Wikidata/Wikidata-Toolkit/issues/511
+        BasicApiConnection connection = mock(BasicApiConnection.class);
+        whenNew(BasicApiConnection.class).withAnyArguments().thenReturn(connection);
+        when(connection.getCurrentUser()).thenReturn(username);
+
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
+        when(request.getParameter(USERNAME)).thenReturn(username);
+        when(request.getParameter(PASSWORD)).thenReturn(password);
+
+        // login first
+        command.doPost(request, response);
+
+        assertTrue(ConnectionManager.getInstance().isLoggedIn(apiEndpoint));
+
+        // logout
+        when(request.getParameter("logout")).thenReturn("true");
+        doThrow(new MediaWikiApiErrorException("assertuserfailed", "No longer logged in")).when(connection).logout();
+        command.doPost(request, response);
+
+        // not logged in anymore
+        assertFalse(ConnectionManager.getInstance().isLoggedIn(apiEndpoint));
+    }
+
+    @Test
+    public void testMultipleConnections() throws Exception {
+        BasicApiConnection connection = mock(BasicApiConnection.class);
+        whenNew(BasicApiConnection.class).withAnyArguments().thenReturn(connection);
+        when(connection.getCurrentUser()).thenReturn(username);
+
+        String wikibase1 = "https://www.wikibase1.org/w/api.php";
+        String wikibase2 = "https://www.wikibase2.org/w/api.php";
+
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter(USERNAME)).thenReturn(username);
+        when(request.getParameter(PASSWORD)).thenReturn(password);
+
+        // login to one endpoint first
+        when(request.getParameter(API_ENDPOINT)).thenReturn(wikibase1);
+        command.doPost(request, response);
+
+        // not logged in to another endpoint
+        assertFalse(ConnectionManager.getInstance().isLoggedIn(wikibase2));
+
+        // login to another endpoint
+        when(request.getParameter(API_ENDPOINT)).thenReturn(wikibase2);
+        command.doPost(request, response);
+
+        // logged in to both endpoints
+        assertTrue(ConnectionManager.getInstance().isLoggedIn(wikibase1));
+        assertTrue(ConnectionManager.getInstance().isLoggedIn(wikibase2));
+
+        // logout from the first endpoint
+        when(request.getParameter("logout")).thenReturn("true");
+        when(request.getParameter(API_ENDPOINT)).thenReturn(wikibase1);
+        command.doPost(request, response);
+
+        // logged out from the first endpoint
+        assertFalse(ConnectionManager.getInstance().isLoggedIn(wikibase1));
+
+        // still logged in to another endpoint
+        assertTrue(ConnectionManager.getInstance().isLoggedIn(wikibase2));
+    }
+    */
+}

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/LoginCommandTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/LoginCommandTest.java
@@ -1,22 +1,27 @@
 package org.openrefine.wikidata.commands;
 
-import com.google.refine.ProjectManager;
-import com.google.refine.commands.Command;
-import com.google.refine.preference.PreferenceStore;
-import com.google.refine.util.ParsingUtilities;
-import org.mockito.ArgumentCaptor;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-import org.wikidata.wdtk.wikibaseapi.BasicApiConnection;
-import org.wikidata.wdtk.wikibaseapi.LoginFailedException;
-import org.wikidata.wdtk.wikibaseapi.OAuthApiConnection;
-import org.wikidata.wdtk.wikibaseapi.apierrors.AssertUserFailedException;
-import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
+import static com.google.refine.util.TestUtils.assertEqualAsJson;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.openrefine.wikidata.commands.LoginCommand.ACCESS_SECRET;
+import static org.openrefine.wikidata.commands.LoginCommand.ACCESS_TOKEN;
+import static org.openrefine.wikidata.commands.LoginCommand.API_ENDPOINT;
+import static org.openrefine.wikidata.commands.LoginCommand.CONSUMER_SECRET;
+import static org.openrefine.wikidata.commands.LoginCommand.CONSUMER_TOKEN;
+import static org.openrefine.wikidata.commands.LoginCommand.PASSWORD;
+import static org.openrefine.wikidata.commands.LoginCommand.USERNAME;
+import static org.openrefine.wikidata.commands.LoginCommand.WIKIBASE_COOKIE_PREFIX;
+import static org.openrefine.wikidata.commands.LoginCommand.getCookieValue;
+import static org.openrefine.wikidata.commands.LoginCommand.removeCRLF;
+import static org.openrefine.wikidata.commands.LoginCommand.sanitizeCookieKey;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.Cookie;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -28,15 +33,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.google.refine.util.TestUtils.assertEqualAsJson;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
-import static org.openrefine.wikidata.commands.LoginCommand.*;
-import static org.powermock.api.mockito.PowerMockito.*;
-import static org.testng.Assert.*;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 
-@PrepareForTest(ConnectionManager.class)
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wikidata.wdtk.wikibaseapi.BasicApiConnection;
+import org.wikidata.wdtk.wikibaseapi.OAuthApiConnection;
+
+import com.google.refine.commands.Command;
+
 public class LoginCommandTest extends CommandTest {
 
     private static final String apiEndpoint = "https://www.wikidata.org/w/api.php";
@@ -70,37 +78,21 @@ public class LoginCommandTest extends CommandTest {
 
     // used for mocking singleton
     Constructor<ConnectionManager> constructor;
+    
+    ConnectionManager connectionManager;
 
-    @BeforeClass
-    public void initConstructor() throws NoSuchMethodException {
-        constructor = ConnectionManager.class.getDeclaredConstructor();
-        constructor.setAccessible(true);
-    }
 
     @BeforeMethod
     public void setUp() throws Exception {
         command = new LoginCommand();
-
-        // mock the ConnectionManager singleton
-        ConnectionManager manager = constructor.newInstance();
-        mockStatic(ConnectionManager.class);
-        given(ConnectionManager.getInstance()).willReturn(manager);
+    	connectionManager = mock(ConnectionManager.class);
+    	((LoginCommand) command).setConnectionManager(connectionManager);
 
         when(request.getCookies()).thenReturn(new Cookie[]{});
         cookieCaptor = ArgumentCaptor.forClass(Cookie.class);
         doNothing().when(response).addCookie(cookieCaptor.capture());
     }
 
-    @Test
-    public void testClearCredentialsInPreferences() throws Exception {
-        PreferenceStore prefStore = new PreferenceStore();
-        ProjectManager.singleton = mock(ProjectManager.class);
-        when(ProjectManager.singleton.getPreferenceStore()).thenReturn(prefStore);
-        prefStore.put(ConnectionManager.PREFERENCE_STORE_KEY, ParsingUtilities.mapper.createArrayNode());
-        assertNotNull(prefStore.get(ConnectionManager.PREFERENCE_STORE_KEY));
-        constructor.newInstance();
-        assertNull(prefStore.get(ConnectionManager.PREFERENCE_STORE_KEY));
-    }
 
     @Test
     public void testNoApiEndpointPost() throws ServletException, IOException {
@@ -137,26 +129,24 @@ public class LoginCommandTest extends CommandTest {
     }
 
     private void assertLogin() {
-        assertTrue(ConnectionManager.getInstance().isLoggedIn(apiEndpoint));
         assertEqualAsJson("{\"logged_in\":true,\"username\":\"" + username + "\",\"mediawiki_api_endpoint\":\"" + apiEndpoint + "\"}",
                 writer.toString());
     }
 
     @Test
-    public void testUsernamePasswordLogin() throws Exception {
-        BasicApiConnection connection = mock(BasicApiConnection.class);
-        whenNew(BasicApiConnection.class).withAnyArguments().thenReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-        when(connection.getCookies()).thenReturn(makeResponseCookies());
-
+    public void testUsernamePasswordLogin() throws Exception {       
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
         when(request.getParameter(USERNAME)).thenReturn(username);
         when(request.getParameter(PASSWORD)).thenReturn(password);
+        
+        when(connectionManager.login(apiEndpoint, username, password)).thenReturn(true);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(true);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(username);
 
         command.doPost(request, response);
-
-        verify(connection).login(username, password);
+        
+        verify(connectionManager, times(1)).login(apiEndpoint, username, password);
 
         assertLogin();
 
@@ -171,20 +161,24 @@ public class LoginCommandTest extends CommandTest {
 
     @Test
     public void testUsernamePasswordLoginRememberCredentials() throws Exception {
-        BasicApiConnection connection = mock(BasicApiConnection.class);
-        whenNew(BasicApiConnection.class).withAnyArguments().thenReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-        when(connection.getCookies()).thenReturn(makeResponseCookies());
-
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter("remember-credentials")).thenReturn("on");
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
         when(request.getParameter(USERNAME)).thenReturn(username);
         when(request.getParameter(PASSWORD)).thenReturn(password);
+        
+        when(connectionManager.login(apiEndpoint, username, password)).thenReturn(true);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(true);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(username);
+        BasicApiConnection connection = mock(BasicApiConnection.class);
+        when(connectionManager.getConnection(apiEndpoint)).thenReturn(connection);
+        when(connection.getCookies()).thenReturn(makeResponseCookies());
+        when(connection.getCurrentUser()).thenReturn(username);
 
         command.doPost(request, response);
 
-        verify(connection).login(username, password);
+        verify(connectionManager, times(1)).login(apiEndpoint, username, password);
+
         assertLogin();
 
         Map<String, Cookie> cookies = getCookieMap(cookieCaptor.getAllValues());
@@ -198,18 +192,22 @@ public class LoginCommandTest extends CommandTest {
 
     @Test
     public void testUsernamePasswordLoginWithCookies() throws Exception {
-        BasicApiConnection connection = mock(BasicApiConnection.class);
-        given(ConnectionManager.convertToBasicApiConnection(anyMap())).willReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-        when(connection.getCookies()).thenReturn(makeResponseCookies());
-
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
         when(request.getCookies()).thenReturn(makeRequestCookies());
+        
+        when(connectionManager.login(eq(apiEndpoint), eq(username), Mockito.<List<Cookie>>any())).thenReturn(true);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(true);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(username);
+        BasicApiConnection connection = mock(BasicApiConnection.class);
+        when(connectionManager.getConnection(apiEndpoint)).thenReturn(connection);
+        when(connection.getCookies()).thenReturn(makeResponseCookies());
+        when(connection.getCurrentUser()).thenReturn(username);
 
         command.doPost(request, response);
 
-        verify(connection).checkCredentials();
+        verify(connectionManager, times(1)).login(eq(apiEndpoint), eq(username), Mockito.<List<Cookie>>any());
+
         assertLogin();
 
         Map<String, Cookie> cookies = getCookieMap(cookieCaptor.getAllValues());
@@ -222,18 +220,23 @@ public class LoginCommandTest extends CommandTest {
 
     @Test
     public void testOwnerOnlyConsumerLogin() throws Exception {
-        OAuthApiConnection connection = mock(OAuthApiConnection.class);
-        whenNew(OAuthApiConnection.class).withAnyArguments().thenReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
         when(request.getParameter(CONSUMER_TOKEN)).thenReturn(consumerToken);
         when(request.getParameter(CONSUMER_SECRET)).thenReturn(consumerSecret);
         when(request.getParameter(ACCESS_TOKEN)).thenReturn(accessToken);
         when(request.getParameter(ACCESS_SECRET)).thenReturn(accessSecret);
+        
+        when(connectionManager.login(apiEndpoint, consumerToken, consumerSecret, accessToken, accessSecret)).thenReturn(true);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(true);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(username);
+        OAuthApiConnection connection = mock(OAuthApiConnection.class);
+        when(connectionManager.getConnection(apiEndpoint)).thenReturn(connection);
+        when(connection.getCurrentUser()).thenReturn(username);
 
         command.doPost(request, response);
+        
+        verify(connectionManager, times(1)).login(apiEndpoint, consumerToken, consumerSecret, accessToken, accessSecret);
 
         assertLogin();
 
@@ -248,10 +251,6 @@ public class LoginCommandTest extends CommandTest {
 
     @Test
     public void testOwnerOnlyConsumerLoginRememberCredentials() throws Exception {
-        OAuthApiConnection connection = mock(OAuthApiConnection.class);
-        whenNew(OAuthApiConnection.class).withAnyArguments().thenReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter("remember-credentials")).thenReturn("on");
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
@@ -260,9 +259,17 @@ public class LoginCommandTest extends CommandTest {
         when(request.getParameter(ACCESS_TOKEN)).thenReturn(accessToken);
         when(request.getParameter(ACCESS_SECRET)).thenReturn(accessSecret);
         when(request.getCookies()).thenReturn(makeRequestCookies());
+        
+        when(connectionManager.login(apiEndpoint, consumerToken, consumerSecret, accessToken, accessSecret)).thenReturn(true);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(true);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(username);
+        OAuthApiConnection connection = mock(OAuthApiConnection.class);
+        when(connectionManager.getConnection(apiEndpoint)).thenReturn(connection);
+        when(connection.getCurrentUser()).thenReturn(username);
 
         command.doPost(request, response);
 
+        verify(connectionManager, times(1)).login(apiEndpoint, consumerToken, consumerSecret, accessToken, accessSecret);
         assertLogin();
 
         Map<String, Cookie> cookies = getCookieMap(cookieCaptor.getAllValues());
@@ -278,10 +285,6 @@ public class LoginCommandTest extends CommandTest {
 
     @Test
     public void testOwnerOnlyConsumerLoginWithCookies() throws Exception {
-        OAuthApiConnection connection = mock(OAuthApiConnection.class);
-        whenNew(OAuthApiConnection.class).withAnyArguments().thenReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
         Cookie consumerTokenCookie = new Cookie(apiEndpointPrefix + CONSUMER_TOKEN, consumerToken);
@@ -289,7 +292,17 @@ public class LoginCommandTest extends CommandTest {
         Cookie accessTokenCookie = new Cookie(apiEndpointPrefix + ACCESS_TOKEN, accessToken);
         Cookie accessSecretCookie = new Cookie(apiEndpointPrefix + ACCESS_SECRET, accessSecret);
         when(request.getCookies()).thenReturn(new Cookie[]{consumerTokenCookie, consumerSecretCookie, accessTokenCookie, accessSecretCookie});
+        
+        when(connectionManager.login(apiEndpoint, consumerToken, consumerSecret, accessToken, accessSecret)).thenReturn(true);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(true);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(username);
+        OAuthApiConnection connection = mock(OAuthApiConnection.class);
+        when(connectionManager.getConnection(apiEndpoint)).thenReturn(connection);
+        when(connection.getCurrentUser()).thenReturn(username);
+        
         command.doPost(request, response);
+        
+        verify(connectionManager, times(1)).login(apiEndpoint, consumerToken, consumerSecret, accessToken, accessSecret);
 
         assertLogin();
 
@@ -304,9 +317,6 @@ public class LoginCommandTest extends CommandTest {
 
     @Test
     public void testCookieEncoding() throws Exception {
-        OAuthApiConnection connection = mock(OAuthApiConnection.class);
-        whenNew(OAuthApiConnection.class).withAnyArguments().thenReturn(connection);
-
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter("remember-credentials")).thenReturn("on");
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
@@ -315,6 +325,13 @@ public class LoginCommandTest extends CommandTest {
         when(request.getParameter(ACCESS_TOKEN)).thenReturn(accessToken);
         when(request.getParameter(ACCESS_SECRET)).thenReturn(accessSecret);
         when(request.getCookies()).thenReturn(makeRequestCookies());
+        
+        when(connectionManager.login(apiEndpoint, "malformed consumer token \r\n %?", consumerSecret, accessToken, accessSecret)).thenReturn(true);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(true);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(username);
+        OAuthApiConnection connection = mock(OAuthApiConnection.class);
+        when(connectionManager.getConnection(apiEndpoint)).thenReturn(connection);
+        when(connection.getCurrentUser()).thenReturn(username);
 
         command.doPost(request, response);
 
@@ -325,13 +342,6 @@ public class LoginCommandTest extends CommandTest {
 
     @Test
     public void testCookieDecoding() throws Exception {
-        ConnectionManager manager = mock(ConnectionManager.class);
-        given(ConnectionManager.getInstance()).willReturn(manager);
-
-        OAuthApiConnection connection = mock(OAuthApiConnection.class);
-        whenNew(OAuthApiConnection.class).withAnyArguments().thenReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
         Cookie consumerTokenCookie = new Cookie(apiEndpointPrefix + CONSUMER_TOKEN, "malformed+consumer+token+%0D%0A+%25%3F");
@@ -340,27 +350,36 @@ public class LoginCommandTest extends CommandTest {
         Cookie accessSecretCookie = new Cookie(apiEndpointPrefix + ACCESS_SECRET, accessSecret);
         when(request.getCookies()).thenReturn(new Cookie[]{consumerTokenCookie, consumerSecretCookie, accessTokenCookie, accessSecretCookie});
 
+        when(connectionManager.login(apiEndpoint, "malformed consumer token \r\n %?", consumerSecret, accessToken, accessSecret)).thenReturn(true);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(true);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(username);
+        OAuthApiConnection connection = mock(OAuthApiConnection.class);
+        when(connectionManager.getConnection(apiEndpoint)).thenReturn(connection);
+        when(connection.getCurrentUser()).thenReturn(username);
+        
         command.doPost(request, response);
 
-        verify(manager).login(apiEndpoint, "malformed consumer token \r\n %?", consumerSecret, accessToken, accessSecret);
+        verify(connectionManager).login(apiEndpoint, "malformed consumer token \r\n %?", consumerSecret, accessToken, accessSecret);
     }
 
     @Test
     public void testLogout() throws Exception {
-        BasicApiConnection connection = mock(BasicApiConnection.class);
-        whenNew(BasicApiConnection.class).withAnyArguments().thenReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-        when(connection.getCookies()).thenReturn(makeResponseCookies());
 
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
         when(request.getParameter(USERNAME)).thenReturn(username);
         when(request.getParameter(PASSWORD)).thenReturn(password);
+        
+        when(connectionManager.login(apiEndpoint, username, password)).thenReturn(true);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(true);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(username);
 
         // login first
         command.doPost(request, response);
 
         int loginCookiesSize = cookieCaptor.getAllValues().size();
+
+        verify(connectionManager, times(1)).login(apiEndpoint, username, password);
 
         assertLogin();
 
@@ -369,10 +388,14 @@ public class LoginCommandTest extends CommandTest {
         when(request.getCookies()).thenReturn(makeRequestCookies()); // will be cleared
         StringWriter logoutWriter = new StringWriter();
         when(response.getWriter()).thenReturn(new PrintWriter(logoutWriter));
+        
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(false);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(null);
 
         command.doPost(request, response);
 
-        assertFalse(ConnectionManager.getInstance().isLoggedIn(apiEndpoint));
+        verify(connectionManager).logout(apiEndpoint);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(false);
         assertEqualAsJson("{\"logged_in\":false,\"username\":null, \"mediawiki_api_endpoint\":\"" + apiEndpoint + "\"}", logoutWriter.toString());
 
         Map<String, Cookie> cookies = getCookieMap(cookieCaptor.getAllValues().subList(loginCookiesSize, cookieCaptor.getAllValues().size()));
@@ -386,46 +409,43 @@ public class LoginCommandTest extends CommandTest {
 
     @Test
     public void testUsernamePasswordLoginFailed() throws Exception {
-        BasicApiConnection connection = mock(BasicApiConnection.class);
-        whenNew(BasicApiConnection.class).withAnyArguments().thenReturn(connection);
-        doThrow(new LoginFailedException("login failed")).when(connection).login(username, password);
-
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
         // we don't check the username/password here
         when(request.getParameter(USERNAME)).thenReturn(username);
         when(request.getParameter(PASSWORD)).thenReturn(password);
+        
+        when(connectionManager.login(apiEndpoint, username, password)).thenReturn(false);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(false);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(null);
 
         // login first
         command.doPost(request, response);
 
-        verify(connection).login(username, password);
-        assertFalse(ConnectionManager.getInstance().isLoggedIn(apiEndpoint));
+        verify(connectionManager).login(apiEndpoint, username, password);
     }
 
     @Test
     public void testUsernamePasswordWithCookiesLoginFailed() throws Exception {
-        BasicApiConnection connection = mock(BasicApiConnection.class);
-        given(ConnectionManager.convertToBasicApiConnection(anyMap())).willReturn(connection);
-        doThrow(new AssertUserFailedException("assert user login failed")).when(connection).checkCredentials();
-
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
         // we don't check the username/password here
         when(request.getCookies()).thenReturn(makeRequestCookies());
+        
+        when(connectionManager.login(eq(apiEndpoint), eq(username), Mockito.<List<Cookie>>any())).thenReturn(false);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(false);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(null);
+        when(connectionManager.getConnection(apiEndpoint)).thenReturn(null);
 
         // login first
         command.doPost(request, response);
 
-        verify(connection).checkCredentials();
+        verify(connectionManager).login(eq(apiEndpoint), eq(username), Mockito.<List<Cookie>>any());
         assertFalse(ConnectionManager.getInstance().isLoggedIn(apiEndpoint));
     }
 
     @Test
     public void testOwnerOnlyConsumerLoginFailed() throws Exception {
-        OAuthApiConnection connection = mock(OAuthApiConnection.class);
-        whenNew(OAuthApiConnection.class).withAnyArguments().thenReturn(connection);
-        doThrow(new AssertUserFailedException("assert user login failed")).when(connection).checkCredentials();
 
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
@@ -433,104 +453,41 @@ public class LoginCommandTest extends CommandTest {
         when(request.getParameter(CONSUMER_SECRET)).thenReturn(consumerSecret);
         when(request.getParameter(ACCESS_TOKEN)).thenReturn(accessToken);
         when(request.getParameter(ACCESS_SECRET)).thenReturn(accessSecret);
+        
+        when(connectionManager.login(apiEndpoint, consumerToken, consumerSecret, accessToken, accessSecret)).thenReturn(false);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(false);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(null);
+        when(connectionManager.getConnection(apiEndpoint)).thenReturn(null);
 
         command.doPost(request, response);
 
-        verify(connection).checkCredentials();
-        assertFalse(connection.isLoggedIn());
+        verify(connectionManager).login(apiEndpoint, consumerToken, consumerSecret, accessToken, accessSecret);
     }
 
     @Test
     public void testLogoutFailed() throws Exception {
-        BasicApiConnection connection = mock(BasicApiConnection.class);
-        whenNew(BasicApiConnection.class).withAnyArguments().thenReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
         when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
         when(request.getParameter(USERNAME)).thenReturn(username);
         when(request.getParameter(PASSWORD)).thenReturn(password);
+        
+        when(connectionManager.login(apiEndpoint, username, password)).thenReturn(true);
+        when(connectionManager.isLoggedIn(apiEndpoint)).thenReturn(true);
+        when(connectionManager.getUsername(apiEndpoint)).thenReturn(username);
 
         // login first
         command.doPost(request, response);
 
-        assertTrue(ConnectionManager.getInstance().isLoggedIn(apiEndpoint));
+        verify(connectionManager).login(apiEndpoint, username, password);
 
         // logout
         when(request.getParameter("logout")).thenReturn("true");
-        doThrow(new MediaWikiApiErrorException("", "")).when(connection).logout();
+        
         command.doPost(request, response);
 
         // still logged in
-        assertTrue(ConnectionManager.getInstance().isLoggedIn(apiEndpoint));
-    }
-
-    @Test
-    public void testLogoutFailedBecauseCredentialsExpired() throws Exception {
-        // if our credentials expire and we try to log out,
-        // we should consider that the logout succeeded.
-        // Workaround for https://github.com/Wikidata/Wikidata-Toolkit/issues/511
-        BasicApiConnection connection = mock(BasicApiConnection.class);
-        whenNew(BasicApiConnection.class).withAnyArguments().thenReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-
-        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
-        when(request.getParameter(API_ENDPOINT)).thenReturn(apiEndpoint);
-        when(request.getParameter(USERNAME)).thenReturn(username);
-        when(request.getParameter(PASSWORD)).thenReturn(password);
-
-        // login first
-        command.doPost(request, response);
-
-        assertTrue(ConnectionManager.getInstance().isLoggedIn(apiEndpoint));
-
-        // logout
-        when(request.getParameter("logout")).thenReturn("true");
-        doThrow(new MediaWikiApiErrorException("assertuserfailed", "No longer logged in")).when(connection).logout();
-        command.doPost(request, response);
-
-        // not logged in anymore
-        assertFalse(ConnectionManager.getInstance().isLoggedIn(apiEndpoint));
-    }
-
-    @Test
-    public void testMultipleConnections() throws Exception {
-        BasicApiConnection connection = mock(BasicApiConnection.class);
-        whenNew(BasicApiConnection.class).withAnyArguments().thenReturn(connection);
-        when(connection.getCurrentUser()).thenReturn(username);
-
-        String wikibase1 = "https://www.wikibase1.org/w/api.php";
-        String wikibase2 = "https://www.wikibase2.org/w/api.php";
-
-        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
-        when(request.getParameter(USERNAME)).thenReturn(username);
-        when(request.getParameter(PASSWORD)).thenReturn(password);
-
-        // login to one endpoint first
-        when(request.getParameter(API_ENDPOINT)).thenReturn(wikibase1);
-        command.doPost(request, response);
-
-        // not logged in to another endpoint
-        assertFalse(ConnectionManager.getInstance().isLoggedIn(wikibase2));
-
-        // login to another endpoint
-        when(request.getParameter(API_ENDPOINT)).thenReturn(wikibase2);
-        command.doPost(request, response);
-
-        // logged in to both endpoints
-        assertTrue(ConnectionManager.getInstance().isLoggedIn(wikibase1));
-        assertTrue(ConnectionManager.getInstance().isLoggedIn(wikibase2));
-
-        // logout from the first endpoint
-        when(request.getParameter("logout")).thenReturn("true");
-        when(request.getParameter(API_ENDPOINT)).thenReturn(wikibase1);
-        command.doPost(request, response);
-
-        // logged out from the first endpoint
-        assertFalse(ConnectionManager.getInstance().isLoggedIn(wikibase1));
-
-        // still logged in to another endpoint
-        assertTrue(ConnectionManager.getInstance().isLoggedIn(wikibase2));
+        verify(connectionManager).logout(apiEndpoint);
+        assertLogin();
     }
 
     private static Cookie[] makeRequestCookies() {

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/PreviewWikibaseSchemaCommandTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/PreviewWikibaseSchemaCommandTest.java
@@ -25,14 +25,15 @@ package org.openrefine.wikidata.commands;
 
 import static org.mockito.Mockito.when;
 import static org.openrefine.wikidata.testing.TestingData.jsonFromFile;
-import org.openrefine.wikidata.utils.EntityCache;
 import static org.testng.Assert.assertEquals;
 
-import org.openrefine.wikidata.qa.EditInspector;
-import org.openrefine.wikidata.qa.ConstraintFetcher;
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.openrefine.wikidata.utils.EntityCache;
 import org.openrefine.wikidata.utils.EntityCacheStub;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -40,23 +41,22 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.util.ParsingUtilities;
 
-import javax.servlet.ServletException;
-import java.io.IOException;
-
-@PrepareForTest({EditInspector.class, EntityCache.class})
 public class PreviewWikibaseSchemaCommandTest extends SchemaCommandTest {
 
     @BeforeMethod
     public void SetUp() {
         command = new PreviewWikibaseSchemaCommand();
+        EntityCacheStub entityCacheStub = new EntityCacheStub();
+        EntityCache.setEntityCache("http://www.wikidata.org/entity/", entityCacheStub);
+    }
+    
+    @AfterMethod
+    public void tearDown() {
+    	EntityCache.removeEntityCache("http://www.wikidata.org/entity/");
     }
 
     @Test
     public void testValidSchema() throws Exception {
-        EntityCacheStub entityCacheStub = new EntityCacheStub();
-        ConstraintFetcher fetcher = new ConstraintFetcher(entityCacheStub, "P2302");
-        PowerMockito.whenNew(ConstraintFetcher.class).withAnyArguments().thenReturn(fetcher);
-        PowerMockito.whenNew(EntityCache.class).withAnyArguments().thenReturn(entityCacheStub);
 
         String schemaJson = jsonFromFile("schema/inception.json");
         String manifestJson = jsonFromFile("manifest/wikidata-manifest-v1.0.json");

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/testing/WikidataRefineTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/testing/WikidataRefineTest.java
@@ -7,7 +7,6 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -22,7 +21,7 @@ import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingManager;
 import com.google.refine.model.Project;
 
-public class WikidataRefineTest extends PowerMockTestCase {
+public class WikidataRefineTest {
 	protected File workspaceDir;
     protected RefineServlet servlet;
     private List<Project> projects = new ArrayList<Project>();


### PR DESCRIPTION
Fixes #4456

Changes proposed in this pull request:
- rewrite tests in Wikidata extension not to use PowerMock
