### PR TITLE
[4952] Save project metadata after import

### DIFF
--- a/main/src/com/google/refine/commands/project/CreateProjectCommand.java
+++ b/main/src/com/google/refine/commands/project/CreateProjectCommand.java
@@ -127,7 +127,12 @@ public class CreateProjectCommand extends Command {
             
             List<Exception> exceptions = new LinkedList<Exception>();
             
-            long projectId = ImportingUtilities.createProject(job, format, optionObj, exceptions, true);
+            long projectId = ImportingUtilities.createProject(job,
+                    format,
+                    optionObj,
+                    exceptions,
+                    true,
+                    ProjectManager.singleton);
 
             HttpUtilities.redirect(response, "/project?project=" + projectId);
         } catch (Exception e) {

--- a/main/src/com/google/refine/importing/DefaultImportingController.java
+++ b/main/src/com/google/refine/importing/DefaultImportingController.java
@@ -49,6 +49,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.refine.ProjectManager;
 import com.google.refine.RefineServlet;
 import com.google.refine.commands.Command;
 import com.google.refine.commands.HttpUtilities;
@@ -248,8 +249,13 @@ public class DefaultImportingController implements ImportingController {
                 request.getParameter("options"));
         
         List<Exception> exceptions = new LinkedList<Exception>();
-        
-        ImportingUtilities.createProject(job, format, optionObj, exceptions, false);
+
+        ImportingUtilities.createProject(job,
+                format,
+                optionObj,
+                exceptions,
+                false,
+                ProjectManager.singleton);
         
         HttpUtilities.respond(response, "ok", "done");
     }

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -1055,7 +1055,7 @@ public class ImportingUtilities {
                 project.update(); // update all internal models, indexes, caches, etc.
                 
                 ProjectManager.singleton.registerProject(project, pm);
-                
+                ProjectManager.singleton.ensureProjectSaved(project.id);
                 job.setProjectID(project.id);
                 job.setState("created-project");
             } else {

--- a/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
@@ -101,7 +101,6 @@ public class ImportingUtilitiesTests extends ImporterTest {
         Assert.assertTrue(pm.getTags().length == 0);
     }
 
-
     @Test
     public void createProjectWhenJobNotCancelled() {
         job.updating = true;
@@ -163,7 +162,6 @@ public class ImportingUtilitiesTests extends ImporterTest {
                 "error");
 
     }
-
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testZipSlip() throws IOException {


### PR DESCRIPTION
Fixes #4952

Changes proposed in this pull request:
The `createProjectSynchronously` calls `registerProject` which registers it only in memory. The project metadata are not persisted so if the application stops, the project is lost.

This PR adds the call to `ensureProjectSaved` which perists the newly imported project metadata

Please let me know if there are any tests that should be modified or added