### PR TITLE
Added fix for Python preview expression error.

### DIFF
--- a/extensions/jython/src/com/google/refine/jython/JythonEvaluable.java
+++ b/extensions/jython/src/com/google/refine/jython/JythonEvaluable.java
@@ -130,7 +130,7 @@ public class JythonEvaluable implements Evaluable {
 
             return unwrap(result);
         } catch (PyException e) {
-            return new EvalError(e.toString());
+            return new EvalError(e.getMessage());
         }
     }
 


### PR DESCRIPTION
Fixes #3012

I looked into this and found errors are being returned, but the Jython parser is return full exception traces instead of just reporting the error.  

I have changed it to return e.getMessage() instead of e.toString()

Msg Before:
Traceback (most recent call last):
  File "<string>", line 2, in __temp_594255022__
AttributeError: 'com.google.refine.jython.JythonHasFieldsWrapper' object has no attribute 'a'

Msg After:
AttributeError: 'com.google.refine.jython.JythonHasFieldsWrapper' object has no attribute 'a'

Before:
![image](https://user-images.githubusercontent.com/42903164/175855074-cd3c7ab9-8dfc-4e0f-b356-c5c467b09fdb.png)

After:
![image](https://user-images.githubusercontent.com/42903164/175855096-158a65a2-45c4-473b-a1a4-8ac905693088.png)
