### PR TITLE
Closes #4080

### DIFF
--- a/extensions/database/src/com/google/refine/extension/database/mariadb/MariaDBDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/mariadb/MariaDBDatabaseService.java
@@ -80,10 +80,9 @@ public class MariaDBDatabaseService extends DatabaseService {
    
     @Override
     public DatabaseInfo executeQuery(DatabaseConfiguration dbConfig, String query) throws DatabaseServiceException{
-        try {
-                Connection connection = MariaDBConnectionManager.getInstance().getConnection(dbConfig, false);
-                Statement statement = connection.createStatement();
-                ResultSet queryResult = statement.executeQuery(query);
+        Connection connection = MariaDBConnectionManager.getInstance().getConnection(dbConfig, false);
+        try(Statement statement = connection.createStatement();
+            ResultSet queryResult = statement.executeQuery(query)) {
                 MariaDbResultSetMetaData metadata = (MariaDbResultSetMetaData)queryResult.getMetaData();
                 int columnCount = metadata.getColumnCount();
                 ArrayList<DatabaseColumn> columns = new ArrayList<DatabaseColumn>(columnCount);
@@ -151,10 +150,9 @@ public class MariaDBDatabaseService extends DatabaseService {
 
     @Override
     public ArrayList<DatabaseColumn> getColumns(DatabaseConfiguration dbConfig, String query) throws DatabaseServiceException{
-        try {
-            Connection connection = MariaDBConnectionManager.getInstance().getConnection(dbConfig, true);
-            Statement statement = connection.createStatement();
-            ResultSet queryResult = statement.executeQuery(query);
+        Connection connection = MariaDBConnectionManager.getInstance().getConnection(dbConfig, true);
+        try(Statement statement = connection.createStatement();
+            ResultSet queryResult = statement.executeQuery(query)) {
             MariaDbResultSetMetaData metadata = (MariaDbResultSetMetaData) queryResult.getMetaData();
             int columnCount = metadata.getColumnCount();
             ArrayList<DatabaseColumn> columns = new ArrayList<DatabaseColumn>(columnCount);
@@ -173,10 +171,9 @@ public class MariaDBDatabaseService extends DatabaseService {
     @Override
     public List<DatabaseRow> getRows(DatabaseConfiguration dbConfig, String query)
             throws DatabaseServiceException {
-        try {
-                Connection connection = MariaDBConnectionManager.getInstance().getConnection(dbConfig, false);
-                Statement statement = connection.createStatement();
-                ResultSet queryResult = statement.executeQuery(query);
+        Connection connection = MariaDBConnectionManager.getInstance().getConnection(dbConfig, false);
+        try(Statement statement = connection.createStatement();
+            ResultSet queryResult = statement.executeQuery(query)) {
                 MariaDbResultSetMetaData metadata = (MariaDbResultSetMetaData)queryResult.getMetaData();
                 int columnCount = metadata.getColumnCount();
                 int index = 0; 


### PR DESCRIPTION
Fixes #4080.

Changes proposed in this pull request:
- Use try-with-resources in MariaDBDatabaseService.java to make sure that Statement and ResultSet resources are getting property closed.