### PR TITLE
Update installing.md

### DIFF
--- a/docs/docs/manual/installing.md
+++ b/docs/docs/manual/installing.md
@@ -111,7 +111,7 @@ Once you have downloaded the `.dmg` file, open it and drag the OpenRefine icon o
 The quick version:
 
 1. Install [Homebrew](https://brew.sh)
-2. In Terminal enter ` brew cask install openrefine`
+2. In Terminal enter ` brew install --cask openrefine`
 1. Then find OpenRefine in your Applications folder.
 
 The long version:

--- a/docs/versioned_docs/version-3.5/manual/installing.md
+++ b/docs/versioned_docs/version-3.5/manual/installing.md
@@ -111,7 +111,7 @@ Once you have downloaded the `.dmg` file, open it and drag the OpenRefine icon o
 The quick version:
 
 1. Install [Homebrew](https://brew.sh)
-2. In Terminal enter ` brew cask install openrefine`
+2. In Terminal enter ` brew install --cask openrefine`
 1. Then find OpenRefine in your Applications folder.
 
 The long version:


### PR DESCRIPTION
Updated the "quick version" instructions for installing on MacOS using brew as `brew cask` is no longer a `brew` command

Fixes #{issue number here}

Changes proposed in this pull request:
- 
- 
- 
