### PR TITLE
Update technical-reference-index.md with an index page containing short introduction to pages

### DIFF
--- a/docs/versioned_docs/version-3.5/technical-reference/technical-reference-index.md
+++ b/docs/versioned_docs/version-3.5/technical-reference/technical-reference-index.md
@@ -5,3 +5,28 @@ sidebar_label: Technical Reference Index
 ---
 
 Technical reference index
+
+
+https://docs.openrefine.org/technical-reference/architecture
+
+https://docs.openrefine.org/technical-reference/openrefine-api
+
+https://docs.openrefine.org/technical-reference/build-test-run
+
+https://docs.openrefine.org/technical-reference/development-roadmap
+
+https://docs.openrefine.org/technical-reference/version-release-process
+
+https://docs.openrefine.org/technical-reference/homebrew-cask-process
+
+https://docs.openrefine.org/technical-reference/writing-extensions
+
+https://docs.openrefine.org/technical-reference/migrating-older-extensions
+
+https://docs.openrefine.org/technical-reference/translating-ui
+
+https://docs.openrefine.org/technical-reference/translating-docs
+
+https://docs.openrefine.org/technical-reference/functional-tests
+
+https://docs.openrefine.org/technical-reference/maintainer-guidelines


### PR DESCRIPTION
Changes proposed in this pull request:
- Add data to the index page of the technical documentation.
- Link to every section with a brief description of the page's content. 