### PR TITLE
Add echo off to windows batch script

### DIFF
--- a/refine.bat
+++ b/refine.bat
@@ -1,4 +1,4 @@
-
+@echo off
 
 rem
 rem Configuration variables


### PR DESCRIPTION
Fixes #4868

Changes proposed in this pull request:
- add « @ echo off » command at the start of the file.

Goes from:
![image](https://user-images.githubusercontent.com/12217525/169211797-ffbc5eba-16b2-4b4b-8076-421ef36d16d1.png)

To:
![image](https://user-images.githubusercontent.com/12217525/169211760-8e5ac5db-cb65-4643-82a1-5ebabefb9bec.png)

Regards, Antoine