### PR TITLE
API: make the get-importing-configuration command available over GET

### DIFF
--- a/main/src/com/google/refine/commands/importing/GetImportingConfigurationCommand.java
+++ b/main/src/com/google/refine/commands/importing/GetImportingConfigurationCommand.java
@@ -50,7 +50,7 @@ public class GetImportingConfigurationCommand extends Command {
         ImportingConfiguration config = new ImportingConfiguration();
     }
     /**
-     * This command uses POST but does not actually modify any state so
+     * Deprecated. This command uses POST but does not actually modify any state so
      * it is not CSRF-protected.
      */
     @Override
@@ -58,5 +58,11 @@ public class GetImportingConfigurationCommand extends Command {
             throws ServletException, IOException {
 
         respondJSON(response, new ConfigurationResponse());
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        doPost(request, response);
     }
 }

--- a/main/webapp/modules/core/scripts/index/create-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/create-project-ui.js
@@ -56,7 +56,7 @@ Refine.CreateProjectUI = function(elmt) {
   $('#create-project-progress-cancel-button').text($.i18n('core-buttons/cancel'));
   $('#create-project-error-ok-button').html($.i18n('core-buttons/ok'));
   
-  $.post(
+  $.get(
     "command/core/get-importing-configuration",
     null,
     function(data) {


### PR DESCRIPTION
This makes the `get-importing-configuration` command accessible through GET requests rather than through `POST` requests as it does not change state.

Notes:

The `POST` option could maybe be safely removed considering that migration should be straightforward for potential API clients.
