### PR TITLE
Remove references to specific versions of OpenRefine in the docs.

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 ---
 
 
-This manual is designed to comprehensively walk through every aspect of setting up and using OpenRefine 3.4.1, including every interface function and feature. 
+This manual is designed to comprehensively walk through every aspect of setting up and using OpenRefine, including every interface function and feature. 
 
 <!-- 
 This documentation platform provides a separate version of the user manual for each version of OpenRefine (from 3.4.1 onwards) - if you're looking for a later version than 3.4.1, please select the correct version from the dropdown menu in the top bar of this page. 

--- a/docs/docs/manual/installing.md
+++ b/docs/docs/manual/installing.md
@@ -47,16 +47,6 @@ If you need a recently developed function, and are willing to risk some untested
 
 For the absolute latest development updates, see the [snapshot releases](https://github.com/OpenRefine/OpenRefine-snapshot-releases/releases). These are created with every commit.
 
-#### What’s changed {#whats-changed}
-
-Our [latest version is OpenRefine 3.5.2](https://github.com/OpenRefine/OpenRefine/releases/tag/3.5.2), released 26th January 2022. The major changes in this version are listed on the [3.5.2 release page](https://github.com/OpenRefine/OpenRefine/releases/tag/3.5.2) with the downloadable packages.
-
-You can find information about all OpenRefine versions on the [Releases page on Github](https://github.com/OpenRefine/OpenRefine/releases).
-
-:::info Other distributions
-OpenRefine may also work in other environments, such as [Chromebooks](https://gist.github.com/organisciak/3e12e5138e44a2fed75240f4a4985b4f) where Linux terminals are available. Look at our list of [Other Distributions on the Downloads page](https://openrefine.org/download.html) for other ways of running OpenRefine, and refer to our contributor community to see new environments in development.
-:::
-
 ## Installing or upgrading {#installing-or-upgrading}
 ### Back up your data {#back-up-your-data}
 

--- a/docs/versioned_docs/version-3.5/index.md
+++ b/docs/versioned_docs/version-3.5/index.md
@@ -6,7 +6,7 @@ sidebar_label: Introduction
 ---
 
 
-This manual is designed to comprehensively walk through every aspect of setting up and using OpenRefine 3.5.0, including every interface function and feature. 
+This manual is designed to comprehensively walk through every aspect of setting up and using OpenRefine 3.5, including every interface function and feature. 
 
 <!-- 
 This documentation platform provides a separate version of the user manual for each version of OpenRefine (from 3.4.1 onwards) - if you're looking for a later version than 3.4.1, please select the correct version from the dropdown menu in the top bar of this page. 

--- a/docs/versioned_docs/version-3.5/manual/installing.md
+++ b/docs/versioned_docs/version-3.5/manual/installing.md
@@ -47,16 +47,6 @@ If you need a recently developed function, and are willing to risk some untested
 
 For the absolute latest development updates, see the [snapshot releases](https://github.com/OpenRefine/OpenRefine-snapshot-releases). These are created with every commit.
 
-#### What’s changed {#whats-changed}
-
-Our [latest version is OpenRefine 3.5.2](https://github.com/OpenRefine/OpenRefine/releases/tag/3.5.2), released January 26, 2022. The major changes in this version are listed on the [3.5.2 release page](https://github.com/OpenRefine/OpenRefine/releases/tag/3.5.2) with the downloadable packages.
-
-You can find information about all OpenRefine versions on the [Releases page on Github](https://github.com/OpenRefine/OpenRefine/releases).
-
-:::info Other distributions
-OpenRefine may also work in other environments, such as [Chromebooks](https://gist.github.com/organisciak/3e12e5138e44a2fed75240f4a4985b4f) where Linux terminals are available. Look at our list of [Other Distributions on the Downloads page](https://openrefine.org/download.html) for other ways of running OpenRefine, and refer to our contributor community to see new environments in development.
-:::
-
 ## Installing or upgrading {#installing-or-upgrading}
 ### Back up your data {#back-up-your-data}
 


### PR DESCRIPTION
Those mentions are getting out of date as we publish new versions.
I also removed the entire "What's new" section because the docs is not
an appropriate place for our changelogs, and the contents of the section
were redundant with the other download links listed before.
