### PR TITLE
Extraction of the Operation History list as a downloadable JSON file

### DIFF
--- a/main/tests/cypress/cypress/integration/project/undo_redo/extract.spec.js
+++ b/main/tests/cypress/cypress/integration/project/undo_redo/extract.spec.js
@@ -1,3 +1,16 @@
+const defaultInducedHistoryJson = [
+  {
+    op: 'core/column-removal',
+    columnName: 'NDB_No',
+    description: 'Remove column NDB_No',
+  },
+  {
+    op: 'core/column-removal',
+    columnName: 'Shrt_Desc',
+    description: 'Remove column Shrt_Desc',
+  },
+]
+
 describe(__filename, function () {
   it('Test select/unselect all', function () {
     cy.loadAndVisitProject('food.mini');
@@ -34,18 +47,7 @@ describe(__filename, function () {
     ).should('be.checked');
     cy.assertTextareaHaveJsonValue(
       '.dialog-container textarea.history-operation-json',
-      [
-        {
-          op: 'core/column-removal',
-          columnName: 'NDB_No',
-          description: 'Remove column NDB_No',
-        },
-        {
-          op: 'core/column-removal',
-          columnName: 'Shrt_Desc',
-          description: 'Remove column Shrt_Desc',
-        },
-      ]
+      defaultInducedHistoryJson
     );
   });
 
@@ -103,20 +105,31 @@ describe(__filename, function () {
     ).click();
     cy.assertTextareaHaveJsonValue(
       '.dialog-container textarea.history-operation-json',
-      [
-        {
-          op: 'core/column-removal',
-          columnName: 'NDB_No',
-          description: 'Remove column NDB_No',
-        },
-        {
-          op: 'core/column-removal',
-          columnName: 'Shrt_Desc',
-          description: 'Remove column Shrt_Desc',
-        },
-      ]
+      defaultInducedHistoryJson
     );
   });
+
+  it('Test download of JSON file', { retries: { runMode: 0 } }, function () {
+    cy.loadAndVisitProject('food.mini');
+    cy.deleteColumn('NDB_No');
+    cy.deleteColumn('Shrt_Desc');
+
+    cy.get('#or-proj-undoRedo').click();
+    cy.get('#refine-tabs-history .history-panel-controls')
+    .contains('Extract')
+    .click();
+    // (the extractable commands are selected by default)
+
+    cy.get('.dialog-container button[bind="saveJsonAsFileButton"]')
+    .contains('Export')
+    .click();
+
+    const downloadsFolder = Cypress.config('downloadsFolder');
+    const downloadedFilename = downloadsFolder + '/history.json';
+
+    cy.readFile(downloadedFilename, 'utf8')
+      .should('deep.equal', defaultInducedHistoryJson)
+  })
 
   it('Test the close button', function () {
     cy.loadAndVisitProject('food.mini');
@@ -151,18 +164,7 @@ describe(__filename, function () {
     // test the json
     cy.assertTextareaHaveJsonValue(
       '.dialog-container textarea.history-operation-json',
-      [
-        {
-          op: 'core/column-removal',
-          columnName: 'NDB_No',
-          description: 'Remove column NDB_No',
-        },
-        {
-          op: 'core/column-removal',
-          columnName: 'Shrt_Desc',
-          description: 'Remove column Shrt_Desc',
-        },
-      ]
+      defaultInducedHistoryJson
     );
   });
 });

--- a/main/webapp/modules/core/scripts/project/history-extract-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-extract-dialog.html
@@ -18,6 +18,7 @@
           <td>
             <button class="button" bind="selectAllButton"></button>
             <button class="button" bind="unselectAllButton"></button>
+            <button class="button" bind="saveJsonAsFileButton" style="float: right"></button>
           </td>
         </tr>
       </table></div>

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -199,6 +199,7 @@ HistoryPanel.prototype._showExtractOperationsDialog = function(json) {
   elmts.or_proj_extractSave.html($.i18n('core-project/extract-save'));
   elmts.selectAllButton.html($.i18n('core-buttons/select-all'));
   elmts.unselectAllButton.html($.i18n('core-buttons/unselect-all'));
+  elmts.saveJsonAsFileButton.html($.i18n('core-buttons/export'))
   elmts.closeButton.html($.i18n('core-buttons/close'));
 
   var entryTable = elmts.entryTable[0];
@@ -254,6 +255,23 @@ HistoryPanel.prototype._showExtractOperationsDialog = function(json) {
     frame.find('input[type="checkbox"]').prop('checked', false);
     updateJson();
   });
+  elmts.saveJsonAsFileButton.click(function() {
+    var historyJson = elmts.textarea[0].value;
+
+    downloadFile('history.json', historyJson);
+  });
+
+  var downloadFile = function(filename, content) {
+    var element = document.createElement('a');
+    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(content));
+    element.setAttribute('download', filename);
+
+    element.style.display = 'none';
+    document.body.appendChild(element);
+
+    element.click();
+    document.body.removeChild(element);
+  }
 
   var level = DialogSystem.showDialog(frame);
 

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -261,6 +261,8 @@ HistoryPanel.prototype._showExtractOperationsDialog = function(json) {
     downloadFile('history.json', historyJson);
   });
 
+  // Function originally created by Matěj Pokorný at StackOverflow:
+  // https://stackoverflow.com/a/18197341/5564816
   var downloadFile = function(filename, content) {
     var element = document.createElement('a');
     element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(content));


### PR DESCRIPTION
Closes #4498 

Changes proposed in this pull request:
- Enabled the extraction of the Operation History list of actions, which is a JSON object, by downloading as a JSON file, called "history.json"
- On the Extract operation history dialog, added a button that can be used to initiate the above task, and placed it on the same level as the "Select all", "Unselect all" buttons, with a right float (to be placed close to the JSON textarea).

For the purpose of creating the downloadable file and actually downloading it on the user's computer, I used a small utility function from the following StackOverflow answer: https://stackoverflow.com/a/18197341/5564816
This approach works with HTML5, however, it could be prone to potential compatibility issues with old browsers.

If you have a better approach to accomplish this task, please share them with me in order to adapt and use them on the code! Also, as this is my first PR, please forgive me if I have missed anything else and I would really appreciate your feedback!
