### PR TITLE
Added ignore to Dependabot for Cypress dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,8 @@ updates:
   directory: "main/tests/cypress"
   schedule:
     interval: "daily"
+  ignore:
+# Ignore cypress updates until interactive 'Run all specs' fixed https://github.com/cypress-io/cypress/discussions/21628
+  - dependency-name: cypress
+    versions:
+    - ">= 10.0.0"


### PR DESCRIPTION
Changes proposed in this pull request:
- Added ignore to Dependabot for the Cypress dependency since we do not want to upgrade until Cypress adds back 'Run all tests,' and based on the comments of the maintainer, 'Run all tests' will not be back for another 6 months to a year.