### PR TITLE
mention Node.js LTS version for building our docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ We use [Docusaurus 2](https://v2.docusaurus.io/) for our docs, a modern static w
 
 ### Requirements
 
-Assuming you have [Node.js](https://nodejs.org/en/download/) installed (which includes npm), you can install Docusaurus with:
+Assuming you have [Node.js (LTS recommended)](https://nodejs.org/en/download/) installed (which includes npm), you can install Docusaurus with:
 
 You will need to install [Yarn](https://yarnpkg.com/getting-started/install) before you can build the site.
 


### PR DESCRIPTION
This updates our docs README.md to mention using LTS version of Node.js since there are numerous problems that exist if the Current version of Node.js is utilized to build our docs.  To mention just one that I had to deal with on Windows and Linux if LTS version was not utilized:
- Error: error:0308010C:digital envelope routines::unsupported
    at String.replace (<anonymous>)
  - export NODE_OPTIONS=--openssl-legacy-provider

