### PR TITLE
Wait a little before reloading in Cypress sort test

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/sort.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/sort.spec.js
@@ -16,6 +16,7 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
+    cy.wait(250); // wait for the rest of the update code to run before reloading, for #5051 (TODO: find a better way?)
     cy.reload();
     cy.waitForProjectTable();
     cy.getCell(0, 'Shrt_Desc').should('to.contain', 'BUTTER,WITH SALT');
@@ -43,6 +44,7 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
+    cy.wait(250); // wait for the rest of the update code to run before reloading, for #5051 (TODO: find a better way?)
     cy.reload();
     cy.waitForProjectTable();
     cy.getCell(0, 'NDB_No').should('to.contain', 1001);
@@ -71,6 +73,7 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
+    cy.wait(250); // wait for the rest of the update code to run before reloading, for #5051 (TODO: find a better way?)
     cy.reload();
     cy.waitForProjectTable();
     cy.getCell(0, 'Date').should('to.contain', '2020-08-17T00:00:00Z');
@@ -111,6 +114,7 @@ describe(__filename, function () {
     cy.get('.viewpanel-sorting a').contains('Sort').click();
     cy.get('.menu-container').contains('Reorder rows permanently').click();
     cy.assertNotificationContainingText('Reorder rows');
+    cy.wait(250); // wait for the rest of the update code to run before reloading, for #5051 (TODO: find a better way?)
     cy.reload();
     cy.waitForProjectTable();
     cy.getCell(0, 'Fat').should('to.contain', 'true');


### PR DESCRIPTION
Closes #5051.

The test sometimes fails apparently because some of the UI update code gets interrupted by the `cy.reload()` action. Intuitively such errors should be ignored by Cypress, but it is not currently the case.

I am not happy with this solution, but it is the only thing I could think of, because I do not see what DOM element I could wait on instead. It does seem to make the test more reliable though. Any other ideas very much welcome!
