### PR TITLE
Option to remove Blank Columns upon project creation

### DIFF
--- a/main/tests/cypress/cypress/e2e/create-project/preview_project.cy.js
+++ b/main/tests/cypress/cypress/e2e/create-project/preview_project.cy.js
@@ -197,4 +197,27 @@ describe(__filename, function () {
     cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
     cy.get('input[bind="disableAutoPreviewCheckbox"]').uncheck();
   });
+
+  it('Tests save blank columns of parsing options', function () {
+    cy.visitOpenRefine();
+    cy.createProjectThroughUserInterface('food-blank-column.mini.csv');
+    cy.get('.create-project-ui-panel').contains('Configure parsing options');
+    // FIXME: data-table in preview has no thead, so first tr in tbody is a header
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(1)').should('to.contain', '1.');
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(2)').should('to.contain', '01001');
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(3)').should('to.contain', 'BUTTER,WITH SALT');
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(4)').should('to.contain', '15.87');
+    // empty cells are filled with NBSP when rendered
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(5)').should('to.contain', '\u00a0');
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(6)').should('to.contain', '717');
+
+    cy.get('input[bind="storeBlankColumnsCheckbox"]').uncheck();
+
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(1)').should('to.contain', '1.');
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(2)').should('to.contain', '01001');
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(3)').should('to.contain', 'BUTTER,WITH SALT');
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(4)').should('to.contain', '15.87');
+    // The next column should be one further to the left with the empty column gone
+    cy.get('table.data-table > tbody > tr:nth-child(2) > td:nth-child(6)').should('to.contain', '717');
+  });
 });

--- a/main/tests/cypress/cypress/fixtures/food-blank-column.mini.csv
+++ b/main/tests/cypress/cypress/fixtures/food-blank-column.mini.csv
@@ -1,0 +1,3 @@
+"NDB_No","Shrt_Desc","Water",,"Energ_Kcal"
+"01001","BUTTER,WITH SALT","15.87",,"717"
+"01002","BUTTER,WHIPPED,WITH SALT","15.87",,"717"

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -422,7 +422,7 @@ public class ExcelImporterTests extends ImporterTest {
     }
 
     @Test
