### PR TITLE
Fixed alignment in wikibase dialogs

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/owner-only-consumer-login-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/owner-only-consumer-login-dialog.html
@@ -1,5 +1,5 @@
 <div class="dialog-frame" style="width: 800px;">
-  <form bind="loginForm" class="wikibase-login-form" method="post">
+  <form bind="loginForm" method="post">
   <div class="dialog-header" bind="dialogHeader"></div>
   <div class="dialog-body" bind="dialogBody" style="position: relative; height: 240px">
     <div class="wikidata-logo">

--- a/extensions/wikidata/module/scripts/dialogs/password-login-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/password-login-dialog.html
@@ -1,5 +1,5 @@
 <div class="dialog-frame" style="width: 800px;">
-  <form bind="loginForm" class="wikibase-login-form" method="post">
+  <form bind="loginForm" method="post">
   <div class="dialog-header" bind="dialogHeader"></div>
   <div class="dialog-body" bind="dialogBody" style="position: relative; height: 165px">
     <div class="wikidata-logo">

--- a/extensions/wikidata/module/styles/dialogs/manage-account-dialog.less
+++ b/extensions/wikidata/module/styles/dialogs/manage-account-dialog.less
@@ -33,10 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 @import-less url("../theme.less");
 
-.wikibase-login-form {
-  text-align: center;
-}
-
 .wikibase-invalid-credentials {
   color: red;
   padding-bottom: 0.3rem;


### PR DESCRIPTION
Fixes alignment in wikibase dialogs as seen here:

**Before:**
![image](https://user-images.githubusercontent.com/42903164/161006189-8a87c415-06eb-42c0-90c0-c61c9d84e90d.png)
![image](https://user-images.githubusercontent.com/42903164/161006220-46b35e0f-9e19-476c-98ce-e32bd022c871.png)

**After:**
![image](https://user-images.githubusercontent.com/42903164/161006269-cfd7a48b-be6f-490e-9711-b9a0769d6b30.png)
![image](https://user-images.githubusercontent.com/42903164/161006281-cd5fbcc9-adee-4c4a-ad0f-fb024f9a480a.png)