### PR TITLE
Improved error message for invalid manifest version

### DIFF
--- a/extensions/wikidata/module/langs/translation-en.json
+++ b/extensions/wikidata/module/langs/translation-en.json
@@ -26,6 +26,7 @@
     "wikibase-addition/add-wikibase": "Add Wikibase",
     "wikibase-addition/cancel": "Cancel",
     "wikibase-addition/invalid-manifest": "Invalid Wikibase manifest.",
+    "wikibase-addition/version-error": "Manifest version $1 is not supported. OpenRefine supports manifest versions 1.x and 2.x only.",
     "wikibase-schema/dialog-header": "Align to Wikibase",
     "wikibase-schema/dialog-explanation": "You are currently working against <a href=\"$1\" target=\"_blank\">$2</a>. You should have your data reconciled to reconciliation services linked to $2 first. The schema below specifies how your tabular data will be transformed into $2 edits. You can drag and drop the column names below in most input boxes: for each row, edits will be generated with the values in these columns.",
     "wikibase-schema/preview-explanation": "This tab shows the first edits (out of $1) that will be made once you upload the changes to <a href=\"$2\" target=\"_blank\">$3</a>. You can use facets to inspect the edits on particular items.",

--- a/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.js
@@ -153,6 +153,12 @@ WikibaseDialog.validateManifest = function (manifest) {
     WikibaseDialog.validateWikibaseManifestV2 = WikibaseDialog.ajv.compile(WikibaseManifestSchemaV2);
   }
 
+  let majorVersion = manifest.version.split('.')[0];
+  if (majorVersion < 1 || majorVersion > 2) {
+    alert($.i18n('wikibase-addition/version-error', manifest.version));
+    return false;
+  }
+
   if (manifest.version !== undefined && manifest.version.startsWith('1.')) {
     if (WikibaseDialog.validateWikibaseManifestV1(manifest)) {
        return true;

--- a/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.js
@@ -152,14 +152,16 @@ WikibaseDialog.validateManifest = function (manifest) {
     WikibaseDialog.validateWikibaseManifestV1 = WikibaseDialog.ajv.compile(WikibaseManifestSchemaV1);
     WikibaseDialog.validateWikibaseManifestV2 = WikibaseDialog.ajv.compile(WikibaseManifestSchemaV2);
   }
-
-  let majorVersion = manifest.version.split('.')[0];
-  if (majorVersion < 1 || majorVersion > 2) {
-    alert($.i18n('wikibase-addition/version-error', manifest.version));
-    return false;
+  let majorVersion;
+  if(manifest.version) {
+    majorVersion = manifest.version.split('.')[0];
+    if (!(majorVersion >= 1 && majorVersion <= 2)) {
+      alert($.i18n('wikibase-addition/version-error', manifest.version));
+      return false;
+    }
   }
 
-  if (manifest.version !== undefined && manifest.version.startsWith('1.')) {
+  if (majorVersion == 1) {
     if (WikibaseDialog.validateWikibaseManifestV1(manifest)) {
        return true;
     } else {


### PR DESCRIPTION
Fixes #4847 

Changes proposed in this pull request:
- Improved error message for invalid manifest version
- Tested for the cases of no version, invalid version (such as letters), 1.x, 2.x, >= 3.0, < 1.0.

Before:
![image](https://user-images.githubusercontent.com/42903164/172525654-6d486405-bff0-45a0-bf90-3d8aa2cdee31.png)

After:
![image](https://user-images.githubusercontent.com/42903164/172525414-508ccc3d-12c1-40a3-b6cf-51d39f871000.png)
