### PR TITLE
Update Velocity version to patch CVE-2020-13936

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <!-- v1.15 of commons-codec is needed for Jena 3.14+ - copied from org.apache.jena:jena:pom -->
     <commons-codec.version>1.15</commons-codec.version>
     <commons-compress.version>1.21</commons-compress.version>
-    <velocity.version>1.5</velocity.version>
+    <velocity.version>2.3</velocity.version>
     <marc4j.version>2.9.2</marc4j.version>
     <jsoup.version>1.14.2</jsoup.version>
     <odfdom-java.version>0.9.0</odfdom-java.version> <!-- do not update to 0.10.0, see issue #4397 -->


### PR DESCRIPTION
Update Velocity version to patch - Sandbox Bypass in Apache Velocity Engine (CVE-2020-13936)

Fixes: https://github.com/OpenRefine/OpenRefine/issues/4078


This has been overlooked for the past year, and it seems to be a valid vulnerability. This PR should resolve the issue by upgrading Velocity to a patched version.

### About CVE-2020-13936 (from NVD DB)
An attacker that is able to modify Velocity templates may execute arbitrary Java code or run arbitrary system commands with the same privileges as the account running the Servlet container. This applies to applications that allow untrusted users to upload/modify velocity templates running Apache Velocity Engine versions up to 2.2.

