### PR TITLE
Change static private final To Private static final #4808

### DIFF
--- a/extensions/database/src/com/google/refine/extension/database/mysql/MySQLDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/mysql/MySQLDatabaseService.java
@@ -115,6 +115,8 @@ public class MySQLDatabaseService extends DatabaseService {
                 DatabaseInfo dbInfo = new DatabaseInfo();
                 dbInfo.setColumns(columns);
                 dbInfo.setRows(rows);
+                queryResult.close();
+                statement.close();
                 return dbInfo;
         } catch (SQLException e) {
             logger.error("SQLException::", e);

--- a/extensions/database/src/com/google/refine/extension/database/sqlite/SQLiteDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/sqlite/SQLiteDatabaseService.java
@@ -138,6 +138,8 @@ public class SQLiteDatabaseService extends DatabaseService {
             DatabaseInfo dbInfo = new DatabaseInfo();
             dbInfo.setColumns(columns);
             dbInfo.setRows(rows);
+            queryResult.close();
+            statement.close();
             return dbInfo;
         } catch (SQLException e) {
             logger.error("SQLException::", e);

--- a/main/src/com/google/refine/RefineServlet.java
+++ b/main/src/com/google/refine/RefineServlet.java
@@ -73,7 +73,7 @@ public class RefineServlet extends Butterfly {
 
     static final long serialVersionUID = 2386057901503517403L;
 
-    static private final String JAVAX_SERVLET_CONTEXT_TEMPDIR = "javax.servlet.context.tempdir";
+    private static final String JAVAX_SERVLET_CONTEXT_TEMPDIR = "javax.servlet.context.tempdir";
     private File tempDir = null;
 
     static private RefineServlet s_singleton;

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -73,8 +73,8 @@ import com.google.refine.Configurations;
  */
 public class Refine {
     
-    static private final String DEFAULT_IFACE = "127.0.0.1";
-    static private final int DEFAULT_PORT = 3333;
+    private static final String DEFAULT_IFACE = "127.0.0.1";
+    private static final int DEFAULT_PORT = 3333;
         
     static private int port;
     static private String host;

--- a/server/src/com/google/refine/ValidateHostHandler.java
+++ b/server/src/com/google/refine/ValidateHostHandler.java
@@ -56,7 +56,7 @@ class ValidateHostHandler extends HandlerWrapper {
      * never be sent by a well-behaved browser - and validating the host header only ever
      * helps if the browser works as expected and cannot be used to fake the Host header.
      */
-    static private final Pattern LOOPBACK_PATTERN = Pattern
+    private static final Pattern LOOPBACK_PATTERN = Pattern
             .compile("^(?:127\\.[0-9\\.]*|\\[[0\\:]*\\:(?:ffff\\:7f[0-9a-f]{2}:[0-9a-f]{1,4}|0{0,3}1)\\]|localhost)(?:\\:[0-9]+)?$", Pattern.CASE_INSENSITIVE);
 
     private String expectedHost;


### PR DESCRIPTION
Fixes #4808

Changes proposed in this pull request:
- Change the remaining "Static private final" to "Private static final" in all the java files.

I didn't change the "Static private" to "private static" because the title of the issue only mentioned "Change static private final To Private static final". I'm not sure if I should also change all the other "Static private", please update the description of the issue so that everyone can know the main idea of the issue is to have a good coding convention.

