### PR TITLE
jQuery 3.x Migration - Fixed Test the history, star Test

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
@@ -295,7 +295,7 @@ ExpressionPreviewDialog.Widget.prototype._renderExpressionHistory = function(dat
                             renderEntry(self,tr,entry);
                             self._renderStarredExpressionsTab();
                         },
-                        "json"
+                        ""
                     );
                 });
         
@@ -332,7 +332,7 @@ ExpressionPreviewDialog.Widget.prototype._renderStarredExpressionsTab = function
         function(data) {
             self._renderStarredExpressions(data);
         },
-        "json"
+        ""
     );
 };
 


### PR DESCRIPTION
Due to a change in behavior in jQuery $.post(), calls to /command/core/toggle-starred-expression would fail if "json" is expected, but an empty response is returned.  By omitting the expected content type (""), then the content-type is set by the server response, so then it works.

Ref: https://github.com/jquery/jquery/issues/3973
Ref: https://bugs.jquery.com/ticket/5156   
