### PR TITLE
build(webapp): bump underscore from 1.51 to 1.13.2

### DIFF
--- a/main/webapp/package.json
+++ b/main/webapp/package.json
@@ -13,7 +13,7 @@
     "moment": "2.19.2",
     "select2": "3.5.2-browserify",
     "tablesorter": "2.29.0",
-    "underscore": "1.5.1"
+    "underscore": "1.13.2"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Updating underscore dependency (low-risk upgrade since it's only used in two places).