### PR TITLE
Fixed snapshot builds (attempt 2)

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -174,6 +174,9 @@ jobs:
       run: |
         mvn jacoco:report coveralls:report -DrepoToken=${{ env.COVERALLS_TOKEN }} -DpullRequest=${{ github.event.number }} -DserviceName="GitHub Actions" -DserviceBuildNumber=${{ env.GITHUB_RUN_ID }} -Dbranch=master
 
+    - name: Install webapp dependencies
+      run: cd main/webapp && npm install
+
     - name: Generate dist files
       run: mvn package -DskipTests=true
 

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -167,15 +167,15 @@ jobs:
       env:
         PGPASSWORD: postgres
 
+    - name: Install webapp dependencies
+      run: cd main/webapp && npm install
+      
     - name: Build and test with Maven
       run: mvn jacoco:prepare-agent test
 
     - name: Submit test coverage to Coveralls
       run: |
         mvn jacoco:report coveralls:report -DrepoToken=${{ env.COVERALLS_TOKEN }} -DpullRequest=${{ github.event.number }} -DserviceName="GitHub Actions" -DserviceBuildNumber=${{ env.GITHUB_RUN_ID }} -Dbranch=master
-
-    - name: Install webapp dependencies
-      run: cd main/webapp && npm install
 
     - name: Generate dist files
       run: mvn package -DskipTests=true
@@ -213,6 +213,9 @@ jobs:
       env:
         P12_PASSPHRASE: ${{ secrets.APPLE_P12_PASSPHRASE }}
 
+    - name: Install webapp dependencies
+      run: cd main/webapp && npm install
+      
     - name: Build, test and package
       run: mvn package -Dapple.notarization.username=$APPLE_USERNAME -Dapple.notarization.password=$APPLE_PASSWORD -Dapple.notarization.team.id=$APPLE_TEAM_ID
       env:


### PR DESCRIPTION
Fixes #4727 

Changes proposed in this pull request:
- Moved `npm install` command up, and added `npm install` for Mac build.

I ran the commands locally and they copied the files in 3rdparty successfully but they don't show up in the real snapshot build for the original fix.