### PR TITLE
Java versioning

### DIFF
--- a/docs/versioned_docs/version-3.5/manual/installing.md
+++ b/docs/versioned_docs/version-3.5/manual/installing.md
@@ -20,7 +20,7 @@ OpenRefine is designed to work with **Windows**, **Mac**, and **Linux** operatin
 
 If you install and start OpenRefine on a Windows computer without Java, it will automatically open up a browser window to the [Java downloads page](https://java.com/en/download/), and you can simply follow the instructions there.
 
-We recommend you [download](https://java.com/en/download/) and install Java before proceeding with the OpenRefine installation. Please note that OpenRefine works with Java 8 to Java 17 for OpenRefine 3.5.
+We recommend you [download](https://java.com/en/download/) and install Java before proceeding with the OpenRefine installation. Please note that OpenRefine works with Java 8 to Java 17 for OpenRefine 3.5. More recent plugins for OpenRefine require Java 17. We recommend [OpenJDK](https://adoptium.net/temurin/releases).
 
 #### Compatible browser {#compatible-browser}
 

--- a/docs/versioned_docs/version-3.5/manual/installing.md
+++ b/docs/versioned_docs/version-3.5/manual/installing.md
@@ -20,7 +20,7 @@ OpenRefine is designed to work with **Windows**, **Mac**, and **Linux** operatin
 
 If you install and start OpenRefine on a Windows computer without Java, it will automatically open up a browser window to the [Java downloads page](https://java.com/en/download/), and you can simply follow the instructions there.
 
-We recommend you [download](https://java.com/en/download/) and install Java before proceeding with the OpenRefine installation. Please note that OpenRefine works with Java 8 to Java 17 for OpenRefine 3.5. More recent plugins for OpenRefine require Java 17. We recommend [OpenJDK](https://adoptium.net/temurin/releases).
+We recommend you [download](https://adoptium.net/temurin/releases) and install Java before proceeding with the OpenRefine installation. Please note that OpenRefine works with Java 8 to Java 17 for OpenRefine 3.5. More recent plugins for OpenRefine require Java 17.
 
 #### Compatible browser {#compatible-browser}
 


### PR DESCRIPTION
Having found out [the hard way](https://github.com/AtesComp/rdf-transform/issues/6#issuecomment-1127394943) that Oracle's JRE is some 10 versions behind the JDK, I suggest a phrase in the installation introduction to point that out. In my case, RDF Transform needed the higher version.

Fixes #{issue number here}

Changes proposed in this pull request:
- 
- 
- 
