### PR TITLE
[SQL Exporter] Substitute invalid characters in column names with underscore (#1940)

### DIFF
--- a/main/src/com/google/refine/exporters/sql/SqlCreateBuilder.java
+++ b/main/src/com/google/refine/exporters/sql/SqlCreateBuilder.java
@@ -83,7 +83,7 @@ public class SqlCreateBuilder {
                 
                 if (name != null) {
                     if(trimColNames) {
-                        String trimmedCol = name.replaceAll("\\s", "");
+                        String trimmedCol = name.replaceAll("[^a-zA-Z0-9_]", "_");
                         createSB.append( trimmedCol + " ");
                     }else{
                         createSB.append(name + " ");

--- a/main/src/com/google/refine/exporters/sql/SqlInsertBuilder.java
+++ b/main/src/com/google/refine/exporters/sql/SqlInsertBuilder.java
@@ -179,7 +179,7 @@ public class SqlInsertBuilder {
         }
 
         boolean trimColNames = options == null ? false : JSONUtilities.getBoolean(options, "trimColumnNames", false);
-        String colNamesWithSep = columns.stream().map(col -> col.replaceAll("\\s", "")).collect(Collectors.joining(","));
+        String colNamesWithSep = columns.stream().map(col -> col.replaceAll("[^a-zA-Z0-9_]", "_")).collect(Collectors.joining(","));
         if(!trimColNames) {
            colNamesWithSep = columns.stream().collect(Collectors.joining(","));  
         }


### PR DESCRIPTION
Fixes #1940

Changes proposed in this pull request:
- Substituting invalid characters in column names with an underscore for SQL Exporter
- The invalid characters are detected through the following regex: `[^a-zA-Z0-9_]`
