### PR TITLE
(I#3805) Fix problem with frequent writes to metadata files

### DIFF
--- a/main/src/com/google/refine/ProjectMetadata.java
+++ b/main/src/com/google/refine/ProjectMetadata.java
@@ -387,6 +387,6 @@ public class ProjectMetadata {
 
     @JsonIgnore
     public void setLastSave() {
-        lastSave = LocalDateTime.now();
+        lastSave = Instant.now();
     }
 }

--- a/main/src/com/google/refine/ProjectMetadata.java
+++ b/main/src/com/google/refine/ProjectMetadata.java
@@ -68,7 +68,7 @@ public class ProjectMetadata {
     @JsonProperty("modified")
     private Instant _modified;
     @JsonIgnore
-    private Instant written = null;
+    private Instant lastSave = null;
     @JsonProperty("name")
     private String _name = "";
     @JsonProperty("password")
@@ -125,23 +125,22 @@ public class ProjectMetadata {
 
     protected ProjectMetadata(Instant date) {
         _created = date;
+        _modified = _created;
         preparePreferenceStore(_preferenceStore);
     }
 
     public ProjectMetadata() {
         this(Instant.now());
-        _modified = _created;
     }
 
     public ProjectMetadata(Instant created, Instant modified, String name) {
         this(created);
-        _modified = modified;
         _name = name;
     }
 
     @JsonIgnore
     public boolean isDirty() {
-        return written == null || _modified.isAfter(written);
+        return lastSave == null || _modified.isAfter(lastSave);
     }
 
     static protected void preparePreferenceStore(PreferenceStore ps) {
@@ -384,5 +383,10 @@ public class ProjectMetadata {
             logger.error(ExceptionUtils.getFullStackTrace(e));
             throw new RuntimeException(e);
         }
+    }
+
+    @JsonIgnore
+    public void setLastSave() {
+        lastSave = LocalDateTime.now();
     }
 }

--- a/main/src/com/google/refine/io/FileProjectManager.java
+++ b/main/src/com/google/refine/io/FileProjectManager.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -297,28 +298,33 @@ public class FileProjectManager extends ProjectManager {
         }
     }
 
-    protected boolean saveNeeded() {
-        boolean projectSaveNeeded = _projectsMetadata.entrySet().stream()
-                .anyMatch(e -> e.getValue() != null && e.getValue().isDirty());
-        return projectSaveNeeded || _preferenceStore.isDirty() || projectRemoved;
+    protected List<Long> getModifiedProjectIds() {
+        List<Long> modified = _projectsMetadata.entrySet().stream()
+                .filter(e -> {
+                    ProjectMetadata metadata = e.getValue();
+                    if (metadata == null) return false;
+                    return metadata.isDirty();
+                }).map(Entry::getKey).collect(Collectors.toList());
+        return modified;
     }
 
-    protected void saveProjectMetadata() throws IOException {
-        for (Entry<Long, ProjectMetadata> entry : _projectsMetadata.entrySet()) {
-            ProjectMetadata metadata = entry.getValue();
-            if (metadata != null && metadata.isDirty()) {
-                ProjectMetadataUtilities.save(metadata, getProjectDir(entry.getKey()));
+    protected void saveProjectMetadata(List<Long> modified) throws IOException {
+        for (Long id : modified) {
+            ProjectMetadata metadata = _projectsMetadata.get(id);
+            if (metadata != null) {
+                ProjectMetadataUtilities.save(metadata, getProjectDir(id));
             }
         }
     }
 
     protected boolean saveToFile(File file) throws IOException {
         OutputStream stream = new FileOutputStream(file);
-        boolean saveWasNeeded = saveNeeded();
+        List<Long> modified = getModifiedProjectIds();
+        boolean saveWasNeeded = (modified.size() > 0) || (_preferenceStore.isDirty());
         try {
             // writeValue(OutputStream) is documented to use JsonEncoding.UTF8
             ParsingUtilities.defaultWriter.writeValue(stream, this);
-            saveProjectMetadata();
+            saveProjectMetadata(modified);
         } finally {
             stream.close();
         }

--- a/main/src/com/google/refine/io/ProjectMetadataUtilities.java
+++ b/main/src/com/google/refine/io/ProjectMetadataUtilities.java
@@ -80,7 +80,7 @@ public class ProjectMetadataUtilities {
                 file.delete();
             }
         }
-
+        projectMeta.setLastSave();
         tempFile.renameTo(file);
     }
 
@@ -132,7 +132,6 @@ public class ProjectMetadataUtilities {
      *            the project directory
      * @param id
      *            the project id
-     * @return
      */
     static public ProjectMetadata recover(File projectDir, long id) {
         ProjectMetadata pm = null;


### PR DESCRIPTION
Fixes #3805

Frequent writes to metadata files are due to deprecated class property `written` in `ProjectMetadata.java` which has been assigned null and remain unchanged. When `FileProjectManager` try to judge whether there is changed in metadata, it utilize this property for every project, resulting in metadata files written for every project.

Solution is to store temporary property recording the last save time for each metadata and update it every time `FileProjectManager` writes the metadata.

Changes proposed in this pull request:
- Modified property `written` by `_lastSave` in `ProjectMetadata.java`
- Add setter for `_lastSave` which store the current localdatetime in `ProjectMetadata.java`
- Modified `isDirty` method in `ProjectMetadata.java` which compares `_lastSave` and `_modified`
- For method `saveToFile` first get ids of the modified project judging by `isDirty`, then save those project with the ids
- State update metadata files as need  if length of id list is not null
- Make `ProjectMetadataUtilities.java` to update '_lastSave` everytime metadata file is updated.

A test is shown in the following screeshots
**Projects**
![project_struct](https://user-images.githubusercontent.com/84132969/170739804-30c424c4-d98f-444c-8929-5387b41a6d7b.png)
**Original Metadata Files**
![origin](https://user-images.githubusercontent.com/84132969/170739817-c24e5ace-1482-4a0b-aed9-767dfaaf333c.png)
**Modify one of the project**
![modified](https://user-images.githubusercontent.com/84132969/170739811-65d67835-5599-4f9c-9d08-c21594dfd129.png)
**Metadata Files After Modification(Only metadata files of one project has been written)**
![aftermodified](https://user-images.githubusercontent.com/84132969/170739825-fb0f6816-9a1c-4658-a722-6ee9e69f9dd4.png)
![terminal](https://user-images.githubusercontent.com/84132969/170739830-37be08b9-4696-4b8d-9928-1580d0b45048.png)

At last, I feel sorry as it seems a bit messy in the `file changes` window. It seems that my editor adds some blank space before some part of the codes for no reason.