### PR TITLE
modify default return of call() for ToString to state for…

### DIFF
--- a/main/src/com/google/refine/expr/functions/ToString.java
+++ b/main/src/com/google/refine/expr/functions/ToString.java
@@ -64,7 +64,7 @@ public class ToString implements Function {
                 } 
             }
         }
-        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " accepts an object and an optional second argument containing a date format string");
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " accepts an object and an optional second argument containing a Date or Number format string");
     }
 
     


### PR DESCRIPTION
… Number format

Fixes #3133

Changes proposed in this pull request:
- The default EvalError constructor arg has been modified to state that the ToString call() function's second optional parameter can be a Date or Number format string.