### PR TITLE
Cleaned up the spacing between the Select and Deselect buttons in multiple file select panel

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/sort.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/sort.spec.js
@@ -16,7 +16,6 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
-    cy.reload();
     cy.getCell(0, 'Shrt_Desc').should('to.contain', 'BUTTER,WITH SALT');
     cy.getCell(1, 'Shrt_Desc').should('to.contain', 'BUTTER,WHIPPED,WITH SALT');
   });
@@ -42,7 +41,6 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
-    cy.reload();
     cy.getCell(0, 'NDB_No').should('to.contain', 1001);
     cy.getCell(1, 'NDB_No').should('to.contain', 1002);
   });
@@ -69,7 +67,6 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
-    cy.reload();
     cy.getCell(0, 'Date').should('to.contain', '2020-08-17T00:00:00Z');
     cy.getCell(1, 'Date').should('to.contain', '2020-12-17T00:00:00Z');
   });
@@ -108,7 +105,6 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
-    cy.reload();
     cy.getCell(0, 'Fat').should('to.contain', 'true');
     cy.getCell(1, 'Fat').should('to.contain', 'false');
   });

--- a/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/sort.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/sort.spec.js
@@ -16,6 +16,8 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
+    cy.reload();
+    cy.waitForProjectTable();
     cy.getCell(0, 'Shrt_Desc').should('to.contain', 'BUTTER,WITH SALT');
     cy.getCell(1, 'Shrt_Desc').should('to.contain', 'BUTTER,WHIPPED,WITH SALT');
   });
@@ -41,6 +43,8 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
+    cy.reload();
+    cy.waitForProjectTable();
     cy.getCell(0, 'NDB_No').should('to.contain', 1001);
     cy.getCell(1, 'NDB_No').should('to.contain', 1002);
   });
@@ -67,6 +71,8 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
+    cy.reload();
+    cy.waitForProjectTable();
     cy.getCell(0, 'Date').should('to.contain', '2020-08-17T00:00:00Z');
     cy.getCell(1, 'Date').should('to.contain', '2020-12-17T00:00:00Z');
   });
@@ -105,6 +111,8 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
+    cy.reload();
+    cy.waitForProjectTable();
     cy.getCell(0, 'Fat').should('to.contain', 'true');
     cy.getCell(1, 'Fat').should('to.contain', 'false');
   });

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.html
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.html
@@ -20,7 +20,7 @@
   </table></div>
   
   <h2 id="or-import-selExt"></h2>
-  <div bind="extensionContainer" class="grid-layout layout-full layout-tightest" style="display:flex;justify-content: flex-end;"></div>
+  <div bind="extensionContainer" class="grid-layout layout-full layout-tightest"></div>
   
   <h2 id="or-import-regex"></h2>
   <div class="grid-layout layout-full layout-tighter"><table>

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.html
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.html
@@ -20,7 +20,7 @@
   </table></div>
   
   <h2 id="or-import-selExt"></h2>
-  <div bind="extensionContainer" class="grid-layout layout-full layout-tightest"></div>
+  <div bind="extensionContainer" class="grid-layout layout-full layout-tightest" style="display:flex;justify-content: flex-end;"></div>
   
   <h2 id="or-import-regex"></h2>
   <div class="grid-layout layout-full layout-tighter"><table>

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
@@ -201,12 +201,12 @@ Refine.DefaultImportingController.prototype._renderFileSelectionPanelControlPane
     var tr = table.insertRow(table.rows.length);
     $('<td>').css('width','25%').css('text-align','left').text(extension.extension).appendTo(tr);
     $('<td>').css('width','25%').css('text-align','left').text($.i18n('core-index-import/file-count', extension.count)).appendTo(tr);
-    var actionTD = $('<td>').css('text-align','right');
-    actionTD.appendTo(tr);
+    var buttonTD = $('<td>').css('text-align','right');
+    buttonTD.appendTo(tr);
     $('<button>')
     .text($.i18n('core-buttons/select'))
     .addClass("button")
