### PR TITLE
drop legacy CSS

### DIFF
--- a/main/webapp/modules/core/styles/index/open-project-ui.less
+++ b/main/webapp/modules/core/styles/index/open-project-ui.less
@@ -147,7 +147,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /* Making metadata table header sticky and darker*/
 #metadata-body table > tbody > tr >th{
-	position: -webkit-sticky;
 	position:sticky;
 	top:0;
 	color:black;
@@ -162,8 +161,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	margin: 5px;
 	font-size: 130%;
 	border-radius: 5px;
-	-moz-border-radius: 5px;
-	-webkit-border-radius: 5px;
 	background: #bcf;
 	min-height: 18px;
 	height: auto;
@@ -200,8 +197,6 @@ ul#tagsUl li a  {
 #projectTags .current {
 	background-color: #DEE6FF;
 	border-radius: 10px;
-	-moz-border-radius: 10px;
-	-webkit-border-radius: 10px;
 }
 
 /* Project List */
@@ -214,8 +209,6 @@ ul#tagsUl li a  {
 	padding: 3px 8px;
 	margin: 0px 2px;
 	border-radius: 3px;
-	-moz-border-radius: 3px;
-	-webkit-border-radius: 3px;
 	font-size: 100%;
 	font-weight: bold;
 	background: #28458A;

