### PR TITLE
Improved the UI for the select Wikibase instance dialog.

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.html
@@ -4,9 +4,9 @@
     <p bind="explainSelectWikibase"></p>
     <p bind="currentSelectedWikibase"></p>
     <div class="wikibase-list-wrapper">
-      <table class="wikibase-dialog-wikibase-list" bind="wikibaseList">
+      <ol class="wikibase-list" bind="wikibaseList">
         <!-- dynamically generated -->
-      </table>
+      </ol>
     </div>
   </div>
   <div class="dialog-footer" bind="dialogFooter">

--- a/extensions/wikidata/module/scripts/dialogs/wikibase-item.html
+++ b/extensions/wikidata/module/scripts/dialogs/wikibase-item.html
@@ -1,0 +1,8 @@
+<li bind="wikibaseItem">
+    <img src="" alt="" bind="wikibaseImage"/>
+    <div class="wikibase-info">
+        <span class="wikibase-name" bind="wikibaseName"></span>
+        <span class="wikibase-url" bind="wikibaseUrl"></span>
+    </div>
+    <a class="ui-icon ui-icon-trash" bind="deleteWikibase"></a>
+</li>

--- a/extensions/wikidata/module/scripts/wikibase-manager.js
+++ b/extensions/wikidata/module/scripts/wikibase-manager.js
@@ -156,6 +156,16 @@ WikibaseManager.getAllWikibases = function () {
   return WikibaseManager.wikibases;
 };
 
+WikibaseManager.getAllWikibaseManifests = function () {
+  let manifests = [];
+  for (let wikibaseName in WikibaseManager.wikibases) {
+    if (WikibaseManager.wikibases.hasOwnProperty(wikibaseName)) {
+      manifests.push(WikibaseManager.wikibases[wikibaseName])
+    }
+  }
+  return manifests;
+};
+
 WikibaseManager.addWikibase = function (manifest) {
   WikibaseManager.wikibases[manifest.mediawiki.name] = manifest;
   WikibaseManager.saveWikibases();
@@ -167,12 +177,7 @@ WikibaseManager.removeWikibase = function (wikibaseName) {
 };
 
 WikibaseManager.saveWikibases = function () {
-  let manifests = [];
-  for (let wikibaseName in WikibaseManager.wikibases) {
-    if (WikibaseManager.wikibases.hasOwnProperty(wikibaseName)) {
-      manifests.push(WikibaseManager.wikibases[wikibaseName])
-    }
-  }
+  let manifests = WikibaseManager.getAllWikibaseManifests();
 
   Refine.wrapCSRF(function (token) {
     $.ajax({

--- a/extensions/wikidata/module/styles/dialogs/wikibase-dialog.less
+++ b/extensions/wikidata/module/styles/dialogs/wikibase-dialog.less
@@ -8,42 +8,65 @@
   max-height: 300px; overflow-y: auto
 }
 
-.wikibase-dialog-wikibase-list {
-  width: 100%
+.wikibase-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex-wrap: wrap;
+  padding: 0;
+  margin: 0;
 }
 
-.wikibase-dialog-wikibase-list tr:hover {
-  background: @dialog_footer;
+.wikibase-list li {
+  display: flex;
+  flex-direction: row;
+  flex-basis: fit-content;
+  align-items: center;
   cursor: pointer;
+  padding: 5px;
+  margin: 5px;
 }
 
-.wikibase-dialog-wikibase-list tr td {
-  padding: 10px;
+.wikibase-list li.selected {
+  background: #bcf;
+  font-weight: bold;
 }
 
-.wikibase-dialog-selector-remove {
-  float: right;
-  position: relative;
-  width: 12px;
-  height: 12px;
-  text-decoration: none;
-  background-image: url(../../images/close-map.png);
-  background-repeat: no-repeat;
-  background-position: 0px 0px;
-}
-.wikibase-dialog-selector-remove:hover {
-  background-position: -12px 0px;
-}
-
-.wikibase-dialog-selector-remove.wikibase-selected:hover {
-  cursor: not-allowed;
-}
-
-.wikibase-dialog-wikibase-logo {
-  width: 12%;
-}
-
-.wikibase-dialog-wikibase-logo img{
+.wikibase-list li img {
+  flex: 0 0;
   max-height: 60px;
   max-width: 60px;
+}
+
+.wikibase-list .wikibase-info {
+  display: flex;
+  flex: 1 1;
+  flex-direction: column;
+  padding: 5px;
+}
+
+.wikibase-list li.selected .wikibase-name {
+  font-weight: bold;
+}
+
+.wikibase-list .wikibase-name {
+  padding: 3px;
+}
+
+.wikibase-list .wikibase-url {
+  padding-left: 13px;
+  color: gray;
+}
+
+.wikibase-list li .ui-icon {
+  margin: 10px;
+  flex: 0 0 20px;
+  -ms-transform: scale(1.5); /* IE 9 */
+  -webkit-transform: scale(1.5); /* Chrome, Safari, Opera */
+  transform: scale(1.5);
+}
+
+.wikibase-list li.selected a.ui-icon-trash {
+  display:none;
 }


### PR DESCRIPTION
Fixes #3824

Changes proposed in this pull request:
* Currently selected Wikibase instance is shown at the top of the list and shown selected.
* Remaining Wikibase instances are shown in alphabetical order.
* Selecting/Adding/Deleting a Wikibase instance updates the list.
* Wikibase URL (mediawiki.root) is shown under the name for each Wikibase.
* Delete icon changed to jquery ui-trash-icon

![image](https://user-images.githubusercontent.com/42903164/163655797-7fd40e22-c106-4d5b-88d1-070009211eed.png)
