### PR TITLE
Issue#4233 Escape single quotes in column name for duplicates facet

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/menu-facets.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-facets.js
@@ -142,13 +142,14 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           id: "core/duplicates-facet",
           label: $.i18n('core-views/duplicates-facet'),
           click: function() {
+            let columnName = column.name.replace(/'/g, "\\'");
             ui.browsingEngine.addFacet(
                 "list",
                 {
                   "name": column.name,
                   "columnName": column.name,
                   "expression": "facetCount(value, 'value', '" +
-                  column.name + "') > 1"
+                  columnName + "') > 1"
                 }
             );
           }


### PR DESCRIPTION
Fixes #4233

Changes proposed in this pull request:
- Escape single quotes in column name to avoid the parsing error
