### PR TITLE
Added whitespaces to the "collapse consecutive whitespaces" command

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/column/edit-cells/common-transforms/collapse-consecutive-whitespace.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/edit-cells/common-transforms/collapse-consecutive-whitespace.spec.js
@@ -3,8 +3,8 @@ describe(__filename, function () {
     const fixture = [
       ['NDB_No', 'Shrt_Desc'],
       ['01001', 'THIS    IS A     TEST'],
-      ['01002', 'THIS    IS ANOTHER     TEST'],
-      ['01003', 'THIS IS a THIRD TEST'],
+      ['01002', 'THIS    IS ANOTHER     TEST'], // this line contains U+00A0 (non-breaking space)
+      ['01003', 'THIS IS a THIRD TEST'], // this one too
     ];
     cy.loadAndVisitProject(fixture);
 

--- a/main/tests/cypress/cypress/integration/project/grid/column/edit-cells/common-transforms/collapse-consecutive-whitespace.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/edit-cells/common-transforms/collapse-consecutive-whitespace.spec.js
@@ -15,7 +15,7 @@ describe(__filename, function () {
     ]);
 
     // Check notification and cell content
-    cy.assertNotificationContainingText('Text transform on 2 cells');
+    cy.assertNotificationContainingText('Text transform on 3 cells');
     cy.assertCellEquals(0, 'Shrt_Desc', 'THIS IS A TEST');
     cy.assertCellEquals(1, 'Shrt_Desc', 'THIS IS ANOTHER TEST');
     cy.assertCellEquals(2, 'Shrt_Desc', 'THIS IS a THIRD TEST');

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
@@ -406,7 +406,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         {
           id: "core/collapse-whitespace",
           label: $.i18n('core-views/collapse-white/single'),
-          click: function() { doTextTransform("value.replace(/\\s+/,' ')", "keep-original", false, ""); }
+          click: function() { doTextTransform("value.replace(/[\\p{Zs}\\s]+/,' ')", "keep-original", false, ""); }
         },
         {},
         {


### PR DESCRIPTION
fixes #4883

Changes proposed in this pull request:
- replaced `value.replace(/\\s+/,' ')` for `value.replace(/[\\p{Zs}\\s]+/,' ')` 
- 
- 
