### PR TITLE
Fixed jitter in column -> sort dialog

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/sorting-criterion-dialog.html
+++ b/main/webapp/modules/core/scripts/views/data-table/sorting-criterion-dialog.html
@@ -8,7 +8,7 @@
           <td><span bind="or_views_positionBlank"></span></td>
         </tr>
         <tr>
-          <td>
+          <td style="vertical-align: top;">
             <div class="grid-layout layout-tightest grid-layout-for-text" bind="valueTypeOptions"><table>
               <tr>
                 <td width="1"><input type="radio" name="sorting-dialog-value-type" value="string" id="$sorting-dialog-value-type-string" /></td>


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed jitter found in column -> sort dialog, as shown here:

Before:
![sort_jitter](https://user-images.githubusercontent.com/42903164/171517238-14ea10ac-f671-40e6-92b2-5c06357de9f5.gif)
After:
![sort_jitter_fixed](https://user-images.githubusercontent.com/42903164/171517310-62a819f5-acd8-43ec-b95f-1245a56b3842.gif)


