### PR TITLE
Assume that unknown datatypes are string-based.

### DIFF
--- a/extensions/wikidata/module/langs/translation-cs.json
+++ b/extensions/wikidata/module/langs/translation-cs.json
@@ -16,7 +16,6 @@
     "wikibase-schema/save-button": "Uložit schéma",
     "wikibase-schema/invalid-schema-warning-preview": "Vaše schéma není kompletní. Dokončete jej a uvidíte náhled.",
     "wikibase-schema/invalid-schema-warning-issues": "Vaše schéma není kompletní. Dokončete jej a uvidíte problémy.",
-    "wikibase-schema/datatype-not-supported-yet": "Tento datový typ bohužel ještě není podporován.",
     "wikibase-schema/geoshape-with-prefix": "název souboru začínající na \"Data:\"",
     "wikibase-schema/math-expression": "matematický vzorec",
     "wikibase-schema/commons-media": "Název souboru",

--- a/extensions/wikidata/module/langs/translation-en.json
+++ b/extensions/wikidata/module/langs/translation-en.json
@@ -81,7 +81,6 @@
     "wikibase-schema/file-path-placeholder": "Absolute path or URL of the media file to upload",
     "wikibase-schema/file-name-placeholder": "File name on the wiki",
     "wikibase-schema/wikitext-placeholder": "Wiki markup associated with the file",
-    "wikibase-schema/datatype-not-supported-yet": "This datatype is not supported yet, sorry.",
     "wikibase-schema/invalid-schema-warning-issues": "Your schema is incomplete, fix it to see the issues.",
     "wikibase-schema/invalid-schema-warning-preview": "Your schema is incomplete, fix it to see the preview.",
     "wikibase-schema/discard-button": "Discard changes",

--- a/extensions/wikidata/module/langs/translation-en_GB.json
+++ b/extensions/wikidata/module/langs/translation-en_GB.json
@@ -132,7 +132,6 @@
     "wikibase-schema/discard-button": "Discard changes",
     "wikibase-schema/invalid-schema-warning-preview": "Your schema is incomplete, fix it to see the preview.",
     "wikibase-schema/invalid-schema-warning-issues": "Your schema is incomplete, fix it to see the issues.",
-    "wikibase-schema/datatype-not-supported-yet": "This datatype is not supported yet, sorry.",
     "wikibase-schema/geoshape-with-prefix": "filename starting with \"Data:\"",
     "wikibase-schema/math-expression": "mathematical expression",
     "wikibase-schema/commons-media": "filename",

--- a/extensions/wikidata/module/langs/translation-es.json
+++ b/extensions/wikidata/module/langs/translation-es.json
@@ -128,7 +128,6 @@
     "wikibase-schema/discard-button": "Descartar cambios",
     "wikibase-schema/invalid-schema-warning-preview": "El esquema está incompleto. Corríjalo para ver la previsualización.",
     "wikibase-schema/invalid-schema-warning-issues": "El esquema está incompleto. Corríjalo para ver los problemas.",
-    "wikibase-schema/datatype-not-supported-yet": "Aún no se admite este tipo de dato.",
     "wikibase-schema/geoshape-with-prefix": "nombre de archivo que comienza por «Data:»",
     "wikibase-schema/math-expression": "expresión matemática",
     "wikibase-schema/commons-media": "nombre de archivo",

--- a/extensions/wikidata/module/langs/translation-fi.json
+++ b/extensions/wikidata/module/langs/translation-fi.json
@@ -90,7 +90,6 @@
     "wikibase-schema/discard-button": "Hylkää muutokset",
     "wikibase-schema/invalid-schema-warning-preview": "Skeemasi on keskeneräinen, täydentämällä näet esikatselun.",
     "wikibase-schema/invalid-schema-warning-issues": "Skeemasi on keskeneräinen, täydentämällä saat nähtäväksi ongelmakohdat.",
-    "wikibase-schema/datatype-not-supported-yet": "Tätä tietotyyppiä ei valitettavasti vielä tueta.",
     "wikibase-schema/geoshape-with-prefix": "tiedoston nimi (sisältäen \"Data:\")",
     "wikibase-schema/math-expression": "matemaattinen lauseke",
     "wikibase-schema/commons-media": "tiedoston nimi",

