### PR TITLE
build(webapp): bump moment from 2.19.2 to 2.29.3

### DIFF
--- a/main/webapp/package.json
+++ b/main/webapp/package.json
@@ -10,7 +10,7 @@
     "jquery": "1.12.4",
     "jquery-migrate": "1.4.1",
     "js-cookie": "2.2.1",
-    "moment": "2.19.2",
+    "moment": "2.29.3",
     "select2": "3.5.2-browserify",
     "tablesorter": "2.29.0",
     "underscore": "1.5.1"


### PR DESCRIPTION
Low-risk upgrade for the moment dependency, as it is only used in one place (the open project UI):

![image](https://user-images.githubusercontent.com/42903164/164168650-4425f1bb-e136-4194-9657-22b37523c943.png)

