### PR TITLE
Added encoding fix

### DIFF
--- a/main/src/com/google/refine/commands/Command.java
+++ b/main/src/com/google/refine/commands/Command.java
@@ -276,6 +276,8 @@ public abstract class Command {
         HistoryEntry historyEntry = project.processManager.queueProcess(process);
         if (historyEntry != null) {
             Writer w = response.getWriter();
+            response.setCharacterEncoding("UTF-8");
+            response.setHeader("Content-Type", "application/json");
             ParsingUtilities.defaultWriter.writeValue(w, new HistoryEntryResponse(historyEntry));
 
             w.flush();


### PR DESCRIPTION
Fixes #4540

The following Commands were not properly setting the Content-Type and Character Encoding in the the HTTP Header returned by the server:

* Save Wikibase Schema
* Denormalize
* Join Multi Value Cells
* Key Value Columnize
* Split Multi Value Cells
* Transpose Columns Into Rows
* Transpose Rows Into Columns
* Move Column
* Remove Column
* Rename Column
* Annotate One Row

![image](https://user-images.githubusercontent.com/42903164/162181788-572eab02-ab2e-43a5-9a9e-2ba185ddb616.png)

