### PR TITLE
Wikibase dialog buttons

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/logged-in-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/logged-in-dialog.html
@@ -12,12 +12,12 @@
         <div class="wikibase-user-logout" bind="logoutArea">
           <p><span bind="loggedInAs"></span>
             <a bind="loggedInUsername" target="_blank"></a></p>
-          <div class="wikibase-dialog-buttons">
-            <button class="button cancel-button" bind="cancelButton"></button>
-            <button class="button button-primary" bind="logoutButton"></button>
-          </div>
         </div>
       </div>
     </div>
+  </div>
+  <div class="dialog-footer">
+    <button class="button cancel-button" bind="cancelButton"></button>
+    <button class="button button-primary" bind="logoutButton"></button>
   </div>
 </div>

--- a/extensions/wikidata/module/scripts/dialogs/manage-account-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/manage-account-dialog.js
@@ -116,7 +116,7 @@ ManageAccountDialog.displayPasswordLogin = function (onSuccess) {
     ManageAccountDialog.displayOwnerOnlyConsumerLogin(onSuccess);
   });
 
-  elmts.loginForm.submit(function (e) {
+  elmts.loginButton.click(function (e) {
     frame.hide();
     let formArr = elmts.loginForm.serializeArray();
     let username = elmts.usernameInput.val();
@@ -176,7 +176,7 @@ ManageAccountDialog.displayOwnerOnlyConsumerLogin = function (onSuccess) {
     ManageAccountDialog.displayPasswordLogin(onSuccess);
   });
 
-  elmts.loginForm.submit(function (e) {
+  elmts.loginButton.click(function (e) {
     frame.hide();
     let formArr = elmts.loginForm.serializeArray();
     formArr.push({name: "wb-api-endpoint", value: WikibaseManager.getSelectedWikibaseApi()});

--- a/extensions/wikidata/module/scripts/dialogs/manage-account-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/manage-account-dialog.js
@@ -116,7 +116,7 @@ ManageAccountDialog.displayPasswordLogin = function (onSuccess) {
     ManageAccountDialog.displayOwnerOnlyConsumerLogin(onSuccess);
   });
 
-  elmts.loginButton.click(function (e) {
+  elmts.loginForm.submit(function (e) {
     frame.hide();
     let formArr = elmts.loginForm.serializeArray();
     let username = elmts.usernameInput.val();
@@ -176,7 +176,7 @@ ManageAccountDialog.displayOwnerOnlyConsumerLogin = function (onSuccess) {
     ManageAccountDialog.displayPasswordLogin(onSuccess);
   });
 
-  elmts.loginButton.click(function (e) {
+  elmts.loginForm.submit(function (e) {
     frame.hide();
     let formArr = elmts.loginForm.serializeArray();
     formArr.push({name: "wb-api-endpoint", value: WikibaseManager.getSelectedWikibaseApi()});

--- a/extensions/wikidata/module/scripts/dialogs/owner-only-consumer-login-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/owner-only-consumer-login-dialog.html
@@ -38,16 +38,14 @@
                 </td>
               </tr>
             </table>
-            <div class="wikibase-login-buttons">
-              <button class="button cancel-button" type="button" bind="cancelButton"></button>
-              <button class="button button-primary" type="submit" bind="loginButton"></button>
-            </div>
           </form>
         </div>
       </div>
     </div>
-  </div>
-  <div class="dialog-footer wikibase-login-dialog-footer">
     <span bind="explainPasswordLogin"></span>
+  </div>
+  <div class="dialog-footer">
+    <button class="button cancel-button" type="button" bind="cancelButton"></button>
+    <button class="button button-primary" type="submit" bind="loginButton"></button>
   </div>
 </div>

--- a/extensions/wikidata/module/scripts/dialogs/owner-only-consumer-login-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/owner-only-consumer-login-dialog.html
@@ -1,4 +1,5 @@
 <div class="dialog-frame" style="width: 800px;">
+  <form bind="loginForm" class="wikibase-login-form" method="post">
   <div class="dialog-header" bind="dialogHeader"></div>
   <div class="dialog-body" bind="dialogBody" style="position: relative; height: 240px">
     <div class="wikidata-logo">
@@ -12,7 +13,6 @@
       <div class="wikibase-user-management-area">
         <div class="wikibase-user-login" bind="loginArea">
           <p bind="invalidCredentials" class="wikibase-invalid-credentials"></p>
-          <form bind="loginForm" class="wikibase-login-form" method="post">
             <table>
               <tr>
                 <td><label for="wb-consumer-token" bind="consumerTokenLabel"></label></td>
@@ -38,14 +38,14 @@
                 </td>
               </tr>
             </table>
-          </form>
         </div>
       </div>
     </div>
-    <span bind="explainPasswordLogin"></span>
+    <span style="cursor: pointer" bind="explainPasswordLogin"></span>
   </div>
   <div class="dialog-footer">
     <button class="button cancel-button" type="button" bind="cancelButton"></button>
     <button class="button button-primary" type="submit" bind="loginButton"></button>
   </div>
+  </form>
 </div>

--- a/extensions/wikidata/module/scripts/dialogs/password-login-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/password-login-dialog.html
@@ -1,4 +1,5 @@
 <div class="dialog-frame" style="width: 800px;">
+  <form bind="loginForm" class="wikibase-login-form" method="post">
   <div class="dialog-header" bind="dialogHeader"></div>
   <div class="dialog-body" bind="dialogBody" style="position: relative; height: 165px">
     <div class="wikidata-logo">
@@ -12,7 +13,6 @@
       <div class="wikibase-user-management-area">
         <div class="wikibase-user-login" bind="loginArea">
           <p bind="invalidCredentials" class="wikibase-invalid-credentials"></p>
-          <form bind="loginForm" class="wikibase-login-form" method="post">
             <table>
               <tr>
                 <td><label for="wb-username" bind="usernameLabel"></label></td>
@@ -32,14 +32,14 @@
               </tr>
               </tr>
             </table>
-          </form>
         </div>
       </div>
     </div>
-    <span bind="explainOwnerOnlyConsumerLogin"></span>
+    <span style="cursor:pointer" bind="explainOwnerOnlyConsumerLogin"></span>
   </div>
   <div class="dialog-footer" bind="dialogFooter">
       <button class="button cancel-button" type="button" bind="cancelButton"></button>
       <button class="button button-primary" type="submit" bind="loginButton"></button>
   </div>
+  </form>
 </div>

--- a/extensions/wikidata/module/scripts/dialogs/password-login-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/password-login-dialog.html
@@ -1,6 +1,6 @@
 <div class="dialog-frame" style="width: 800px;">
   <div class="dialog-header" bind="dialogHeader"></div>
-  <div class="dialog-body" bind="dialogBody" style="position: relative; height: 140px">
+  <div class="dialog-body" bind="dialogBody" style="position: relative; height: 165px">
     <div class="wikidata-logo">
       <a bind="wikibaseMainPage" target="_blank">
         <img bind="wikibaseLogoImg" alt="Wikibase logo"/>
@@ -32,16 +32,14 @@
               </tr>
               </tr>
             </table>
-            <div class="wikibase-login-buttons">
-              <button class="button cancel-button" type="button" bind="cancelButton"></button>
-              <button class="button button-primary" type="submit" bind="loginButton"></button>
-            </div>
           </form>
         </div>
       </div>
     </div>
-  </div>
-  <div class="dialog-footer wikibase-login-dialog-footer" bind="dialogFooter">
     <span bind="explainOwnerOnlyConsumerLogin"></span>
+  </div>
+  <div class="dialog-footer" bind="dialogFooter">
+      <button class="button cancel-button" type="button" bind="cancelButton"></button>
+      <button class="button button-primary" type="submit" bind="loginButton"></button>
   </div>
 </div>

--- a/extensions/wikidata/module/styles/dialogs/manage-account-dialog.less
+++ b/extensions/wikidata/module/styles/dialogs/manage-account-dialog.less
@@ -67,18 +67,3 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .wikidata-logo img {
   height: 120px;
 }
-
-.wikibase-login-buttons {
-  text-align: right;
-  position: absolute;
-  right: 12px;
-  bottom: 12px;
-}
-
-.wikibase-login-dialog-footer {
-  text-align: center;
-}
-
-.wikibase-login-dialog-footer span {
-  cursor: pointer;
-}


### PR DESCRIPTION
Fixes #4628
Changes proposed in this pull request:
- Move login note to be under the "Remember me" checkbox.
- Move dialog buttons to the dialog footer of Wikibase login and logged-in dialogs:

![image](https://user-images.githubusercontent.com/42903164/159625468-aa1b7286-e256-4af8-afb6-956d20788443.png)
![image](https://user-images.githubusercontent.com/42903164/159625477-1f3c8ca3-6995-4c77-afbb-1316b2a2fc35.png)
![image](https://user-images.githubusercontent.com/42903164/159625484-9abaacde-b944-4c92-b214-ab7ab23ec823.png)

