### PR TITLE
Update build-test-run.md

### DIFF
--- a/docs/versioned_docs/version-3.5/technical-reference/build-test-run.md
+++ b/docs/versioned_docs/version-3.5/technical-reference/build-test-run.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 You will need:
 * [OpenRefine source code](https://github.com/OpenRefine/OpenRefine)
-* [Java JDK](http://java.sun.com/javase/downloads/index.jsp) (Get [OpenJDK from here](https://jdk.java.net/15/).)
+* [Java JDK](http://java.sun.com/javase/downloads/index.jsp) (Get [OpenJDK from here](https://jdk.java.net/).)
 * [Apache Maven](https://maven.apache.org)  (OPTIONAL)
 * A Unix/Linux shell environment OR the Windows command line
 
@@ -21,7 +21,7 @@ With Git installed, use the `git clone` command to download the [project's repo]
 
 ### Set up JDK {#set-up-jdk}
 
-You must [install JDK](https://jdk.java.net/15/) and set the JAVA_HOME environment variable (please ensure it points to the JDK, and not the JRE).
+You must [install JDK](https://jdk.java.net/) and set the JAVA_HOME environment variable (please ensure it points to the JDK, and not the JRE).
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';


### PR DESCRIPTION
Changes proposed in this pull request:
- Update two Java JDK links to general download page which showcases current version (17 at this moment)

Note: in general, references to the Java JDK seem outdated in this document. It's probably not feasible to keep these up to date at all times so a bit of rewriting to make this less 'expirable' may be good, but the specifics are beyond my knowledge unfortunately.
