### PR TITLE
CC license rather than (c) for OpenRefine's documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -104,3 +104,7 @@ Your translations will not be immediately published on <https://docs.openrefine.
 The translated pages will first appear under <https://docs.openrefine.org/next/> (the documentation for the development version).
 When we publish a version, the translations for that version, we will take a snapshot of the translations during that time.
 We will trial this process for 3.5.
+
+### License
+
+This documentation is published under the [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -87,7 +87,7 @@ module.exports = {
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} OpenRefine contributors`,
+      copyright: `<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br />OpenRefine's documentation is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.`,
     },
   },
   themes: [],


### PR DESCRIPTION
Replacing copyright (c) line in footer with sentence indicating docs fall under a CC-BY 4.0 license.

Fixes #4876

Changes proposed in this pull request:
- Small update to docusaurus.config.js