### PR TITLE
Replaced usage of removed load method for jQuery

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/scatterplot-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/scatterplot-dialog.js
@@ -202,7 +202,7 @@ ScatterplotDialog.prototype._renderMatrix = function() {
                 if (src2) {
                     img.attr("src", src2);
                     img.removeAttr("src2");
-                    img.load(function() {
+                    img.on("load", function() {
                         data.batch++;
                         if (data.batch == data.batch_size) {
                             load_images(data);


### PR DESCRIPTION
Migrating code step-by-step to prepare for the upgrade to jQuery 3.6.0

Most of the migration required for the jQuery upgrade can be done while still on the current jquery 1.12.4, so the plan is to incrementally migrate the code while on the old version, and then do the final changes to upgrade to jquery 3.6.0.  This will make the process more manageable and less risky.

In This PR: Replaced jquery API load(function) call which is removed in the latest version.