### PR TITLE
Added grid/column/reconcile Cypress tests to the CI build matrix

### DIFF
--- a/main/tests/cypress/build-test-matrix.js
+++ b/main/tests/cypress/build-test-matrix.js
@@ -28,6 +28,7 @@ const groups = [
   },
   {
     specs: [
+      'cypress/integration/project/grid/column/reconcile/**/*.spec.js',
       'cypress/integration/project/grid/column/transpose/**/*.spec.js',
       'cypress/integration/project/grid/column/view/**/*.spec.js',
     ],


### PR DESCRIPTION
The reconciliation tests were not included in the CI test run.
I added them to the test group that ran the quickest (3m).

Changes proposed in this pull request:
- Added reconciliation tests to the CI test run.