--- a/extensions/wikidata/module/langs/translation-fr.json
+++ b/extensions/wikidata/module/langs/translation-fr.json
@@ -43,7 +43,6 @@
     "wikibase-schema/commons-media": "nom de fichier",
     "wikibase-schema/math-expression": "expression mathématique",
     "wikibase-schema/geoshape-with-prefix": "nom de fichier commençant par \"Data:\"",
-    "wikibase-schema/datatype-not-supported-yet": "Ce type de données n'est pas encore supporté, désolé.",
     "wikibase-schema/invalid-schema-warning-issues": "Votre schéma est incomplet, complétez-le pour voir les problèmes.",
     "wikibase-schema/invalid-schema-warning-preview": "Votre schéma est incomplet, complétez-le pour la prévisualisation.",
     "wikibase-schema/discard-button": "Annuler les modifications",

--- a/extensions/wikidata/module/langs/translation-id.json
+++ b/extensions/wikidata/module/langs/translation-id.json
@@ -5,7 +5,6 @@
     "wikibase-schema/discard-button": "Buang perubahan",
     "wikibase-schema/invalid-schema-warning-preview": "Skema Anda tidak lengkap, perbaiki untuk melihat pratinjau.",
     "wikibase-schema/invalid-schema-warning-issues": "Skema Anda tidak lengkap, perbaiki untuk melihat masalah.",
-    "wikibase-schema/datatype-not-supported-yet": "Tipe data ini belum didukung, maaf.",
     "wikibase-schema/geoshape-with-prefix": "nama file dimulai dengan \"Data:\"",
     "wikibase-schema/math-expression": "ekspresi matematika",
     "wikibase-schema/commons-media": "nama file",

--- a/extensions/wikidata/module/langs/translation-it.json
+++ b/extensions/wikidata/module/langs/translation-it.json
@@ -36,7 +36,6 @@
     "wikibase-schema/commons-media": "nome del file",
     "wikibase-schema/math-expression": "espressione matematica",
     "wikibase-schema/geoshape-with-prefix": "nome del file (compreso \"Data:\")",
-    "wikibase-schema/datatype-not-supported-yet": "Ci dispiace, questo tipo di dato non è ancora supportato.",
     "wikibase-schema/invalid-schema-warning-issues": "Il tuo schema è incompleto, per favore correggilo per vedere gli errori.",
     "wikibase-schema/invalid-schema-warning-preview": "Il tuo schema è incompleto, per favore correggilo per vedere l'anteprima.",
     "wikibase-schema/discard-button": "Non salvare le modifiche",

--- a/extensions/wikidata/module/langs/translation-jp.json
+++ b/extensions/wikidata/module/langs/translation-jp.json
@@ -41,7 +41,6 @@
     "wikibase-schema/commons-media": "ファイル名",
     "wikibase-schema/math-expression": "数学的表現",
     "wikibase-schema/geoshape-with-prefix": "\"Data:\"で始まるファイル名",
-    "wikibase-schema/datatype-not-supported-yet": "このデータ型は未対応です.",
     "wikibase-schema/invalid-schema-warning-issues": "スキーマが不完全です。修正してください.",
     "wikibase-schema/invalid-schema-warning-preview": "スキーマが不完全です。修正してください.",
     "wikibase-schema/discard-button": "変更を破棄",

--- a/extensions/wikidata/module/langs/translation-ko.json
+++ b/extensions/wikidata/module/langs/translation-ko.json
@@ -39,7 +39,6 @@
     "wikibase-schema/commons-media": "파일이름",
     "wikibase-schema/math-expression": "수학적인 표현",
     "wikibase-schema/geoshape-with-prefix": "\"Data:\"로 시작하는 파일이름",
-    "wikibase-schema/datatype-not-supported-yet": "이 데이터타입은 아직 지원하지 않습니다. 미안합니다.",
     "wikibase-schema/invalid-schema-warning-issues": "스키마가 불완전합니다. 이슈롤 보기위해서는 스키마를 수정해주세요.",
     "wikibase-schema/invalid-schema-warning-preview": "스키마가 불완전합니다. 미리보기를 보려면 스키마를 수정해주세요.",
     "wikibase-schema/discard-button": "변경사항 버리기",

--- a/extensions/wikidata/module/langs/translation-nb_NO.json
+++ b/extensions/wikidata/module/langs/translation-nb_NO.json
@@ -39,7 +39,6 @@
     "wikibase-schema/commons-media": "filnavn",
     "wikibase-schema/math-expression": "matematisk uttrykk",
     "wikibase-schema/geoshape-with-prefix": "filnavn som begynner med «Data:»",
