### PR TITLE
Addition of a link to the GREL docs in the Help section of the Expression dialog

### DIFF
--- a/main/src/com/google/refine/expr/functions/date/DatePart.java
+++ b/main/src/com/google/refine/expr/functions/date/DatePart.java
@@ -139,7 +139,7 @@ public class DatePart implements Function {
     
     @Override
     public String getDescription() {
-    	return "Returns part of a date. The data type returned depends on the unit. See https://docs.openrefine.org/manual/grelfunctions/#datepartd-s-timeunit for a table. ";
+    	return "Returns part of a date. The data type returned depends on the unit. See https://docs.openrefine.org/manual/grelfunctions/#datepartd-s-timeunit, https://docs.openrefine.org/manual/grelfunctions#date-functions for a table. ";
     }
     
     @Override


### PR DESCRIPTION
Fixes #1122 

Changes proposed in this pull request:
- Addition of a link to the GREL docs in the Help section of the Expression dialog
