### PR TITLE
update link to get testng

### DIFF
--- a/docs/docs/technical-reference/build-test-run.md
+++ b/docs/docs/technical-reference/build-test-run.md
@@ -256,7 +256,7 @@ You can manually apply the code style (regardless of your IDE) with the `mvn for
 
 ## Testing in Eclipse {#testing-in-eclipse}
 
-You can run the server tests directly from Eclipse. To do that you need to have the TestNG launcher plugin installed, as well as the TestNG M2E plugin (for integration with Maven). If you don't have it, you can get it by [installing new software](https://help.eclipse.org/2020-03/index.jsp?topic=/org.eclipse.platform.doc.user/tasks/tasks-129.htm) from this update URL http://dl.bintray.com/testng-team/testng-eclipse-release/
+You can run the server tests directly from Eclipse. To do that you need to have the TestNG launcher plugin installed, as well as the TestNG M2E plugin (for integration with Maven). If you don't have it, you can get it by [installing new software](https://help.eclipse.org/2020-03/index.jsp?topic=/org.eclipse.platform.doc.user/tasks/tasks-129.htm) from this update URL https://testng.org/doc/download.html
 
 Once the TestNG launching plugin is installed in your Eclipse, right click on the source folder "main/tests/server/src", select `Run As` -> `TestNG Test`. This should open a new tab with the TestNG launcher running the OpenRefine tests.
 


### PR DESCRIPTION
Fixes #4675

Changes proposed in this pull request:
- Replaced the non-accessible link to get testng with that stated [here](https://github.com/cbeust/testng-eclipse#install-release).
