### PR TITLE
Migrate jQuery deprecated functions

### DIFF
--- a/extensions/database/module/scripts/index/database-import-controller.js
+++ b/extensions/database/module/scripts/index/database-import-controller.js
@@ -160,7 +160,7 @@ Refine.DatabaseImportController.prototype._showParsingPanel = function() {
     this._parsingPanelElmts.database_disable_auto_preview.text($.i18n('database-parsing/disable-auto-preview'));
 
     if (this._parsingPanelResizer) {
-      $(window).unbind('resize', this._parsingPanelResizer);
+      $(window).off('resize', this._parsingPanelResizer);
     }
 
     this._parsingPanelResizer = function() {
@@ -188,10 +188,10 @@ Refine.DatabaseImportController.prototype._showParsingPanel = function() {
       .css("height", (controlPanelHeight - DOM.getVPaddings(elmts.controlPanel)) + "px");
     };
 
-    $(window).resize(this._parsingPanelResizer);
+    $(window).on('resize',this._parsingPanelResizer);
     this._parsingPanelResizer();
 
-    this._parsingPanelElmts.startOverButton.click(function() {
+    this._parsingPanelElmts.startOverButton.on('click',function() {
       // explicitly cancel the import job
       Refine.CreateProjectUI.cancelImportingJob(self._jobID);
 

--- a/extensions/database/module/scripts/index/database-source-ui.js
+++ b/extensions/database/module/scripts/index/database-source-ui.js
@@ -94,7 +94,7 @@ Refine.DatabaseSourceUI.prototype.attachUI = function(body) {
 
   $('input#connectionName').val($.i18n('database-source/connectionNameDefaultValue'));
 
-  this._elmts.newConnectionButton.click(function(evt) {
+  this._elmts.newConnectionButton.on('click',function(evt) {
       self._resetDatabaseImportForm();
       $( "#newConnectionDiv" ).show();
       $( "#sqlEditorDiv" ).hide();
@@ -102,7 +102,7 @@ Refine.DatabaseSourceUI.prototype.attachUI = function(body) {
     //   self._body.find('.sqlEditorDiv').hide();
   });
   
-  this._elmts.databaseTypeSelect.change(function(event) {
+  this._elmts.databaseTypeSelect.on('change',function(event) {
     var type = $( "select#databaseTypeSelect" ).val();
 
     self._updateDatabaseType(type);
@@ -111,7 +111,7 @@ Refine.DatabaseSourceUI.prototype.attachUI = function(body) {
   var defaultDatabase = $( "select#databaseTypeSelect" ).val();
   self._updateDatabaseType(defaultDatabase);
 
-  this._elmts.testDatabaseButton.click(function(evt) {
+  this._elmts.testDatabaseButton.on('click',function(evt) {
       
           if(self._validateNewConnectionForm() === true){
              self._testDatabaseConnect(self._getConnectionInfo());
@@ -119,7 +119,7 @@ Refine.DatabaseSourceUI.prototype.attachUI = function(body) {
        
    });
   
-  this._elmts.databaseConnectButton.click(function(evt) {
+  this._elmts.databaseConnectButton.on('click',function(evt) {
       
       if(self._validateNewConnectionForm() === true){
              self._connect(self._getConnectionInfo());
@@ -128,7 +128,7 @@ Refine.DatabaseSourceUI.prototype.attachUI = function(body) {
    
  });
   
- this._elmts.saveConnectionButton.click(function(evt) {
+ this._elmts.saveConnectionButton.on('click',function(evt) {
       
        if(self._validateNewConnectionForm() == true){
             var connectionNameInput = $.trim(self._elmts.connectionNameInput[0].value);
@@ -142,7 +142,7 @@ Refine.DatabaseSourceUI.prototype.attachUI = function(body) {
 
  });
   
-  this._elmts.executeQueryButton.click(function(evt) {
+  this._elmts.executeQueryButton.on('click',function(evt) {
         var jdbcQueryInfo = {};
         jdbcQueryInfo.connectionName = $( "#currentConnectionNameInput" ).val();
         jdbcQueryInfo.databaseType = $( "#currentDatabaseTypeInput" ).val();
@@ -162,7 +162,7 @@ Refine.DatabaseSourceUI.prototype.attachUI = function(body) {
 
 
   
-  this._elmts.editConnectionButton.click(function(evt) {
+  this._elmts.editConnectionButton.on('click',function(evt) {
       
       if(self._validateNewConnectionForm() == true){
                var connectionNameInput = $.trim(self._elmts.connectionNameInput[0].value);
@@ -176,7 +176,7 @@ Refine.DatabaseSourceUI.prototype.attachUI = function(body) {
     
  });
   
- this._elmts.cancelEditConnectionButton.click(function(evt) {
+ this._elmts.cancelEditConnectionButton.on('click',function(evt) {
      self._resetDatabaseImportForm();
         
  });

--- a/extensions/gdata/module/scripts/index/gdata-source-ui.js
+++ b/extensions/gdata/module/scripts/index/gdata-source-ui.js
@@ -53,7 +53,7 @@ Refine.GDataSourceUI.prototype.attachUI = function(body) {
   $('#gdata-re-signin-another').text($.i18n('gdata-import/re-sign-in-another'));
   
   var self = this;
-  this._body.find('.gdata-signin.button').click(function() {
+  this._body.find('.gdata-signin.button').on('click',function() {
     GdataExtension.showAuthorizationDialog(
       function() {
         self._listDocuments();
@@ -64,13 +64,13 @@ Refine.GDataSourceUI.prototype.attachUI = function(body) {
       }
     );
   });
-  this._body.find('.gdata-signout.button').click(function() {
+  this._body.find('.gdata-signout.button').on('click',function() {
       $.get("command/gdata/deauthorize" );
       self._body.find('.gdata-page').hide();
       self._elmts.signinPage.show();
   });
   
-  this._elmts.urlNextButton.click(function(evt) {
+  this._elmts.urlNextButton.on('click',function(evt) {
     var url = $.trim(self._elmts.urlInput[0].value);
     if (url.length === 0) {
       window.alert($.i18n('gdata-source/alert-url'));

--- a/extensions/gdata/module/scripts/index/importing-controller.js
+++ b/extensions/gdata/module/scripts/index/importing-controller.js
@@ -190,7 +190,7 @@ Refine.GDataImportingController.prototype._showParsingPanel = function() {
   this._parsingPanelElmts.gdata_store_cell.html($.i18n('gdata-parsing/store-cell'));
   
   if (this._parsingPanelResizer) {
-    $(window).unbind('resize', this._parsingPanelResizer);
+    $(window).off('resize', this._parsingPanelResizer);
   }
   
   this._parsingPanelResizer = function() {
@@ -217,10 +217,10 @@ Refine.GDataImportingController.prototype._showParsingPanel = function() {
     .css("width", (width - DOM.getHPaddings(elmts.controlPanel)) + "px")
     .css("height", (controlPanelHeight - DOM.getVPaddings(elmts.controlPanel)) + "px");
   };
-  $(window).resize(this._parsingPanelResizer);
+  $(window).on('resize',this._parsingPanelResizer);
   this._parsingPanelResizer();
   
-  this._parsingPanelElmts.startOverButton.click(function() {
+  this._parsingPanelElmts.startOverButton.on('click',function() {
     // explicitly cancel the import job
     Refine.CreateProjectUI.cancelImportingJob(self._jobID);
     

--- a/extensions/pc-axis/module/scripts/pc-axis-parser-ui.js
+++ b/extensions/pc-axis/module/scripts/pc-axis-parser-ui.js
@@ -120,11 +120,11 @@ Refine.PCAxisParserUI.prototype._initialize = function() {
   this._optionContainer.unbind().empty().html(
       DOM.loadHTML("pc-axis", "scripts/pc-axis-parser-ui.html"));
   this._optionContainerElmts = DOM.bind(this._optionContainer);
-  this._optionContainerElmts.previewButton.click(function() { self._updatePreview(); });
+  this._optionContainerElmts.previewButton.on('click',function() { self._updatePreview(); });
 
   this._optionContainerElmts.encodingInput
     .val(this._config.encoding || '')
-    .click(function() {
+    .on('click',function() {
       Encoding.selectEncoding($(this), function() {
         self._updatePreview();
       });

--- a/extensions/wikidata/module/scripts/schema-alignment.js
+++ b/extensions/wikidata/module/scripts/schema-alignment.js
@@ -264,7 +264,7 @@ var beforeUnload = function(e) {
   }
 };
 
-$(window).bind('beforeunload', beforeUnload);
+$(window).on('beforeunload', beforeUnload);
 
 SchemaAlignment._reset = function(schema) {
   if (!schema) {

--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
@@ -264,7 +264,7 @@ ClusteringDialog.prototype._renderTable = function(clusters) {
                 .append(div);
 
             var editCheck = $('<input type="checkbox" />')
-                .change(function() {
+                .on('change',function() {
                     cluster.edit = this.checked;
                 }).appendTo(tr.insertCell(3));
 
@@ -569,11 +569,11 @@ ClusteringDialog.Facet = function(dialog, title, property, elmt, clusters) {
         this._histogram = new HistogramWidget(this._elmts.histogramContainer, { binColors: [ "#ccccff", "#6666ff" ] });
         this._sliderWidget = new SliderWidget(this._elmts.sliderWidgetDiv);
 
-        this._elmts.sliderWidgetDiv.bind("slide", function(evt, data) {
+        this._elmts.sliderWidgetDiv.on("slide", function(evt, data) {
             self._from = data.from;
             self._to = data.to;
             self._setRangeIndicators();
-        }).bind("stop", function(evt, data) {
+        }).on("stop", function(evt, data) {
             self._from = data.from;
             self._to = data.to;
             self._setRangeIndicators();

--- a/main/webapp/modules/core/scripts/dialogs/column-reordering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/column-reordering-dialog.js
@@ -40,10 +40,10 @@ ColumnReorderingDialog.prototype._createDialog = function() {
     var dialog = $(DOM.loadHTML("core", "scripts/dialogs/column-reordering-dialog.html"));
     this._elmts = DOM.bind(dialog);
 
-    this._elmts.removeAllButton.click(function() { self._removeAll(); });
-    this._elmts.addAllButton.click(function() { self._addAll() });
-    this._elmts.cancelButton.click(function() { self._dismiss(); });
-    this._elmts.okButton.click(function() { self._commit(); });
+    this._elmts.removeAllButton.on('click',function() { self._removeAll(); });
+    this._elmts.addAllButton.on('click',function() { self._addAll() });
+    this._elmts.cancelButton.on('click',function() { self._dismiss(); });
+    this._elmts.okButton.on('click',function() { self._commit(); });
     
     this._elmts.dialogHeader.html($.i18n('core-dialogs/reorder-column'));
     this._elmts.or_dialog_dragCol.html($.i18n('core-dialogs/drag-column'));

--- a/main/webapp/modules/core/scripts/dialogs/custom-tabular-exporter-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/custom-tabular-exporter-dialog.js
@@ -207,47 +207,47 @@ CustomTabularExporterDialog.prototype._createDialog = function(options) {
           .attr('width', '100%'));
     }
     
-    this._elmts.uploadButton.click(function() { self._upload(); });
+    this._elmts.uploadButton.on('click',function() { self._upload(); });
   }
   
   /*
    * Hook up event handlers.
    */
-  this._elmts.encodingInput.click(function(evt) {
+  this._elmts.encodingInput.on('click',function(evt) {
     Encoding.selectEncoding($(this), function() {
       self._updateOptionCode();
     });
   });
   
-  this._elmts.columnList.find('.custom-tabular-exporter-dialog-column').click(function() {
+  this._elmts.columnList.find('.custom-tabular-exporter-dialog-column').on('click',function() {
     self._elmts.columnList.find('.custom-tabular-exporter-dialog-column').removeClass('selected');
     $(this).addClass('selected');
     self._selectColumn(this.getAttribute('column'));
     self._updateOptionCode();
   });
-  this._elmts.selectAllButton.click(function() {
+  this._elmts.selectAllButton.on('click',function() {
     self._elmts.columnList.find('input[type="checkbox"]').prop('checked', true);
     self._updateOptionCode();
   });
-  this._elmts.deselectAllButton.click(function() {
+  this._elmts.deselectAllButton.on('click',function() {
     self._elmts.columnList.find('input[type="checkbox"]').prop('checked', false);
     self._updateOptionCode();
   });
   
-  this._elmts.columnOptionPane.find('input').bind('change', function() {
+  this._elmts.columnOptionPane.find('input').on('change', function() {
     self._updateCurrentColumnOptions();
   });
-  $('#custom-tabular-exporter-tabs-content').find('input').bind('change', function() {
+  $('#custom-tabular-exporter-tabs-content').find('input').on('change', function() {
     self._updateOptionCode();
   });
-  $('#custom-tabular-exporter-tabs-download').find('input').bind('change', function() {
+  $('#custom-tabular-exporter-tabs-download').find('input').on('change', function() {
     self._updateOptionCode();
   });
   
-  this._elmts.applyOptionCodeButton.click(function(evt) { self._applyOptionCode(); });
-  this._elmts.cancelButton.click(function() { self._dismiss(); });
-  this._elmts.downloadButton.click(function() { self._download(); });
-  this._elmts.downloadPreviewButton.click(function(evt) { self._previewDownload(); });
+  this._elmts.applyOptionCodeButton.on('click',function(evt) { self._applyOptionCode(); });
+  this._elmts.cancelButton.on('click',function() { self._dismiss(); });
+  this._elmts.downloadButton.on('click',function() { self._download(); });
+  this._elmts.downloadPreviewButton.on('click',function(evt) { self._previewDownload(); });
   
   this._configureUIFromOptionCode(options);
   this._updateOptionCode();

--- a/main/webapp/modules/core/scripts/dialogs/expression-column-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-column-dialog.js
@@ -64,7 +64,7 @@ ExpressionColumnDialog.prototype._createDialog = function() {
    * Hook up event handlers.
    */
   
-  this._elmts.columnList.find('.custom-tabular-exporter-dialog-column').click(function() {
+  this._elmts.columnList.find('.custom-tabular-exporter-dialog-column').on('click',function() {
     self._elmts.columnList.find('.custom-tabular-exporter-dialog-column').removeClass('selected');
     $(this).addClass('selected');
   });

--- a/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
@@ -44,12 +44,12 @@ function ExpressionPreviewDialog(title, cellIndex, rowIndices, values, expressio
     
     this._elmts = DOM.bind(html);
     
-    $('<button class="button"></button>').html($.i18n('core-buttons/ok')).click(function() {
+    $('<button class="button"></button>').html($.i18n('core-buttons/ok')).on('click',function() {
         DialogSystem.dismissUntil(self._level - 1);
         self._onDone(self._previewWidget.getExpression(true));
     }).appendTo(footer);
     
-    $('<button class="button"></button>').text($.i18n('core-buttons/cancel')).click(function() {
+    $('<button class="button"></button>').text($.i18n('core-buttons/cancel')).on('click',function() {
         DialogSystem.dismissUntil(self._level - 1);
     }).appendTo(footer);
     
@@ -119,7 +119,7 @@ ExpressionPreviewDialog.Widget = function(
     $("#expression-preview-tabs").tabs();
     
     this._elmts.expressionPreviewLanguageSelect[0].value = language;
-    this._elmts.expressionPreviewLanguageSelect.bind("change", function() {
+    this._elmts.expressionPreviewLanguageSelect.on("change", function() {
         Cookies.set("scripting.lang", this.value, {"SameSite" : "Lax"});
         self.update();
     });
@@ -127,11 +127,11 @@ ExpressionPreviewDialog.Widget = function(
     var self = this;
     this._elmts.expressionPreviewTextarea
         .val(this.expression)
-        .bind("keyup change input",function(){
+        .on("keyup change input",function(){
             self._scheduleUpdate();
         })
-        .select()
-        .focus();
+        .trigger('select')
+        .trigger('focus');
 
     this._elmts.or_dialog_expr.html($.i18n('core-dialogs/expression'));
     this._elmts.or_dialog_lang.html($.i18n('core-dialogs/language'));
@@ -284,7 +284,7 @@ ExpressionPreviewDialog.Widget.prototype._renderExpressionHistory = function(dat
         $('<a href="javascript:{}">&nbsp;</a>')
                 .addClass(entry.starred ? "data-table-star-on" : "data-table-star-off")
                 .appendTo(tr.insertCell(0))
-                .click(function() {
+                .on('click',function() {
                     Refine.postCSRF(
                         "command/core/toggle-starred-expression",
                         {
@@ -299,13 +299,13 @@ ExpressionPreviewDialog.Widget.prototype._renderExpressionHistory = function(dat
                     );
                 });
         
-        $('<a href="javascript:{}">'+$.i18n('core-dialogs/reuse')+'</a>').appendTo(tr.insertCell(1)).click(function() {
+        $('<a href="javascript:{}">'+$.i18n('core-dialogs/reuse')+'</a>').appendTo(tr.insertCell(1)).on('click',function() {
             self._elmts.expressionPreviewTextarea[0].value = o.expression;
             self._elmts.expressionPreviewLanguageSelect[0].value = o.language;
             
             $("#expression-preview-tabs").tabs();
             
-            self._elmts.expressionPreviewTextarea.select().focus();
+            self._elmts.expressionPreviewTextarea.trigger('select').trigger('focus');
             
             self.update();
         });
@@ -350,14 +350,14 @@ ExpressionPreviewDialog.Widget.prototype._renderStarredExpressions = function(da
         var tr = table.insertRow(table.rows.length);
         var o = Scripting.parse(entry.code);
         
-        $('<a href="javascript:{}">'+$.i18n('core-dialogs/remove')+'</a>').appendTo(tr.insertCell(0)).click(function() {
+        $('<a href="javascript:{}">'+$.i18n('core-dialogs/remove')+'</a>').appendTo(tr.insertCell(0)).on('click',function() {
             var removeExpression = DialogSystem.createDialog();
                 removeExpression.width("250px");
             var removeExpressionHead = $('<div></div>').addClass("dialog-header").text($.i18n('core-dialogs/unstar-expression'))
                 .appendTo(removeExpression);
             var removeExpressionFooter = $('<div></div>').addClass("dialog-footer").appendTo(removeExpression);
 
-            $('<button class="button"></button>').html($.i18n('core-buttons/ok')).click(function() {
+            $('<button class="button"></button>').html($.i18n('core-buttons/ok')).on('click',function() {
                 Refine.postCSRF(
                     "command/core/toggle-starred-expression",
                     { expression: entry.code, returnList: true },
@@ -370,20 +370,20 @@ ExpressionPreviewDialog.Widget.prototype._renderStarredExpressions = function(da
                 DialogSystem.dismissUntil(DialogSystem._layers.length - 1);
             }).appendTo(removeExpressionFooter);
 
-            $('<button class="button" style="float:right;"></button>').text($.i18n('core-buttons/cancel')).click(function() {
+            $('<button class="button" style="float:right;"></button>').text($.i18n('core-buttons/cancel')).on('click',function() {
                 DialogSystem.dismissUntil(DialogSystem._layers.length - 1);
             }).appendTo(removeExpressionFooter);
 
             this._level = DialogSystem.showDialog(removeExpression);
         });
         
-        $('<a href="javascript:{}">Reuse</a>').appendTo(tr.insertCell(1)).click(function() {
+        $('<a href="javascript:{}">Reuse</a>').appendTo(tr.insertCell(1)).on('click',function() {
             self._elmts.expressionPreviewTextarea[0].value = o.expression;
             self._elmts.expressionPreviewLanguageSelect[0].value = o.language;
             
             $("#expression-preview-tabs").tabs();
             
-            self._elmts.expressionPreviewTextarea.select().focus();
+            self._elmts.expressionPreviewTextarea.trigger('select').trigger('focus');
             
             self.update();
         });

--- a/main/webapp/modules/core/scripts/dialogs/scatterplot-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/scatterplot-dialog.js
@@ -46,7 +46,7 @@ ScatterplotDialog.prototype._createDialog = function() {
             $.i18n('core-dialogs/scatterplot-matrix') + 
             ((typeof this._column == "undefined") ? "" : $.i18n('core-dialogs/focusing-on-column', this._column)));
 
-    this._elmts.closeButton.click(function() { self._dismiss(); });
+    this._elmts.closeButton.on('click',function() { self._dismiss(); });
     this._elmts.or_dialog_linplot.attr("title", $.i18n('core-dialogs/linear-plot'));
     this._elmts.or_dialog_logplot.attr("title", $.i18n('core-dialogs/logarithmic-plot'));
     this._elmts.or_dialog_counter.attr("title", $.i18n('core-dialogs/rotated-counter-clock'));
@@ -57,17 +57,17 @@ ScatterplotDialog.prototype._createDialog = function() {
     this._elmts.or_dialog_bigDot.attr("title", $.i18n('core-dialogs/big-dot'));
     this._elmts.closeButton.text($.i18n('core-buttons/close'));
     
-    this._elmts.plotSelector.buttonset().change(function() {
+    this._elmts.plotSelector.buttonset().on('change',function() {
         self._plot_method = $(this).find("input:checked").val();
         self._renderMatrix();
     });
 
-    this._elmts.rotationSelector.buttonset().change(function() {
+    this._elmts.rotationSelector.buttonset().on('change',function() {
         self._rotation = $(this).find("input:checked").val();
         self._renderMatrix();
     });
     
-    this._elmts.dotSelector.buttonset().change(function() {
+    this._elmts.dotSelector.buttonset().on('change',function() {
         var dot_size = $(this).find("input:checked").val();
         if (dot_size == "small") {
             self._dot_size = 0.4;
@@ -169,7 +169,7 @@ ScatterplotDialog.prototype._renderMatrix = function() {
             var width = container.width();
             container.empty().css("width", width + "px").html(table);
             
-            container.find("a").click(function() {
+            container.find("a").on('click',function() {
                 var options = {
                     "name" : $(this).attr("title"),
                     "cx" : $(this).attr("cx"), 

--- a/main/webapp/modules/core/scripts/dialogs/sql-exporter-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/sql-exporter-dialog.js
@@ -229,7 +229,7 @@ function SqlExporterDialog(options) {
           };
     }
    
-    this._elmts.allowNullToggleCheckbox.click(function() {
+    this._elmts.allowNullToggleCheckbox.on('click',function() {
         if(this.checked){
             $("input:checkbox[class=allowNullCheckboxStyle]").each(function () {
                 $(this).prop('checked', true);
@@ -249,32 +249,32 @@ function SqlExporterDialog(options) {
         
     });
     
-    this._elmts.selectAllButton.click(function() {
+    this._elmts.selectAllButton.on('click',function() {
        $("input:checkbox[class=columnNameCheckboxStyle]").each(function () {
            $(this).prop('checked', true);
         });
       self._updateOptionCode();
     });
-    this._elmts.deselectAllButton.click(function() {
+    this._elmts.deselectAllButton.on('click',function() {
         $("input:checkbox[class=columnNameCheckboxStyle]").each(function () {
            $(this).prop('checked', false);
         });
        self._updateOptionCode();
     });
 
-    this._elmts.includeStructureCheckbox.click(function() {
+    this._elmts.includeStructureCheckbox.on('click',function() {
         $('#includeDropStatementCheckboxId').prop("disabled", !this.checked);
         $('#includeIfExistDropStatementCheckboxId').prop("disabled", !this.checked);
     });
     
-    this._elmts.includeContentCheckbox.click(function() {
+    this._elmts.includeContentCheckbox.on('click',function() {
         $('#nullCellValueToEmptyStringCheckboxId').prop("disabled", !this.checked);
     });
     
 
-    this._elmts.cancelButton.click(function() { self._dismiss(); });
-    this._elmts.downloadButton.click(function() { self._download(); });
-    this._elmts.downloadPreviewButton.click(function(evt) { self._previewDownload(); });
+    this._elmts.cancelButton.on('click',function() { self._dismiss(); });
+    this._elmts.downloadButton.on('click',function() { self._download(); });
+    this._elmts.downloadPreviewButton.on('click',function(evt) { self._previewDownload(); });
     this._configureUIFromOptionCode(options);
     this._updateOptionCode();
   };

--- a/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.js
@@ -41,7 +41,7 @@ TemplatingExporterDialog.prototype._createDialog = function() {
     var self = this;
     var dialog = $(DOM.loadHTML("core", "scripts/dialogs/templating-exporter-dialog.html"));
     this._elmts = DOM.bind(dialog);
-    this._elmts.controls.find("textarea").bind("keyup change input",function() { self._scheduleUpdate(); });
+    this._elmts.controls.find("textarea").on("keyup change input",function() { self._scheduleUpdate(); });
     
     this._elmts.dialogHeader.html($.i18n('core-dialogs/template-export'));
     this._elmts.or_dialog_prefix.html($.i18n('core-dialogs/template-prefix'));
@@ -52,9 +52,9 @@ TemplatingExporterDialog.prototype._createDialog = function() {
     this._elmts.exportButton.html($.i18n('core-buttons/export'));
     this._elmts.cancelButton.html($.i18n('core-buttons/cancel'));
     
-    this._elmts.exportButton.click(function() { self._export(); self._dismiss(); });
-    this._elmts.cancelButton.click(function() { self._dismiss(); });
-    this._elmts.resetButton.click(function() {
+    this._elmts.exportButton.on('click',function() { self._export(); self._dismiss(); });
+    this._elmts.cancelButton.on('click',function() { self._dismiss(); });
+    this._elmts.resetButton.on('click',function() {
         self._fillInTemplate(self._createDefaultTemplate());
         self._updatePreview();
     });

--- a/main/webapp/modules/core/scripts/facets/list-facet.js
+++ b/main/webapp/modules/core/scripts/facets/list-facet.js
@@ -172,7 +172,7 @@ class ListFacet extends Facet {
     this._elmts = DOM.bind(this._div);
 
     this._elmts.titleSpan.text(this._config.name);
-    this._elmts.changeButton.attr("title",$.i18n('core-facets/current-exp')+": " + this._config.expression).click(function() {
+    this._elmts.changeButton.attr("title",$.i18n('core-facets/current-exp')+": " + this._config.expression).on('click',function() {
       self._elmts.expressionDiv.slideToggle(100, function() {
         if (self._elmts.expressionDiv.css("display") != "none") {
           self._editExpression();
@@ -180,21 +180,21 @@ class ListFacet extends Facet {
       });
     });
     
-    this._elmts.expressionDiv.text(this._config.expression).hide().click(function() { self._editExpression(); });
-    this._elmts.removeButton.click(function() { self._remove(); });
-    this._elmts.minimizeButton.click(function() { self._minimize(); });
-    this._elmts.resetButton.click(function() { self._reset(); });
-    this._elmts.invertButton.click(function() { self._invert(); });
+    this._elmts.expressionDiv.text(this._config.expression).hide().on('click',function() { self._editExpression(); });
+    this._elmts.removeButton.on('click',function() { self._remove(); });
+    this._elmts.minimizeButton.on('click',function() { self._minimize(); });
+    this._elmts.resetButton.on('click',function() { self._reset(); });
+    this._elmts.invertButton.on('click',function() { self._invert(); });
 
-    this._elmts.choiceCountContainer.click(function() { self._copyChoices(); });
-    this._elmts.sortByCountLink.click(function() {
+    this._elmts.choiceCountContainer.on('click',function() { self._copyChoices(); });
+    this._elmts.sortByCountLink.on('click',function() {
       if (self._options.sort != "count") {
         self._options.sort = "count";
         self._reSortChoices();
         self._update(true);
       }
     });
-    this._elmts.sortByNameLink.click(function() {
+    this._elmts.sortByNameLink.on('click',function() {
       if (self._options.sort != "name") {
         self._options.sort = "name";
         self._reSortChoices();
@@ -202,7 +202,7 @@ class ListFacet extends Facet {
       }
     });
 
-    this._elmts.clusterLink.click(function() { self._doEdit(); });
+    this._elmts.clusterLink.on('click',function() { self._doEdit(); });
     if (this._config.expression != "value" && this._config.expression != "grel:value") {
       this._elmts.clusterLink.hide();
     }
@@ -231,7 +231,7 @@ class ListFacet extends Facet {
     body.html('<textarea disabled wrap="off" bind="textarea" style="display: block; width: 100%; height: 400px;"></textarea>');
     var elmts = DOM.bind(body);
 
-    $('<button class="button"></button>').text($.i18n('core-buttons/close')).click(function() {
+    $('<button class="button"></button>').text($.i18n('core-buttons/close')).on('click',function() {
       DialogSystem.dismissUntil(level - 1);
     }).appendTo(footer);
 
@@ -487,7 +487,7 @@ class ListFacet extends Facet {
     .addClass("action")
     .addClass("secondary")
     .appendTo(bodyControls)
-    .click(function() {
+    .on('click',function() {
       ui.browsingEngine.addFacet(
         "range", 
         {
@@ -595,10 +595,10 @@ class ListFacet extends Facet {
       );            
     };
 
-    elmts.okButton.click(commit);
+    elmts.okButton.on('click',commit);
     elmts.textarea
     .text(originalContent)
-    .keydown(function(evt) {
+    .on('keydown',function(evt) {
       if (!evt.shiftKey) {
         if (evt.keyCode === 13) {
           commit();
@@ -607,10 +607,10 @@ class ListFacet extends Facet {
         }
       }
     })
-    .select()
-    .focus();
+    .trigger('select')
+    .trigger('focus');
 
-    elmts.cancelButton.click(function() {
+    elmts.cancelButton.on('click',function() {
       MenuSystem.dismissAll();
     });
   };

--- a/main/webapp/modules/core/scripts/facets/range-facet.js
+++ b/main/webapp/modules/core/scripts/facets/range-facet.js
@@ -153,33 +153,33 @@ class RangeFacet extends Facet {
     this._elmts = DOM.bind(this._div);
 
     this._elmts.facetTitle.text(this._config.name);
-    this._elmts.changeButton.attr("title",$.i18n('core-facets/current-expression')+": " + this._config.expression).click(function() {
+    this._elmts.changeButton.attr("title",$.i18n('core-facets/current-expression')+": " + this._config.expression).on('click',function() {
       self._elmts.expressionDiv.slideToggle(100, function() {
         if (self._elmts.expressionDiv.css("display") != "none") {
           self._editExpression();
         }
       });
     });
-    this._elmts.expressionDiv.text(this._config.expression).click(function() { 
+    this._elmts.expressionDiv.text(this._config.expression).on('click',function() { 
       self._editExpression(); 
     }).hide();
 
-    this._elmts.resetButton.click(function() {
+    this._elmts.resetButton.on('click',function() {
       self.reset();
       self._updateRest();
     });
     
-    this._elmts.removeButton.click(function() { self._remove(); });
-    this._elmts.minimizeButton.click(function() { self._minimize(); });
+    this._elmts.removeButton.on('click',function() { self._remove(); });
+    this._elmts.minimizeButton.on('click',function() { self._minimize(); });
 
     this._histogram = new HistogramWidget(this._elmts.histogramDiv, { binColors: [ "#bbccff", "#88aaee" ] });
     this._sliderWidget = new SliderWidget(this._elmts.sliderWidgetDiv);
 
-    this._elmts.sliderWidgetDiv.bind("slide", function(evt, data) {
+    this._elmts.sliderWidgetDiv.on("slide", function(evt, data) {
       self._from = data.from;
       self._to = data.to;
       self._setRangeIndicators();
-    }).bind("stop", function(evt, data) {
+    }).on("stop", function(evt, data) {
       self._from = data.from;
       self._to = data.to;
       self._selectNumeric = true;
@@ -202,7 +202,7 @@ class RangeFacet extends Facet {
     // ----------------- numeric -----------------
 
     var numericDiv = $('<div class="facet-range-item"></div>').appendTo(choices);
-    var numericCheck = $('<input type="checkbox" />').attr("id",facet_id + "-numeric").appendTo(numericDiv).change(function() {
+    var numericCheck = $('<input type="checkbox" />').attr("id",facet_id + "-numeric").appendTo(numericDiv).on('change',function() {
       self._selectNumeric = !self._selectNumeric;
       self._updateRest();
     });
@@ -215,7 +215,7 @@ class RangeFacet extends Facet {
     // ----------------- non-numeric -----------------
 
     var nonNumericDiv = $('<div class="facet-range-item"></div>').appendTo(choices);    
-    var nonNumericCheck = $('<input type="checkbox" />').attr("id",facet_id + "-non-numeric").appendTo(nonNumericDiv).change(function() {
+    var nonNumericCheck = $('<input type="checkbox" />').attr("id",facet_id + "-non-numeric").appendTo(nonNumericDiv).on('change',function() {
       self._selectNonNumeric = !self._selectNonNumeric;
       self._updateRest();
     });
@@ -230,7 +230,7 @@ class RangeFacet extends Facet {
     // ----------------- blank -----------------
 
     var blankDiv = $('<div class="facet-range-item"></div>').appendTo(choices);        
-    var blankCheck = $('<input type="checkbox" />').attr("id",facet_id + "-blank").appendTo(blankDiv).change(function() {
+    var blankCheck = $('<input type="checkbox" />').attr("id",facet_id + "-blank").appendTo(blankDiv).on('change',function() {
       self._selectBlank = !self._selectBlank;
       self._updateRest();
     });
@@ -245,7 +245,7 @@ class RangeFacet extends Facet {
     // ----------------- error -----------------
 
     var errorDiv = $('<div class="facet-range-item"></div>').appendTo(choices);
-    var errorCheck = $('<input type="checkbox" />').attr("id",facet_id + "-error").appendTo(errorDiv).change(function() {
+    var errorCheck = $('<input type="checkbox" />').attr("id",facet_id + "-error").appendTo(errorDiv).on('change',function() {
       self._selectError = !self._selectError;
       self._updateRest();
     });

--- a/main/webapp/modules/core/scripts/facets/scatterplot-facet.js
+++ b/main/webapp/modules/core/scripts/facets/scatterplot-facet.js
@@ -137,10 +137,10 @@ class ScatterplotFacet extends Facet {
     this._elmts = DOM.bind(this._div);
 
     this._elmts.titleSpan.text(this._config.name);
-    this._elmts.removeButton.click(function() { self._remove(); });
-    this._elmts.minimizeButton.click(function() { self._minimize(); });
+    this._elmts.removeButton.on('click',function() { self._remove(); });
+    this._elmts.minimizeButton.on('click',function() { self._minimize(); });
     
-    this._elmts.resetButton.click(function() {
+    this._elmts.resetButton.on('click',function() {
       self.reset();
       self._updateRest();
     });
@@ -189,7 +189,7 @@ class ScatterplotFacet extends Facet {
       this._elmts.selectors.find("#" + facet_id + "-dot-regular").prop('checked', true);
     }
 
-    this._elmts.selectors.find(".scatterplot-dim-selector").change(function() {
+    this._elmts.selectors.find(".scatterplot-dim-selector").on('change',function() {
       var dim = $(this).find("input:checked").val();
       self._config.dim_x = dim;
       self._config.dim_y = dim;
@@ -198,14 +198,14 @@ class ScatterplotFacet extends Facet {
       self.changePlot();
     });
 
-    this._elmts.selectors.find(".scatterplot-rot-selector").change(function() {
+    this._elmts.selectors.find(".scatterplot-rot-selector").on('change',function() {
       self._config.r = $(this).find("input:checked").val();
       self.reset();
       self._updateRest();
       self.changePlot();        
     });
 
-    this._elmts.selectors.find(".scatterplot-dot-selector").change(function() {
+    this._elmts.selectors.find(".scatterplot-dot-selector").on('change',function() {
       var dot_size = $(this).find("input:checked").val();
       if (dot_size == "small") {
         self._config.dot = 0.4;

--- a/main/webapp/modules/core/scripts/facets/text-search-facet.js
+++ b/main/webapp/modules/core/scripts/facets/text-search-facet.js
@@ -118,18 +118,18 @@ class TextSearchFacet extends Facet {
       this._elmts.regexCheckbox.prop('checked', true);
     }
 
-    this._elmts.removeButton.click(function() { self._remove(); });
-    this._elmts.minimizeButton.click(function() { self._minimize(); });
-    this._elmts.resetButton.click(function() { self._reset(); });
-    this._elmts.invertButton.click(function() { self._invert(); });
+    this._elmts.removeButton.on('click',function() { self._remove(); });
+    this._elmts.minimizeButton.on('click',function() { self._minimize(); });
+    this._elmts.resetButton.on('click',function() { self._reset(); });
+    this._elmts.invertButton.on('click',function() { self._invert(); });
 
-    this._elmts.caseSensitiveCheckbox.bind("change", function() {
+    this._elmts.caseSensitiveCheckbox.on("change", function() {
       self._config.caseSensitive = this.checked;
       if (self._query !== null && self._query.length > 0) {
         self._scheduleUpdate();
       }
     });
-    this._elmts.regexCheckbox.bind("change", function() {
+    this._elmts.regexCheckbox.on("change", function() {
       self._config.mode = this.checked ? "regex" : "text";
       if (self._query !== null && self._query.length > 0) {
         self._scheduleUpdate();
@@ -140,14 +140,14 @@ class TextSearchFacet extends Facet {
       this._elmts.input[0].value = this._query;
     }
     
-    this._elmts.input.bind("keyup change input",function(evt) {
+    this._elmts.input.on("keyup change input",function(evt) {
       // Ignore events which don't change our input value
       if(this.value === self._query || this.value === '' && !self._query) {
         return;
       }
       self._query = this.value;
       self._scheduleUpdate();
-    }).focus();
+    }).trigger('focus');
 
   };
 

--- a/main/webapp/modules/core/scripts/facets/timerange-facet.js
+++ b/main/webapp/modules/core/scripts/facets/timerange-facet.js
@@ -151,7 +151,7 @@ class TimeRangeFacet extends Facet{
     this._elmts = DOM.bind(this._div);
 
     this._elmts.facetTitle.text(this._config.name);
-    this._elmts.changeButton.attr("title",$.i18n('core-facets/current-exp')+": " + this._config.expression).click(function() {
+    this._elmts.changeButton.attr("title",$.i18n('core-facets/current-exp')+": " + this._config.expression).on('click',function() {
       self._elmts.expressionDiv.slideToggle(100, function() {
         if (self._elmts.expressionDiv.css("display") != "none") {
           self._editExpression();
@@ -162,22 +162,22 @@ class TimeRangeFacet extends Facet{
       self._editExpression(); 
     }).hide();
 
-    this._elmts.resetButton.click(function() {
+    this._elmts.resetButton.on('click',function() {
       self.reset();
       self._updateRest();
     });
     
-    this._elmts.removeButton.click(function() { self._remove(); });
-    this._elmts.minimizeButton.click(function() { self._minimize(); });
+    this._elmts.removeButton.on('click',function() { self._remove(); });
+    this._elmts.minimizeButton.on('click',function() { self._minimize(); });
 
     this._histogram = new HistogramWidget(this._elmts.histogramDiv, { binColors: [ "#ccccff", "#6666ff" ] });
     this._sliderWidget = new SliderWidget(this._elmts.sliderWidgetDiv);
 
-    this._elmts.sliderWidgetDiv.bind("slide", function(evt, data) {
+    this._elmts.sliderWidgetDiv.on("slide", function(evt, data) {
       self._from = data.from;
       self._to = data.to;
       self._setRangeIndicators();
-    }).bind("stop", function(evt, data) {
+    }).on("stop", function(evt, data) {
       self._from = data.from;
       self._to = data.to;
       self._selectTime = true;

--- a/main/webapp/modules/core/scripts/index.js
+++ b/main/webapp/modules/core/scripts/index.js
@@ -211,7 +211,7 @@ $(function() {
       Refine.actionAreas[i].ui.resize();
     }
   };
-  $(window).bind("resize", resize);
+  $(window).on("resize", resize);
   window.setTimeout(resize, 100); // for Chrome, give the window some time to layout first
 
   var renderActionArea = function(actionArea) {
@@ -223,7 +223,7 @@ $(function() {
     .addClass('action-area-tab')
     .text(actionArea.label)
     .appendTo($('#action-area-tabs'))
-    .click(function() {
+    .on('click', function() {
       Refine.selectActionArea(actionArea.id);
     });
 

--- a/main/webapp/modules/core/scripts/index/create-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/create-project-ui.js
@@ -100,7 +100,7 @@ Refine.CreateProjectUI.prototype.addSourceSelectionUI = function(sourceSelection
   .addClass('create-project-ui-source-selection-tab')
   .text(sourceSelectionUI.label)
   .appendTo(headerContainer)
-  .click(function() { self.selectImportSource(sourceSelectionUI.id); });
+  .on('click',function() { self.selectImportSource(sourceSelectionUI.id); });
 
   sourceSelectionUI.ui.attachUI(sourceSelectionUI._divBody);
 
@@ -178,7 +178,7 @@ Refine.CreateProjectUI.prototype.showImportProgressPanel = function(progressMess
   $('#create-project-progress-message-right').empty();
   $('#create-project-progress-timing').empty();
 
-  $('#create-project-progress-cancel-button').unbind().click(onCancel);
+  $('#create-project-progress-cancel-button').unbind().on('click',onCancel);
 };
 
 Refine.CreateProjectUI.prototype.pollImportJob = function(start, jobID, timerID, checkDone, callback, onError) {

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
@@ -46,7 +46,7 @@ Refine.DefaultImportingController.prototype._showFileSelectionPanel = function()
 
 Refine.DefaultImportingController.prototype._disposeFileSelectionPanel = function() {
   if (this._fileSelectionPanelResizer) {
-    $(window).unbind("resize", this._fileSelectionPanelResizer);
+    $(window).off("resize", this._fileSelectionPanelResizer);
   }
   this._fileSelectionPanel.unbind().empty();
 };
@@ -96,7 +96,7 @@ Refine.DefaultImportingController.prototype._prepareFileSelectionPanel = functio
     .css("height", (height - headerHeight - DOM.getVPaddings(elmts.filePanel)) + "px");
   };
 
-  $(window).resize(this._fileSelectionPanelResizer);
+  $(window).on('resize',this._fileSelectionPanelResizer);
   this._fileSelectionPanelResizer();
 };
 

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/parsing-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/parsing-panel.js
@@ -46,11 +46,11 @@ Refine.DefaultImportingController.prototype._showParsingPanel = function(hasFile
   }
   
   this._prepareParsingPanel();
-  this._parsingPanelElmts.nextButton.click(function() {
+  this._parsingPanelElmts.nextButton.on('click',function() {
     self._createProject();
   });
   if (hasFileSelection) {
-    this._parsingPanelElmts.previousButton.click(function() {
+    this._parsingPanelElmts.previousButton.on('click',function() {
       self._createProjectUI.showCustomPanel(self._fileSelectionPanel);
     });
   } else {
@@ -77,7 +77,7 @@ Refine.DefaultImportingController.prototype._disposeFileSelectionPanel = functio
   this._disposeParserUI();
 
   if (this._parsingPanelResizer) {
-    $(window).unbind("resize", this._parsingPanelResizer);
+    $(window).off("resize", this._parsingPanelResizer);
   }
 
   this._parsingPanel.unbind().empty();
@@ -91,7 +91,7 @@ Refine.DefaultImportingController.prototype._prepareParsingPanel = function() {
       DOM.loadHTML("core", "scripts/index/default-importing-controller/parsing-panel.html"));
 
   this._parsingPanelElmts = DOM.bind(this._parsingPanel);
-  this._parsingPanelElmts.startOverButton.click(function() {
+  this._parsingPanelElmts.startOverButton.on('click',function() {
     self._startOver();
   });
   this._parsingPanelElmts.progressPanel.hide();
@@ -136,7 +136,7 @@ Refine.DefaultImportingController.prototype._prepareParsingPanel = function() {
     .css("height", (controlPanelHeight - DOM.getVPaddings(elmts.controlPanel)) + "px");
   };
 
-  $(window).resize(this._parsingPanelResizer);
+  $(window).on('resize',this._parsingPanelResizer);
   this._parsingPanelResizer();
 
   var formats = this._job.config.rankedFormats;
@@ -147,7 +147,7 @@ Refine.DefaultImportingController.prototype._prepareParsingPanel = function() {
     .attr("format", format)
     .addClass("default-importing-parsing-control-panel-format")
     .appendTo(self._parsingPanelElmts.formatsContainer)
-    .click(function() {
+    .on('click',function() {
       self._selectFormat(format);
     });
 
@@ -167,9 +167,9 @@ Refine.DefaultImportingController.prototype._disposeParserUI = function() {
     delete this._formatParserUI;
   }
   if (this._parsingPanelElmts) {
-    this._parsingPanelElmts.optionsContainer.unbind().empty();
-    this._parsingPanelElmts.progressPanel.unbind();
-    this._parsingPanelElmts.dataPanel.unbind().empty();
+    this._parsingPanelElmts.optionsContainer.off().empty();
+    this._parsingPanelElmts.progressPanel.off();
+    this._parsingPanelElmts.dataPanel.off().empty();
   }
 };
 

--- a/main/webapp/modules/core/scripts/index/default-importing-sources/sources.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-sources/sources.js
@@ -57,7 +57,7 @@ ThisComputerImportingSourceUI.prototype.attachUI = function(bodyDiv) {
   $('#or-import-locate-files').text($.i18n('core-index-import/locate-files'));
   this._elmts.nextButton.html($.i18n('core-buttons/next'));
   
-  this._elmts.nextButton.click(function(evt) {
+  this._elmts.nextButton.on('click',function(evt) {
     if (self._elmts.fileInput[0].files.length === 0) {
       window.alert($.i18n('core-index-import/warning-data-file'));
     } else {
@@ -89,7 +89,7 @@ UrlImportingSourceUI.prototype.attachUI = function(bodyDiv) {
   this._elmts.addButton.html($.i18n('core-buttons/add-url'));
   this._elmts.nextButton.html($.i18n('core-buttons/next'));
 
-  this._elmts.form.submit(function(evt) {
+  this._elmts.form.on('submit',function(evt) {
     evt.preventDefault();
     let errorString = '';
     $(self._elmts.form).find('input:text').each(function () {
@@ -106,7 +106,7 @@ UrlImportingSourceUI.prototype.attachUI = function(bodyDiv) {
       self._controller.startImportJob(self._elmts.form, $.i18n('core-index-import/downloading-data'));
     }
   });
-  this._elmts.addButton.click(function(evt) {
+  this._elmts.addButton.on('click',function(evt) {
     let newRow = self._elmts.urlRow.clone();
     let trashButton = $('<a href="javascript:{}"><span class="ui-icon ui-icon-trash"></span></a>');
     trashButton.attr("title",$.i18n("core-index-import/remove-row"));
@@ -142,7 +142,7 @@ ClipboardImportingSourceUI.prototype.attachUI = function(bodyDiv) {
   $('#or-import-clipboard').text($.i18n('core-index-import/clipboard-label'));
   this._elmts.nextButton.html($.i18n('core-buttons/next'));
   
-  this._elmts.nextButton.click(function(evt) {
+  this._elmts.nextButton.on('click',function(evt) {
     if ($.trim(self._elmts.textInput[0].value).length === 0) {
       window.alert($.i18n('core-index-import/warning-clipboard'));
     } else {
@@ -152,6 +152,6 @@ ClipboardImportingSourceUI.prototype.attachUI = function(bodyDiv) {
 };
 
 ClipboardImportingSourceUI.prototype.focus = function() {
-  this._elmts.textInput.focus();
+  this._elmts.textInput.trigger('focus');
 };
 

--- a/main/webapp/modules/core/scripts/index/edit-metadata-dialog.js
+++ b/main/webapp/modules/core/scripts/index/edit-metadata-dialog.js
@@ -22,7 +22,7 @@ function EditMetadataDialog(metaData, targetRowElem) {
       var td2 = tr.insertCell(2);
       
       if(key==="tags"){
-          $('<button class="button">').text($.i18n('core-index/edit')).appendTo(td2).click(function() {
+          $('<button class="button">').text($.i18n('core-index/edit')).appendTo(td2).on('click',function() {
               var oldTags = $(td1).text().replace("[","").replace("]","");
               oldTags = replaceAll(oldTags,"\"","");
               var newTags = window.prompt($.i18n('core-index/change-metadata-value')+" " + key, $(td1).text());
@@ -53,7 +53,7 @@ function EditMetadataDialog(metaData, targetRowElem) {
               key !== "importOptionMetadata" && 
               key !== "id" &&
               key !== "tags")  {
-          $('<button class="button">').text($.i18n('core-index/edit')).appendTo(td2).click(function() {
+          $('<button class="button">').text($.i18n('core-index/edit')).appendTo(td2).on('click',function() {
             var newValue = window.prompt($.i18n('core-index/change-metadata-value')+" " + key, value);
             if (newValue !== null) {
               $(td1).text(newValue);
@@ -90,7 +90,7 @@ EditMetadataDialog.prototype._createDialog = function() {
 
   this._level = DialogSystem.showDialog(frame);
   this._elmts.closeButton.html($.i18n('core-buttons/close'));
-  this._elmts.closeButton.click(function() { self._dismiss();Refine.OpenProjectUI.prototype._addTagFilter()});
+  this._elmts.closeButton.on('click',function() { self._dismiss();Refine.OpenProjectUI.prototype._addTagFilter()});
   
   var body = $("#metadata-body");
     

--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -39,26 +39,26 @@ Refine.OpenProjectUI = function(elmt) {
   this._elmt = elmt;
   this._elmts = DOM.bind(elmt);
 
-  $("#project-file-input").change(function() {
+  $("#project-file-input").on('change',function() {
     if ($("#project-name-input")[0].value.length === 0) {
       var fileName = this.files[0].fileName;
       if (fileName) {
         $("#project-name-input")[0].value = fileName.replace(/\.\w+/, "").replace(/[_\-]/g, " ");
       }
-      $("#project-name-input").focus().select();
+      $("#project-name-input").trigger('focus').select();
     }
-  }).keypress(function(evt) {
+  }).on('keypress',function(evt) {
     if (evt.keyCode == 13) {
       return self._onClickUploadFileButton(evt);
     }
   });
 
-  $("#upload-file-button").click(function(evt) {
+  $("#upload-file-button").on('click',function(evt) {
     return self._onClickUploadFileButton(evt);
   });
 
   $('#projects-workspace-open').text($.i18n('core-index-open/browse'));
-  $('#projects-workspace-open').click(function() {
+  $('#projects-workspace-open').on('click',function() {
     Refine.postCSRF(
       "command/core/open-workspace-dir",
       {},
@@ -211,7 +211,7 @@ Refine.OpenProjectUI.prototype._renderProjects = function(data) {
       .attr("title",$.i18n('core-index-open/del-title'))
       .attr("href","")
       .html("<img src='images/close.png' />")
-      .click(function() {
+      .on('click',function() {
         if (window.confirm($.i18n('core-index-open/del-body', project.name))) {
           Refine.postCSRF(
             "command/core/delete-project",
@@ -234,7 +234,7 @@ Refine.OpenProjectUI.prototype._renderProjects = function(data) {
       .text($.i18n('core-index-open/edit-meta-data'))
       .addClass("secondary")
       .attr("href", "javascript:{}")
-      .click(function() {
+      .on('click',function() {
           new EditMetadataDialog(project, $(this).parent().parent());
       })
       .appendTo(

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/fixed-width-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/fixed-width-parser-ui.js
@@ -150,7 +150,7 @@ Refine.FixedWidthParserUI.prototype._initialize = function() {
   
   this._optionContainerElmts.encodingInput
     .val(this._config.encoding || '')
-    .click(function() {
+    .on('click',function() {
       Encoding.selectEncoding($(this), function() {
         self.updatePreview();
       });

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/json-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/json-parser-ui.js
@@ -108,7 +108,7 @@ Refine.JsonParserUI.prototype._initialize = function() {
   this._optionContainer.unbind().empty().html(
       DOM.loadHTML("core", "scripts/index/parser-interfaces/json-parser-ui.html"));
   this._optionContainerElmts = DOM.bind(this._optionContainer);
-  this._optionContainerElmts.previewButton.click(function() { self._updatePreview(); });
+  this._optionContainerElmts.previewButton.on('click',function() { self._updatePreview(); });
 
   this._optionContainerElmts.pickRecordElementsButton.text($.i18n('core-index-import/warning-record-path'));
   this._optionContainerElmts.previewButton.html($.i18n('core-buttons/update-preview'));
@@ -141,7 +141,7 @@ Refine.JsonParserUI.prototype._initialize = function() {
   if (this._config.includeArchiveFileName) {
     this._optionContainerElmts.includeArchiveFileCheckbox.prop("checked", true);
   }
-  this._optionContainerElmts.pickRecordElementsButton.click(function() {
+  this._optionContainerElmts.pickRecordElementsButton.on('click',function() {
     self._showPickRecordNodesUI();
   });
 
@@ -189,10 +189,10 @@ Refine.JsonParserUI.prototype._showPickRecordNodesUI = function() {
         elmt.addClass('highlight');
       }
     })
-    .bind('mouseout', function(evt) {
+    .on('mouseout', function(evt) {
       elmt.removeClass('highlight');
     })
-    .click(function(evt) {
+    .on('click',function(evt) {
       if (hittest(evt, elmt)) {
         self._setRecordPath(path);
       }

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/line-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/line-based-parser-ui.js
@@ -111,7 +111,7 @@ Refine.LineBasedParserUI.prototype._initialize = function() {
   this._optionContainer.unbind().empty().html(
       DOM.loadHTML("core", "scripts/index/parser-interfaces/line-based-parser-ui.html"));
   this._optionContainerElmts = DOM.bind(this._optionContainer);
-  this._optionContainerElmts.previewButton.click(function() { self._updatePreview(); });
+  this._optionContainerElmts.previewButton.on('click',function() { self._updatePreview(); });
 
   $('#or-import-encoding').html($.i18n('core-index-import/char-encoding'));
   this._optionContainerElmts.previewButton.html($.i18n('core-buttons/update-preview'));
@@ -133,7 +133,7 @@ Refine.LineBasedParserUI.prototype._initialize = function() {
   
   this._optionContainerElmts.encodingInput
     .val(this._config.encoding || '')
-    .click(function() {
+    .on('click',function() {
       Encoding.selectEncoding($(this), function() {
         self._updatePreview();
       });

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/rdf-triples-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/rdf-triples-parser-ui.js
@@ -77,7 +77,7 @@ Refine.RdfTriplesParserUI.prototype._initialize = function() {
   this._optionContainer.unbind().empty().html(
       DOM.loadHTML("core", "scripts/index/parser-interfaces/rdf-triples-parser-ui.html"));
   this._optionContainerElmts = DOM.bind(this._optionContainer);
-  this._optionContainerElmts.previewButton.click(function() { self._updatePreview(); });
+  this._optionContainerElmts.previewButton.on('click',function() { self._updatePreview(); });
   
   this._optionContainerElmts.previewButton.html($.i18n('core-buttons/update-preview'));
   $('#or-disable-auto-preview').text($.i18n('core-index-parser/disable-auto-preview'));
@@ -85,7 +85,7 @@ Refine.RdfTriplesParserUI.prototype._initialize = function() {
 
   this._optionContainerElmts.encodingInput
     .val(this._config.encoding || '')
-    .click(function() {
+    .on('click',function() {
       Encoding.selectEncoding($(this), function() {
         self._updatePreview();
       });

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
@@ -138,7 +138,7 @@ Refine.SeparatorBasedParserUI.prototype._initialize = function() {
   this._optionContainer.unbind().empty().html(
       DOM.loadHTML("core", "scripts/index/parser-interfaces/separator-based-parser-ui.html"));
   this._optionContainerElmts = DOM.bind(this._optionContainer);
-  this._optionContainerElmts.previewButton.click(function() { self._updatePreview(); });
+  this._optionContainerElmts.previewButton.on('click',function() { self._updatePreview(); });
   
   this._optionContainerElmts.previewButton.html($.i18n('core-buttons/update-preview'));
   $('#or-disable-auto-preview').text($.i18n('core-index-parser/disable-auto-preview'));
@@ -172,7 +172,7 @@ Refine.SeparatorBasedParserUI.prototype._initialize = function() {
 
   this._optionContainerElmts.encodingInput
     .val(this._config.encoding || '')
-    .click(function() {
+    .on('click',function() {
       Encoding.selectEncoding($(this), function() {
         self._updatePreview();
       });

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.js
@@ -115,7 +115,7 @@ Refine.WikitextParserUI.prototype._initialize = function() {
   this._optionContainer.unbind().empty().html(
       DOM.loadHTML("core", "scripts/index/parser-interfaces/wikitext-parser-ui.html"));
   this._optionContainerElmts = DOM.bind(this._optionContainer);
-  this._optionContainerElmts.previewButton.click(function() { self._updatePreview(); });
+  this._optionContainerElmts.previewButton.on('click',function() { self._updatePreview(); });
   
   this._optionContainerElmts.previewButton.html($.i18n('core-buttons/update-preview'));
   $('#or-disable-auto-preview').text($.i18n('core-index-parser/disable-auto-preview'));
@@ -137,7 +137,7 @@ Refine.WikitextParserUI.prototype._initialize = function() {
 /*
   this._optionContainerElmts.encodingInput
     .val(this._config.encoding || '')
-    .click(function() {
+    .on('click',function() {
       Encoding.selectEncoding($(this), function() {
         self._updatePreview();
       });

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/xml-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/xml-parser-ui.js
@@ -106,7 +106,7 @@ Refine.XmlParserUI.prototype._initialize = function() {
   this._optionContainer.unbind().empty().html(
       DOM.loadHTML("core", "scripts/index/parser-interfaces/xml-parser-ui.html"));
   this._optionContainerElmts = DOM.bind(this._optionContainer);
-  this._optionContainerElmts.previewButton.click(function() { self._updatePreview(); });
+  this._optionContainerElmts.previewButton.on('click',function() { self._updatePreview(); });
 
   this._optionContainerElmts.pickRecordElementsButton.html($.i18n('core-buttons/pick-record'));
   this._optionContainerElmts.previewButton.html($.i18n('core-buttons/update-preview'));

--- a/main/webapp/modules/core/scripts/preferences.js
+++ b/main/webapp/modules/core/scripts/preferences.js
@@ -114,7 +114,7 @@ function PreferenceUI(tr, key, initialValue) {
 
   var td2 = tr.insertCell(2);
 
-  $('<button class="button">').text($.i18n('core-index/edit')).appendTo(td2).click(function() {
+  $('<button class="button">').text($.i18n('core-index/edit')).appendTo(td2).on('click',function() {
     var newValue = window.prompt($.i18n('core-index/change-value')+" " + key, $(td1).text());
     if (newValue !== null) {
       if (key === "userMetadata")  {
@@ -138,7 +138,7 @@ function PreferenceUI(tr, key, initialValue) {
     }
   });
 
-  $('<button class="button">').text($.i18n('core-index/delete')).appendTo(td2).click(function() {
+  $('<button class="button">').text($.i18n('core-index/delete')).appendTo(td2).on('click',function() {
     if (window.confirm($.i18n('core-index/delete-key')+" " + key + "?")) {
       Refine.postCSRF(
         "command/core/set-preference",
@@ -186,7 +186,7 @@ function populatePreferences(prefs) {
   var tdLast0 = trLast.insertCell(0);
   trLast.insertCell(1);
   trLast.insertCell(2);
-  $('<button class="button">').text($.i18n('core-index/add-pref')).appendTo(tdLast0).click(function() {
+  $('<button class="button">').text($.i18n('core-index/add-pref')).appendTo(tdLast0).on('click',function() {
     var key = window.prompt($.i18n('core-index/add-pref'));
     if (key) {
       var value = window.prompt($.i18n('core-index/pref-key'));

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -138,7 +138,7 @@ function initializeUI(uiState) {
   $("#or-proj-undoRedo").text($.i18n('core-project/undo-redo'));
   $("#or-proj-ext").text($.i18n('core-project/extensions'));
 
-  $('#project-name-button').on('click',(Refine._renameProject));
+  $('#project-name-button').on('click',Refine._renameProject);
   $('#project-permalink-button').on('mouseenter',function() {
     this.href = Refine.getPermanentLink();
   });

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -138,8 +138,8 @@ function initializeUI(uiState) {
   $("#or-proj-undoRedo").text($.i18n('core-project/undo-redo'));
   $("#or-proj-ext").text($.i18n('core-project/extensions'));
 
-  $('#project-name-button').click(Refine._renameProject);
-  $('#project-permalink-button').mouseenter(function() {
+  $('#project-name-button').on('click',(Refine._renameProject));
+  $('#project-permalink-button').on('mouseenter',function() {
     this.href = Refine.getPermanentLink();
   });
 
@@ -156,12 +156,12 @@ function initializeUI(uiState) {
 
   $('<a>').attr("id", "hide-left-panel-button")
     .addClass("visibility-panel-button")
-    .click(function() { Refine._showHideLeftPanel(); })
+    .on('click',function() { Refine._showHideLeftPanel(); })
     .prependTo(ui.leftPanelTabs);
 
   $('<a>').attr("id", "show-left-panel-button")
     .addClass("visibility-panel-button")
-    .click(function() { Refine._showHideLeftPanel(); })
+    .on('click',function() { Refine._showHideLeftPanel(); })
     .prependTo(ui.toolPanelDiv);
   
   ui.summaryBar = new SummaryBar(ui.summaryBarDiv);
@@ -170,11 +170,11 @@ function initializeUI(uiState) {
   ui.historyPanel = new HistoryPanel(ui.historyPanelDiv, ui.historyTabHeader);
   ui.dataTableView = new DataTableView(ui.viewPanelDiv);
 
-  ui.leftPanelTabs.bind('tabsactivate', function(event, tabs) {
-    tabs.newPanel.resize();
+  ui.leftPanelTabs.on('tabsactivate', function(event, tabs) {
+    tabs.newPanel.trigger('resize');
   });
 
-  $(window).bind("resize", resizeAll);
+  $(window).on("resize", resizeAll);
 
   if (uiState.facets) {
     Refine.update({ engineChanged: true });

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -123,9 +123,9 @@ BrowsingEngine.prototype._initializeUI = function() {
     }
   });
 
-  this._elmts.refreshLink.click(function() { self.update(); });
-  this._elmts.resetLink.click(function() { self.reset(); });
-  this._elmts.removeLink.click(function() { self.remove(); });
+  this._elmts.refreshLink.on('click',function() { self.update(); });
+  this._elmts.resetLink.on('click',function() { self.reset(); });
+  this._elmts.removeLink.on('click',function() { self.remove(); });
 };
 
 BrowsingEngine.prototype._updateFacetOrder = function() {

--- a/main/webapp/modules/core/scripts/project/exporters.js
+++ b/main/webapp/modules/core/scripts/project/exporters.js
@@ -92,7 +92,7 @@ ExporterManager.MenuItems = [
 ];
 
 ExporterManager.prototype._initializeUI = function() {
-  this._button.click(function(evt) {
+  this._button.on('click',function(evt) {
     MenuSystem.createAndShowStandardMenu(
         ExporterManager.MenuItems,
         this,

--- a/main/webapp/modules/core/scripts/project/extension-bar.js
+++ b/main/webapp/modules/core/scripts/project/extension-bar.js
@@ -72,7 +72,7 @@ ExtensionBar.prototype._createMenuButton = function(label, submenu) {
 
   var menuItem = $("<a>").addClass("button").append('<span class="button-menu">' + label + '</span>');
 
-  menuItem.click(function(evt) {
+  menuItem.on('click',function(evt) {
     MenuSystem.createAndShowStandardMenu(
         submenu,
         this,

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -71,7 +71,7 @@ HistoryPanel.prototype._render = function() {
 
   this._tabHeader.html($.i18n('core-project/undo-redo')+' <span class="count">' + this._data.past.length + ' / ' + ( this._data.future.length + this._data.past.length ) + '</span>');
 
-  this._div.empty().unbind().html(DOM.loadHTML("core", "scripts/project/history-panel.html"));
+  this._div.empty().off().html(DOM.loadHTML("core", "scripts/project/history-panel.html"));
 
   var elmts = DOM.bind(this._div);
   
@@ -87,17 +87,17 @@ HistoryPanel.prototype._render = function() {
     var a = $(DOM.loadHTML("core", "scripts/project/history-entry.html")).appendTo(container);
     if (lastDoneID >= 0) {
       a.attr("href", "javascript:{}")
-      .click(function(evt) {
+      .on('click',function(evt) {
         return self._onClickHistoryEntry(evt, entry, lastDoneID);
       })
-      .mouseover(function() {
+      .on('mouseover',function() {
         if (past) {
           elmts.pastHighlightDiv.show().height(elmts.pastDiv.height() - this.offsetTop - this.offsetHeight);
         } else {
           elmts.futureHighlightDiv.show().height(this.offsetTop + this.offsetHeight);
         }
       })
-      .mouseout(function() {
+      .on('mouseout',function() {
         if (past) {
           elmts.pastHighlightDiv.hide();
         } else {
@@ -139,7 +139,7 @@ HistoryPanel.prototype._render = function() {
 
     elmts.helpDiv.hide();
 
-    elmts.filterInput.bind("keyup change input",function() {
+    elmts.filterInput.on("keyup change input",function() {
       var filter = $.trim(this.value.toLowerCase());
       if (filter.length === 0) {
         elmts.bodyDiv.find(".history-entry").removeClass("filtered-out");
@@ -159,8 +159,8 @@ HistoryPanel.prototype._render = function() {
     elmts.bodyControlsDiv.hide();
   }
 
-  elmts.extractLink.click(function() { self._extractOperations(); });
-  elmts.applyLink.click(function() { self._showApplyOperationsDialog(); });
+  elmts.extractLink.on('click',function() { self._extractOperations(); });
+  elmts.applyLink.on('click',function() { self._showApplyOperationsDialog(); });
 
   this.resize();
 };
@@ -212,7 +212,7 @@ HistoryPanel.prototype._showExtractOperationsDialog = function(json) {
     if ("operation" in entry) {
       entry.selected = true;
 
-      $('<input type="checkbox" checked="true" />').appendTo(td0).click(function() {
+      $('<input type="checkbox" checked="true" />').appendTo(td0).on('click',function() {
         entry.selected = !entry.selected;
         updateJson();
       });
@@ -238,8 +238,8 @@ HistoryPanel.prototype._showExtractOperationsDialog = function(json) {
   };
   updateJson();
 
-  elmts.closeButton.click(function() { DialogSystem.dismissUntil(level - 1); });
-  elmts.selectAllButton.click(function() {
+  elmts.closeButton.on('click',function() { DialogSystem.dismissUntil(level - 1); });
+  elmts.selectAllButton.on('click',function() {
     for (var i = 0; i < json.entries.length; i++) {
       json.entries[i].selected = true;
     }
@@ -247,7 +247,7 @@ HistoryPanel.prototype._showExtractOperationsDialog = function(json) {
     frame.find('input[type="checkbox"]').prop('checked', true);
     updateJson();
   });
-  elmts.deselectAllButton.click(function() {
+  elmts.deselectAllButton.on('click',function() {
     for (var i = 0; i < json.entries.length; i++) {
       json.entries[i].selected = false;
     }
@@ -255,7 +255,7 @@ HistoryPanel.prototype._showExtractOperationsDialog = function(json) {
     frame.find('input[type="checkbox"]').prop('checked', false);
     updateJson();
   });
-  elmts.saveJsonAsFileButton.click(function() {
+  elmts.saveJsonAsFileButton.on('click',function() {
     var historyJson = elmts.textarea[0].value;
 
     downloadFile('history.json', historyJson);
@@ -303,7 +303,7 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
     return json.replace(/\}\s*\,\s*\]/g, "} ]").replace(/\}\s*\{/g, "}, {");
   };
 
-  elmts.applyButton.click(function() {
+  elmts.applyButton.on('click',function() {
     var json;
 
     try {
@@ -333,11 +333,11 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
     DialogSystem.dismissUntil(level - 1);
   });
 
-  elmts.cancelButton.click(function() {
+  elmts.cancelButton.on('click',function() {
     DialogSystem.dismissUntil(level - 1);
   });
 
   var level = DialogSystem.showDialog(frame);
 
-  elmts.textarea.focus();
+  elmts.textarea.trigger('focus');
 };

--- a/main/webapp/modules/core/scripts/project/process-panel.js
+++ b/main/webapp/modules/core/scripts/project/process-panel.js
@@ -46,7 +46,7 @@ function ProcessPanel(div) {
   this._elmts.undoLink.html($.i18n('core-project/undo'));
   
   var self = this;
-  $(window).keypress(function(evt) {
+  $(window).on('keypress',function(evt) {
     if (evt.charCode == 26 || (evt.charCode == 122 && (evt.ctrlKey || evt.metaKey))) { // ctrl-z or meta-z
       var t = evt.target;
       if (t) {
@@ -103,7 +103,7 @@ ProcessPanel.prototype.showUndo = function(historyEntry) {
   this._elmts.progressDiv.hide();
   this._elmts.undoDiv.show();
   this._elmts.undoDescription.text( truncDescription );
-  this._elmts.undoLink.unbind().click(function() { self.undo(); });
+  this._elmts.undoLink.off().on('click',function() { self.undo(); });
   
   this._div
     .fadeIn(200)

--- a/main/webapp/modules/core/scripts/util/dialog.js
+++ b/main/webapp/modules/core/scripts/util/dialog.js
@@ -68,7 +68,7 @@ DialogSystem.showDialog = function(elmt, onCancel) {
 
   var level = DialogSystem._layers.length;
 
-  $(window).keydown(escapeKey);
+  $(window).on('keydown',escapeKey);
   
   return level;
 };
@@ -76,11 +76,11 @@ DialogSystem.showDialog = function(elmt, onCancel) {
 DialogSystem.dismissLevel = function(level) {
     var layer = DialogSystem._layers[level];
 
-    $(document).unbind("keydown", layer.keyHandler);
+    $(document).off("keydown", layer.keyHandler);
 
     layer.overlay.remove();
     layer.container.remove();
-    layer.container.unbind();
+    layer.container.off();
 
     if (layer.onCancel) {
       try {

--- a/main/webapp/modules/core/scripts/util/menu.js
+++ b/main/webapp/modules/core/scripts/util/menu.js
@@ -41,7 +41,7 @@ MenuSystem.showMenu = function(elmt, onDismiss) {
     MenuSystem._overlay = $('<div>&nbsp;</div>')
     .addClass("menu-overlay")
     .appendTo(document.body)
-    .click(MenuSystem.dismissAll);
+    .on('click',MenuSystem.dismissAll);
   }
 
   elmt.css("z-index", 1010 + MenuSystem._layers.length).appendTo(document.body);
@@ -70,10 +70,10 @@ MenuSystem.dismissUntil = function(level) {
   for (var i = MenuSystem._layers.length - 1; i >= level; i--) {
     var layer = MenuSystem._layers[i];
 
-    $(document).unbind("keydown", layer.keyHandler);
+    $(document).off("keydown", layer.keyHandler);
 
     layer.elmt.remove();
-    layer.elmt.unbind();
+    layer.elmt.off();
     layer.onDismiss();
   }
   MenuSystem._layers = MenuSystem._layers.slice(0, level);
@@ -143,7 +143,7 @@ MenuSystem.createAndShowStandardMenu = function(items, elmt, options) {
           '<td width="1%"><img src="images/right-arrow.png" /></td>' +
           '</tr></table>'
         );
-        menuItem.mouseenter(function() {
+        menuItem.on('mouseenter',function() {
           MenuSystem.dismissUntil(level);
 
           menuItem.addClass("menu-expanded");
@@ -161,14 +161,14 @@ MenuSystem.createAndShowStandardMenu = function(items, elmt, options) {
           MenuSystem.createAndShowStandardMenu(item.submenu, this, options);
         });
       } else {
-        menuItem.html(item.label).click(function(evt) {
+        menuItem.html(item.label).on('click',function(evt) {
           item.click.call(this, evt);
           MenuSystem.dismissAll();
         });
         if ("tooltip" in item) {
           menuItem.attr("title", item.tooltip);
         }
-        menuItem.mouseenter(function() {
+        menuItem.on('mouseenter',function() {
           MenuSystem.dismissUntil(level);
         });
       }

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -75,9 +75,9 @@ DataTableCellUI.prototype._render = function() {
   editLink.addEventListener('click', function() { self._startEdit(this); });
 
   $(this._td).empty()
-  .unbind()
-  .mouseenter(function() { editLink.style.visibility = "visible" })
-  .mouseleave(function() { editLink.style.visibility = "hidden" });
+  .off()
+  .on('mouseenter',function() { editLink.style.visibility = "visible" })
+  .on('mouseleave',function() { editLink.style.visibility = "hidden" });
 
   if (!cell || ("v" in cell && cell.v === null)) {
     var nullSpan = document.createElement('span');
@@ -140,7 +140,7 @@ DataTableCellUI.prototype._render = function() {
       $('<a href="javascript:{}"></a>')
       .text($.i18n('core-views/choose-match'))
       .addClass("data-table-recon-action")
-      .appendTo(divContentRecon).click(function(evt) {
+      .appendTo(divContentRecon).on('click',function(evt) {
         self._doRematch();
       });
     } else if (r.j == "matched" && "m" in r && r.m !== null) {
@@ -163,7 +163,7 @@ DataTableCellUI.prototype._render = function() {
       .text($.i18n('core-views/choose-match'))
       .addClass("data-table-recon-action")
       .appendTo(divContentRecon)
-      .click(function(evt) {
+      .on('click',function(evt) {
         self._doRematch();
       });
     } else {
@@ -180,14 +180,14 @@ DataTableCellUI.prototype._render = function() {
             $('<a href="javascript:{}">&nbsp;</a>')
             .addClass("data-table-recon-match-similar")
             .attr("title", $.i18n('core-views/match-all-cells'))
-            .appendTo(liSpan).click(function(evt) {
+            .appendTo(liSpan).on('click',function(evt) {
               self._doMatchTopicToSimilarCells(candidate);
             });
 
             $('<a href="javascript:{}">&nbsp;</a>')
             .addClass("data-table-recon-match")
             .attr("title", $.i18n('core-views/match-this-cell') )
-            .appendTo(liSpan).click(function(evt) {
+            .appendTo(liSpan).on('click',function(evt) {
               self._doMatchTopicToOneCell(candidate);
             });
 
@@ -221,14 +221,14 @@ DataTableCellUI.prototype._render = function() {
         $('<a href="javascript:{}">&nbsp;</a>')
         .addClass("data-table-recon-match-similar")
         .attr("title", $.i18n('core-views/create-topic-cells'))
-        .appendTo(liNew).click(function(evt) {
+        .appendTo(liNew).on('click',function(evt) {
           self._doMatchNewTopicToSimilarCells();
         });
 
         $('<a href="javascript:{}">&nbsp;</a>')
         .addClass("data-table-recon-match")
         .attr("title", $.i18n('core-views/create-topic-cell'))
-        .appendTo(liNew).click(function(evt) {
+        .appendTo(liNew).on('click',function(evt) {
           self._doMatchNewTopicToOneCell();
         });
 
@@ -546,12 +546,12 @@ DataTableCellUI.prototype._previewOnHover = function(service, candidate, hoverEl
 
     if (preview) {
         var dismissCallback = null;
-        hoverElement.hover(function(evt) {
+        hoverElement.on('mouseenter',function(evt) {
         if (!evt.metaKey && !evt.ctrlKey) {
             dismissCallback = self._previewCandidateTopic(candidate, coreElement, preview, showActions);
             evt.preventDefault();
         }
-        }, function(evt) {
+        }).on('mouseleave',function(evt) {
         if(dismissCallback !== null) {
             dismissCallback();
         }
@@ -661,11 +661,11 @@ DataTableCellUI.prototype._startEdit = function(elmt) {
     }
   };
 
-  elmts.okButton.click(commit);
-  elmts.okallButton.click(commit);
+  elmts.okButton.on('click',commit);
+  elmts.okallButton.on('click',commit);
   elmts.textarea
   .text(originalContent)
-  .keydown(function(evt) {
+  .on('keydown',function(evt) {
     if (!evt.shiftKey) {
       if (evt.keyCode == 13) {
         if (evt.ctrlKey) {
@@ -678,10 +678,10 @@ DataTableCellUI.prototype._startEdit = function(elmt) {
       }
     }
   })
-  .select()
-  .focus();
+  .trigger('select')
+  .trigger('focus');
 
-  elmts.cancelButton.click(function() {
+  elmts.cancelButton.on('click',function() {
     MenuSystem.dismissAll();
   });
 };

--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -66,7 +66,7 @@ DataTableColumnHeaderUI.prototype._render = function() {
   var elmts = DOM.bind(td);
 
   elmts.nameContainer.text(this._column.name);
-  elmts.dropdownMenu.click(function() {
+  elmts.dropdownMenu.on('click',function() {
     self._createMenuForColumnHeader(this);
   });
 
@@ -326,7 +326,7 @@ DataTableColumnHeaderUI.prototype._showSortingCriterion = function(criterion, ha
   };
   elmts.valueTypeOptions
   .find("input[type='radio']")
-  .change(function() {
+  .on('change',function() {
     setValueType(this.value);
   });
 
@@ -370,8 +370,8 @@ DataTableColumnHeaderUI.prototype._showSortingCriterion = function(criterion, ha
 
   setValueType(criterion.valueType); 
 
-  elmts.cancelButton.click(dismiss);
-  elmts.okButton.click(function() {
+  elmts.cancelButton.on('click',dismiss);
+  elmts.okButton.on('click',function() {
     var criterion2 = {
         column: self._column.name,
         valueType: elmts.valueTypeOptions.find("input[type='radio']:checked")[0].value,

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -127,7 +127,7 @@ DataTableView.prototype.render = function() {
     if (value == ui.browsingEngine.getMode()) {
       a.addClass("selected");
     } else {
-      a.addClass("action").click(function(evt) {
+      a.addClass("action").on('click',function(evt) {
         ui.browsingEngine.setMode(value);
       });
     }
@@ -159,7 +159,7 @@ DataTableView.prototype._renderSortingControls = function(sortingControls) {
   .text($.i18n('core-views/sort') + " ")
   .append($('<img>').attr("src", "images/down-arrow.png"))
   .appendTo(sortingControls)
-  .click(function() {
+  .on('click',function() {
     self._createSortingMenu(this);
   });
 };
@@ -175,8 +175,8 @@ DataTableView.prototype._renderPagingControls = function(pageSizeControls, pagin
   var firstPage = $('<a href="javascript:{}">&laquo; '+$.i18n('core-views/first')+'</a>').appendTo(pagingControls);
   var previousPage = $('<a href="javascript:{}">&lsaquo; '+$.i18n('core-views/previous')+'</a>').appendTo(pagingControls);
   if (theProject.rowModel.start > 0) {
-    firstPage.addClass("action").click(function(evt) { self._onClickFirstPage(this, evt); });
-    previousPage.addClass("action").click(function(evt) { self._onClickPreviousPage(this, evt); });
+    firstPage.addClass("action").on('click',function(evt) { self._onClickFirstPage(this, evt); });
+    previousPage.addClass("action").on('click',function(evt) { self._onClickPreviousPage(this, evt); });
   } else {
     firstPage.addClass("inaction");
     previousPage.addClass("inaction");
@@ -186,8 +186,8 @@ DataTableView.prototype._renderPagingControls = function(pageSizeControls, pagin
   
   var pageInputSize = 20 + (8 * ui.dataTableView._lastPageNumber.toString().length);
   var currentPageInput = $('<input type="number">')
-    .change(function(evt) { self._onChangeGotoPage(this, evt); })
-    .keydown(function(evt) { self._onKeyDownGotoPage(this, evt); })
+    .on('change',function(evt) { self._onChangeGotoPage(this, evt); })
+    .on('keydown',function(evt) { self._onKeyDownGotoPage(this, evt); })
     .attr("id", "viewpanel-paging-current-input")
     .attr("min", 1)
     .attr("max", self._lastPageNumber)
@@ -209,8 +209,8 @@ DataTableView.prototype._renderPagingControls = function(pageSizeControls, pagin
   var nextPage = $('<a href="javascript:{}">'+$.i18n('core-views/next')+' &rsaquo;</a>').appendTo(pagingControls);
   var lastPage = $('<a href="javascript:{}">'+$.i18n('core-views/last')+' &raquo;</a>').appendTo(pagingControls);
   if (theProject.rowModel.start + theProject.rowModel.limit < theProject.rowModel.filtered) {
-    nextPage.addClass("action").click(function(evt) { self._onClickNextPage(this, evt); });
-    lastPage.addClass("action").click(function(evt) { self._onClickLastPage(this, evt); });
+    nextPage.addClass("action").on('click',function(evt) { self._onClickNextPage(this, evt); });
+    lastPage.addClass("action").on('click',function(evt) { self._onClickLastPage(this, evt); });
   } else {
     nextPage.addClass("inaction");
     lastPage.addClass("inaction");
@@ -226,7 +226,7 @@ DataTableView.prototype._renderPagingControls = function(pageSizeControls, pagin
     if (pageSize == self._pageSize) {
       a.text(pageSize).addClass("selected");
     } else {
-      a.text(pageSize).addClass("action").click(function(evt) {
+      a.text(pageSize).addClass("action").on('click',function(evt) {
         self._pageSize = pageSize;
         self.update();
       });
@@ -365,7 +365,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
           '<a class="column-header-menu" bind="dropdownMenu"></a><span class="column-header-name">'+$.i18n('core-views/all')+'</span>' +
         '</div>'
       )
-  ).dropdownMenu.click(function() {
+  ).dropdownMenu.on('click',function() {
     self._createMenuForAllColumns(this);
   });
   this._columnHeaderUIs = [];
@@ -373,7 +373,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     var th = trHead.appendChild(document.createElement("th"));
     $(th).addClass("column-header").attr('title', column.name);
     if (self._collapsedColumnNames.hasOwnProperty(column.name)) {
-      $(th).html("&nbsp;").click(function(evt) {
+      $(th).html("&nbsp;").on('click',function(evt) {
         delete self._collapsedColumnNames[column.name];
         self.render();
       });
@@ -1148,11 +1148,11 @@ DataTableView.prototype._createPendingSortWarningDialog = function(func) {
   var level = DialogSystem.showDialog(frame);
   var dismiss = function() { DialogSystem.dismissLevel(level - 1); };
 
-  elmts.cancelButton.click( function () {
+  elmts.cancelButton.on('click', function () {
      dismiss();
   });
 
-  elmts.okButton.click( function () {
+  elmts.okButton.on('click', function () {
      func();
      dismiss();
   });

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
@@ -66,8 +66,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     var level = DialogSystem.showDialog(frame);
     var dismiss = function() { DialogSystem.dismissUntil(level - 1); };
 
-    elmts.cancelButton.click(dismiss);
-    elmts.okButton.click(function() {
+    elmts.cancelButton.on('click',dismiss);
+    elmts.okButton.on('click',function() {
       doTextTransform(
         previewWidget.getExpression(true),
         $('input[name="text-transform-dialog-onerror-choice"]:checked')[0].value,
@@ -89,7 +89,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       params.repeat = elmts.repeatCheckbox[0].checked;
       params.repeatCount = elmts.repeatCountInput[0].value;
     };
-    elmts.repeatCheckbox.click(function() {
+    elmts.repeatCheckbox.on('click',function() {
       previewWidget.update();
     });
   };
@@ -248,9 +248,9 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     elmts.cancelButton.text($.i18n('core-buttons/cancel'));
     var level = DialogSystem.showDialog(frame);
     var dismiss = function() { DialogSystem.dismissUntil(level - 1); };
-    elmts.cancelButton.click(dismiss);
-    elmts.text_to_findInput.focus();
-    elmts.okButton.click(function() {
+    elmts.cancelButton.on('click',dismiss);
+    elmts.text_to_findInput.trigger('focus');
+    elmts.okButton.on('click',function() {
       var text_to_find = elmts.text_to_findInput[0].value;
       var replacement_text = elmts.replacement_textInput[0].value;
       var replace_dont_escape = elmts.replace_dont_escapeInput[0].checked;
@@ -319,10 +319,10 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     
     var defaultValue = Refine.getPreference("ui.cell.rowSplitDefaultSeparator", ",");
     elmts.separatorInput[0].value = defaultValue;
-    elmts.separatorInput.focus().select();
+    elmts.separatorInput.trigger('focus').trigger('select');
     
-    elmts.cancelButton.click(dismiss);
-    elmts.okButton.click(function() {
+    elmts.cancelButton.on('click',dismiss);
+    elmts.okButton.on('click',function() {
       var mode = $("input[name='split-by-mode']:checked")[0].value;
       var config = {
         columnName: column.name,
@@ -544,8 +544,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
 
     var columns = theProject.columnModel.columns;
 
-    elmts.cancelButton.click(function() { dismiss(); });
-    elmts.okButton.click(function() {
+    elmts.cancelButton.on('click',function() { dismiss(); });
+    elmts.okButton.on('click',function() {
       var config = {
         startColumnName: elmts.fromColumnSelect[0].value,
         columnCount: elmts.toColumnSelect[0].value,
@@ -622,7 +622,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     };
     populateToColumn();
 
-    elmts.fromColumnSelect.bind("change", populateToColumn);
+    elmts.fromColumnSelect.on("change", populateToColumn);
   };
 
   var doTransposeRowsIntoColumns = function() {
@@ -671,8 +671,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
 
     var columns = theProject.columnModel.columns;
 
-    elmts.cancelButton.click(function() { dismiss(); });
-    elmts.okButton.click(function() {
+    elmts.cancelButton.on('click',function() { dismiss(); });
+    elmts.okButton.on('click',function() {
       var config = {
         keyColumnName: elmts.keyColumnSelect[0].value,
         valueColumnName: elmts.valueColumnSelect[0].value,

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
@@ -77,8 +77,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       null
     );
     
-    elmts.cancelButton.click(dismiss);
-    elmts.okButton.click(function() {
+    elmts.cancelButton.on('click',dismiss);
+    elmts.okButton.on('click',function() {
       var columnName = $.trim(elmts.columnNameInput[0].value);
       if (!columnName.length) {
         alert($.i18n('core-views/warning-col-name'));
@@ -149,8 +149,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     );
 
 
-    elmts.cancelButton.click(dismiss);
-    elmts.okButton.click(function() {
+    elmts.cancelButton.on('click',dismiss);
+    elmts.okButton.on('click',function() {
       var columnName = $.trim(elmts.columnNameInput[0].value);
       if (!columnName.length) {
         alert($.i18n('core-views/warning-col-name'));
@@ -227,8 +227,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
 
     var level = DialogSystem.showDialog(frame);
     var dismiss = function() { DialogSystem.dismissUntil(level - 1); };
-    elmts.cancelButton.click(dismiss);
-    elmts.form.submit(function(event) {
+    elmts.cancelButton.on('click',dismiss);
+    elmts.form.on('submit',function(event) {
       event.preventDefault();
       var newColumnName = $.trim(elmts.columnNameInput[0].value);
       if (newColumnName === column.name) {
@@ -304,10 +304,10 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     var level = DialogSystem.showDialog(frame);
     var dismiss = function() { DialogSystem.dismissUntil(level - 1); };
     
-    elmts.separatorInput.focus().select();
+    elmts.separatorInput.trigger('focus').trigger('select');
 
-    elmts.cancelButton.click(dismiss);
-    elmts.okButton.click(function() {
+    elmts.cancelButton.on('click',dismiss);
+    elmts.okButton.on('click',function() {
       var mode = $("input[name='split-by-mode']:checked")[0].value;
       var config = {
         columnName: column.name,
@@ -531,32 +531,32 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     */
     elmts.column_join_columnPicker
       .find('.column-join-column')
-      .click(function() {
+      .on('click',function() {
         elmts.column_join_columnPicker
         .find('.column-join-column')
         .removeClass('selected');
         $(this).addClass('selected');
       });
     elmts.selectAllButton
-      .click(function() {
+      .on('click',function() {
         elmts.column_join_columnPicker
         .find('input[type="checkbox"]')
         .prop('checked',true);
        });
     elmts.deselectAllButton
-      .click(function() {
+      .on('click',function() {
         elmts.column_join_columnPicker
         .find('input[type="checkbox"]')
         .prop('checked',false);
       });
-    elmts.okButton.click(function() {
+    elmts.okButton.on('click',function() {
       transform();
       dismiss();
     });
-    elmts.cancelButton.click(function() {
+    elmts.cancelButton.on('click',function() {
       dismiss();
     });
-    elmts.new_column_nameInput.change(function() {
+    elmts.new_column_nameInput.on('change',function() {
       if (elmts.new_column_nameInput[0].value != "") {
         elmts.copy_to_new_columnInput.prop('checked',true);
       } else
@@ -564,7 +564,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         elmts.write_selected_columnInput.prop('checked',true);
         }
     });
-    elmts.null_substituteInput.change(function() {
+    elmts.null_substituteInput.on('change',function() {
         elmts.replace_nullsInput.prop('checked',true);
     });
   };

--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -155,10 +155,10 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
            .appendTo(select);
     }
 
-    $('<button class="button"></button>').text($.i18n('core-buttons/cancel')).click(function() {
+    $('<button class="button"></button>').text($.i18n('core-buttons/cancel')).on('click',function() {
       DialogSystem.dismissUntil(level - 1);
     }).appendTo(footer);
-    $('<button class="button"></button>').html($.i18n('core-buttons/ok')).click(function() {
+    $('<button class="button"></button>').html($.i18n('core-buttons/ok')).on('click',function() {
         
         var service = select.val();
         var identifierSpace = null;
@@ -206,8 +206,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
 
     var o = DataTableView.sampleVisibleRows(column);
     
-    elmts.cancelButton.click(dismiss);
-    elmts.form.submit(function(event) {
+    elmts.cancelButton.on('click',dismiss);
+    elmts.form.on('submit',function(event) {
       event.preventDefault();
       var columnName = $.trim(elmts.columnNameInput[0].value);
       if (!columnName.length) {
@@ -260,8 +260,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     var level = DialogSystem.showDialog(frame);
     var dismiss = function() { DialogSystem.dismissUntil(level - 1); };
 
-    elmts.cancelButton.click(dismiss);
-    elmts.okButton.click(function() {
+    elmts.cancelButton.on('click',dismiss);
+    elmts.okButton.on('click',function() {
       var config = {
         fromColumnName: column.name,
         toColumnName: [],

--- a/main/webapp/modules/core/scripts/widgets/slider-widget.js
+++ b/main/webapp/modules/core/scripts/widgets/slider-widget.js
@@ -85,11 +85,11 @@ SliderWidget.prototype._initializeUI = function() {
 
   var self = this;
   this._elmt.find(".slider-widget-draggable")
-  .mousedown(function(evt) {
+  .on('mousedown',function(evt) {
     return self._onMouseDown(evt, this.getAttribute("part"));
   });
 
-  this._highlightRect.dblclick(function(evt) {
+  this._highlightRect.on('dblclick',function(evt) {
     if (self._range.from > self._range.min || self._range.to < self._range.max) {
       self._range.from = self._range.min;
       self._range.to = self._range.max;
@@ -99,10 +99,10 @@ SliderWidget.prototype._initializeUI = function() {
   });
 
   this._elmt
-  .mousemove(function(evt) {
+  .on('mousemove',function(evt) {
     return self._onMouseMove(evt);
   })
-  .mouseup(function(evt) {
+  .on('mouseup',function(evt) {
     return self._onMouseUp(evt);
   });
 };
@@ -112,8 +112,8 @@ SliderWidget.prototype._onMouseDown = function(evt, part) {
     return;
   }
 
-  $(document).mousemove(this._mouseMoveHandler);
-  $(document).mouseup(this._mouseUpHandler);
+  $(document).on('mousemove',this._mouseMoveHandler);
+  $(document).on('mouseup',this._mouseUpHandler);
 
   this._drag = {
     sureDrag: false,
@@ -144,8 +144,8 @@ SliderWidget.prototype._onMouseUp = function(evt) {
     return;
   }
 
-  $(document).unbind("mousemove", this._mouseMoveHandler);
-  $(document).unbind("mouseup", this._mouseUpHandler);
+  $(document).off("mousemove", this._mouseMoveHandler);
+  $(document).off("mouseup", this._mouseUpHandler);
 
   if (this._drag.sureDrag) {
     this._update();


### PR DESCRIPTION
Migrated jQuery deprecated functions that showed up as warnings that are flagged by jQuery migrate while running Cypress tests.

Notes:
- Did not migrate $.trim() because the behavior is different.
- There are still deprecated function calls in 3rdparty and externals dependencies.
- This is not upgrading jQuery yet, all of these migrations can be done on the currently used jQuery.

ref: https://api.jquery.com/category/deprecated/