--- a/main/webapp/modules/core/styles/jquery-ui-overrides.less
+++ b/main/webapp/modules/core/styles/jquery-ui-overrides.less
@@ -92,10 +92,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .ui-tabs .ui-corner-top, .ui-tabs .ui-corner-top {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
-  -webkit-border-top-right-radius: 0;
-  -webkit-border-top-left-radius: 0;
-  -moz-border-radius-topright: 0;
-  -moz-border-radius-topleft: 0;
   }
   
 .ui-tabs .ui-tabs-panel {

--- a/main/webapp/modules/core/styles/project/facets.less
+++ b/main/webapp/modules/core/styles/project/facets.less
@@ -294,39 +294,23 @@ img.facet-choice-link {
   margin: 0px;
   }
 
-.scatterplot-selectors .buttonset .ui-corner-top { 
-  -moz-border-radius-topleft: 0.5em; 
-  -webkit-border-top-left-radius: 0.5em; 
-  border-top-left-radius: 0.5em; 
-  -moz-border-radius-topright: 0.5em; 
-  -webkit-border-top-right-radius: 0.5em; 
+.scatterplot-selectors .buttonset .ui-corner-top {
+  border-top-left-radius: 0.5em;
   border-top-right-radius: 0.5em; 
   }
 
-.scatterplot-selectors .buttonset .ui-corner-bottom { 
-  -moz-border-radius-bottomleft: 0.5em; 
-  -webkit-border-bottom-left-radius: 0.5em; 
-  border-bottom-left-radius: 0.5em; 
-  -moz-border-radius-bottomright: 0.5em; 
-  -webkit-border-bottom-right-radius: 0.5em; 
-  border-bottom-right-radius: 0.5em; 
+.scatterplot-selectors .buttonset .ui-corner-bottom {
+  border-bottom-left-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
   }
 
-.scatterplot-selectors .buttonset .ui-corner-right { 
-  -moz-border-radius-topright: 0.5em; 
-  -webkit-border-top-right-radius: 0.5em; 
-  border-top-right-radius: 0.5em; 
-  -moz-border-radius-bottomright: 0.5em; 
-  -webkit-border-bottom-right-radius: 0.5em; 
-  border-bottom-right-radius: 0.5em; 
+.scatterplot-selectors .buttonset .ui-corner-right {
+  border-top-right-radius: 0.5em;
+  border-bottom-right-radius: 0.5em;
   }
 
-.scatterplot-selectors .buttonset .ui-corner-left { 
-  -moz-border-radius-topleft: 0.5em; 
-  -webkit-border-top-left-radius: 0.5em; 
-  border-top-left-radius: 0.5em; 
-  -moz-border-radius-bottomleft: 0.5em; 
-  -webkit-border-bottom-left-radius: 0.5em; 
+.scatterplot-selectors .buttonset .ui-corner-left {
+  border-top-left-radius: 0.5em;
   border-bottom-left-radius: 0.5em; 
   }
 

--- a/main/webapp/modules/core/styles/project/process.less
+++ b/main/webapp/modules/core/styles/project/process.less
@@ -40,10 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   background: #DBE8EB;
   border: 1px solid #aaa;
   border-top: none;
-  -moz-border-radius-bottomleft: 10px;
-  -webkit-border-bottom-left-radius: 10px;
-  -moz-border-radius-bottomright: 10px;
-  -webkit-border-bottom-right-radius: 10px;
+  border-radius: 0 0 10px 10px;
   }
 
 .process-panel-inner {

--- a/main/webapp/modules/core/styles/project/sidebar.less
+++ b/main/webapp/modules/core/styles/project/sidebar.less
@@ -47,8 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   background: #fff0f4; 
   color: #c51244;
   padding: 4px 4px;
-  -moz-border-radius: 4px;
-  -webkit-border-radius: 4px;
+  border-radius: 4px;
   border: 1px solid #ccc;
   }
 
@@ -62,8 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   text-align: center;
   background-color: #fff;
   padding: 4px 4px;
-  -moz-border-radius: 4px;
-  -webkit-border-radius: 4px;
+  border-radius: 4px;
   border: 1px solid #ccc;
   }
 

--- a/main/webapp/modules/core/styles/pure.css
+++ b/main/webapp/modules/core/styles/pure.css
@@ -32,13 +32,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 .button, a.button { 
-  background: -webkit-gradient(linear, left top, left bottom, from(#f9f9f9), to(#e3e3e3));
-  background: -moz-linear-gradient(top,  #f9f9f9,  #e3e3e3);
-  filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#f9f9f9', endColorstr='#e3e3e3');
-  }
+  background: linear-gradient(#f9f9f9,  #e3e3e3);
+}
 
-.button:active, a.button:active { 
-  background: -webkit-gradient(linear, left top, left bottom, from(#e3e3e3), to(#f9f9f9));
-  background: -moz-linear-gradient(top,  #e3e3e3,  #f9f9f9);
-  filter:  progid:DXImageTransform.Microsoft.gradient(startColorstr='#e3e3e3', endColorstr='#f9f9f9');
-  }
+.button:active, a.button:active {
+  background: linear-gradient(#e3e3e3,  #f9f9f9);
+}

--- a/main/webapp/modules/core/styles/theme.less
+++ b/main/webapp/modules/core/styles/theme.less
@@ -57,62 +57,36 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 @padding_loose: 10px;
 @padding_looser: 15px;
 
-.rounded_corners (@radius: 5px) { 
-  -moz-border-radius: @radius;
-  -webkit-border-radius: @radius;
+.rounded_corners (@radius: 5px) {
   border-radius: @radius;
-  }
+}
 
-.rounded_corners_top (@radius: 5px) { 
-  -webkit-border-top-left-radius: @radius;
-  -webkit-border-top-right-radius: @radius;
-  -moz-border-radius-topleft: @radius;
-  -moz-border-radius-topright: @radius;
+.rounded_corners_top (@radius: 5px) {
   border-top-right-radius: @radius;
   border-top-left-radius: @radius;
-  }
+}
 
-.rounded_corners_bottom (@radius: 5px) { 
-  -webkit-border-bottom-left-radius: @radius;
-  -webkit-border-bottom-right-radius: @radius;
-  -moz-border-radius-bottomleft: @radius;
-  -moz-border-radius-bottomright: @radius;
+.rounded_corners_bottom (@radius: 5px) {
   border-bottom-right-radius: @radius;
   border-bottom-left-radius: @radius;
-  }
+}
 
-.rounded_corners_left (@radius: 5px) { 
-  -webkit-border-top-left-radius: @radius;
-  -webkit-border-bottom-left-radius: @radius;
-  -moz-border-radius-topleft: @radius;
-  -moz-border-radius-bottomleft: @radius;
+.rounded_corners_left (@radius: 5px) {
   border-top-left-radius: @radius;
   border-bottom-left-radius: @radius;
-  }
+}
 
-.rounded_corners_right (@radius: 5px) { 
-  -webkit-border-top-right-radius: @radius;
-  -webkit-border-bottom-right-radius: @radius;
-  -moz-border-radius-topright: @radius;
-  -moz-border-radius-bottomright: @radius;
+.rounded_corners_right (@radius: 5px) {
   border-top-right-radius: @radius;
   border-bottom-right-radius: @radius;
-  }
+}
 
 .sharp_corners_left () {
-  -webkit-border-top-right-radius: 0;
-  -webkit-border-bottom-right-radius: 0;
-  -moz-border-radius-topright: 0;
-  -moz-border-radius-bottomright: 0;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;	
-  }
+}
 
 .sharp_corners_right () {
-  -moz-border-radius-topleft: 0;
-  -moz-border-radius-bottomleft: 0;
-  -webkit-border-top-left-radius: 0;
-  -webkit-border-bottom-left-radius: 0;
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  }
+}

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -131,7 +131,6 @@ table {
   }
 
 th.column-header {
-  position: -webkit-sticky; /* Safari */ 
   position: sticky;
   top: 0;
   z-index: 1;


### PR DESCRIPTION
Drop various legacy CSS features/prefixes.

These changes should only affect browsers older than:

 - IE 10
 - Safari 13
 - Firefox 50
 - Chrome 56