### PR TITLE
Add linting check in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,7 +64,7 @@ jobs:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
 
-    - name: Check Java linting
+    - name: Check Java linting
       id: java_linting
       run: |
         mvn formatter:validate

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,6 +64,11 @@ jobs:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
 
+    - name: Check Java linting
+      id: java_linting
+      run: |
+        mvn formatter:validate
+
     - name: Configure connections to databases
       id: configure_db_connections
       run: cat extensions/database/tests/conf/github_actions_tests.xml | sed -e "s/MYSQL_PORT/${{ job.services.mysql.ports[3306] }}/g" | sed -e "s/POSTGRES_PORT/${{ job.services.postgres.ports[5432] }}/g" > extensions/database/tests/conf/tests.xml

--- a/docs/docs/technical-reference/build-test-run.md
+++ b/docs/docs/technical-reference/build-test-run.md
@@ -230,6 +230,11 @@ Right click on the `server` subproject, click `Run as...` and `Run configuration
 
 This will add a run configuration that you can then use to run OpenRefine from Eclipse.
 
+## Code style in Eclipse
+
+You can apply the supplied Eclipse code style (in `IDEs/eclipse/Refine.style.xml`) to make sure Eclipse lints your files according to the existing style.
+Pull requests deviating from this style will fail in the CI.
+
 ## Testing in Eclipse {#testing-in-eclipse}
 
 You can run the server tests directly from Eclipse. To do that you need to have the TestNG launcher plugin installed, as well as the TestNG M2E plugin (for integration with Maven). If you don't have it, you can get it by [installing new software](https://help.eclipse.org/2020-03/index.jsp?topic=/org.eclipse.platform.doc.user/tasks/tasks-129.htm) from this update URL http://dl.bintray.com/testng-team/testng-eclipse-release/

--- a/docs/docs/technical-reference/build-test-run.md
+++ b/docs/docs/technical-reference/build-test-run.md
@@ -235,6 +235,8 @@ This will add a run configuration that you can then use to run OpenRefine from E
 You can apply the supplied Eclipse code style (in `IDEs/eclipse/Refine.style.xml`) to make sure Eclipse lints your files according to the existing style.
 Pull requests deviating from this style will fail in the CI.
 
+You can manually apply the code style (regardless of your IDE) with the `mvn formatter:format` command.
+
 ## Testing in Eclipse {#testing-in-eclipse}
 
 You can run the server tests directly from Eclipse. To do that you need to have the TestNG launcher plugin installed, as well as the TestNG M2E plugin (for integration with Maven). If you don't have it, you can get it by [installing new software](https://help.eclipse.org/2020-03/index.jsp?topic=/org.eclipse.platform.doc.user/tasks/tasks-129.htm) from this update URL http://dl.bintray.com/testng-team/testng-eclipse-release/

--- a/docs/docs/technical-reference/contributing.md
+++ b/docs/docs/technical-reference/contributing.md
@@ -61,6 +61,8 @@ This describes the overall steps to your first code contribution in OpenRefine. 
 
 - Make changes to the code to fix the issue. If you are changing backend code, it would be great if you could also write a test in Java to demonstrate the fix. You can imitate existing tests for that. We currently do not have frontend tests.
 
+- If you made Java changes, run linting to make sure they conform to our code style, with `mvn formatter:format`.
+
 - commit your changes, using a message that contains one of the special words "closes" and "fixes" which are detected by Github, followed by the issue number, e.g. "closes #1234" or "fixes #1234", this will link the commit to the issue you are working on.
 
 - push your branch to your fork and create a pull request for it, explaining the approach you have used, any design decisions you have made.

--- a/docs/versioned_docs/version-3.5/technical-reference/build-test-run.md
+++ b/docs/versioned_docs/version-3.5/technical-reference/build-test-run.md
@@ -230,6 +230,11 @@ Right click on the `server` subproject, click `Run as...` and `Run configuration
 
 This will add a run configuration that you can then use to run OpenRefine from Eclipse.
 
+## Code style in Eclipse
+
+You can apply the supplied Eclipse code style (in `IDEs/eclipse/Refine.style.xml`) to make sure Eclipse lints your files according to the existing style.
+Pull requests deviating from this style will fail in the CI.
+
 ## Testing in Eclipse {#testing-in-eclipse}
 
 You can run the server tests directly from Eclipse. To do that you need to have the TestNG launcher plugin installed, as well as the TestNG M2E plugin (for integration with Maven). If you don't have it, you can get it by [installing new software](https://help.eclipse.org/2020-03/index.jsp?topic=/org.eclipse.platform.doc.user/tasks/tasks-129.htm) from this update URL http://dl.bintray.com/testng-team/testng-eclipse-release/

--- a/docs/versioned_docs/version-3.5/technical-reference/build-test-run.md
+++ b/docs/versioned_docs/version-3.5/technical-reference/build-test-run.md
@@ -235,6 +235,8 @@ This will add a run configuration that you can then use to run OpenRefine from E
 You can apply the supplied Eclipse code style (in `IDEs/eclipse/Refine.style.xml`) to make sure Eclipse lints your files according to the existing style.
 Pull requests deviating from this style will fail in the CI.
 
+You can manually apply the code style (regardless of your IDE) with the `mvn formatter:format` command.
+
 ## Testing in Eclipse {#testing-in-eclipse}
 
 You can run the server tests directly from Eclipse. To do that you need to have the TestNG launcher plugin installed, as well as the TestNG M2E plugin (for integration with Maven). If you don't have it, you can get it by [installing new software](https://help.eclipse.org/2020-03/index.jsp?topic=/org.eclipse.platform.doc.user/tasks/tasks-129.htm) from this update URL http://dl.bintray.com/testng-team/testng-eclipse-release/

--- a/docs/versioned_docs/version-3.5/technical-reference/contributing.md
+++ b/docs/versioned_docs/version-3.5/technical-reference/contributing.md
@@ -61,6 +61,8 @@ This describes the overall steps to your first code contribution in OpenRefine. 
 
 - Make changes to the code to fix the issue. If you are changing backend code, it would be great if you could also write a test in Java to demonstrate the fix. You can imitate existing tests for that. We currently do not have frontend tests.
 
+- If you made Java changes, run linting to make sure they conform to our code style, with `mvn formatter:format`.
+
 - commit your changes, using a message that contains one of the special words "closes" and "fixes" which are detected by Github, followed by the issue number, e.g. "closes #1234" or "fixes #1234", this will link the commit to the issue you are working on.
 
 - push your branch to your fork and create a pull request for it, explaining the approach you have used, any design decisions you have made.


### PR DESCRIPTION
Fixes #2338

This adds support for Java linting in CI. The build will fail if the code is not correctly linted, which can be fixed by running `mvn formatter:format`.