### PR TITLE
Semantics: change two buttons to links

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.html
@@ -11,7 +11,7 @@
   <div class="dialog-footer" style="justify-content: space-between" bind="dialogFooter">
       <div>
           <button class="button" bind="addButton"></button>
-          <button class="button" bind="discoverManifestsButton"></button>
+          <a class="button" bind="discoverManifestsButton" href="https://github.com/OpenRefine/wikibase-manifests" target="_blank"></a>
       </div>
       <button class="button" bind="closeButton"></button>
   </div>

--- a/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.js
@@ -20,10 +20,6 @@ WikibaseDialog.launch = function () {
   elmts.addButton.on('click',function () {
     WikibaseDialog.addWikibaseManifest();
   });
-
-  elmts.discoverManifestsButton.on('click',function () {
-    window.open('https://github.com/OpenRefine/wikibase-manifests');
-  });
 };
 
 WikibaseDialog.populateDialog = function () {

--- a/main/webapp/modules/core/scripts/reconciliation/recon-dialog.html
+++ b/main/webapp/modules/core/scripts/reconciliation/recon-dialog.html
@@ -23,7 +23,7 @@
 			<tr>
 				<td align="left">
 					<button class="button" bind="addStandardServiceButton"></button>
-					<button class="button" bind="discoverServicesButton" onClick = "window.open('https://reconciliation-api.github.io/testbench', '_blank')" ></button>
+					<a class="button" bind="discoverServicesButton" href="https://reconciliation-api.github.io/testbench" target="_blank" ></a>
 				</td>
 				<td align="right">
 					<button class="button" bind="reconcileButton"></button>


### PR DESCRIPTION
So that the security and accessibility features of the browser work as intended.