-    public void testDeleteEmptyColumns() throws FileNotFoundException, IOException {
+    public void testDeleteEmptyColumns() throws Exception {
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
                 .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
@@ -438,11 +438,8 @@ public class ExcelImporterTests extends ImporterTest {
         whenGetBooleanOption("storeBlankColumns", options, false);
 
         InputStream stream = new FileInputStream(xlsxFile);
-        try {
-            parseOneFile(SUT, stream);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+        parseOneFile(SUT, stream);
+
         // We should have one less than the start due to empty column being skipped
         assertEquals(project.columnModel.columns.size(), 12);
         // NOTE: we need to redirect through the column model because the rows will still have empty cells

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -39,7 +39,6 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,7 +64,6 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -78,7 +78,6 @@ public class ExcelImporterTests extends ImporterTest {
 
     private static final int SHEETS = 3;
     private static final int ROWS = 4;
-
     private static final String DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm";
     private static final String DATE_FORMAT = "yyyy-MM-dd";
     private static final String LEADING_ZERO_FORMAT = "0000";

--- a/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
@@ -159,7 +159,7 @@ public class FixedWidthImporterTests extends ImporterTest {
     }
 
     @Test
-    public void testDeleteEmptyColumns(){
+    public void testDeleteEmptyColumns() {
         StringReader reader = new StringReader(SAMPLE_ROW + "\nTooShort");
 
         ArrayNode columnWidths = ParsingUtilities.mapper.createArrayNode();

--- a/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
@@ -32,6 +32,7 @@ import java.io.StringReader;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.slf4j.LoggerFactory;
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
@@ -157,4 +158,45 @@ public class FixedWidthImporterTests extends ImporterTest {
         assertProjectEquals(project, expectedProject);
     }
 
+    @Test
+    public void testDeleteEmptyColumns(){
+        StringReader reader = new StringReader(SAMPLE_ROW + "\nTooShort");
+
+        ArrayNode columnWidths = ParsingUtilities.mapper.createArrayNode();
+        // Set up blank column in project
+        JSONUtilities.append(columnWidths, 6);
+        JSONUtilities.append(columnWidths, 0);
+        JSONUtilities.append(columnWidths, 5);
+        JSONUtilities.append(columnWidths, 0);
+        JSONUtilities.append(columnWidths, 3);
+        whenGetArrayOption("columnWidths", options, columnWidths);
+
+        ArrayNode columnNames = ParsingUtilities.mapper.createArrayNode();
+        columnNames.add("Col 1");
+        columnNames.add("Col 2");
+        columnNames.add("Col 3");
+        columnNames.add("Col 4");
+        columnNames.add("Col 5");
+        columnNames.add("Col 6");
+        whenGetArrayOption("columnNames", options, columnNames);
+
+        whenGetIntegerOption("ignoreLines", options, 0);
+        whenGetIntegerOption("headerLines", options, 1);
+        whenGetIntegerOption("skipDataLines", options, 0);
+        whenGetIntegerOption("limit", options, -1);
+
+        // This will mock the situation of deleting empty columns(col2&col4)
+        whenGetBooleanOption("storeBlankCellsAsNulls", options, false);
+        whenGetBooleanOption("storeBlankColumns", options, false);
+
+        try {
+            parseOneFile(SUT, reader);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+
+        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "Col 1");
+        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "Col 3");
+        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "Col 5");
+    }
 }

--- a/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
@@ -159,7 +159,7 @@ public class FixedWidthImporterTests extends ImporterTest {
     }
 
     @Test
-    public void testDeleteEmptyColumns() {
+    public void testDeleteEmptyColumns() throws Exception {
         StringReader reader = new StringReader(SAMPLE_ROW + "\nTooShort");
 
         ArrayNode columnWidths = ParsingUtilities.mapper.createArrayNode();
@@ -189,11 +189,7 @@ public class FixedWidthImporterTests extends ImporterTest {
         whenGetBooleanOption("storeBlankCellsAsNulls", options, false);
         whenGetBooleanOption("storeBlankColumns", options, false);
 
-        try {
-            parseOneFile(SUT, reader);
-        } catch (Exception e) {
-            Assert.fail(e.getMessage());
-        }
+        parseOneFile(SUT, reader);
 
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "Col 1");
         Assert.assertEquals(project.columnModel.columns.get(1).getName(), "Col 3");

--- a/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
@@ -38,10 +38,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import com.google.refine.model.*;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
@@ -177,5 +179,42 @@ public class ImporterUtilitiesTests extends RefineTest {
         Assert.assertEquals(c0.getName(), OpenRefineMessage.importer_utilities_column() + " 1");
         Assert.assertEquals(c1.getName(), OpenRefineMessage.importer_utilities_column() + " 2");
         Assert.assertEquals(newColumnNames.size(), 2);
+    }
+
+    @Test
+    public void testDeleteEmptyColumns(){
+        Project project = new Project();
+        // Set up column names in project
+        List<String> columnNames = new ArrayList<String>();
+        List<Boolean> columnsHasData = new ArrayList<>();
+        columnNames.add("Column 1");
+        columnsHasData.add(true);
+
+        columnNames.add("Column 2");
+        columnsHasData.add(false);
+
+        columnNames.add("Column 3");
+        columnsHasData.add(true);
+
+        columnNames.add("Column 4");
+        columnsHasData.add(false);
+
+        columnNames.add("Column 5");
+        columnsHasData.add(true);
+
+        ImporterUtilities.setupColumns(project, columnNames);
+        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "Column 1");
+        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "Column 2");
+        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "Column 3");
+
+        // This will mock the situation of deleting empty columns(col2&col4)
+        try {
+            ImporterUtilities.deleteEmptyColumns(columnsHasData,project);
+        } catch (ModelException e) {
+            e.printStackTrace();
+        }
+        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "Column 1");
+        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "Column 3");
+        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "Column 5");
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -184,7 +185,7 @@ public class ImporterUtilitiesTests extends RefineTest {
     public void testDeleteEmptyColumns() {
         Project project = new Project();
         // Set up column names in project
-        List<String> columnNames = new ArrayList<String>();
+        List<String> columnNames = new ArrayList<>();
         List<Boolean> columnsHasData = new ArrayList<>();
         columnNames.add("Column 1");
         columnsHasData.add(true);
@@ -208,9 +209,9 @@ public class ImporterUtilitiesTests extends RefineTest {
 
         // This will mock the situation of deleting empty columns(col2&col4)
         try {
-            ImporterUtilities.deleteEmptyColumns(columnsHasData, project);
+            TabularImportingParserBase.deleteEmptyColumns(columnsHasData, project);
         } catch (ModelException e) {
-            e.printStackTrace();
+            fail();
         }
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "Column 1");
         Assert.assertEquals(project.columnModel.columns.get(1).getName(), "Column 3");

--- a/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
@@ -38,12 +38,10 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import com.google.refine.model.*;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
@@ -51,6 +49,7 @@ import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.messages.OpenRefineMessage;
+import com.google.refine.model.*;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
@@ -182,7 +181,7 @@ public class ImporterUtilitiesTests extends RefineTest {
     }
 
     @Test
-    public void testDeleteEmptyColumns(){
+    public void testDeleteEmptyColumns() {
         Project project = new Project();
         // Set up column names in project
         List<String> columnNames = new ArrayList<String>();
@@ -209,7 +208,7 @@ public class ImporterUtilitiesTests extends RefineTest {
 
         // This will mock the situation of deleting empty columns(col2&col4)
         try {
-            ImporterUtilities.deleteEmptyColumns(columnsHasData,project);
+            ImporterUtilities.deleteEmptyColumns(columnsHasData, project);
         } catch (ModelException e) {
             e.printStackTrace();
         }

--- a/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -182,7 +181,7 @@ public class ImporterUtilitiesTests extends RefineTest {
     }
 
     @Test
-    public void testDeleteEmptyColumns() {
+    public void testDeleteEmptyColumns() throws ModelException {
         Project project = new Project();
         // Set up column names in project
         List<String> columnNames = new ArrayList<>();
@@ -208,11 +207,7 @@ public class ImporterUtilitiesTests extends RefineTest {
         Assert.assertEquals(project.columnModel.columns.get(2).getName(), "Column 3");
 
         // This will mock the situation of deleting empty columns(col2&col4)
-        try {
-            TabularImportingParserBase.deleteEmptyColumns(columnsHasData, project);
-        } catch (ModelException e) {
-            fail();
-        }
+        TabularImportingParserBase.deleteEmptyColumns(columnsHasData, project);
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "Column 1");
         Assert.assertEquals(project.columnModel.columns.get(1).getName(), "Column 3");
         Assert.assertEquals(project.columnModel.columns.get(2).getName(), "Column 5");

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -613,14 +613,11 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         columnNames.add("Col 5");
 
         // This will mock the situation of deleting empty columns(col2&col4)
-        try {
-            prepareOptions(sep, -1, 0, 0, 1, false, true);
-            whenGetBooleanOption("storeBlankColumns", options, false);
-            whenGetArrayOption("columnNames", options, columnNames);
-            parseOneFile(SUT, new StringReader(input));
-        } catch (Exception e) {
-            Assert.fail("Exception during file parse", e);
-        }
+        prepareOptions(sep, -1, 0, 0, 1, false, true);
+        whenGetBooleanOption("storeBlankColumns", options, false);
+        whenGetArrayOption("columnNames", options, columnNames);
+        parseOneFile(SUT, new StringReader(input));
+
         Assert.assertEquals(project.columnModel.columns.size(), 3);
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "Col 1");
         Assert.assertEquals(project.columnModel.columns.get(1).getName(), "Col 3");

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.CharSequenceReader;
@@ -595,6 +596,34 @@ public class SeparatorBasedImporterTests extends ImporterTest {
                         { "da\rta1", "dat\ta2", "data3", "dat\na4" },
                 });
         assertProjectEquals(project, expectedProject);
+    }
+
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
+    public void testDeleteEmptyColumns(String sep){
+        // Set up blank column in project
+        String inputSeparator = sep == null ? "\t" : sep;
+        String input = "data1" +inputSeparator +inputSeparator + "data2\"" + inputSeparator +inputSeparator + "data3" + inputSeparator +"\n"+
+                "data4" +inputSeparator +inputSeparator + "data5\"" + inputSeparator +inputSeparator + "data6" ;
+        ArrayNode columnNames = ParsingUtilities.mapper.createArrayNode();
+        columnNames.add("Col 1");
+        columnNames.add("Col 2");
+        columnNames.add("Col 3");
+        columnNames.add("Col 4");
+        columnNames.add("Col 5");
+
+        // This will mock the situation of deleting empty columns(col2&col4)
+        try {
+            prepareOptions(sep, -1, 0, 0, 1, false, true);
+            whenGetBooleanOption("storeBlankColumns", options, false);
+            whenGetArrayOption("columnNames", options, columnNames);
+            parseOneFile(SUT, new StringReader(input));
+        } catch (Exception e) {
+            Assert.fail("Exception during file parse", e);
+        }
+        Assert.assertEquals(project.columnModel.columns.size(), 3);
+        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "Col 1");
+        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "Col 3");
+        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "Col 5");
     }
 
     // ---------------------guess separators------------------------

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -599,11 +599,12 @@ public class SeparatorBasedImporterTests extends ImporterTest {
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
-    public void testDeleteEmptyColumns(String sep){
+    public void testDeleteEmptyColumns(String sep) {
         // Set up blank column in project
         String inputSeparator = sep == null ? "\t" : sep;
-        String input = "data1" +inputSeparator +inputSeparator + "data2\"" + inputSeparator +inputSeparator + "data3" + inputSeparator +"\n"+
-                "data4" +inputSeparator +inputSeparator + "data5\"" + inputSeparator +inputSeparator + "data6" ;
+        String input = "data1" + inputSeparator + inputSeparator + "data2\"" + inputSeparator + inputSeparator + "data3" + inputSeparator
+                + "\n" +
+                "data4" + inputSeparator + inputSeparator + "data5\"" + inputSeparator + inputSeparator + "data6";
         ArrayNode columnNames = ParsingUtilities.mapper.createArrayNode();
         columnNames.add("Col 1");
         columnNames.add("Col 2");

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -159,6 +159,7 @@
     "core-index-parser/load-at-most": "Load at most",
     "core-index-parser/parse-cell": "Attempt to parse cell<br>text into numbers",
     "core-index-parser/store-blank": "Store blank rows",
+    "core-index-parser/store-blank-columns": "Store blank columns",
     "core-index-parser/store-nulls": "Store blank cells as nulls",
     "core-index-parser/blank-spanning-cells": "Pad cells spanning over multiple rows or columns with nulls",
     "core-index-parser/include-raw-templates": "Include templates and images as raw wikicode",

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.html
@@ -43,6 +43,8 @@
     <td><div class="grid-layout layout-tightest"><table>
       <tr><td width="1%"><input type="checkbox" bind="storeBlankRowsCheckbox" id="$store-blank-rows" /></td>
         <td colspan="2"><label for="$store-blank-rows" id="or-import-blank"></label></td></tr>
+      <tr><td width="1%"><input type="checkbox" bind="storeBlankColumnsCheckbox" id="$store-blank-columns" /></td>
+        <td colspan="2"><label for="$store-blank-columns" id="or-import-blank-columns"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="storeBlankCellsAsNullsCheckbox" id="$store-blank-cells" /></td>
         <td colspan="2"><label for="$store-blank-cells" id="or-import-null"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="includeFileSourcesCheckbox" id="$include-file-sources" /></td>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.js
@@ -106,6 +106,7 @@ Refine.ExcelParserUI.prototype.getOptions = function() {
     options.limit = -1;
   }
   options.storeBlankRows = this._optionContainerElmts.storeBlankRowsCheckbox[0].checked;
+  options.storeBlankColumns = this._optionContainerElmts.storeBlankColumnsCheckbox[0].checked;
   options.storeBlankCellsAsNulls = this._optionContainerElmts.storeBlankCellsAsNullsCheckbox[0].checked;
   options.includeFileSources = this._optionContainerElmts.includeFileSourcesCheckbox[0].checked;
   options.includeArchiveFileName = this._optionContainerElmts.includeArchiveFileCheckbox[0].checked;
@@ -139,6 +140,7 @@ Refine.ExcelParserUI.prototype._initialize = function() {
   $('#or-import-load').text($.i18n('core-index-parser/load-at-most'));
   $('#or-import-rows2').text($.i18n('core-index-parser/rows-data'));
   $('#or-import-blank').text($.i18n('core-index-parser/store-blank'));
+  $('#or-import-blank-columns').text($.i18n('core-index-parser/store-blank-columns'));
   $('#or-import-null').text($.i18n('core-index-parser/store-nulls'));
   $('#or-import-source').html($.i18n('core-index-parser/store-source'));
   $('#or-import-archive').html($.i18n('core-index-parser/store-archive'));
@@ -186,6 +188,9 @@ Refine.ExcelParserUI.prototype._initialize = function() {
   }
   if (this._config.storeBlankRows) {
     this._optionContainerElmts.storeBlankRowsCheckbox.prop("checked", true);
+  }
+  if (this._config.storeBlankColumns) {
+    this._optionContainerElmts.storeBlankColumnsCheckbox.prop("checked", true);
   }
   if (this._config.storeBlankCellsAsNulls) {
     this._optionContainerElmts.storeBlankCellsAsNullsCheckbox.prop("checked", true);

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/fixed-width-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/fixed-width-parser-ui.html
@@ -49,6 +49,8 @@
         <td><label for="$guess" id="or-import-parseCell"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="storeBlankRowsCheckbox" id="$store-blank-rows" /></td>
         <td colspan="2"><label for="$store-blank-rows" id="or-import-blank"></label></td></tr>
+      <tr><td width="1%"><input type="checkbox" bind="storeBlankColumnsCheckbox" id="$store-blank-columns" /></td>
+        <td colspan="2"><label for="$store-blank-columns" id="or-import-blank-columns"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="storeBlankCellsAsNullsCheckbox" id="$store-blank-cells" /></td>
         <td colspan="2"><label for="$store-blank-cells" id="or-import-null"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="includeFileSourcesCheckbox" id="$include-file-sources" /></td>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/fixed-width-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/fixed-width-parser-ui.js
@@ -107,6 +107,7 @@ Refine.FixedWidthParserUI.prototype.getOptions = function() {
   options.guessCellValueTypes = this._optionContainerElmts.guessCellValueTypesCheckbox[0].checked;
 
   options.storeBlankRows = this._optionContainerElmts.storeBlankRowsCheckbox[0].checked;
+  options.storeBlankColumns = this._optionContainerElmts.storeBlankColumnsCheckbox[0].checked;
   options.storeBlankCellsAsNulls = this._optionContainerElmts.storeBlankCellsAsNullsCheckbox[0].checked;
   options.includeFileSources = this._optionContainerElmts.includeFileSourcesCheckbox[0].checked;
   options.includeArchiveFile = this._optionContainerElmts.includeFileSourcesCheckbox[0].checked;
@@ -143,6 +144,7 @@ Refine.FixedWidthParserUI.prototype._initialize = function() {
   $('#or-import-rows2').text($.i18n('core-index-parser/rows-data'));
   $('#or-import-parseCell').html($.i18n('core-index-parser/parse-cell'));
   $('#or-import-blank').text($.i18n('core-index-parser/store-blank'));
+  $('#or-import-blank-columns').text($.i18n('core-index-parser/store-blank-columns'));
   $('#or-import-null').text($.i18n('core-index-parser/store-nulls'));
   $('#or-import-source').html($.i18n('core-index-parser/store-source'));
   $('#or-import-archive').html($.i18n('core-index-parser/store-archive'));
@@ -180,7 +182,9 @@ Refine.FixedWidthParserUI.prototype._initialize = function() {
   if (this._config.storeBlankRows) {
     this._optionContainerElmts.storeBlankRowsCheckbox.prop('checked', true);
   }
-
+  if (this._config.storeBlankColumns) {
+    this._optionContainerElmts.storeBlankColumnsCheckbox.prop("checked", true);
+  }
   if (this._config.guessCellValueTypes) {
     this._optionContainerElmts.guessCellValueTypesCheckbox.prop('checked', true);
   }

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/line-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/line-based-parser-ui.html
@@ -47,6 +47,8 @@
       
       <tr><td width="1%"><input type="checkbox" bind="storeBlankRowsCheckbox" id="$store-blank-rows" /></td>
         <td colspan="2"><label for="$store-blank-rows" id="or-import-blank"></label></td></tr>
+      <tr><td width="1%"><input type="checkbox" bind="storeBlankColumnsCheckbox" id="$store-blank-columns" /></td>
+        <td colspan="2"><label for="$store-blank-columns" id="or-import-blank-columns"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="storeBlankCellsAsNullsCheckbox" id="$store-blank-cells" /></td>
         <td colspan="2"><label for="$store-blank-cells" id="or-import-null"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="includeFileSourcesCheckbox" id="$include-file-sources" /></td>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/line-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/line-based-parser-ui.js
@@ -104,6 +104,7 @@ Refine.LineBasedParserUI.prototype.getOptions = function() {
     options.skipDataLines = -1;
   }
   options.storeBlankRows = this._optionContainerElmts.storeBlankRowsCheckbox[0].checked;
+  options.storeBlankColumns = this._optionContainerElmts.storeBlankColumnsCheckbox[0].checked;
   options.storeBlankCellsAsNulls = this._optionContainerElmts.storeBlankCellsAsNullsCheckbox[0].checked;
   options.includeFileSources = this._optionContainerElmts.includeFileSourcesCheckbox[0].checked;
   options.includeArchiveFileName = this._optionContainerElmts.includeArchiveFileCheckbox[0].checked;
@@ -127,6 +128,7 @@ Refine.LineBasedParserUI.prototype._initialize = function() {
   $('#or-import-parseEvery').html($.i18n('core-index-parser/parse-every'));
   $('#or-import-linesIntoRow').html($.i18n('core-index-parser/lines-into-row'));
   $('#or-import-blank').text($.i18n('core-index-parser/store-blank'));
+  $('#or-import-blank-columns').text($.i18n('core-index-parser/store-blank-columns'));
   $('#or-import-null').text($.i18n('core-index-parser/store-nulls'));
   $('#or-import-source').html($.i18n('core-index-parser/store-source'));
   $('#or-import-archive').html($.i18n('core-index-parser/store-archive'));
@@ -173,6 +175,9 @@ Refine.LineBasedParserUI.prototype._initialize = function() {
   }
   if (this._config.storeBlankRows) {
     this._optionContainerElmts.storeBlankRowsCheckbox.prop("checked", true);
+  }
+  if (this._config.storeBlankColumns) {
+    this._optionContainerElmts.storeBlankColumnsCheckbox.prop("checked", true);
   }
   if (this._config.storeBlankCellsAsNulls) {
     this._optionContainerElmts.storeBlankCellsAsNullsCheckbox.prop("checked", true);

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
@@ -158,6 +158,12 @@
             </tr>
 
             <tr>
+              <td width="1%"><input type="checkbox" bind="storeBlankColumnsCheckbox" id="$store-blank-columns" /></td>
+              <td colspan="2"><label for="$store-blank-columns" id="or-import-blank-columns"></label>
+              </td>
+            </tr>
+
+            <tr>
               <td width="1%"><input type="checkbox" bind="storeBlankCellsAsNullsCheckbox" id="$store-blank-cells" />
               </td>
               <td colspan="2"><label for="$store-blank-cells" id="or-import-null"></label></td>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
@@ -108,6 +108,7 @@ Refine.SeparatorBasedParserUI.prototype.getOptions = function() {
     options.limit = -1;
   }
   options.storeBlankRows = this._optionContainerElmts.storeBlankRowsCheckbox[0].checked;
+  options.storeBlankColumns = this._optionContainerElmts.storeBlankColumnsCheckbox[0].checked;
 
   options.guessCellValueTypes = this._optionContainerElmts.guessCellValueTypesCheckbox[0].checked;
   options.processQuotes = this._optionContainerElmts.processQuoteMarksCheckbox[0].checked;
@@ -166,6 +167,7 @@ Refine.SeparatorBasedParserUI.prototype._initialize = function() {
   $('#or-import-quote').html($.i18n('core-index-parser/use-quote'));
   $('#or-import-quote-character').html($.i18n('core-index-parser/quote-delimits-cells'));
   $('#or-import-blank').text($.i18n('core-index-parser/store-blank'));
+  $('#or-import-blank-columns').text($.i18n('core-index-parser/store-blank-columns'));
   $('#or-import-null').text($.i18n('core-index-parser/store-nulls'));
   $('#or-import-source').html($.i18n('core-index-parser/store-source'));
   $('#or-import-archive').html($.i18n('core-index-parser/store-archive'));
@@ -228,7 +230,9 @@ Refine.SeparatorBasedParserUI.prototype._initialize = function() {
   if (this._config.storeBlankRows) {
     this._optionContainerElmts.storeBlankRowsCheckbox.prop("checked", true);
   }
-
+  if (this._config.storeBlankColumns) {
+    this._optionContainerElmts.storeBlankColumnsCheckbox.prop("checked", true);
+  }
   if (this._config.guessCellValueTypes) {
     this._optionContainerElmts.guessCellValueTypesCheckbox.prop("checked", true);
   }

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.html
@@ -18,6 +18,8 @@
         <td><label for="$blank-spanning-cells" id="or-import-blankSpanningCells"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="storeBlankRowsCheckbox" id="$store-blank-rows" /></td>
         <td colspan="2"><label for="$store-blank-rows" id="or-import-blank"></label></td></tr>
+      <tr><td width="1%"><input type="checkbox" bind="storeBlankColumnsCheckbox" id="$store-blank-columns" /></td>
+        <td colspan="2"><label for="$store-blank-columns" id="or-import-blank-columns"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="includeRawTemplatesCheckbox" id="$include-raw-templates" /></td>
         <td colspan="2"><label for="$include-raw-templates" id="or-import-includeRawTemplates"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="parseReferencesCheckbox" id="$parse-references" /></td>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.js
@@ -92,6 +92,7 @@ Refine.WikitextParserUI.prototype.getOptions = function() {
   }
 
   options.storeBlankRows = this._optionContainerElmts.storeBlankRowsCheckbox[0].checked;
+  options.storeBlankColumns = this._optionContainerElmts.storeBlankColumnsCheckbox[0].checked;
   options.blankSpanningCells = this._optionContainerElmts.blankSpanningCellsCheckbox[0].checked;
   options.includeRawTemplates = this._optionContainerElmts.includeRawTemplatesCheckbox[0].checked;
   options.parseReferences = this._optionContainerElmts.parseReferencesCheckbox[0].checked;
@@ -129,6 +130,7 @@ Refine.WikitextParserUI.prototype._initialize = function() {
   $('#or-import-includeRawTemplates').text($.i18n('core-index-parser/include-raw-templates'));
   $('#or-import-parseReferences').text($.i18n('core-index-parser/parse-references'));
   $('#or-import-blank').text($.i18n('core-index-parser/store-blank'));
+  $('#or-import-blank-columns').text($.i18n('core-index-parser/store-blank-columns'));
   $('#or-import-null').text($.i18n('core-index-parser/store-nulls'));
   $('#or-import-source').html($.i18n('core-index-parser/store-source'));
   $('#or-import-archive').html($.i18n('core-index-parser/store-archive'));
@@ -174,6 +176,10 @@ Refine.WikitextParserUI.prototype._initialize = function() {
 
   if (this._config.storeBlankRows) {
     this._optionContainerElmts.storeBlankRowsCheckbox.prop("checked", true);
+  }
+
+  if (this._config.storeBlankColumns) {
+    this._optionContainerElmts.storeBlankColumnsCheckbox.prop("checked", true);
   }
 
   if (this._config.guessCellValueTypes) {

--- a/modules/core/src/main/java/com/google/refine/importers/ImporterUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/importers/ImporterUtilities.java
@@ -258,23 +258,29 @@ public class ImporterUtilities {
             }
         };
     }
+
     /**
      * Ensure this ArrayList(determine if this column is blank) is larger than row size.
-     * @param columnsHasData Record if there is data in each column( false:null;true:has data)
+     * 
+     * @param columnsHasData
+     *            Record if there is data in each column( false:null;true:has data)
      */
     static public void ensureColumnsHasDataExpands(List<Boolean> columnsHasData, int rowSize) {
         while (rowSize > columnsHasData.size()) {
             columnsHasData.add(false);
         }
     }
+
     /**
      * If "storeBlankColumns" == false, delete blank columns.
-     * @param columnsHasData Record if there is data in each column( false:null;true:has data)
+     * 
+     * @param columnsHasData
+     *            Record if there is data in each column( false:null;true:has data)
      */
     static public void deleteEmptyColumns(List<Boolean> columnsHasData, Project project) throws ModelException {
         for (int c = 0; c < columnsHasData.size(); c++) {
             if (columnsHasData.get(c) == false) {
-                //remove column from columns
+                // remove column from columns
                 project.columnModel.removeColumn(c);
             }
         }

--- a/modules/core/src/main/java/com/google/refine/importers/ImporterUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/importers/ImporterUtilities.java
@@ -258,4 +258,50 @@ public class ImporterUtilities {
             }
         };
     }
+    /**
+     * Ensure this ArrayList(determine if this column is blank) is larger than row size.
+     * @param columnsHasData Record if there is data in each column( false:null;true:has data)
+     */
+    static public void ensureColumnsHasDataExpands(List<Boolean> columnsHasData, int rowSize) {
+        while (rowSize > columnsHasData.size()) {
+            columnsHasData.add(false);
+        }
+    }
+    /**
+     * If "storeBlankColumns" == false, delete blank columns.
+     * @param columnsHasData Record if there is data in each column( false:null;true:has data)
+     */
+    static public void deleteEmptyColumns(List<Boolean> columnsHasData, Project project) throws ModelException {
+//      int deletedSoFar = 0;
+        for (int c = 0; c < columnsHasData.size(); c++) {
+            if (columnsHasData.get(c) == false) {
+                //remove column from columns
+                project.columnModel.removeColumn(c);
+
+                //if you want to don't change the headlines,use this
+//                List<String> columnNames = new ArrayList<>();
+//                columnNames = (List<String>) project.columnModel.getColumnByCellIndex(c);
+//                System.out.println(columnNames);
+//               columnNames.remove(0);
+
+                //set col[c] = col[c+1];col[c+1]=col[c+2];...
+//                int deletedIndex = c-deletedSoFar;
+//                deletedSoFar++;
+//                for (int i = 0; i < project.rows.size(); i++) {
+//                    Row row = project.rows.get(i);
+//                    for (int j = deletedIndex; j < row.cells.size(); j++) {
+//                        row.setCell(j, row.getCell(j+1));
+//                    }
+//                }
+            }
+        }
+//        if (deletedSoFar != 0){//set col[row.size()-1] to col[row.size()-1-deletedSoFa]  =null;
+//            for (int i = 0; i < project.rows.size(); i++) {
+//                Row row = project.rows.get(i);
+//                for (int j = 0; j < deletedSoFar ; j++) {
+//                    row.setCell(row.cells.size()-1-j, null);
+//                }
+//            }
+//        }
+    }
 }

--- a/modules/core/src/main/java/com/google/refine/importers/ImporterUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/importers/ImporterUtilities.java
@@ -272,36 +272,11 @@ public class ImporterUtilities {
      * @param columnsHasData Record if there is data in each column( false:null;true:has data)
      */
     static public void deleteEmptyColumns(List<Boolean> columnsHasData, Project project) throws ModelException {
-//      int deletedSoFar = 0;
         for (int c = 0; c < columnsHasData.size(); c++) {
             if (columnsHasData.get(c) == false) {
                 //remove column from columns
                 project.columnModel.removeColumn(c);
-
-                //if you want to don't change the headlines,use this
-//                List<String> columnNames = new ArrayList<>();
-//                columnNames = (List<String>) project.columnModel.getColumnByCellIndex(c);
-//                System.out.println(columnNames);
-//               columnNames.remove(0);
-
-                //set col[c] = col[c+1];col[c+1]=col[c+2];...
-//                int deletedIndex = c-deletedSoFar;
-//                deletedSoFar++;
-//                for (int i = 0; i < project.rows.size(); i++) {
-//                    Row row = project.rows.get(i);
-//                    for (int j = deletedIndex; j < row.cells.size(); j++) {
-//                        row.setCell(j, row.getCell(j+1));
-//                    }
-//                }
             }
         }
-//        if (deletedSoFar != 0){//set col[row.size()-1] to col[row.size()-1-deletedSoFa]  =null;
-//            for (int i = 0; i < project.rows.size(); i++) {
-//                Row row = project.rows.get(i);
-//                for (int j = 0; j < deletedSoFar ; j++) {
-//                    row.setCell(row.cells.size()-1-j, null);
-//                }
-//            }
-//        }
     }
 }

--- a/modules/core/src/main/java/com/google/refine/importers/ImporterUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/importers/ImporterUtilities.java
@@ -152,7 +152,7 @@ public class ImporterUtilities {
                 } else {
                     column = new Column(project.columnModel.allocateNewCellIndex(), columnName);
                     try {
-                        project.columnModel.addColumn(project.columnModel.columns.size(), column, false);
+                        project.columnModel.addColumn(-1, column, false);
                     } catch (ModelException e) {
                         // Ignore: shouldn't get in here since we just checked for duplicate names.
                     }
@@ -189,12 +189,13 @@ public class ImporterUtilities {
             if (project.columnModel.getColumnByName(cell) == null) {
                 Column column = new Column(project.columnModel.allocateNewCellIndex(), cell);
                 try {
-                    project.columnModel.addColumn(project.columnModel.columns.size(), column, false);
+                    project.columnModel.addColumn(-1, column, false);
                 } catch (ModelException e) {
                     // Ignore: shouldn't get in here since we just checked for duplicate names.
                 }
             }
         }
+        project.columnModel.update();
     }
 
     static public interface MultiFileReadingProgress {
@@ -257,32 +258,5 @@ public class ImporterUtilities {
                 return l;
             }
         };
-    }
-
-    /**
-     * Ensure this ArrayList(determine if this column is blank) is larger than row size.
-     * 
-     * @param columnsHasData
-     *            Record if there is data in each column( false:null;true:has data)
-     */
-    static public void ensureColumnsHasDataExpands(List<Boolean> columnsHasData, int rowSize) {
-        while (rowSize > columnsHasData.size()) {
-            columnsHasData.add(false);
-        }
-    }
-
-    /**
-     * If "storeBlankColumns" == false, delete blank columns.
-     * 
-     * @param columnsHasData
-     *            Record if there is data in each column( false:null;true:has data)
-     */
-    static public void deleteEmptyColumns(List<Boolean> columnsHasData, Project project) throws ModelException {
-        for (int c = 0; c < columnsHasData.size(); c++) {
-            if (columnsHasData.get(c) == false) {
-                // remove column from columns
-                project.columnModel.removeColumn(c);
-            }
-        }
     }
 }

--- a/modules/core/src/main/java/com/google/refine/importers/TabularImportingParserBase.java
+++ b/modules/core/src/main/java/com/google/refine/importers/TabularImportingParserBase.java
@@ -46,6 +46,7 @@ import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.util.JSONUtilities;
@@ -135,7 +136,7 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
         List<String> columnNames = new ArrayList<String>();
         boolean hasOurOwnColumnNames = headerLines > 0;
 
-        List<Boolean> columnsHasData = new ArrayList<>();//Determine if there is data in each column,def = false
+        List<Boolean> columnsHasData = new ArrayList<>();// Determine if there is data in each column,def = false
 
         List<Object> cells = null;
         int rowsWithData = 0;
@@ -219,7 +220,7 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
                     }
                 }
             }
-            if(!storeBlankColumns) {//if user don't choose storeBlankColumns, delete all empty columns.
+            if (!storeBlankColumns) {// if user don't choose storeBlankColumns, delete all empty columns.
                 ImporterUtilities.deleteEmptyColumns(columnsHasData, project);
             }
         } catch (IOException e) {

--- a/modules/core/src/main/java/com/google/refine/model/ColumnModel.java
+++ b/modules/core/src/main/java/com/google/refine/model/ColumnModel.java
@@ -36,7 +36,14 @@ package com.google.refine.model;
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.Writer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -110,6 +117,20 @@ public class ColumnModel {
         internalInitialize();
     }
 
+    /**
+     * Add a new column to the list of columns. NOTE: This does not update all indices, so the caller is responsible for
+     * calling {@link #update()} at the appropriate time.
+     *
+     * @param index
+     *            index to add column at or -1 to add after the last column
+     * @param column
+     *            column to insert
+     * @param avoidNameCollision
+     *            true if column name should be made unique. If false, this method will throw a ModelException on
+     *            duplicate column names
+     * @throws ModelException
+     *             if the name of the column to be inserted already exists
+     */
     synchronized public void addColumn(int index, Column column, boolean avoidNameCollision) throws ModelException {
         String name = column.getName();
 
@@ -305,21 +326,9 @@ public class ColumnModel {
         }
     }
 
-    public void removeColumn(int index) {
-        // if index = cellindex, then remove ColumnName.
-        if (index <= _nameToColumn.size()) {
-            Iterator<Map.Entry<String, Column>> iterator = _nameToColumn.entrySet().iterator();
-            while (iterator.hasNext()) {
-                Map.Entry<String, Column> next = iterator.next();
-                String key = next.getKey();
-                Column column = _nameToColumn.get(key);
-                int cellIndex = column.getCellIndex();
-                if (cellIndex == index) {
-                    columns.remove(column);
-                }
-            }
-        }
-
+    public void removeColumnByCellIndex(int index) {
+        Column column = getColumnByCellIndex(index);
+        columns.remove(column);
     }
 
 }

--- a/modules/core/src/main/java/com/google/refine/model/ColumnModel.java
+++ b/modules/core/src/main/java/com/google/refine/model/ColumnModel.java
@@ -305,16 +305,16 @@ public class ColumnModel {
         }
     }
 
-    public void removeColumn(int index)  {
-        //if index = cellindex, then remove ColumnName.
-        if (index<=_nameToColumn.size() ){
+    public void removeColumn(int index) {
+        // if index = cellindex, then remove ColumnName.
+        if (index <= _nameToColumn.size()) {
             Iterator<Map.Entry<String, Column>> iterator = _nameToColumn.entrySet().iterator();
-            while(iterator.hasNext()){
+            while (iterator.hasNext()) {
                 Map.Entry<String, Column> next = iterator.next();
                 String key = next.getKey();
                 Column column = _nameToColumn.get(key);
                 int cellIndex = column.getCellIndex();
-                if(cellIndex == index){
+                if (cellIndex == index) {
                     columns.remove(column);
                 }
             }

--- a/modules/core/src/main/java/com/google/refine/model/ColumnModel.java
+++ b/modules/core/src/main/java/com/google/refine/model/ColumnModel.java
@@ -36,14 +36,7 @@ package com.google.refine.model;
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -311,4 +304,22 @@ public class ColumnModel {
             column.clearPrecomputes();
         }
     }
+
+    public void removeColumn(int index)  {
+        //if index = cellindex, then remove ColumnName.
+        if (index<=_nameToColumn.size() ){
+            Iterator<Map.Entry<String, Column>> iterator = _nameToColumn.entrySet().iterator();
+            while(iterator.hasNext()){
+                Map.Entry<String, Column> next = iterator.next();
+                String key = next.getKey();
+                Column column = _nameToColumn.get(key);
+                int cellIndex = column.getCellIndex();
+                if(cellIndex == index){
+                    columns.remove(column);
+                }
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
Fixes #1750 
Changes proposed in this pull request:
-  Determine whether a column is blank: (based on https://github.com/OpenRefine/OpenRefine/pull/3497): Create a new list<Boolean> in the TabularImportingParserBase class, that represents whether each column has data.
-  If the store blank column is false, delete this column (only happens when store blank column == false): removeColumn method is created in the ColumnModel class. This will use columns.remove(all empty columns), which will remove both data lines and header lines. 
- The checkbox of the store blank column added to the front-end page. After testing with real files (csv, xls, tsv), this function works. I think it should work on other Tabular files as well, since I'm optimizing directly in the TabularImportingParserBase class. But I'm not really sure how to test in TabularImportingParserBase directly. In addition, I've tested tree files (xml, json), and now it is possible to do blank columns. So I didn't make changes.
