### PR TITLE
Fixed snapshot builds

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -174,6 +174,9 @@ jobs:
       run: |
         mvn jacoco:report coveralls:report -DrepoToken=${{ env.COVERALLS_TOKEN }} -DpullRequest=${{ github.event.number }} -DserviceName="GitHub Actions" -DserviceBuildNumber=${{ env.GITHUB_RUN_ID }} -Dbranch=master
 
+    - name: Install webapp dependencies
+      run: cd main/webapp && npm install
+
     - name: Generate dist files
       run: mvn package -DskipTests=true
 


### PR DESCRIPTION
Fixes #4727 

The snapshot workflow file doesn't run `npm install` because it just runs `mvn package`, so this fix adds just adds `npm install` to that file.

Changes proposed in this pull request:
- Added `npm install` to snapshot workflow.

The fix is minor but I'm unable to test.