### PR TITLE
Cleaned up preferences set in Cypress tests

### DIFF
--- a/main/tests/cypress/cypress/integration/preferences/change_preference.spec.js
+++ b/main/tests/cypress/cypress/integration/preferences/change_preference.spec.js
@@ -1,5 +1,5 @@
 describe(__filename, function () {
-  const testPreferenceName = '"PreferenceName_Test"';
+  const testPreferenceName = 'PreferenceName_Test';
   const testPreferenceValue = '"PreferenceValue_Test"';
   
   afterEach(function () {

--- a/main/tests/cypress/cypress/integration/preferences/change_preference.spec.js
+++ b/main/tests/cypress/cypress/integration/preferences/change_preference.spec.js
@@ -1,6 +1,6 @@
 describe(__filename, function () {
-  const testPreferenceName = `PreferenceName_${Date.now()}`;
-  const testPreferenceValue = `"PreferenceValue_${Date.now()}"`;
+  const testPreferenceName = `PreferenceName_Test`;
+  const testPreferenceValue = `"PreferenceValue_Test"`;
   
   afterEach(function () {
     cy.deletePreference(testPreferenceName);

--- a/main/tests/cypress/cypress/integration/preferences/change_preference.spec.js
+++ b/main/tests/cypress/cypress/integration/preferences/change_preference.spec.js
@@ -1,8 +1,13 @@
 describe(__filename, function () {
+  const testPreferenceName = `PreferenceName_${Date.now()}`;
+  const testPreferenceValue = `"PreferenceValue_${Date.now()}"`;
+  
+  afterEach(function () {
+    cy.deletePreference(testPreferenceName);
+  });
+  
   it('Edit a preference', function () {
     cy.visitOpenRefine();
-    const testPreferenceName = `PreferenceName_${Date.now()}`;
-    const testPreferenceValue = `"PreferenceValue_${Date.now()}"`;
 
     cy.setPreference(testPreferenceName, testPreferenceValue);
 
@@ -24,8 +29,6 @@ describe(__filename, function () {
   it('Add a new preference', function () {
     cy.visitOpenRefine();
     cy.get('#project-links a').contains('Preferences').click();
-
-    const testPreferenceName = Date.now();
 
     cy.window().then(($win) => {
       cy.stub($win, 'prompt').returns(testPreferenceName);

--- a/main/tests/cypress/cypress/integration/preferences/change_preference.spec.js
+++ b/main/tests/cypress/cypress/integration/preferences/change_preference.spec.js
@@ -1,9 +1,23 @@
 describe(__filename, function () {
-  const testPreferenceName = `PreferenceName_Test`;
-  const testPreferenceValue = `"PreferenceValue_Test"`;
+  const testPreferenceName = '"PreferenceName_Test"';
+  const testPreferenceValue = '"PreferenceValue_Test"';
   
   afterEach(function () {
     cy.deletePreference(testPreferenceName);
+  });
+
+  it('Add a new preference', function () {
+    cy.visitOpenRefine();
+    cy.get('#project-links a').contains('Preferences').click();
+
+    cy.window().then(($win) => {
+      cy.stub($win, 'prompt').returns(testPreferenceName);
+      cy.get('table.preferences tr:last-child button.button').click();
+    });
+
+    cy.get('table.preferences tr:nth-last-child(2)').contains(
+        testPreferenceName
+    );
   });
   
   it('Edit a preference', function () {
@@ -24,19 +38,5 @@ describe(__filename, function () {
     });
 
     cy.get('table.preferences tr').contains(testPreferenceValue + '_Edited');
-  });
-
-  it('Add a new preference', function () {
-    cy.visitOpenRefine();
-    cy.get('#project-links a').contains('Preferences').click();
-
-    cy.window().then(($win) => {
-      cy.stub($win, 'prompt').returns(testPreferenceName);
-      cy.get('table.preferences tr:last-child button.button').click();
-    });
-
-    cy.get('table.preferences tr:nth-last-child(2)').contains(
-      testPreferenceName
-    );
   });
 });

--- a/main/tests/cypress/cypress/support/openrefine_api.js
+++ b/main/tests/cypress/cypress/support/openrefine_api.js
@@ -26,6 +26,29 @@ Cypress.Commands.add('setPreference', (preferenceName, preferenceValue) => {
     });
 });
 
+Cypress.Commands.add('deletePreference', (preferenceName) => {
+  const openRefineUrl = Cypress.env('OPENREFINE_URL');
+  return cy
+      .request(openRefineUrl + '/command/core/get-csrf-token')
+      .then((response) => {
+        return cy
+            .request({
+              method: 'POST',
+              url: `${openRefineUrl}/command/core/set-preference`,
+              body: `name=${preferenceName}&csrf_token=${response.body.token}`,
+              form: false,
+              headers: {
+                'content-type': 'application/x-www-form-urlencoded; charset=UTF-8',
+              },
+            })
+            .then((resp) => {
+              cy.log(
+                  'Delete preference ' +
+                  preferenceName 
+              );
+            });
+      });
+});
 
 Cypress.Commands.add('importProject', (projectTarFile, projectName) => {
   const openRefineUrl = Cypress.env('OPENREFINE_URL');


### PR DESCRIPTION
Changes proposed in this pull request:
- Added  a clean up for the preferences set in the Cypress tests.
- Changed test preferences to not use Date.now() because they are being cleaned up now.

Example of how the preferences are cluttered from running tests before these changes:
![image](https://user-images.githubusercontent.com/42903164/166859837-f1a4a30a-c634-411d-9f70-e7dea8ee27a8.png)