### PR TITLE
set division operator call to return NaN on 0/0

### DIFF
--- a/main/src/com/google/refine/grel/ast/OperatorCallExpr.java
+++ b/main/src/com/google/refine/grel/ast/OperatorCallExpr.java
@@ -74,7 +74,9 @@ public class OperatorCallExpr implements Evaluable {
                     } else if ("*".equals(_op)) {
                         return n1 * n2;
                     } else if ("/".equals(_op)) {
-                        if(n2 == 0 && n1 == 0) { return Double.NaN; }
+                        if (n2 == 0 && n1 == 0) {
+                            return Double.NaN;
+                        }
                         return n1 / n2;
                     } else if ("%".equals(_op)) {
                         return n1 % n2;
@@ -102,7 +104,9 @@ public class OperatorCallExpr implements Evaluable {
                     } else if ("*".equals(_op)) {
                         return n1 * n2;
                     } else if ("/".equals(_op)) {
-                        if(n2 == 0&& n1 == 0) { return Double.NaN; }
+                        if (n2 == 0 && n1 == 0) {
+                            return Double.NaN;
+                        }
                         return n1 / n2;
                     } else if ("%".equals(_op)) {
                         return n1 % n2;

--- a/main/src/com/google/refine/grel/ast/OperatorCallExpr.java
+++ b/main/src/com/google/refine/grel/ast/OperatorCallExpr.java
@@ -74,6 +74,7 @@ public class OperatorCallExpr implements Evaluable {
                     } else if ("*".equals(_op)) {
                         return n1 * n2;
                     } else if ("/".equals(_op)) {
+                        if(n2 == 0 && n1 == 0) { return Double.NaN; }
                         return n1 / n2;
                     } else if ("%".equals(_op)) {
                         return n1 % n2;
@@ -101,6 +102,7 @@ public class OperatorCallExpr implements Evaluable {
                     } else if ("*".equals(_op)) {
                         return n1 * n2;
                     } else if ("/".equals(_op)) {
+                        if(n2 == 0&& n1 == 0) { return Double.NaN; }
                         return n1 / n2;
                     } else if ("%".equals(_op)) {
                         return n1 % n2;

--- a/main/tests/server/src/com/google/refine/grel/GrelTests.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTests.java
@@ -136,6 +136,7 @@ public class GrelTests extends RefineTest {
                 { "1<=2", "true" },
                 { "2<=2", "true" },
                 { "3<=2", "false" },
+                { "0/0", "NaN" },
 //                { "", "" }, 
         };
         for (String[] test : tests) {
@@ -163,6 +164,7 @@ public class GrelTests extends RefineTest {
                 { "3/2", "1" },
                 { "3.0/2", "1.5" },
                 { "1", "1" },
+                { "0/0", "NaN" },
         };
         for (String[] test : tests) {
             parseEval(bindings, test);


### PR DESCRIPTION
Fixes #377

Changes proposed in this pull request:
- fix the division operator call to return a Double.NaN when `n1 <- 0, n2 <- 0`
