### PR TITLE
Revert back to previous behaviour for insertion of ids in URL templates for reconciliation

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -151,7 +151,7 @@ DataTableCellUI.prototype._render = function() {
       .appendTo(divContentRecon);
 
       if (service && (service.view) && (service.view.url)) {
-        a.attr("href", service.view.url.replace("{{id}}", encodeURIComponent(match.id)));
+        a.attr("href", encodeURI(service.view.url.replace("{{id}}", match.id)));
       }
 
       if (DataTableCellUI.previewMatchedCells) {
@@ -198,7 +198,7 @@ DataTableCellUI.prototype._render = function() {
             .appendTo(liSpan);
 
             if ((service) && (service.view) && (service.view.url)) {
-              a.attr("href", service.view.url.replace("{{id}}", encodeURIComponent(candidate.id)));
+              a.attr("href", encodeURI(service.view.url.replace("{{id}}", candidate.id)));
             }
 
             self._previewOnHover(service, candidate, liSpan.parent(), liSpan, true);
@@ -494,7 +494,7 @@ DataTableCellUI.prototype._previewCandidateTopic = function(candidate, elmt, pre
   }
 
   if (preview && preview.url) { // Service has a preview URL associated with it
-    var url = preview.url.replace("{{id}}", encodeURIComponent(id));
+    var url = encodeURI(preview.url.replace("{{id}}", id));
     var iframe = $('<iframe></iframe>')
     .width(preview.width)
     .height(preview.height)


### PR DESCRIPTION
We recently changed (in #3731) the way the identifiers of entities are inserted into the URLs to view them, in the context of the reconciliation service. This breaks compatibility with some important reconciliation services such as OpenCorporates'.

It was instead suggested in https://github.com/reconciliation-api/specs/issues/39 that we leave it up to the services whether (and how) the ids are escaped when inserted in the URL.

Temporarily fixes #4645, for the sake of getting a release (3.6) out of the door soon. I intend to go back to this.
