### PR TITLE
added margin prop to move cell editor 1cell size down

### DIFF
--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -344,6 +344,10 @@ a.data-table-flag-off {
   background-position: -17px -17px;
   }
 
+.data-table-cell-editor {
+  margin: 20px 0;
+}
+
 .data-table-cell-editor, .data-table-topic-popup {
   border: 1px solid @chrome_primary;
   background: @chrome_secondary;


### PR DESCRIPTION
Fixes #1116

Changes proposed in this pull request:
- an additional margin rule for the `data-table-cell-editor` to move cell editors one cell down when editing the content
