### PR TITLE
Rearranged "Search for Match" dialog so the dropdown doesn't cover the buttons

### DIFF
--- a/main/webapp/modules/core/scripts/util/dialog.js
+++ b/main/webapp/modules/core/scripts/util/dialog.js
@@ -74,25 +74,36 @@ DialogSystem.showDialog = function(elmt, onCancel) {
 
   var level = DialogSystem._layers.length;
 
-  $(window).on('keydown',escapeKey);
-  
+  DialogSystem.setupEscapeKeyHandling();
+
   return level;
 };
+
+
+DialogSystem.pauseEscapeKeyHandling = function() {
+  $(window).off('keydown',escapeKey);
+}
+
+DialogSystem.setupEscapeKeyHandling = function() {
+  $(window).on('keydown',escapeKey);
+}
 
 DialogSystem.dismissLevel = function(level) {
     var layer = DialogSystem._layers[level];
 
-    $(document).off("keydown", layer.keyHandler);
+    if (layer) {
+      $(document).off("keydown", layer.keyHandler);
 
-    layer.overlay.remove();
-    layer.container.remove();
-    layer.container.off();
+      layer.overlay.remove();
+      layer.container.remove();
+      layer.container.off();
 
-    if (layer.onCancel) {
-      try {
-        layer.onCancel();
-      } catch (e) {
-        Refine.reportException(e);
+      if (layer.onCancel) {
+        try {
+          layer.onCancel();
+        } catch (e) {
+          Refine.reportException(e);
+        }
       }
     }
 };

--- a/main/webapp/modules/core/scripts/views/data-table/cell-recon-search-for-match.html
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-recon-search-for-match.html
@@ -1,19 +1,17 @@
-<div class="dialog-frame" style="width: 450px;">
+<div class="dialog-frame" style="width: 700px;">
   <div class="dialog-border">
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body" bind="dialogBody">
       <div class="grid-layout layout-tighter"><table>
         <tr>
-          <td colspan="2"><span bind="or_views_searchFor"></span> "<span bind="cellTextSpan"></span>"</td>
+          <td><span bind="or_views_searchFor"></span> "<span bind="cellTextSpan"></span>"</td>
+          <td><input type="radio" name="cell-recon-search-for-match-mode" checked="true" bind="radioSimilar" id="$cell-recon-search-match-similar" />
+            <label for="$cell-recon-search-match-similar" bind="or_views_matchOther"></label></td>
+        </tr>
+        <tr>
           <td><input bind="input" /></td>
-        </tr>
-        <tr>
-          <td width="1%"><input type="radio" name="cell-recon-search-for-match-mode" checked="true" bind="radioSimilar" id="$cell-recon-search-match-similar" /></td>
-          <td><label for="$cell-recon-search-match-similar" bind="or_views_matchOther"></label></td>
-        </tr>
-        <tr>
-          <td width="1%"><input type="radio" name="cell-recon-search-for-match-mode" bind="radioOne" id="$cell-recon-search-match-one" /></td>
-          <td><label for="$cell-recon-search-match-one" bind="or_views_matchThis"></label></td>
+          <td><input type="radio" name="cell-recon-search-for-match-mode" bind="radioOne" id="$cell-recon-search-match-one" />
+            <label for="$cell-recon-search-match-one" bind="or_views_matchThis"></label></td>
         </tr>
       </table></div>
     </div>

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -438,15 +438,25 @@ DataTableCellUI.prototype._searchForMatch = function(suggestOptions) {
     suggestOptions2.key = null;
     suggestOptions2.query_param_name = "prefix";
   }
-  elmts.input
+  var suggest = elmts.input
   .val(this._cell.v)
-  .suggest(suggestOptions2)
-  .on("fb-select", function(e, data) {
+  .suggest(suggestOptions2);
+
+  suggest.on("fb-pane-show", function(e, data) {
+    DialogSystem.pauseEscapeKeyHandling();
+  });
+
+  suggest.on("fb-pane-hide", function(e, data) {
+    DialogSystem.setupEscapeKeyHandling();
+  });
+
+  suggest.on("fb-select", function(e, data) {
     match = data;
     commit();
   })
-  .trigger('focus')
-  .data("suggest").textchange();
+      .trigger('focus')
+      .data("suggest").textchange();
+
 };
 
 DataTableCellUI.prototype._postProcessOneCell = function(command, params, bodyParams, columnStatsChanged) {


### PR DESCRIPTION
Fixes #4821

Changes proposed in this pull request:
- Rearranged "Search for Match" dialog so the dropdown doesn't cover the buttons.
- Fixed escape key handling so hitting escape will close the dropdown without closing the dialog. To close the dialog hit escape again.

New layout:
![search-for-match-new-layout](https://user-images.githubusercontent.com/42903164/172778655-1e41e47e-8135-49bf-aebb-d9e051af891c.gif)
