### PR TITLE
Updated textarea closing tags for jQuery 3.6.0 support

### DIFF
--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -278,7 +278,7 @@ Cypress.Commands.add('waitForOrOperation', () => {
 Cypress.Commands.add('waitForImportUpdate', () => {
   cy.get('#or-import-updating').should('be.visible');
   cy.get('#or-import-updating').should('not.be.visible');
-  cy.wait(1000); // eslint-disable-line
+  cy.wait(1500); // eslint-disable-line
 });
 
 /**

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -278,7 +278,7 @@ Cypress.Commands.add('waitForOrOperation', () => {
 Cypress.Commands.add('waitForImportUpdate', () => {
   cy.get('#or-import-updating').should('be.visible');
   cy.get('#or-import-updating').should('not.be.visible');
-  cy.wait(500); // eslint-disable-line
+  cy.wait(1000); // eslint-disable-line
 });
 
 /**

--- a/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.html
@@ -5,7 +5,7 @@
     <td colspan="2"><select bind="expressionPreviewLanguageSelect">$LANGUAGE_OPTIONS$</select></td>
   </tr>
   <tr>
-    <td colspan="3"><div class="input-container"><textarea class="expression-preview-code" bind="expressionPreviewTextarea" spellcheck="false" /></div></td>
+    <td colspan="3"><div class="input-container"><textarea class="expression-preview-code" bind="expressionPreviewTextarea" spellcheck="false"></textarea></div></td>
     <td class="expression-preview-parsing-status" bind="expressionPreviewParsingStatus" width="150" style="vertical-align: top;"></td>
   </tr>
   <tr>

--- a/main/webapp/modules/core/scripts/facets/list-facet.js
+++ b/main/webapp/modules/core/scripts/facets/list-facet.js
@@ -228,7 +228,7 @@ class ListFacet extends Facet {
     var body = $('<div></div>').addClass("dialog-body").appendTo(frame);
     var footer = $('<div></div>').addClass("dialog-footer").appendTo(frame);
 
-    body.html('<textarea disabled wrap="off" bind="textarea" style="display: block; width: 100%; height: 400px;" />');
+    body.html('<textarea disabled wrap="off" bind="textarea" style="display: block; width: 100%; height: 400px;"></textarea>');
     var elmts = DOM.bind(body);
 
     $('<button class="button"></button>').text($.i18n('core-buttons/close')).click(function() {
@@ -521,7 +521,7 @@ class ListFacet extends Facet {
 
     var menu = MenuSystem.createMenu().addClass("data-table-cell-editor").width("400px");
     menu.html(
-        '<textarea class="data-table-cell-editor-editor" bind="textarea" />' +
+        '<textarea class="data-table-cell-editor-editor" bind="textarea"></textarea>' +
         '<div id="data-table-cell-editor-actions">' +
           '<div class="data-table-cell-editor-action">' +
             '<button class="button" bind="okButton">'+$.i18n('core-buttons/apply')+'</button>' +

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -3,7 +3,7 @@
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body" bind="dialogBody">
       <div class="dialog-instruction" bind="or_proj_pasteJson"></div>  
-      <div class="input-container"><textarea spellcheck="false" wrap="off" bind="textarea" class="history-operation-json" /></div>
+      <div class="input-container"><textarea spellcheck="false" wrap="off" bind="textarea" class="history-operation-json"></textarea></div>
     </div>
     <div class="dialog-footer" bind="dialogFooter">
     <button class="button" bind="applyButton"></button>

--- a/main/webapp/modules/core/scripts/project/history-extract-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-extract-dialog.html
@@ -11,7 +11,7 @@
         <tr>
           <td width="50%" style="vertical-align: top"><div class="history-extract-dialog-panel"><table class="history-extract-dialog-entries" bind="entryTable"></table></div></td>
           <td width="50%" rowspan="2" style="vertical-align: top">
-              <div class="input-container"><textarea spellcheck="false" wrap="off" class="history-operation-json" bind="textarea" /></div>
+              <div class="input-container"><textarea spellcheck="false" wrap="off" class="history-operation-json" bind="textarea"></textarea></div>
           </td>
         </tr>
         <tr>

--- a/main/webapp/modules/core/scripts/views/data-table/cell-editor.html
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-editor.html
@@ -6,7 +6,7 @@
     <option value="date" bind="or_views_date"></option>
   </select>
 
-<textarea class="data-table-cell-editor-editor" bind="textarea" />
+  <textarea class="data-table-cell-editor-editor" bind="textarea"></textarea>
 
 <div id="data-table-cell-editor-actions">
   <div class="data-table-cell-editor-action">


### PR DESCRIPTION
Changes proposed in this pull request:
- Made textarea closing tags explicit for jQuery 3.6.0 support.
- Increased the wait from 500ms to 1500ms on a flaky test.