-    .appendTo(actionTD)
+    .appendTo(buttonTD)
     .on('click',function() {
       for (var i = 0; i < files.length; i++) {
         var file = files[i];
@@ -225,7 +225,7 @@ Refine.DefaultImportingController.prototype._renderFileSelectionPanelControlPane
     .text($.i18n('core-buttons/deselect'))
     .addClass("button")
     .css('margin-left','5px')
-    .appendTo(actionTD)
+    .appendTo(buttonTD)
     .on('click',function() {
       for (var i = 0; i < files.length; i++) {
         var file = files[i];

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
@@ -205,8 +205,7 @@ Refine.DefaultImportingController.prototype._renderFileSelectionPanelControlPane
     $('<button>')
     .text($.i18n('core-buttons/select'))
     .addClass("button")
-    .css('margin-right','3px')
-    .appendTo(tr)
+    .appendTo($('<td>').appendTo(tr))
     .on('click',function() {
       for (var i = 0; i < files.length; i++) {
         var file = files[i];
@@ -224,8 +223,7 @@ Refine.DefaultImportingController.prototype._renderFileSelectionPanelControlPane
     $('<button>')
     .text($.i18n('core-buttons/deselect'))
     .addClass("button")
-    .css('margin-left','3px')
-    .appendTo(tr)
+    .appendTo($('<td>').appendTo(tr))
     .on('click',function() {
       for (var i = 0; i < files.length; i++) {
         var file = files[i];

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
@@ -201,12 +201,12 @@ Refine.DefaultImportingController.prototype._renderFileSelectionPanelControlPane
     var tr = table.insertRow(table.rows.length);
     $('<td>').css('width','25%').css('text-align','left').text(extension.extension).appendTo(tr);
     $('<td>').css('width','25%').css('text-align','left').text($.i18n('core-index-import/file-count', extension.count)).appendTo(tr);
-    var buttonTD = $('<td>').css('text-align','right');
-    buttonTD.appendTo(tr);
+    var actionTD = $('<td>').css('text-align','right');
+    actionTD.appendTo(tr);
     $('<button>')
     .text($.i18n('core-buttons/select'))
     .addClass("button")
-    .appendTo(buttonTD)
+    .appendTo(actionTD)
     .on('click',function() {
       for (var i = 0; i < files.length; i++) {
         var file = files[i];
@@ -225,7 +225,7 @@ Refine.DefaultImportingController.prototype._renderFileSelectionPanelControlPane
     .text($.i18n('core-buttons/deselect'))
     .addClass("button")
     .css('margin-left','5px')
-    .appendTo(buttonTD)
+    .appendTo(actionTD)
     .on('click',function() {
       for (var i = 0; i < files.length; i++) {
         var file = files[i];

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
@@ -205,7 +205,8 @@ Refine.DefaultImportingController.prototype._renderFileSelectionPanelControlPane
     $('<button>')
     .text($.i18n('core-buttons/select'))
     .addClass("button")
-    .appendTo($('<td>').appendTo(tr))
+    .css('margin-right','3px')
+    .appendTo(tr)
     .on('click',function() {
       for (var i = 0; i < files.length; i++) {
         var file = files[i];
@@ -223,7 +224,8 @@ Refine.DefaultImportingController.prototype._renderFileSelectionPanelControlPane
     $('<button>')
     .text($.i18n('core-buttons/deselect'))
     .addClass("button")
-    .appendTo($('<td>').appendTo(tr))
+    .css('margin-left','3px')
+    .appendTo(tr)
     .on('click',function() {
       for (var i = 0; i < files.length; i++) {
         var file = files[i];

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/file-selection-panel.js
@@ -195,17 +195,18 @@ Refine.DefaultImportingController.prototype._renderFileSelectionPanelControlPane
     self._updateFileSelectionSummary();
   });
 
-  var table = $('<table></table>')
-  .appendTo(this._fileSelectionPanelElmts.extensionContainer)[0];
+  var table = $('<table></table>').appendTo(this._fileSelectionPanelElmts.extensionContainer)[0];
 
   var renderExtension = function(extension) {
     var tr = table.insertRow(table.rows.length);
-    $('<td>').text(extension.extension).appendTo(tr);
-    $('<td>').text($.i18n('core-index-import/file-count', extension.count)).appendTo(tr);
+    $('<td>').css('width','25%').css('text-align','left').text(extension.extension).appendTo(tr);
+    $('<td>').css('width','25%').css('text-align','left').text($.i18n('core-index-import/file-count', extension.count)).appendTo(tr);
+    var actionTD = $('<td>').css('text-align','right');
+    actionTD.appendTo(tr);
     $('<button>')
     .text($.i18n('core-buttons/select'))
     .addClass("button")
-    .appendTo($('<td>').appendTo(tr))
+    .appendTo(actionTD)
     .on('click',function() {
       for (var i = 0; i < files.length; i++) {
         var file = files[i];
@@ -223,7 +224,8 @@ Refine.DefaultImportingController.prototype._renderFileSelectionPanelControlPane
     $('<button>')
     .text($.i18n('core-buttons/deselect'))
     .addClass("button")
-    .appendTo($('<td>').appendTo(tr))
+    .css('margin-left','5px')
+    .appendTo(actionTD)
     .on('click',function() {
       for (var i = 0; i < files.length; i++) {
         var file = files[i];


### PR DESCRIPTION
Changes proposed in this pull request:
- Cleaned up the spacing between the Select and Deselect buttons in multiple file select panel.

Before:
![image](https://user-images.githubusercontent.com/42903164/174965109-270df1c1-cc62-4de8-a4d5-b191c2d00ce7.png)

After:
![image](https://user-images.githubusercontent.com/42903164/175185805-8cafc45c-bd7c-4707-8fb4-87ee39d05996.png)