### PR TITLE
Redirect to wiki for Google Export options

### DIFF
--- a/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
@@ -60,10 +60,8 @@ abstract public class GoogleAPIExtension {
     static public String getAuthorizationUrl(ButterflyModule module, HttpServletRequest request)
             throws MalformedURLException {
         String host = request.getHeader("Host");
-        if (host.startsWith("127.0.0.1")) {
-            if (CLIENT_ID.equals("") || CLIENT_SECRET.equals("") || API_KEY.equals("")) {
-                return "https://github.com/OpenRefine/OpenRefine/wiki/Google-Extension#missing-credentials";
-            }
+        if (CLIENT_ID.equals("") || CLIENT_SECRET.equals("")) {
+	    return "https://github.com/OpenRefine/OpenRefine/wiki/Google-Extension#missing-credentials";
         }
         String authorizedUrl = makeRedirectUrl(module, request);
         String state = makeState(module, request);

--- a/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GoogleAPIExtension.java
@@ -59,6 +59,12 @@ abstract public class GoogleAPIExtension {
     
     static public String getAuthorizationUrl(ButterflyModule module, HttpServletRequest request)
             throws MalformedURLException {
+        String host = request.getHeader("Host");
+        if (host.startsWith("127.0.0.1")) {
+            if (CLIENT_ID.equals("") || CLIENT_SECRET.equals("") || API_KEY.equals("")) {
+                return "https://github.com/OpenRefine/OpenRefine/wiki/Google-Extension#missing-credentials";
+            }
+        }
         String authorizedUrl = makeRedirectUrl(module, request);
         String state = makeState(module, request);
         


### PR DESCRIPTION
Fixes #4631

Changes proposed in this pull request:
- Added redirect to [wiki](https://github.com/OpenRefine/OpenRefine/wiki/Google-Extension#missing-credentials) for when the Google export to Drive/Sheets options are clicked while the Google API credentials are undefined.
