### PR TITLE
Add 3rdparty js libraries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ open-refine.log
 
 main/target/
 main/webapp/WEB-INF/lib/
+main/webapp/modules/core/3rdparty/
 server/target/
 extensions/*/target/
 extensions/*/module/MOD-INF/classes/


### PR DESCRIPTION
(no issue)

Since our Javascript dependencies are now managed by NPM, we should not add them back to the repository, hence the corresponding directory should be added to our `.gitignore`.

@elebitzero we are not currently tracking `main/webapp/package-lock.json`, but perhaps we should? Otherwise I would also add it to `.gitignore`.