### PR TITLE
Spacing between ok/cancel buttons for custom text/numeric facet dialogs

### DIFF
--- a/main/webapp/modules/core/styles/util/dialog.less
+++ b/main/webapp/modules/core/styles/util/dialog.less
@@ -82,7 +82,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .dialog-footer {
   font-size: 1.3em;
-  text-align: right;
+  display: flex;
+  column-gap: 5px;
+  justify-content: right;
   background: @dialog_footer;
   padding: @padding_loose;
   }


### PR DESCRIPTION
Fixes #4622

Changes proposed in this pull request:
- Added spacing between ok/cancel buttons:
![image (5)](https://user-images.githubusercontent.com/42903164/159111821-9644e928-c55b-4126-a3e9-ea400ef982d5.png)
