### PR TITLE
Fix missing import options metadata for XML

### DIFF
--- a/main/src/com/google/refine/importers/tree/TreeImportingParserBase.java
+++ b/main/src/com/google/refine/importers/tree/TreeImportingParserBase.java
@@ -23,8 +23,8 @@ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -62,44 +62,44 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
     protected TreeImportingParserBase(final boolean useInputStream) {
         super(useInputStream);
     }
-    
+
     @Override
     public ObjectNode createParserUIInitializationData(ImportingJob job,
             List<ObjectNode> fileRecords, String format) {
         ObjectNode options = super.createParserUIInitializationData(job, fileRecords, format);
-        
+
         JSONUtilities.safePut(options, "trimStrings", false);
         JSONUtilities.safePut(options, "guessCellValueTypes", false);
         JSONUtilities.safePut(options, "storeEmptyStrings", true);
         return options;
     }
 
-    
+
     @Override
     public void parse(Project project, ProjectMetadata metadata,
             ImportingJob job, List<ObjectNode> fileRecords, String format,
             int limit, ObjectNode options, List<Exception> exceptions) {
-        
+
         MultiFileReadingProgress progress = ImporterUtilities.createMultiFileReadingProgress(job, fileRecords);
         ImportColumnGroup rootColumnGroup = new ImportColumnGroup();
-        
+
         for (ObjectNode fileRecord : fileRecords) {
             try {
                 parseOneFile(project, metadata, job, fileRecord, rootColumnGroup, limit, options, exceptions, progress);
             } catch (IOException e) {
                 exceptions.add(e);
             }
-            
+
             if (limit > 0 && project.rows.size() >= limit) {
                 break;
             }
         }
-        
+
         rootColumnGroup.tabulate();
         XmlImportUtilities.createColumnsFromImport(project, rootColumnGroup);
         project.columnModel.update();
     }
-    
+
     public void parseOneFile(
         Project project,
         ProjectMetadata metadata,
@@ -117,7 +117,7 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
         int filenameColumnIndex = -1;
         int archiveColumnIndex = -1;
         int startingRowCount = project.rows.size();
-        
+
         progress.startFile(fileSource);
         try {
             InputStream inputStream = ImporterUtilities.openAndTrackFile(fileSource, file, progress);
@@ -139,7 +139,7 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
                     if (commonEncoding != null && commonEncoding.isEmpty()) {
                         commonEncoding = null;
                     }
-                    
+
                     Reader reader = ImportingUtilities.getFileReader(file, fileRecord, commonEncoding);
                     parseOneFile(project, metadata, job, fileSource, reader,
                             rootColumnGroup, limit, options, exceptions);
@@ -156,6 +156,13 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
                         row.setCell(filenameColumnIndex, new Cell(fileSource, null));
                     }
                 }
+
+                ObjectNode fileOptions = options.deepCopy();
+                JSONUtilities.safePut(fileOptions, "fileSource", fileSource);
+                JSONUtilities.safePut(fileOptions, "archiveFileName", archiveFileName);
+                // TODO: This will save a separate copy for each file in the import, but they're
+                // going to be mostly the same
+                metadata.appendImportOptionMetadata(fileOptions);
             } finally {
                 inputStream.close();
             }
@@ -163,10 +170,10 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
             progress.endFile(fileSource, file.length());
         }
     }
-    
+
     /**
      * Parse a single file from a Reader.
-     * 
+     *
      * The default implementation just throws a NotImplementedException.
      * Override in subclasses to implement.
      */
@@ -183,10 +190,10 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
     ) {
         throw new NotImplementedException();
     }
-    
+
     /**
      * Parse a single file from an InputStream.
-     * 
+     *
      * The default implementation just throws a NotImplementedException.
      * Override in subclasses to implement.
      */
@@ -203,10 +210,10 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
     ) {
         throw new NotImplementedException();
     }
-    
+
     /**
      * Parse a single file from a TreeReader.
-     * 
+     *
      */
     protected void parseOneFile(
         Project project,

--- a/main/tests/server/src/com/google/refine/importers/XmlImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/XmlImporterTests.java
@@ -23,8 +23,8 @@ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -32,6 +32,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 package com.google.refine.importers;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -103,6 +106,32 @@ public class XmlImporterTests extends ImporterTest {
         Assert.assertNotNull(row);
         Assert.assertNotNull(row.getCell(1));
         Assert.assertEquals(row.getCell(1).value, "Author 1, The");
+    }
+
+    @Test
+    public void setsProjectMetadata() throws IOException {
+        // Setup a file record to import
+        FileUtils.writeStringToFile(new File(job.getRawDataDir(), "test-file.xml"), getSample(), "UTF-8");
+        List<ObjectNode> fileRecords = new ArrayList<>();
+        fileRecords.add(ParsingUtilities.evaluateJsonStringToObjectNode(
+                "{\"location\": \"test-file.xml\",\"fileName\": \"test-file.xml\"}"));
+
+        // We need a real ObjectNode to support the deepCopy() method
+        ObjectNode options = ParsingUtilities.mapper.createObjectNode();
+
+        SUT.parse(
+                project,
+                metadata,
+                job,
+                fileRecords,
+                "text/json",
+                -1,
+                options,
+                new ArrayList<Exception>());
+
+        assertNotNull(metadata.getModified());
+        assertNotNull(metadata.getCreated());
+        assertNotEquals(metadata.getImportOptionMetadata().size(), 0);
     }
 
     @Test


### PR DESCRIPTION
Fixes #4566

Duplicates the base ImportingParserBase metadata append into the TreeImportingParserBase, which completely overrides the original method.