### PR TITLE
build(webapp): bump tablesorter from 2.29.0 to 2.31.3

### DIFF
--- a/main/webapp/package.json
+++ b/main/webapp/package.json
@@ -12,7 +12,7 @@
     "js-cookie": "2.2.1",
     "moment": "2.19.2",
     "select2": "3.5.2-browserify",
-    "tablesorter": "2.29.0",
+    "tablesorter": "2.31.3",
     "underscore": "1.13.2"
   },
   "devDependencies": {}


### PR DESCRIPTION
Low-risk upgrade for the tablesorter dependency, as it is only used in one place (the open project UI):

![image](https://user-images.githubusercontent.com/42903164/164168724-dd2a8707-445d-4986-8311-cfedb38687c6.png)
