### PR TITLE
fixes OpenRefine#4644 update Maven version to 3.8.5

### DIFF
--- a/refine
+++ b/refine
@@ -309,7 +309,7 @@ tools_prepare() {
 mvn_prepare() {
     tools_prepare
 
-    MVN_VERSION="3.8.4"
+    MVN_VERSION="3.8.5"
     MVN_URL="https://dlcdn.apache.org/maven/maven-3/${MVN_VERSION}/binaries/apache-maven-${MVN_VERSION}-bin.tar.gz"
     MVN_FILE=`echo $MVN_URL | sed 's|.*/||'`
     MVN_DIR="apache-maven-${MVN_VERSION}"


### PR DESCRIPTION
Fixes #4644

Changes proposed in this pull request:
- Modify MVN_VERSION="3.8.4" variable to MVN_VERSION="3.8.5" in refine script.
- 
- 
