### PR TITLE
Cleaned up projects that are being created through Cypress UI commands

### DIFF
--- a/main/tests/cypress/cypress/integration/create-project/create_project.spec.js
+++ b/main/tests/cypress/cypress/integration/create-project/create_project.spec.js
@@ -1,4 +1,8 @@
 describe(__filename, function () {
+  afterEach(() => {
+    cy.addProjectForDeletion();
+  });
+  
   it('Test the create project from this computer based on CSV', function () {
     // navigate to the create page
     cy.visitOpenRefine();
@@ -33,10 +37,7 @@ describe(__filename, function () {
     cy.get('.default-importing-wizard-header button[bind="nextButton"]')
       .contains('Create project »')
       .click();
-    cy.get('#create-project-progress-message').contains('Done.');
-
-    // ensure the project is loading by checking presence of a project-title element
-    cy.get('#project-title').should('exist');
+    cy.waitForProjectTable();
   });
   it('Test the create project from this computer based on TSV', function () {
     // navigate to the create page
@@ -72,10 +73,7 @@ describe(__filename, function () {
     cy.get('.default-importing-wizard-header button[bind="nextButton"]')
       .contains('Create project »')
       .click();
-    cy.get('#create-project-progress-message').contains('Done.');
-
-    // ensure the project is loading by checking presence of a project-title element
-    cy.get('#project-title').should('exist');
+    cy.waitForProjectTable();
   });
   it('Test the create project from clipboard based on CSV', function () {
     // navigate to the create page
@@ -112,10 +110,7 @@ describe(__filename, function () {
     cy.get('.default-importing-wizard-header button[bind="nextButton"]')
       .contains('Create project »')
       .click();
-    cy.get('#create-project-progress-message').contains('Done.');
-
-    // ensure the project is loading by checking presence of a project-title element
-    cy.get('#project-title').should('exist');
+    cy.waitForProjectTable();
   });
   it('Test the create project from clipboard based on TSV', function () {
     // navigate to the create page
@@ -148,10 +143,61 @@ describe(__filename, function () {
     cy.get('.default-importing-wizard-header button[bind="nextButton"]')
       .contains('Create project »')
       .click();
-    cy.get('#create-project-progress-message').contains('Done.');
+    cy.waitForProjectTable();
+  });
 
-    // ensure the project is loading by checking presence of a project-title element
-    cy.get('#project-title').should('exist');
+  it('Test project renaming', function () {
+    cy.visitOpenRefine();
+    cy.createProjectThroughUserInterface('food.mini.csv');
+    cy.get('.create-project-ui-panel').contains('Configure parsing options');
+    cy.get(
+        '.default-importing-wizard-header input[bind="projectNameInput"]'
+    ).type('this is a test');
+
+    // click next to create the project, and wait until it's loaded
+    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+        .contains('Create project »')
+        .click();
+    cy.waitForProjectTable();
+
+    cy.get('#project-name-button').contains('this is a test');
+  });
+  
+  it('Test project tagging by adding various tags', function () {
+    cy.visitOpenRefine();
+    cy.createProjectThroughUserInterface('food.mini.csv');
+    cy.get('.create-project-ui-panel').contains('Configure parsing options');
+    const uniqueProjectName = Date.now();
+    const uniqueTagName1 = 'tag1_' + Date.now();
+    const uniqueTagName2 = 'tag2_' + Date.now();
+
+    cy.get('#project-tags-container').click();
+    // Type and Validate the tag, pressing enter
+    cy.get('#project-tags-container .select2-input').type(uniqueTagName1, { force: true });
+    cy.get('body').type('{enter}');
+    cy.get('#project-tags-container .select2-input').type(uniqueTagName2, { force: true });
+    cy.get('body').type('{enter}');
+    cy.get('#or-import-parsopt').click();
+
+    // click next to create the project, and wait until it's loaded
+    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
+        .contains('Create project »')
+        .click();
+    cy.waitForProjectTable();
+
+    cy.addProjectForDeletion();
+    cy.visitOpenRefine();
+    cy.navigateTo('Open project');
+    cy.get('#projects-list')
+        .contains(uniqueProjectName)
+        .parent()
+        .parent()
+        .contains(uniqueTagName1);
+    cy.get('#projects-list')
+        .contains(uniqueProjectName)
+        .parent()
+        .parent()
+        .contains(uniqueTagName2);
   });
   // it('Test the create project from Web URL based on CSV', function () {
   //   // navigate to the create page

--- a/main/tests/cypress/cypress/integration/create-project/preview_project.spec.js
+++ b/main/tests/cypress/cypress/integration/create-project/preview_project.spec.js
@@ -91,59 +91,6 @@ describe(__filename, function () {
     );
   });
 
-  it('Test project renaming', function () {
-    cy.visitOpenRefine();
-    cy.createProjectThroughUserInterface('food.mini.csv');
-    cy.get('.create-project-ui-panel').contains('Configure parsing options');
-    cy.get(
-      '.default-importing-wizard-header input[bind="projectNameInput"]'
-    ).type('this is a test');
-
-    // click next to create the project, and wait until it's loaded
-    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
-      .contains('Create project »')
-      .click();
-    cy.get('#create-project-progress-message').contains('Done.');
-
-    cy.get('#project-name-button').contains('this is a test');
-  });
-
-  it('Test project tagging by adding various tags', function () {
-    cy.visitOpenRefine();
-    cy.createProjectThroughUserInterface('food.mini.csv');
-    cy.get('.create-project-ui-panel').contains('Configure parsing options');
-    const uniqueProjectName = Date.now();
-    const uniqueTagName1 = 'tag1_' + Date.now();
-    const uniqueTagName2 = 'tag2_' + Date.now();
-
-    cy.get('#project-tags-container').click();
-    // Type and Validate the tag, pressing enter
-    cy.get('#project-tags-container .select2-input').type(uniqueTagName1, { force: true });
-    cy.get('body').type('{enter}');
-    cy.get('#project-tags-container .select2-input').type(uniqueTagName2, { force: true });
-    cy.get('body').type('{enter}');
-    cy.get('#or-import-parsopt').click();
-
-    // click next to create the project, and wait until it's loaded
-    cy.get('.default-importing-wizard-header button[bind="nextButton"]')
-      .contains('Create project »')
-      .click();
-    cy.get('#create-project-progress-message').contains('Done.');
-
-    cy.visitOpenRefine();
-    cy.navigateTo('Open project');
-    cy.get('#projects-list')
-      .contains(uniqueProjectName)
-      .parent()
-      .parent()
-      .contains(uniqueTagName1);
-    cy.get('#projects-list')
-      .contains(uniqueProjectName)
-      .parent()
-      .parent()
-      .contains(uniqueTagName2);
-  });
-
   it('Tests ignore-first of parsing options', function () {
     cy.visitOpenRefine();
     cy.createProjectThroughUserInterface('food.mini.csv');

--- a/main/tests/cypress/cypress/integration/import-project/import_project.spec.js
+++ b/main/tests/cypress/cypress/integration/import-project/import_project.spec.js
@@ -1,4 +1,8 @@
 describe(__filename, function () {
+  afterEach(() => {
+    cy.addProjectForDeletion();
+  });
+  
   it('Check the layout for importing a project', function () {
     cy.visitOpenRefine();
     cy.navigateTo('Import project');
@@ -18,6 +22,7 @@ describe(__filename, function () {
     );
     cy.get('#project-upload-form').submit();
 
+    cy.waitForProjectTable(199);
     // ensure is loaded
     cy.get('div[bind="summaryBarDiv"]').contains('199 rows');
   });
@@ -39,7 +44,7 @@ describe(__filename, function () {
     cy.get('#project-name-input').type(projectName);
     cy.get('#project-upload-form').submit();
 
-    // ensure is loaded
+    cy.waitForProjectTable();
     cy.get('#project-name-button').contains(projectName);
   });
 });

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/clear_reconciliation_data.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/clear_reconciliation_data.spec.js
@@ -1,4 +1,8 @@
 describe('Clear reconciliation data', () => {
+    afterEach(() => {
+        cy.addProjectForDeletion();
+    });
+    
     it('Test clearing reconciliation for a reconciled dataset', () => {
         cy.visitOpenRefine();
         cy.navigateTo('Import project');

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/create_new_item_for_each.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/create_new_item_for_each.spec.js
@@ -1,4 +1,8 @@
 describe('Create new item for each cell', () => {
+    afterEach(() => {
+        cy.addProjectForDeletion();
+    });
+    
     it('Test discard existing reconciliation judgments', () => {
         cy.visitOpenRefine();
         cy.navigateTo('Import project');

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/discard_reconciliation_judgments.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/discard_reconciliation_judgments.spec.js
@@ -1,4 +1,8 @@
 describe('Discard reconciliation judgments', () => {
+    afterEach(() => {
+        cy.addProjectForDeletion();
+    });
+    
     it('Test discard existing reconciliation judgments', () => {
         cy.visitOpenRefine();
         cy.navigateTo('Import project');

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/match_to_best_candidate.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/match_to_best_candidate.spec.js
@@ -1,4 +1,8 @@
 describe('Match each cell to its best candidate', () => {
+    afterEach(() => {
+        cy.addProjectForDeletion();
+    });
+    
     it('Match each cell to its best candidate', () => {
         cy.visitOpenRefine();
         cy.navigateTo('Import project');

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/add_entity_identifiers.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/add_entity_identifiers.spec.js
@@ -1,4 +1,8 @@
 describe('Add entity identifiers', () => {
+  afterEach(() => {
+    cy.addProjectForDeletion();
+  });
+  
   it('Add a new column that contains the reconciliation id', () => {
     cy.visitOpenRefine();
     cy.navigateTo('Import project');

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/copy_reconciliation_data.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/copy_reconciliation_data.spec.js
@@ -1,4 +1,8 @@
 describe('Copy reconciliation data', () => {
+  afterEach(() => {
+    cy.addProjectForDeletion();
+  });
+  
   it('Copy reconciliation data from species to species_copy', () => {
     cy.visitOpenRefine();
     cy.navigateTo('Import project');

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
@@ -1,5 +1,8 @@
 describe('Facet by judgment', () => {
-
+  afterEach(() => {
+    cy.addProjectForDeletion();
+  });
+  
   it('Facets by judgment', () => {
     cy.visitOpenRefine();
     cy.navigateTo('Import project');

--- a/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/rows_records.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/rows_records.spec.js
@@ -129,6 +129,10 @@ const jsonValue = `[
   }
 ]`;
 describe(__filename, function () {
+  afterEach(() => {
+    cy.addProjectForDeletion();
+  });
+
   it('ensures rows and records display same in csv file', function () {
     cy.loadAndVisitProject('food.small');
 

--- a/main/tests/cypress/cypress/integration/project/project-header/export_project.spec.js
+++ b/main/tests/cypress/cypress/integration/project/project-header/export_project.spec.js
@@ -7,7 +7,7 @@ describe(__filename, function () {
   ];
   it('Export a project through "OpenRefine project archive to file"', function () {
 
-    cy.loadAndVisitProject(fixture);
+    cy.loadAndVisitProject(fixture, Date.now());
 
     cy.get('#export-button').click();
     cy.get('.menu-container a')
@@ -21,7 +21,7 @@ describe(__filename, function () {
   });
   it('Export a project through "Tab-separated value"', function () {
 
-    cy.loadAndVisitProject(fixture);
+    cy.loadAndVisitProject(fixture, Date.now());
 
     cy.get('#export-button').click();
     cy.get('.menu-container a')
@@ -35,7 +35,7 @@ describe(__filename, function () {
   });
   it('Export a project through "Comma-separated value"', function () {
 
-    cy.loadAndVisitProject(fixture);
+    cy.loadAndVisitProject(fixture, Date.now());
 
     cy.get('#export-button').click();
     cy.get('.menu-container a')
@@ -49,7 +49,7 @@ describe(__filename, function () {
   });
   it('Export a project through "HTML table"', function () {
 
-    cy.loadAndVisitProject(fixture);
+    cy.loadAndVisitProject(fixture, Date.now());
 
     cy.get('#export-button').click();
     cy.get('.menu-container a')
@@ -63,7 +63,7 @@ describe(__filename, function () {
   });
   it('Export a project through "Excel (.xls)"', function () {
 
-    cy.loadAndVisitProject(fixture);
+    cy.loadAndVisitProject(fixture, Date.now());
 
     cy.get('#export-button').click();
     cy.get('.menu-container a')
@@ -77,7 +77,7 @@ describe(__filename, function () {
   });
   it('Export a project through "Excel 2007+ (.xlsx)"', function () {
 
-    cy.loadAndVisitProject(fixture);
+    cy.loadAndVisitProject(fixture, Date.now());
 
     cy.get('#export-button').click();
     cy.get('.menu-container a')
@@ -91,7 +91,7 @@ describe(__filename, function () {
   });
   it('Export a project through "ODF spreadsheet"', function () {
 
-    cy.loadAndVisitProject(fixture);
+    cy.loadAndVisitProject(fixture, Date.now());
 
     cy.get('#export-button').click();
     cy.get('.menu-container a')
@@ -105,7 +105,7 @@ describe(__filename, function () {
   });
   it('Export a project through "Custom tabular exporter"', function () {
 
-    cy.loadAndVisitProject(fixture);
+    cy.loadAndVisitProject(fixture, Date.now());
 
     cy.get('#export-button').click();
     cy.get('.menu-container a')
@@ -121,7 +121,7 @@ describe(__filename, function () {
   });
   it('Export a project through "SQL Exporter"', function () {
 
-    cy.loadAndVisitProject(fixture);
+    cy.loadAndVisitProject(fixture, Date.now());
 
     cy.get('#export-button').click();
     cy.get('.menu-container a')
@@ -137,7 +137,7 @@ describe(__filename, function () {
   });
   it('Export a project through "Templating"', function () {
 
-    cy.loadAndVisitProject(fixture);
+    cy.loadAndVisitProject(fixture, Date.now());
 
     cy.get('#export-button').click();
     cy.get('.menu-container a')

--- a/main/tests/cypress/cypress/integration/tutorial/importing-data-into-openrefine.spec.js
+++ b/main/tests/cypress/cypress/integration/tutorial/importing-data-into-openrefine.spec.js
@@ -1,6 +1,10 @@
 // This spec is implementation for chapter 02 of following tutorial https://librarycarpentry.org/lc-open-refine/02-importing-data/index.html
 
 describe(__filename, function () {
+  afterEach(() => {
+    cy.addProjectForDeletion();
+  });
+  
   it('Create your first OpenRefine project (using provided data)', function () {
     // For sake of the tutorial we have already downloaded the data into fixtures
     // Step-1:Once OpenRefine is launched in your browser, click Create project from the left hand menu and select Get data from This Computer
@@ -42,9 +46,7 @@ describe(__filename, function () {
     cy.get('.default-importing-wizard-header button[bind="nextButton"]')
       .contains('Create project »')
       .click();
-    cy.get('#create-project-progress-message').contains('Done.');
 
-    // ensure that the project data is loaded completely
-    cy.get('#summary-bar').should('to.contain', '1001 rows');
+    cy.waitForProjectTable(1001);
   });
 });

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -356,16 +356,25 @@ Cypress.Commands.add('visitProject', (projectId) => {
  *   * a file referenced in fixtures.js (food.mini | food.small)
  */
 Cypress.Commands.add(
-  'loadAndVisitProject',
-  (fixture, projectName = Date.now()) => {
-    cy.loadProject(fixture, projectName).then((projectId) => {
-      cy.visit(Cypress.env('OPENREFINE_URL') + '/project?project=' + projectId);
-
-      cy.get('#left-panel', { log: false }).should('be.visible');
-      cy.get('#right-panel', { log: false }).should('be.visible');
-    });
-  }
+    'loadAndVisitProject',
+    (fixture, projectName = Cypress.currentTest.title +'-'+Date.now()) => {
+      cy.loadProject(fixture, projectName).then((projectId) => {
+        cy.visit(Cypress.env('OPENREFINE_URL') + '/project?project=' + projectId);
+        cy.waitForProjectTable();
+      });
+    }
 );
+
+Cypress.Commands.add('waitForProjectTable', (numRows) => {
+  cy.url().should('contain', '/project?project=')
+  cy.get('#left-panel', { log: false }).should('be.visible');
+  cy.get('#right-panel', { log: false }).should('be.visible');
+  cy.get('#project-title').should('exist');
+  cy.get(".data-table").find("tr").its('length').should('be.gte', 0);
+  if (arguments.length == 1) {
+    cy.get('#summary-bar').should('to.contain', numRows+' rows');
+  }
+});
 
 Cypress.Commands.add('assertNotificationContainingText', (text) => {
   cy.get('#notification-container').should('be.visible');

--- a/main/tests/cypress/cypress/support/openrefine_api.js
+++ b/main/tests/cypress/cypress/support/openrefine_api.js
@@ -1,5 +1,19 @@
 const fixtures = require('../fixtures/fixtures.js');
 
+Cypress.Commands.add('addProjectForDeletion', () => {
+const path = '/project?project=';
+  cy.url().then(($url) => {
+    if($url.includes(path)) {
+      const projectId = $url.split('=').slice(-1)[0];
+      cy.get('@loadedProjectIds', { log: true }).then((loadedProjectIds) => {
+        loadedProjectIds.push(projectId);
+        cy.wrap(loadedProjectIds, { log: true })
+            .as('loadedProjectIds');
+      });
+    }
+  })
+});
+
 Cypress.Commands.add('setPreference', (preferenceName, preferenceValue) => {
   const openRefineUrl = Cypress.env('OPENREFINE_URL');
   return cy
@@ -151,7 +165,7 @@ Cypress.Commands.add('loadProject', (fixture, projectName, tagName) => {
     });
     content = csv.join('\n');
   }
-
+  
   cy.get('@token', { log: false }).then((token) => {
     // cy.request(Cypress.env('OPENREFINE_URL')+'/command/core/get-csrf-token').then((response) => {
     const openRefineFormat = 'text/line-based/*sv';


### PR DESCRIPTION

Cleaned up projects that are being created through Cypress UI commands.  There is already a cleanup for projects created programmatically through cy.loadAndVisitProject().  However, if you run the Cypress test suite, there were 17 projects not getting deleted. See screenshot below.

* added addProjectForDeletion()
* added waitForProjectTable()

There are 17 projects created on each test run:
doaj article sample csv
1651727097719
1638261281543 csv
1638261281543 csv
1638261281543 csv
1638261281543 csv
1638261281543 csv
1638261281543 csv
1638261281543 csv
heym
1651726631244
Clipboard
food mini csvthis is a test
food mini csv
Clipboard
food mini csv
shop mini tsv

![image](https://user-images.githubusercontent.com/42903164/167242291-ac4f8c04-f6d4-4087-bb21-9a34dfdf57eb.png)
