### PR TITLE
Fix preview of MediaInfo entities

### DIFF
--- a/extensions/wikidata/module/styles/schema-alignment.less
+++ b/extensions/wikidata/module/styles/schema-alignment.less
@@ -206,6 +206,10 @@
 	margin: 1em 0em;
 }
 
+.schema-alignment-dialog-preview .wbs-mediainfo-file-fields {
+	grid-template-columns: max-content min(450px, 50%);
+}
+
 /* Fix input rendering for Firefox */
 
 .wbs-entity-input input, .wbs-prop-input input, .wbs-target-input input,


### PR DESCRIPTION
Closes #5089.
Fixes bug introduced by #5028.

Changes proposed in this pull request:
- restore the size of the grid used to render mediainfo previews
