### PR TITLE
Added support for .zst compressed files

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -145,6 +145,12 @@
   </build>
 
   <dependencies>
+
+    <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+      <version>${zstd-jni.version}</version>
+    </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -67,6 +67,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
+import org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.ProgressListener;
@@ -723,6 +724,11 @@ public class ImportingUtilities {
                     is.reset();
                 }
                 return new BZip2CompressorInputStream(is);
+            }
+            else if (fileName.endsWith(".zstd") || fileName.endsWith(".zst")
+                ||"application/zstd".equals(mimeType)){
+                InputStream inputStream = new FileInputStream(file);
+                return new ZstdCompressorInputStream(inputStream);
             }
         } catch (IOException e) {
             logger.warn("Something that looked like a compressed file gave an error on open: "+file,e);

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,9 @@
     <jasypt.version>1.9.3</jasypt.version>
     <mockito.version>4.3.1</mockito.version>
 
+    <!-- ZSTD compression of org.apache.commons.compress.compressors.zstandard depends on std-jni -->
+    <zstd-jni.version>1.5.2-1</zstd-jni.version>
+
     <!-- plugin versions -->
     <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
     <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>


### PR DESCRIPTION
Fixes #4058 

Changes proposed in this pull request:
- Added `ZstdCompressorInputStream` from `org.apache.commons.compress.compressors.zstandard.ZstdCompressorInputStream` .
- Added a new dependency [zstd-jni](https://github.com/luben/zstd-jni) .
