### PR TITLE
Upgrading jQuery to 3.6.0

### DIFF
--- a/main/webapp/package.json
+++ b/main/webapp/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "@wikimedia/jquery.i18n": "1.0.7",
     "datejs-coolite": "1.0.0",
-    "jquery": "1.12.4",
-    "jquery-migrate": "1.4.1",
+    "jquery": "3.6.0",
+    "jquery-migrate": "3.4.0",
     "js-cookie": "2.2.1",
     "moment": "2.29.3",
     "select2": "4.1.0-rc.0",


### PR DESCRIPTION
Changes proposed in this pull request:
- Upgrade jQuery and jQuery Migrate.

The jQuery migration from 1.12.4 to the latest (3.6.0) version required many fixes due to deprecated and removed methods, and also some behavior changes.

Luckily, all the work was able to be done incrementally since all of the fixes were compatible with the old version (1.12.4).

All of the Cypress tests are passing, and I have done some additional manual testing.

Summary of Changes:
* Replaced usages of jQuery functions removed in 3.6.0 or earlier. (Ref: https://api.jquery.com/category/removed/).
* Replaced usages of jQuery functions deprecated in 3.6.0 or earlier. (Ref:  https://api.jquery.com/category/deprecated/).
* Fix broken code due to jQuery no longer auto-inserting tbody tags.
* Correct <textarea/> to <textarea></textarea> becuase latest jQuery did not like self-closing <textarea/>.
* Fix deprecations in external dependencies jquery.imgareaselect.js and suggest-4_3a.js.
* Due to a change in behavior in jQuery $.post(), calls to /command/core/toggle-starred-expression would fail if a "json" is expected, but an empty response is returned. By omitting the expected content type (""), then the content-type is set by the server response. (Ref: https://github.com/jquery/jquery/issues/3973).
* Updated select2 package which fixed jQuery deprecations.
* Resolves security issues with jquery 1.12.4. (Ref: https://snyk.io/vuln/npm:jquery?lh=1.12.4):
![image](https://user-images.githubusercontent.com/42903164/170802451-171ac82a-f45e-4703-ae19-4e981745c235.png)


Pending:
* The tablesorter dependency has an open PR to remove calls to deprecated functions. (Ref: https://github.com/Mottie/tablesorter/pull/1786). The current tablesorter does work with jQuery 3.6.0, so it's still okay to go ahead.
* May want to remove jquery-migrate.  They don't recommend you have it enabled in production.  We should just add it in dev builds when we are doing migrations from one jQuery version to the next.

Associated PRs:
* https://github.com/OpenRefine/OpenRefine/pull/4886
* https://github.com/OpenRefine/OpenRefine/pull/4882
* https://github.com/OpenRefine/OpenRefine/pull/4874
* https://github.com/OpenRefine/OpenRefine/pull/4872
* https://github.com/OpenRefine/OpenRefine/pull/4862
* https://github.com/OpenRefine/OpenRefine/pull/4861
* https://github.com/OpenRefine/OpenRefine/pull/4853
* https://github.com/OpenRefine/OpenRefine/pull/4852
* https://github.com/OpenRefine/OpenRefine/pull/4851
* https://github.com/OpenRefine/OpenRefine/pull/4840
* https://github.com/OpenRefine/OpenRefine/pull/4837
* https://github.com/OpenRefine/OpenRefine/pull/4827
* https://github.com/OpenRefine/OpenRefine/pull/4822
* https://github.com/OpenRefine/OpenRefine/pull/4817
* https://github.com/OpenRefine/OpenRefine/pull/4811