### PR TITLE
 Fixed flaky drag-n-drop tests for jQuery migration

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/all-column/edit-columns.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/all-column/edit-columns.spec.js
@@ -7,8 +7,8 @@ describe(__filename, function () {
     ]);
     cy.waitForDialogPanel();
 
-    cy.dragAndDrop('div[column="Shrt_Desc"]', 'div[column="NDB_No"]');
-    cy.dragAndDrop('div[column="Energ_Kcal"]', 'div[column="Water"]');
+    cy.dragAndDrop('div[column="Shrt_Desc"]', 'div[column="NDB_No"]', 'top');
+    cy.dragAndDrop('div[column="Energ_Kcal"]', 'div[column="Water"]', 'top');
 
     cy.confirmDialogPanel();
 
@@ -28,8 +28,8 @@ describe(__filename, function () {
     ]);
     cy.waitForDialogPanel();
 
-    cy.dragAndDrop('div[column="Shrt_Desc"]', 'div[bind="trashContainer"]');
-    cy.dragAndDrop('div[column="Water"]', 'div[bind="trashContainer"]');
+    cy.dragAndDrop('div[column="Shrt_Desc"]', 'div[bind="trashContainer"]','center');
+    cy.dragAndDrop('div[column="Water"]', 'div[bind="trashContainer"]','center');
 
     cy.confirmDialogPanel();
 

--- a/main/tests/cypress/cypress/integration/project/grid/column/edit-column/join_columns.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/edit-column/join_columns.spec.js
@@ -19,7 +19,7 @@ describe(__filename, function () {
     cy.waitForDialogPanel();
 
     cy.get('input[column="NDB_No"]').check();
-    cy.dragAndDrop('div[column="NDB_No"]', 'div[column="Shrt_Desc"]');
+    cy.dragAndDrop('div[column="NDB_No"]', 'div[column="Shrt_Desc"]','top');
 
     cy.confirmDialogPanel();
 
@@ -46,7 +46,7 @@ describe(__filename, function () {
     cy.columnActionClick('Shrt_Desc', ['Edit column', 'Join columns…']);
     cy.waitForDialogPanel();
 
-    cy.dragAndDrop('div[column="NDB_No"]', 'div[column="Shrt_Desc"]');
+    cy.dragAndDrop('div[column="NDB_No"]', 'div[column="Shrt_Desc"]','top');
     cy.get('input[column="NDB_No"]').check();
     cy.get('input[bind="field_separatorInput"]').type(':-:');
 

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -392,12 +392,15 @@ Cypress.Commands.add(
 
 /**
  * Performs drag and drop on target and source item
+ * sourcSelector jquery selector for the element to be dragged
+ * targetSelector jquery selector for the element to be dropped on
+ * position position relative to the target element to perform the drop
  */
-Cypress.Commands.add('dragAndDrop', (sourceSelector, targetSelector) => {
+Cypress.Commands.add('dragAndDrop', (sourceSelector, targetSelector, position = 'center') => {
   cy.get(sourceSelector).trigger('mousedown', { which: 1 });
 
   cy.get(targetSelector) // eslint-disable-line
-    .trigger('mousemove')
+    .trigger('mousemove',position)
     .trigger('mouseup', { force: true });
 });
 


### PR DESCRIPTION
Three cypress tests that use drag-n-drop to reorder columns are flaky when using jQuery 3.6.  The issue arises when one column is dragged upward and it is dropped on the center of the other column name. By dropping the column name at the 'top' of the target, the tests work.

This fix also works with the existing jQuery.

The following tests are fixed with this change:
-  edit-columns.spec.js
    - Ensure columns are reordered as per order
 
-  cypress\integration\project\grid\column\edit-column\join_columns.spec.js
     -  Ensures two columns are joined respecting the column ordering
     -  Ensures two columns are joined with given seperator with columns reorder
![image](https://user-images.githubusercontent.com/42903164/168532065-932e70de-25cd-4885-ac82-c74f4a9c60cb.png)

     