### PR TITLE
Updated refine.bat to use %JAVA_HOME% and be consistent with the refine script

### DIFF
--- a/refine
+++ b/refine
@@ -776,8 +776,8 @@ checkJavaMajorVersion() {
     # Java 9+ starts with x using semver versioning
     major=`echo ${java_ver} | sed -E 's/([0-9]+)(-ea|(\.[0-9]+)*)/\1/g'`
   fi
-  if (( ${major} < 8 )); then
-    error "OpenRefine requires Java version 8 or later. If you have multiple versions of Java installed, please set the environment variable JAVA_HOME to the correct version."
+  if (( ${major} < 11 )); then
+    error "OpenRefine requires Java version 11 or later. If you have multiple versions of Java installed, please set the environment variable JAVA_HOME to the correct version."
   fi
   if (( ${major} > 17 )); then
     echo "WARNING: OpenRefine is not tested and not recommended for use with Java versions greater than 17."


### PR DESCRIPTION
Fixes #4930 

Changes for refine.bat:
-  Only use java found in %JAVA_HOME% to check the version and run.  
-  Exit if Java Release < 11 
-  Warn if Java Release > 17

Changes for refine:
- Exit if Java Release < 11

Running with Java 8:
```
>refine.bat run
Using refine.ini for configuration
Java 8 (1.8.0_332)
OpenRefine requires Java version 11 or later. If you have multiple versions of Java installed, please set the environment variable JAVA_HOME to the correct version.
```
Running with Java 17:
```
>refine.bat run
Using refine.ini for configuration
Java 17 (17.0.2)
Getting Free Ram...
23:47:36.994 [            refine_server] Starting Server bound to '[127.0.0.1:3333](http://127.0.0.1:3333/)' (0ms)

```