-    "wikibase-schema/datatype-not-supported-yet": "Denne datatypen støttes ikke ennå.",
     "wikibase-schema/invalid-schema-warning-issues": "Skjemaet ditt er ufullstendig, fiks det for å se problemene.",
     "wikibase-schema/invalid-schema-warning-preview": "Skjemaet ditt er ufullstendig, fiks det for å se forhåndsvisningen.",
     "wikibase-schema/discard-button": "Forkast endringer",

--- a/extensions/wikidata/module/langs/translation-nl.json
+++ b/extensions/wikidata/module/langs/translation-nl.json
@@ -38,7 +38,6 @@
     "wikibase-schema/commons-media": "bestandsnaam",
     "wikibase-schema/math-expression": "wiskundige uitdrukking",
     "wikibase-schema/geoshape-with-prefix": "bestandsnaam beginnend met \"Data:\"",
-    "wikibase-schema/datatype-not-supported-yet": "Dit gegevenstype wordt nog niet ondersteund.",
     "wikibase-schema/invalid-schema-warning-issues": "Je schema is incompleet. Pas het aan om de issues te bekijken.",
     "wikibase-schema/invalid-schema-warning-preview": "Je schema is incompleet. Pas het aan om de preview te bekijken.",
     "wikibase-schema/discard-button": "Wijzigingen ongedaan maken",

--- a/extensions/wikidata/module/langs/translation-pl.json
+++ b/extensions/wikidata/module/langs/translation-pl.json
@@ -36,7 +36,6 @@
     "wikibase-account/invalid-credentials": "Niepoprawne dane logowania",
     "wikibase-account/password-label": "Hasło",
     "wikibase-schema/invalid-schema-warning-issues": "Twój schemat jest niekompletny. Napraw go, aby zobaczyć problemy.",
-    "wikibase-schema/datatype-not-supported-yet": "Przepraszamy, ten typ danych nie jest jeszcze obsługiwany.",
     "wikibase-schema/reference-copied": "Skopiowano",
     "wikibase-schema/discard-button": "Odrzuć zmiany",
     "wikibase-schema/commons-media": "Nazwa pliku",

--- a/extensions/wikidata/module/langs/translation-sv.json
+++ b/extensions/wikidata/module/langs/translation-sv.json
@@ -52,7 +52,6 @@
     "wikibase-schema/add-qualifier": "lägg till kvalifikator",
     "wikibase-schema/item-or-reconciled-column": "skriv in objekt eller dra avstämd kolumn hit",
     "wikibase-schema/full-url": "full URL inklusive protokoll",
-    "wikibase-schema/datatype-not-supported-yet": "Denna datatyp stöds tyvärr inte ännu.",
     "wikibase-schema/discard-button": "Ignorera ändringar",
     "wikibase-schema/unsaved-changes-alt": "Du har olagrade ändringar i ditt Wikidata-schema.",
     "wikibase-schema/discard-schema-changes-alt": "Ignorera ändringarna i schemat.",

--- a/extensions/wikidata/module/scripts/schema-alignment.js
+++ b/extensions/wikidata/module/scripts/schema-alignment.js
@@ -1394,20 +1394,8 @@ SchemaAlignment._initField = function(inputContainer, mode, initialValue, change
     } else if (mode === "wikitext") {
         input.attr("placeholder", $.i18n('wikibase-schema/wikitext-placeholder'));
     } else {
+        // Assume that other datatypes are string-based
         SchemaAlignment.setupStringInputValidation(input, /^.+$/);
-    }
-    if (mode !== "external-id" &&
-        mode !== "url" &&
-        mode !== "string" &&
-        mode !== "amount" &&
-        mode !== "tabular-data" &&
-        mode !== "commonsMedia" &&
-        mode !== "geo-shape" &&
-        mode !== "math" &&
-		mode !== "filepath" &&
-		mode !== "filename" &&
-		mode !== "wikitext") {
-       alert($.i18n('wikibase-schema/datatype-not-supported-yet'));
     }
   }
 


### PR DESCRIPTION
Fixes #3263.

Changes proposed in this pull request: Added support for custom Wikibase datatypes by assuming that their datavalue type is "string". Looking at the datatypes developed recently, this seems to be a reasonable assumption and should work with all extensions I am aware of.

To make this more robust, one should ideally lookup the datavalue type from the Wikibase instance (or store this information in the manifest). I could not find a way to lookup the datavalue type of a given datatype with the MediaWiki API.