### PR TITLE
Change the current working directory at the start of the batch script to the folder of the batch script

### DIFF
--- a/refine.bat
+++ b/refine.bat
@@ -1,4 +1,8 @@
 @echo off
+rem Previous line hides the remarks from being displayed with the prompt for each line
+
+rem Change current working directory to directory of the batch script
+cd %~dp0
 
 rem
 rem Configuration variables


### PR DESCRIPTION
Fixes #4878

Changes proposed in this pull request:
- This adds a command at the start to change the current directory to the folder of the batch script: `cd %~dp0`