### PR TITLE
Backend support for incomplete schemas

### DIFF
--- a/extensions/wikidata/src/org/openrefine/wikidata/commands/CommandUtilities.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/commands/CommandUtilities.java
@@ -1,11 +1,10 @@
 package org.openrefine.wikidata.commands;
 
 import java.io.IOException;
-import java.io.Writer;
 
 import javax.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.commands.Command;
 import com.google.refine.util.ParsingUtilities;
 
@@ -22,15 +21,9 @@ public class CommandUtilities {
      */
     public static void respondError(HttpServletResponse response, String errorMessage)
             throws IOException {
-        Writer w = response.getWriter();
-        JsonGenerator writer = ParsingUtilities.mapper.getFactory().createGenerator(w);
-        writer.writeStartObject();
-        writer.writeStringField("code", "error");
-        writer.writeStringField("message", errorMessage);
-        writer.writeEndObject();
-        writer.flush();
-        writer.close();
-        w.flush();
-        w.close();
+    	ObjectNode jsonObject = ParsingUtilities.mapper.createObjectNode();
+    	jsonObject.put("code", "error");
+    	jsonObject.put("message", errorMessage);
+    	Command.respondJSON(response, jsonObject);
     }
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/commands/PreviewWikibaseSchemaCommand.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/commands/PreviewWikibaseSchemaCommand.java
@@ -27,7 +27,9 @@ package org.openrefine.wikidata.commands;
 import static org.openrefine.wikidata.commands.CommandUtilities.respondError;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.servlet.ServletException;
@@ -40,13 +42,16 @@ import org.openrefine.wikidata.manifests.ManifestParser;
 import org.openrefine.wikidata.qa.EditInspector;
 import org.openrefine.wikidata.qa.QAWarningStore;
 import org.openrefine.wikidata.schema.WikibaseSchema;
+import org.openrefine.wikidata.schema.validation.ValidationError;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.updates.EntityEdit;
-import org.openrefine.wikidata.updates.TermedStatementEntityEdit;
 import org.openrefine.wikidata.updates.scheduler.WikibaseAPIUpdateScheduler;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.browsing.Engine;
 import com.google.refine.commands.Command;
 import com.google.refine.model.Project;
+import com.google.refine.util.ParsingUtilities;
 
 public class PreviewWikibaseSchemaCommand extends Command {
 	
@@ -82,6 +87,19 @@ public class PreviewWikibaseSchemaCommand extends Command {
             }
             if (schema == null) {
                 respondError(response, "No Wikibase schema provided.");
+                return;
+            }
+            
+            ValidationState validation = new ValidationState(project.columnModel);
+            schema.validate(validation);
+            List<ValidationError> errors = validation.getValidationErrors();
+            if (!errors.isEmpty()) {
+            	Map<String, Object> json = new HashMap<>();
+            	json.put("code", "error");
+            	json.put("reason", "invalid-schema");
+            	json.put("message", "Invalid Wikibase schema");
+            	json.put("errors", errors);
+                Command.respondJSON(response, json);
                 return;
             }
 

--- a/extensions/wikidata/src/org/openrefine/wikidata/commands/SaveWikibaseSchemaCommand.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/commands/SaveWikibaseSchemaCommand.java
@@ -26,6 +26,8 @@ package org.openrefine.wikidata.commands;
 import static org.openrefine.wikidata.commands.CommandUtilities.respondError;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import javax.servlet.ServletException;
@@ -34,6 +36,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.openrefine.wikidata.operations.SaveWikibaseSchemaOperation;
 import org.openrefine.wikidata.schema.WikibaseSchema;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 
 import com.google.refine.commands.Command;
 import com.google.refine.model.AbstractOperation;
@@ -55,23 +58,28 @@ public class SaveWikibaseSchemaCommand extends Command {
             Project project = getProject(request);
 
             String jsonString = request.getParameter("schema");
-            if (jsonString == null) {
+            if (jsonString == null || "null".equals(jsonString)) {
                 respondError(response, "No Wikibase schema provided.");
                 return;
             }
 
             WikibaseSchema schema = ParsingUtilities.mapper.readValue(jsonString, WikibaseSchema.class);
+            
+            ValidationState validation = new ValidationState(project.columnModel);
+            schema.validate(validation);
+            if (!validation.getValidationErrors().isEmpty()) {
+            	Map<String, Object> json = new HashMap<>();
+            	json.put("reason", "invalid-schema");
+            	json.put("message", "Invalid Wikibase schema");
+            	json.put("errors", validation.getValidationErrors());
+				respondJSON(response, json);
+				return;
+            }
 
             AbstractOperation op = new SaveWikibaseSchemaOperation(schema);
             Process process = op.createProcess(project, new Properties());
 
             performProcessAndRespond(request, response, project, process);
-
-        } catch (IOException e) {
-            // We do not use respondException here because this is an expected
-            // exception which happens every time a user tries to save an incomplete
-            // schema - the exception should not be logged.
-            respondError(response, String.format("Wikibase schema could not be parsed: ", e.getMessage()));
         } catch (Exception e) {
             // This is an unexpected exception, so we log it.
             respondException(response, e);

--- a/extensions/wikidata/src/org/openrefine/wikidata/operations/PerformWikibaseEditsOperation.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/operations/PerformWikibaseEditsOperation.java
@@ -40,6 +40,7 @@ import org.openrefine.wikidata.editing.EditBatchProcessor;
 import org.openrefine.wikidata.editing.NewEntityLibrary;
 import org.openrefine.wikidata.manifests.Manifest;
 import org.openrefine.wikidata.schema.WikibaseSchema;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.updates.EntityEdit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -215,6 +216,13 @@ public class PerformWikibaseEditsOperation extends EngineDependentOperation {
                 editGroupsUrlSchema = WIKIDATA_EDITGROUPS_URL_SCHEMA;
             }
             this._editGroupsUrlSchema = editGroupsUrlSchema;
+            
+            // validate the schema
+            ValidationState validation = new ValidationState(_project.columnModel);
+			_schema.validate(validation);
+			if (!validation.getValidationErrors().isEmpty()) {
+				throw new IllegalStateException("Schema is incomplete");
+			}
         }
 
         @Override

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/ExpressionContext.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/ExpressionContext.java
@@ -129,4 +129,8 @@ public class ExpressionContext {
             warningStore.addWarning(warning);
         }
     }
+
+	public ColumnModel getColumnModel() {
+		return columnModel;
+	}
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbEntityIdValueConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbEntityIdValueConstant.java
@@ -1,7 +1,8 @@
 package org.openrefine.wikidata.schema;
 
-import org.jsoup.helper.Validate;
 import org.openrefine.wikidata.schema.entityvalues.SuggestedEntityIdValue;
+import org.openrefine.wikidata.schema.validation.ValidationState;
+import org.wikidata.wdtk.datamodel.implementation.EntityIdValueImpl;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -22,11 +23,25 @@ public class WbEntityIdValueConstant implements WbExpression<EntityIdValue> {
     public WbEntityIdValueConstant(
     		@JsonProperty("id") String id,
     		@JsonProperty("label") String label) {
-        Validate.notNull(id, "id cannot be null");
         this.id = id;
-        Validate.notNull(label, "label cannot be null");
         this.label = label;
     }
+    
+	@Override
+	public void validate(ValidationState validation) {
+		if (id == null) {
+			validation.addError("No entity id provided");
+		} else {
+			try {
+				EntityIdValueImpl.guessEntityTypeFromId(id);
+			} catch(IllegalArgumentException e) {
+				validation.addError("Invalid entity id format: '"+id+"'");
+			}
+		}
+		if (label == null) {
+			validation.addError("No entity label provided");
+		}
+	}
 
     @Override
     public EntityIdValue evaluate(ExpressionContext ctxt) {
@@ -56,4 +71,5 @@ public class WbEntityIdValueConstant implements WbExpression<EntityIdValue> {
     public int hashCode() {
         return id.hashCode() + label.hashCode();
     }
+
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbExpression.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbExpression.java
@@ -25,6 +25,7 @@ package org.openrefine.wikidata.schema;
 
 import org.openrefine.wikidata.schema.exceptions.QAWarningException;
 import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
@@ -59,7 +60,17 @@ public interface WbExpression<T> {
     /**
      * Evaluates the value expression in a given context, returns a Wikibase value
      * suitable to be the target of a claim.
+     * 
+     * As a premise to calling that method, we assume that calling {@link #validate(ValidationState)}
+     * did not log any error in the validation state.
      */
     public T evaluate(ExpressionContext ctxt)
             throws SkipSchemaExpressionException, QAWarningException;
+
+    
+    /**
+     * Check that this expression is fully formed and ready to be evaluated.
+     * @param state
+     */
+    public void validate(ValidationState validation);
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbItemConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbItemConstant.java
@@ -23,8 +23,9 @@
  ******************************************************************************/
 package org.openrefine.wikidata.schema;
 
-import org.jsoup.helper.Validate;
 import org.openrefine.wikidata.schema.entityvalues.SuggestedItemIdValue;
+import org.openrefine.wikidata.schema.validation.ValidationState;
+import org.wikidata.wdtk.datamodel.implementation.EntityIdValueImpl;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -40,11 +41,25 @@ public class WbItemConstant implements WbExpression<ItemIdValue> {
 
     @JsonCreator
     public WbItemConstant(@JsonProperty("qid") String qid, @JsonProperty("label") String label) {
-        Validate.notNull(qid);
         this.qid = qid;
-        Validate.notNull(label);
         this.label = label;
     }
+    
+	@Override
+	public void validate(ValidationState validation) {
+		if (qid == null) {
+			validation.addError("No entity id provided");
+		} else {
+			try {
+				EntityIdValueImpl.guessEntityTypeFromId(qid);
+			} catch(IllegalArgumentException e) {
+				validation.addError("Invalid entity id format: '"+qid+"'");
+			}
+		}
+		if (label == null) {
+			validation.addError("No entity label provided");
+		}
+	}
 
     @Override
     public ItemIdValue evaluate(ExpressionContext ctxt) {

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbLanguageConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbLanguageConstant.java
@@ -23,8 +23,8 @@
  ******************************************************************************/
 package org.openrefine.wikidata.schema;
 
-import org.apache.commons.lang.Validate;
 import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.utils.LanguageCodeStore;
 import org.wikidata.wdtk.datamodel.interfaces.WikimediaLanguageCodes;
 
@@ -40,15 +40,27 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class WbLanguageConstant implements WbExpression<String> {
 
     protected String _langId;
+    protected String _origLangId; // for error reporting purposes during validation
     protected String _langLabel;
 
     @JsonCreator
     public WbLanguageConstant(@JsonProperty("id") String langId, @JsonProperty("label") String langLabel) {
         _langId = normalizeLanguageCode(langId);
-        Validate.notNull(_langId, "A valid language code must be provided.");
-        Validate.notNull(langLabel);
         _langLabel = langLabel;
+        _origLangId = langId;
     }
+
+	@Override
+	public void validate(ValidationState validation) {
+		if (_origLangId != null && _langId == null) {
+			validation.addError("Invalid language code '" + _origLangId + "'");
+		} else if (_langId == null) {
+			validation.addError("Empty language field");
+		}
+        if (_langLabel == null) {
+        	validation.addError("Empty text field");
+        }
+	}
 
     public static String normalizeLanguageCode(String lang) {
         return normalizeLanguageCode(lang, null);

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbLocationConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbLocationConstant.java
@@ -25,8 +25,8 @@ package org.openrefine.wikidata.schema;
 
 import java.text.ParseException;
 
-import org.apache.commons.lang.Validate;
 import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
 
@@ -48,12 +48,21 @@ public class WbLocationConstant implements WbExpression<GlobeCoordinatesValue> {
     private GlobeCoordinatesValue parsed;
 
     @JsonCreator
-    public WbLocationConstant(@JsonProperty("value") String origValue) throws ParseException {
+    public WbLocationConstant(@JsonProperty("value") String origValue) {
         this.value = origValue;
-        Validate.notNull(origValue);
-        this.parsed = parse(origValue);
-        Validate.notNull(this.parsed);
     }
+    
+	@Override
+	public void validate(ValidationState validation) {
+		if (value == null) {
+			validation.addError("Empty geographical coordinates value");
+		}
+        try {
+        	parsed = parse(value);
+        } catch(ParseException e) {
+        	validation.addError("Invalid geographical coordinates: '"+value+"'");
+        }
+	}
 
     /**
      * Parses a string to a location.

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbMonolingualExpr.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbMonolingualExpr.java
@@ -23,10 +23,10 @@
  ******************************************************************************/
 package org.openrefine.wikidata.schema;
 
-import org.apache.commons.lang.Validate;
 import org.openrefine.wikidata.qa.QAWarning;
 import org.openrefine.wikidata.schema.exceptions.QAWarningException;
 import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.StringValue;
@@ -42,11 +42,23 @@ public class WbMonolingualExpr implements WbExpression<MonolingualTextValue> {
     @JsonCreator
     public WbMonolingualExpr(@JsonProperty("language") WbExpression<? extends String> languageExpr,
             @JsonProperty("value") WbExpression<? extends StringValue> valueExpr) {
-        Validate.notNull(languageExpr);
         this.languageExpr = languageExpr;
-        Validate.notNull(valueExpr);
         this.valueExpr = valueExpr;
     }
+
+	@Override
+	public void validate(ValidationState validation) {
+		if (languageExpr == null) {
+			validation.addError("No language provided");
+		} else {
+			languageExpr.validate(validation);
+		}
+		if (valueExpr == null) {
+			validation.addError("No text value provided");
+		} else {
+			valueExpr.validate(validation);
+		}
+	}
 
     @Override
     public MonolingualTextValue evaluate(ExpressionContext ctxt)
@@ -87,4 +99,5 @@ public class WbMonolingualExpr implements WbExpression<MonolingualTextValue> {
     public int hashCode() {
         return languageExpr.hashCode() + valueExpr.hashCode();
     }
+
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbPropConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbPropConstant.java
@@ -23,8 +23,8 @@
  ******************************************************************************/
 package org.openrefine.wikidata.schema;
 
-import org.jsoup.helper.Validate;
 import org.openrefine.wikidata.schema.entityvalues.SuggestedPropertyIdValue;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -45,12 +45,20 @@ public class WbPropConstant implements WbExpression<PropertyIdValue> {
     @JsonCreator
     public WbPropConstant(@JsonProperty("pid") String pid, @JsonProperty("label") String label,
             @JsonProperty("datatype") String datatype) {
-        Validate.notNull(pid);
         this.pid = pid;
-        Validate.notNull(label);
         this.label = label;
         this.datatype = datatype;
     }
+
+	@Override
+	public void validate(ValidationState validation) {
+		if (pid == null) {
+			validation.addError("Missing property id");
+		}
+		if (label == null) {
+			validation.addError("Missing property label");
+		}
+	}
 
     @Override
     public PropertyIdValue evaluate(ExpressionContext ctxt) {
@@ -86,4 +94,5 @@ public class WbPropConstant implements WbExpression<PropertyIdValue> {
     public int hashCode() {
         return pid.hashCode() + label.hashCode();
     }
+
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbReferenceExpr.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbReferenceExpr.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.apache.commons.lang.Validate;
 import org.openrefine.wikidata.schema.exceptions.QAWarningException;
 import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.Reference;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
@@ -57,6 +58,22 @@ public class WbReferenceExpr implements WbExpression<Reference> {
         Validate.notNull(snakExprs);
         this.snakExprs = snakExprs;
     }
+
+	@Override
+	public void validate(ValidationState validation) {
+		if (snakExprs == null) {
+			validation.addError("No reference snaks provided");
+		} else {
+			// empty reference snaks are allowed
+			snakExprs.forEach(snak -> {
+				if (snak == null) {
+					validation.addError("Null snak in reference");
+				} else {
+					snak.validate(validation);
+				}
+			});
+		}
+	}
 
     @Override
     public Reference evaluate(ExpressionContext ctxt)
@@ -95,4 +112,5 @@ public class WbReferenceExpr implements WbExpression<Reference> {
     public int hashCode() {
         return snakExprs.hashCode();
     }
+
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbSnakExpr.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbSnakExpr.java
@@ -23,10 +23,11 @@
  ******************************************************************************/
 package org.openrefine.wikidata.schema;
 
-import org.jsoup.helper.Validate;
 import org.openrefine.wikidata.schema.entityvalues.FullyPropertySerializingValueSnak;
 import org.openrefine.wikidata.schema.exceptions.QAWarningException;
 import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
+import org.openrefine.wikidata.schema.validation.PathElement;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
@@ -52,11 +53,32 @@ public class WbSnakExpr implements WbExpression<Snak> {
     @JsonCreator
     public WbSnakExpr(@JsonProperty("prop") WbExpression<? extends PropertyIdValue> propExpr,
             @JsonProperty("value") WbExpression<? extends Value> valueExpr) {
-        Validate.notNull(propExpr);
         this.prop = propExpr;
-        Validate.notNull(valueExpr);
         this.value = valueExpr;
     }
+    
+	@Override
+	public void validate(ValidationState validation) {
+		if (prop == null) {
+			validation.addError("Missing property");
+		} else {
+			validation.enter(new PathElement(PathElement.Type.PROPERTY));
+			prop.validate(validation);
+			validation.leave();
+		}
+		if (value == null) {
+			validation.addError("Missing value");
+		} else {
+			String propertyId = null;
+			if (prop instanceof WbPropConstant) {
+				WbPropConstant propConstant = (WbPropConstant) prop;
+				propertyId = propConstant.getLabel() + " (" + propConstant.getPid() + ")";
+			}
+			validation.enter(new PathElement(PathElement.Type.VALUE, propertyId));
+			value.validate(validation);
+			validation.leave();
+		}
+	}
 
     @Override
     public Snak evaluate(ExpressionContext ctxt)
@@ -89,4 +111,5 @@ public class WbSnakExpr implements WbExpression<Snak> {
     public int hashCode() {
         return prop.hashCode() + value.hashCode();
     }
+
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbStatementGroupExpr.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbStatementGroupExpr.java
@@ -30,8 +30,11 @@ import java.util.List;
 import org.jsoup.helper.Validate;
 import org.openrefine.wikidata.schema.exceptions.QAWarningException;
 import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
-import org.openrefine.wikidata.updates.StatementGroupEdit;
+import org.openrefine.wikidata.schema.validation.PathElement;
+import org.openrefine.wikidata.schema.validation.PathElement.Type;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.updates.StatementEdit;
+import org.openrefine.wikidata.updates.StatementGroupEdit;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 
@@ -54,6 +57,38 @@ public class WbStatementGroupExpr {
         Validate.isTrue(!claimExprs.isEmpty());
         this.statementExprs = claimExprs;
     }
+    
+    /**
+     * Checks that the expression has all its required components and is ready to be evaluated.
+     * @param validation
+     */
+	public void validate(ValidationState validation) {
+		validation.enter(new PathElement(Type.STATEMENT));
+		if (propertyExpr == null) {
+			validation.addError("No property");
+		} else {
+			propertyExpr.validate(validation);
+		}
+		validation.leave();
+		
+		// Extract property name to contribute to further validation paths
+		String propertyName = null;
+		if (propertyExpr instanceof WbPropConstant) {
+			WbPropConstant propConstant = (WbPropConstant)propertyExpr;
+			if (propConstant.getLabel() != null && propConstant.getPid() != null) {
+				propertyName = String.format("%s (%s)", propConstant.getLabel(), propConstant.getPid());
+			}
+		}
+		for (WbStatementExpr statement : statementExprs) {
+			validation.enter(new PathElement(Type.STATEMENT, propertyName));
+			if (statement != null) {
+				statement.validate(validation);
+			} else {
+				validation.addError("Empty statement");
+			}
+			validation.leave();
+		}
+	}
 
     public StatementGroupEdit evaluate(ExpressionContext ctxt, EntityIdValue subject)
             throws SkipSchemaExpressionException, QAWarningException {

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbStringConstant.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbStringConstant.java
@@ -23,7 +23,7 @@
  ******************************************************************************/
 package org.openrefine.wikidata.schema;
 
-import org.apache.commons.lang.Validate;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.StringValue;
 
@@ -36,11 +36,17 @@ public class WbStringConstant implements WbExpression<StringValue> {
 
     @JsonCreator
     public WbStringConstant(@JsonProperty("value") String value) {
-        Validate.notNull(value);
-        Validate.isTrue(!value.isEmpty()); // for now we don't accept empty strings
-        // because in the variable counterpart of this expression, they are skipped
-        this.value = value.trim();
+        this.value = value == null ? value : value.trim();
     }
+    
+	@Override
+	public void validate(ValidationState validation) {
+		if (value == null || value.isEmpty()) {
+	        // for now we don't accept empty strings
+	        // because in the variable counterpart of this expression, they are skipped
+			validation.addError("Empty value");
+		}
+	}
 
     @Override
     public StringValue evaluate(ExpressionContext ctxt) {
@@ -64,4 +70,5 @@ public class WbStringConstant implements WbExpression<StringValue> {
     public int hashCode() {
         return value.hashCode();
     }
+
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/WbVariableExpr.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/WbVariableExpr.java
@@ -25,6 +25,7 @@ package org.openrefine.wikidata.schema;
 
 import org.openrefine.wikidata.schema.exceptions.QAWarningException;
 import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -51,6 +52,19 @@ public abstract class WbVariableExpr<T> implements WbExpression<T> {
     @JsonCreator
     public WbVariableExpr() {
         columnName = null;
+    }
+    
+    /**
+     * Checks that we have a valid column name.
+     */
+    @Override
+    public void validate(ValidationState validation) {
+    	if (columnName == null) {
+    		validation.addError("No column provided");
+    	}
+    	if (validation.getColumnModel().getColumnByName(columnName) == null) {
+    		validation.addError("Column '"+columnName+"' does not exist");
+    	}
     }
 
     /**

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/validation/PathElement.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/validation/PathElement.java
@@ -1,0 +1,129 @@
+package org.openrefine.wikidata.schema.validation;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A part of a path to a faulty/missing element in a schema.
+ * 
+ * @author Antonin Delpeuch
+ *
+ */
+public class PathElement {
+	
+	/**
+	 * The type of data field to follow to reach the faulty/missing part of the schema
+	 */
+	public enum Type {
+		@JsonProperty("entity")
+		ENTITY,
+		@JsonProperty("subject")
+		SUBJECT,
+		@JsonProperty("label")
+		LABEL,
+		@JsonProperty("description")
+		DESCRIPTION,
+		@JsonProperty("alias")
+		ALIAS,
+		@JsonProperty("sitelink")
+		SITELINK,
+		@JsonProperty("badge")
+		BADGE,
+		@JsonProperty("statement")
+		STATEMENT,
+		@JsonProperty("property")
+		PROPERTY,
+		@JsonProperty("rank")
+		RANK,
+		@JsonProperty("value")
+		VALUE,
+		@JsonProperty("unit")
+		UNIT,
+		@JsonProperty("language")
+		LANGUAGE,
+		@JsonProperty("qualifier")
+		QUALIFIER,
+		@JsonProperty("reference")
+		REFERENCE,
+		@JsonProperty("filename")
+		FILENAME,
+		@JsonProperty("filepath")
+		FILEPATH,
+		@JsonProperty("wikitext")
+		WIKITEXT
+	};
+	
+	private final Type type;
+	private final int position;
+	private final String name;
+
+	/**
+	 * Constructs a PathElement given by the type of element in which to recurse, and an ordinal
+	 * number indicating which of the children of that type to follow.
+	 */
+	public PathElement(Type type, int position) {
+		this.type = type;
+		this.position = position;
+		this.name = null;
+	}
+	
+	/**
+	 * Constructs a PathElement given by the type of the element in which to recurse, as well
+	 * as a string to identify which one (in case there are multiple ones). For instance, indicating
+	 * which property to follow, to select the right statement in an item.
+	 */
+	public PathElement(Type type, String name) {
+		this.type = type;
+		this.position = -1;
+		this.name = name;
+	}
+	
+	/**
+	 * A PathElement in which there is a single element of the given type, so the ordinal
+	 * number is not needed.
+	 */
+	public PathElement(Type type) {
+		this.type = type;
+		this.position = -1;
+		this.name = null;
+	}
+	
+	@JsonProperty("type")
+	public Type getType() {
+		return type;
+	}
+	
+	@JsonProperty("name")
+	public String getName() {
+		return name;
+	}
+	
+	@JsonProperty("position")
+	public int getPosition() {
+		return position;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(position, type);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		PathElement other = (PathElement) obj;
+		return position == other.position && type == other.type && Objects.equals(name, other.getName());
+	}
+
+	@Override
+	public String toString() {
+		return "PathElement [type=" + type + ", position=" + position + ", name=" + Objects.toString(name) + "]";
+	}
+
+}

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/validation/ValidationError.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/validation/ValidationError.java
@@ -1,0 +1,58 @@
+package org.openrefine.wikidata.schema.validation;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A sign that a schema is incomplete or incorrect, which is described
+ * by an error message, as well as a list of steps to reach the place where
+ * the problem is, from the root of the schema.
+ * 
+ * @author Antonin Delpeuch
+ *
+ */
+public class ValidationError {
+	
+	private final List<PathElement> path;
+	private final String message;
+	
+	public ValidationError(List<PathElement> path, String message) {
+		this.path = path;
+		this.message = message;
+	}
+	
+	@JsonProperty("path")
+	List<PathElement> getPath() {
+		return path;
+	}
+	
+	@JsonProperty("message")
+	public String getMessage() {
+		return message;
+	}
+
+	@Override
+	public String toString() {
+		return "ValidationError [path=" + path + ", message=" + message + "]";
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(message, path);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ValidationError other = (ValidationError) obj;
+		return Objects.equals(message, other.message) && Objects.equals(path, other.path);
+	}
+
+}

--- a/extensions/wikidata/src/org/openrefine/wikidata/schema/validation/ValidationState.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/schema/validation/ValidationState.java
@@ -1,0 +1,92 @@
+package org.openrefine.wikidata.schema.validation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.google.refine.model.ColumnModel;
+
+/**
+ * A sort of logger which can be used when traversing a schema
+ * and logging issues about it. By using the {@link #enter()} and
+ * {@link #leave()} methods appropriately, it keeps track of the path
+ * taken to arrive at the current position in the schema.
+ * 
+ * @author Antonin Delpeuch
+ *
+ */
+public class ValidationState {
+	
+	private final List<Optional<PathElement>> currentPath;
+	private final List<ValidationError> validationErrors;
+	private final ColumnModel columnModel;
+	
+	public ValidationState(ColumnModel columnModel) {
+		currentPath = new ArrayList<>();
+		validationErrors = new ArrayList<>();
+		this.columnModel = columnModel;
+	}
+
+	/**
+	 * Called when entering a schema element which should
+	 * not be recorded in the path displayed to the user.
+	 * 
+	 * Useful for classes like StatementGroup or SnakGroup which 
+	 * do not really have a user-facing counterpart.
+	 */
+	public ValidationState enter() {
+		currentPath.add(Optional.empty());
+		return this;
+	}
+	
+	/**
+	 * Called when entering a schema element which should
+	 * be recorded in the path displayed to the user.
+	 */
+	public ValidationState enter(PathElement element) {
+		currentPath.add(Optional.of(element));
+		return this;
+	}
+	
+	/**
+	 * Called when leaving a schema element and returning to its
+	 * parent.
+	 */
+	public ValidationState leave() {
+		if (currentPath.isEmpty()) {
+			throw new IllegalStateException("Already at the root level of the schema");
+		}
+		currentPath.remove(currentPath.size() - 1);
+		return this;
+	}
+	
+	
+	/**
+	 * Logs an error at the current position in the schema
+	 * @param message the error message
+	 */
+	public ValidationState addError(String message) {
+		List<PathElement> cleanedPath = currentPath.stream()
+				.filter(element -> element.isPresent())
+				.map(element -> element.get())
+				.collect(Collectors.toList());
+		validationErrors.add(new ValidationError(cleanedPath, message));
+		return this;
+	}
+	
+	/**
+	 * Returns the column model in the context of which this schema is validated.
+	 */
+	public ColumnModel getColumnModel() {
+		return columnModel;
+	}
+	
+	/**
+	 * Retrieves the validation errors emitted so far.
+	 */
+	public List<ValidationError> getValidationErrors() {
+		return validationErrors;
+	}
+	
+}

--- a/extensions/wikidata/tests/data/schema/inception_with_errors.json
+++ b/extensions/wikidata/tests/data/schema/inception_with_errors.json
@@ -1,0 +1,60 @@
+{
+  "itemDocuments": [
+    {
+      "subject": {
+        "type": "wbitemvariable",
+        "columnName": "subject"
+      },
+      "statementGroups": [
+        {
+          "property": {
+            "type": "wbpropconstant",
+            "pid": "P571",
+            "label": "inception",
+            "datatype": "time"
+          },
+          "statements": [
+            {
+              "value": {
+                "type": "wbdatevariable",
+                "columnName": "inception"
+              },
+              "qualifiers": [],
+              "references": [
+                {
+                  "snaks": [
+                    {
+                      "prop": {
+                        "type": "wbpropconstant",
+                        "pid": "P854",
+                        "label": "reference URL",
+                        "datatype": "url"
+                      },
+                      "value": {
+                        "type": "wbstringvariable",
+                        "columnName": "nonexisting_column_name"
+                      }
+                    },
+                    {
+                      "prop": {
+                        "type": "wbpropconstant",
+                        "pid": "P813",
+                        "label": "retrieved",
+                        "datatype": "time"
+                      },
+                      "value": {
+                        "type": "wbdateconstant"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "nameDescs": []
+    }
+  ],
+  "siteIri": "http://www.wikidata.org/entity/"
+}

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/PreviewWikibaseSchemaCommandTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/PreviewWikibaseSchemaCommandTest.java
@@ -70,7 +70,7 @@ public class PreviewWikibaseSchemaCommandTest extends SchemaCommandTest {
         ArrayNode edits = (ArrayNode) response.get("edits_preview");
         assertEquals(3, edits.size());
     }
-    
+
     @Test
     public void testIncompleteSchema() throws IOException, ServletException {
         String schemaJson = jsonFromFile("schema/inception_with_errors.json");

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/PreviewWikibaseSchemaCommandTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/PreviewWikibaseSchemaCommandTest.java
@@ -70,6 +70,20 @@ public class PreviewWikibaseSchemaCommandTest extends SchemaCommandTest {
         ArrayNode edits = (ArrayNode) response.get("edits_preview");
         assertEquals(3, edits.size());
     }
+    
+    @Test
+    public void testIncompleteSchema() throws IOException, ServletException {
+        String schemaJson = jsonFromFile("schema/inception_with_errors.json");
+        String manifestJson = jsonFromFile("manifest/wikidata-manifest-v1.0.json");
+        when(request.getParameter("schema")).thenReturn(schemaJson);
+        when(request.getParameter("manifest")).thenReturn(manifestJson);
+
+        command.doPost(request, response);
+
+        ObjectNode response = ParsingUtilities.evaluateJsonStringToObjectNode(writer.toString());
+        ArrayNode validationErrors = (ArrayNode) response.get("errors");
+        assertEquals(validationErrors.size(), 2);
+    }
 
     @Test
     public void testNoManifest() throws IOException, ServletException {

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/SaveWikibaseSchemaCommandTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/SaveWikibaseSchemaCommandTest.java
@@ -71,9 +71,9 @@ public class SaveWikibaseSchemaCommandTest extends SchemaCommandTest {
         command.doPost(request, response);
 
         String string = writer.toString();
-		assertTrue(string.contains("\"error\""));
+        assertTrue(string.contains("\"error\""));
     }
-    
+
     @Test
     public void testNoSchema() throws ServletException, IOException {
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
@@ -81,36 +81,36 @@ public class SaveWikibaseSchemaCommandTest extends SchemaCommandTest {
         command.doPost(request, response);
 
         String string = writer.toString();
-		assertTrue(string.contains("\"error\""));
+        assertTrue(string.contains("\"error\""));
     }
-    
+
     @Test
     public void testIncompleteSchema() throws IOException, ServletException {
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
 
-    	// schema that is syntactically correct but misses some elements
-    	String schemaJson = jsonFromFile("schema/inception_with_errors.json").toString();
+        // schema that is syntactically correct but misses some elements
+        String schemaJson = jsonFromFile("schema/inception_with_errors.json").toString();
         when(request.getParameter("schema")).thenReturn(schemaJson);
 
         command.doPost(request, response);
-        
+
         String expectedError = "{"
-        		+ "\"reason\":\"invalid-schema\","
-        		+ "\"message\":\"Invalid Wikibase schema\","
-        		+ "\"errors\":["
-        		+ "{\"path\":["
-        		+ "{\"type\":\"entity\",\"position\":0,\"name\":null},"
-        		+ "{\"type\":\"statement\",\"position\":-1,\"name\":\"inception (P571)\"},"
-        		+ "{\"type\":\"reference\",\"position\":0,\"name\":null},"
-        		+ "{\"type\":\"value\",\"position\":-1,\"name\":\"reference URL (P854)\"}],"
-        		+ "\"message\":\"Column 'nonexisting_column_name' does not exist\"},"
-        		+ "{\"path\":["
-        		+ "{\"type\":\"entity\",\"position\":0,\"name\":null},"
-        		+ "{\"type\":\"statement\",\"position\":-1,\"name\":\"inception (P571)\"},"
-        		+ "{\"type\":\"reference\",\"position\":0,\"name\":null},"
-        		+ "{\"type\":\"value\",\"position\":-1,\"name\":\"retrieved (P813)\"}"
-        		+ "],\"message\":\"Empty date field\"}]}";
-        
+                + "\"reason\":\"invalid-schema\","
+                + "\"message\":\"Invalid Wikibase schema\","
+                + "\"errors\":["
+                + "{\"path\":["
+                + "{\"type\":\"entity\",\"position\":0,\"name\":null},"
+                + "{\"type\":\"statement\",\"position\":-1,\"name\":\"inception (P571)\"},"
+                + "{\"type\":\"reference\",\"position\":0,\"name\":null},"
+                + "{\"type\":\"value\",\"position\":-1,\"name\":\"reference URL (P854)\"}],"
+                + "\"message\":\"Column 'nonexisting_column_name' does not exist\"},"
+                + "{\"path\":["
+                + "{\"type\":\"entity\",\"position\":0,\"name\":null},"
+                + "{\"type\":\"statement\",\"position\":-1,\"name\":\"inception (P571)\"},"
+                + "{\"type\":\"reference\",\"position\":0,\"name\":null},"
+                + "{\"type\":\"value\",\"position\":-1,\"name\":\"retrieved (P813)\"}"
+                + "],\"message\":\"Empty date field\"}]}";
+
         assertEquals(writer.toString(), expectedError);
     }
 

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/SaveWikibaseSchemaCommandTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/commands/SaveWikibaseSchemaCommandTest.java
@@ -26,6 +26,7 @@ package org.openrefine.wikidata.commands;
 
 import static org.mockito.Mockito.when;
 import static org.openrefine.wikidata.testing.TestingData.jsonFromFile;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
@@ -62,13 +63,55 @@ public class SaveWikibaseSchemaCommandTest extends SchemaCommandTest {
     public void testInvalidSchema() throws ServletException, IOException {
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
 
+        // schema that is syntactically incorrect
         String schemaJson = "{\"itemDocuments\":[{\"statementGroups\":[{\"statements\":[]}],"
                 + "\"nameDescs\":[]}],\"siteIri\":\"http://www.wikidata.org/entity/\"}";
 
         when(request.getParameter("schema")).thenReturn(schemaJson);
         command.doPost(request, response);
 
-        assertTrue(writer.toString().contains("\"error\""));
+        String string = writer.toString();
+		assertTrue(string.contains("\"error\""));
+    }
+    
+    @Test
+    public void testNoSchema() throws ServletException, IOException {
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("schema")).thenReturn("null");
+        command.doPost(request, response);
+
+        String string = writer.toString();
+		assertTrue(string.contains("\"error\""));
+    }
+    
+    @Test
+    public void testIncompleteSchema() throws IOException, ServletException {
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+
+    	// schema that is syntactically correct but misses some elements
+    	String schemaJson = jsonFromFile("schema/inception_with_errors.json").toString();
+        when(request.getParameter("schema")).thenReturn(schemaJson);
+
+        command.doPost(request, response);
+        
+        String expectedError = "{"
+        		+ "\"reason\":\"invalid-schema\","
+        		+ "\"message\":\"Invalid Wikibase schema\","
+        		+ "\"errors\":["
+        		+ "{\"path\":["
+        		+ "{\"type\":\"entity\",\"position\":0,\"name\":null},"
+        		+ "{\"type\":\"statement\",\"position\":-1,\"name\":\"inception (P571)\"},"
+        		+ "{\"type\":\"reference\",\"position\":0,\"name\":null},"
+        		+ "{\"type\":\"value\",\"position\":-1,\"name\":\"reference URL (P854)\"}],"
+        		+ "\"message\":\"Column 'nonexisting_column_name' does not exist\"},"
+        		+ "{\"path\":["
+        		+ "{\"type\":\"entity\",\"position\":0,\"name\":null},"
+        		+ "{\"type\":\"statement\",\"position\":-1,\"name\":\"inception (P571)\"},"
+        		+ "{\"type\":\"reference\",\"position\":0,\"name\":null},"
+        		+ "{\"type\":\"value\",\"position\":-1,\"name\":\"retrieved (P813)\"}"
+        		+ "],\"message\":\"Empty date field\"}]}";
+        
+        assertEquals(writer.toString(), expectedError);
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/exporters/QuickStatementsExporterTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/exporters/QuickStatementsExporterTest.java
@@ -35,11 +35,12 @@ import java.util.Properties;
 import org.openrefine.wikidata.schema.WikibaseSchema;
 import org.openrefine.wikidata.schema.strategies.StatementEditingMode;
 import org.openrefine.wikidata.schema.strategies.StatementMerger;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.testing.TestingData;
 import org.openrefine.wikidata.testing.WikidataRefineTest;
+import org.openrefine.wikidata.updates.ItemEditBuilder;
 import org.openrefine.wikidata.updates.StatementEdit;
 import org.openrefine.wikidata.updates.TermedStatementEntityEdit;
-import org.openrefine.wikidata.updates.ItemEditBuilder;
 import org.testng.annotations.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
@@ -74,6 +75,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         TestingData.reconcileInceptionCells(project);
         String serialized = TestingData.jsonFromFile("schema/inception.json");
         WikibaseSchema schema = WikibaseSchema.reconstruct(serialized);
+        schema.validate(new ValidationState(project.columnModel));
         project.overlayModels.put("wikibaseSchema", schema);
         Engine engine = new Engine(project);
 

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbDateConstantTest.java
@@ -147,18 +147,18 @@ public class WbDateConstantTest extends WbExpressionTest<TimeValue> {
         evaluatesTo(expectedDate, new WbDateConstant("TODAY"));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testInvalid() {
-        new WbDateConstant("invalid format");
+        hasValidationError("Invalid date provided: 'invalid format'", new WbDateConstant("invalid format"));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testPartlyValid() {
-        new WbDateConstant("2018-partly valid");
+        hasValidationError("Invalid date provided: '2018-partly valid'", new WbDateConstant("2018-partly valid"));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testInvalidCalendar() {
-        new WbDateConstant("2018-01-02_P234");
+        hasValidationError("Invalid date provided: '2018-01-02_P234'", new WbDateConstant("2018-01-02_P234"));
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbEntityIdValueConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbEntityIdValueConstantTest.java
@@ -22,13 +22,13 @@ public class WbEntityIdValueConstantTest extends WbExpressionTest<EntityIdValue>
         JacksonSerializationTest.canonicalSerialization(WbExpression.class, constant,
                 "{\"type\":\"wbentityidvalueconstant\",\"id\":\"P48\",\"label\":\"my ID\"}");
     }
-    
+
     @Test
     public void testValidate() {
-    	hasNoValidationError(constant);
-    	hasValidationError("No entity label provided", new WbEntityIdValueConstant("P48", null));
-    	hasValidationError("No entity id provided", new WbEntityIdValueConstant(null, "my label"));
-    	hasValidationError("Invalid entity id format: 'invalid format'", new WbEntityIdValueConstant("invalid format", "my label"));
+        hasNoValidationError(constant);
+        hasValidationError("No entity label provided", new WbEntityIdValueConstant("P48", null));
+        hasValidationError("No entity id provided", new WbEntityIdValueConstant(null, "my label"));
+        hasValidationError("Invalid entity id format: 'invalid format'", new WbEntityIdValueConstant("invalid format", "my label"));
 
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbEntityIdValueConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbEntityIdValueConstantTest.java
@@ -22,4 +22,13 @@ public class WbEntityIdValueConstantTest extends WbExpressionTest<EntityIdValue>
         JacksonSerializationTest.canonicalSerialization(WbExpression.class, constant,
                 "{\"type\":\"wbentityidvalueconstant\",\"id\":\"P48\",\"label\":\"my ID\"}");
     }
+    
+    @Test
+    public void testValidate() {
+    	hasNoValidationError(constant);
+    	hasValidationError("No entity label provided", new WbEntityIdValueConstant("P48", null));
+    	hasValidationError("No entity id provided", new WbEntityIdValueConstant(null, "my label"));
+    	hasValidationError("Invalid entity id format: 'invalid format'", new WbEntityIdValueConstant("invalid format", "my label"));
+
+    }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbExpressionTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbExpressionTest.java
@@ -105,9 +105,9 @@ public class WbExpressionTest<T> extends WikidataRefineTest {
      *            the expression to evaluate
      */
     public void evaluatesTo(T expected, WbExpression<T> expression) {
-    	ValidationState validation = new ValidationState(ctxt.getColumnModel());
-    	expression.validate(validation);
-    	
+        ValidationState validation = new ValidationState(ctxt.getColumnModel());
+        expression.validate(validation);
+
         try {
             T result = expression.evaluate(ctxt);
             Assert.assertEquals(expected, result);
@@ -148,61 +148,62 @@ public class WbExpressionTest<T> extends WikidataRefineTest {
             Assert.assertEquals(e.getWarning(), warning);
         }
     }
-    
+
     /**
-     * Tests that an expression has a validation error. Used when the column model is irrelevant
-     * to the validation problem.
+     * Tests that an expression has a validation error. Used when the column model is irrelevant to the validation
+     * problem.
      */
     public void hasValidationError(String errorMessage, WbExpression<T> expression) {
-    	ColumnModel columnModel = new ColumnModel();
-    	try {
-			columnModel.addColumn(0, new Column(0, "column"), true);
-		} catch (ModelException e) {
-		}
-    	hasValidationError(errorMessage, expression, columnModel);
+        ColumnModel columnModel = new ColumnModel();
+        try {
+            columnModel.addColumn(0, new Column(0, "column"), true);
+        } catch (ModelException e) {
+        }
+        hasValidationError(errorMessage, expression, columnModel);
     }
-    
+
     /**
-     * Tests that an expression has a validation error. Used when the column model is relevant to the validation problem.
+     * Tests that an expression has a validation error. Used when the column model is relevant to the validation
+     * problem.
      */
     public void hasValidationError(String errorMessage, WbExpression<T> expression, ColumnModel columnModel) {
-    	ValidationState validationState = new ValidationState(columnModel);
-    	expression.validate(validationState);
-    	List<String> validationMessages = validationState.getValidationErrors()
-    			.stream()
-    			.map(e -> e.getMessage())
-    			.collect(Collectors.toList());
-    	if (!Collections.singletonList(errorMessage).equals(validationMessages)) {
-    		Assert.fail("Unexpected validation status: expected error '"
-    					+ errorMessage + "', but found errors: "+validationMessages.toString());
-    	}
+        ValidationState validationState = new ValidationState(columnModel);
+        expression.validate(validationState);
+        List<String> validationMessages = validationState.getValidationErrors()
+                .stream()
+                .map(e -> e.getMessage())
+                .collect(Collectors.toList());
+        if (!Collections.singletonList(errorMessage).equals(validationMessages)) {
+            Assert.fail("Unexpected validation status: expected error '"
+                    + errorMessage + "', but found errors: " + validationMessages.toString());
+        }
     }
-    
+
     /**
      * Tests that an expression has no validation error.
      */
     public void hasNoValidationError(WbExpression<T> expression) {
-    	ColumnModel columnModel = new ColumnModel();
-    	try {
-			columnModel.addColumn(0, new Column(0, "column"), true);
-		} catch (ModelException e) {
-		}
-    	hasNoValidationError(expression, columnModel);
+        ColumnModel columnModel = new ColumnModel();
+        try {
+            columnModel.addColumn(0, new Column(0, "column"), true);
+        } catch (ModelException e) {
+        }
+        hasNoValidationError(expression, columnModel);
     }
-    
+
     /**
      * Tests that an expression has no validation error.
      */
     public void hasNoValidationError(WbExpression<T> expression, ColumnModel columnModel) {
-    	ValidationState validationState = new ValidationState(columnModel);
-    	expression.validate(validationState);
-    	List<String> validationMessages = validationState.getValidationErrors()
-    			.stream()
-    			.map(e -> e.getMessage())
-    			.collect(Collectors.toList());
-    	if (!validationMessages.isEmpty()) {
-    		Assert.fail("Unexpected validation status: expected no error, but found errors: "+validationMessages.toString());
-    	}
+        ValidationState validationState = new ValidationState(columnModel);
+        expression.validate(validationState);
+        List<String> validationMessages = validationState.getValidationErrors()
+                .stream()
+                .map(e -> e.getMessage())
+                .collect(Collectors.toList());
+        if (!validationMessages.isEmpty()) {
+            Assert.fail("Unexpected validation status: expected no error, but found errors: " + validationMessages.toString());
+        }
     }
 
     /**

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbExpressionTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbExpressionTest.java
@@ -27,16 +27,14 @@ package org.openrefine.wikidata.schema;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
-
-import okhttp3.mockwebserver.Dispatcher;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.openrefine.wikidata.qa.QAWarning;
 import org.openrefine.wikidata.qa.QAWarningStore;
 import org.openrefine.wikidata.schema.exceptions.QAWarningException;
 import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.testing.TestingData;
 import org.openrefine.wikidata.testing.WikidataRefineTest;
 import org.testng.Assert;
@@ -45,10 +43,17 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 
 import com.google.refine.model.Cell;
+import com.google.refine.model.Column;
+import com.google.refine.model.ColumnModel;
 import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Row;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 
 public class WbExpressionTest<T> extends WikidataRefineTest {
 
@@ -100,6 +105,9 @@ public class WbExpressionTest<T> extends WikidataRefineTest {
      *            the expression to evaluate
      */
     public void evaluatesTo(T expected, WbExpression<T> expression) {
+    	ValidationState validation = new ValidationState(ctxt.getColumnModel());
+    	expression.validate(validation);
+    	
         try {
             T result = expression.evaluate(ctxt);
             Assert.assertEquals(expected, result);
@@ -139,6 +147,62 @@ public class WbExpressionTest<T> extends WikidataRefineTest {
         } catch (QAWarningException e) {
             Assert.assertEquals(e.getWarning(), warning);
         }
+    }
+    
+    /**
+     * Tests that an expression has a validation error. Used when the column model is irrelevant
+     * to the validation problem.
+     */
+    public void hasValidationError(String errorMessage, WbExpression<T> expression) {
+    	ColumnModel columnModel = new ColumnModel();
+    	try {
+			columnModel.addColumn(0, new Column(0, "column"), true);
+		} catch (ModelException e) {
+		}
+    	hasValidationError(errorMessage, expression, columnModel);
+    }
+    
+    /**
+     * Tests that an expression has a validation error. Used when the column model is relevant to the validation problem.
+     */
+    public void hasValidationError(String errorMessage, WbExpression<T> expression, ColumnModel columnModel) {
+    	ValidationState validationState = new ValidationState(columnModel);
+    	expression.validate(validationState);
+    	List<String> validationMessages = validationState.getValidationErrors()
+    			.stream()
+    			.map(e -> e.getMessage())
+    			.collect(Collectors.toList());
+    	if (!Collections.singletonList(errorMessage).equals(validationMessages)) {
+    		Assert.fail("Unexpected validation status: expected error '"
+    					+ errorMessage + "', but found errors: "+validationMessages.toString());
+    	}
+    }
+    
+    /**
+     * Tests that an expression has no validation error.
+     */
+    public void hasNoValidationError(WbExpression<T> expression) {
+    	ColumnModel columnModel = new ColumnModel();
+    	try {
+			columnModel.addColumn(0, new Column(0, "column"), true);
+		} catch (ModelException e) {
+		}
+    	hasNoValidationError(expression, columnModel);
+    }
+    
+    /**
+     * Tests that an expression has no validation error.
+     */
+    public void hasNoValidationError(WbExpression<T> expression, ColumnModel columnModel) {
+    	ValidationState validationState = new ValidationState(columnModel);
+    	expression.validate(validationState);
+    	List<String> validationMessages = validationState.getValidationErrors()
+    			.stream()
+    			.map(e -> e.getMessage())
+    			.collect(Collectors.toList());
+    	if (!validationMessages.isEmpty()) {
+    		Assert.fail("Unexpected validation status: expected no error, but found errors: "+validationMessages.toString());
+    	}
     }
 
     /**

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbItemConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbItemConstantTest.java
@@ -43,4 +43,12 @@ public class WbItemConstantTest extends WbExpressionTest<ItemIdValue> {
     public void testEvaluate() {
         evaluatesTo(Datamodel.makeWikidataItemIdValue("Q42"), constant);
     }
+    
+    @Test
+    public void testValidate() {
+    	hasNoValidationError(constant);
+    	hasValidationError("No entity id provided", new WbItemConstant(null, "my label"));
+    	hasValidationError("No entity label provided", new WbItemConstant("Q23", null));
+    	hasValidationError("Invalid entity id format: 'invalid format'", new WbItemConstant("invalid format", "my label"));
+    }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbItemConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbItemConstantTest.java
@@ -43,12 +43,12 @@ public class WbItemConstantTest extends WbExpressionTest<ItemIdValue> {
     public void testEvaluate() {
         evaluatesTo(Datamodel.makeWikidataItemIdValue("Q42"), constant);
     }
-    
+
     @Test
     public void testValidate() {
-    	hasNoValidationError(constant);
-    	hasValidationError("No entity id provided", new WbItemConstant(null, "my label"));
-    	hasValidationError("No entity label provided", new WbItemConstant("Q23", null));
-    	hasValidationError("Invalid entity id format: 'invalid format'", new WbItemConstant("invalid format", "my label"));
+        hasNoValidationError(constant);
+        hasValidationError("No entity id provided", new WbItemConstant(null, "my label"));
+        hasValidationError("No entity label provided", new WbItemConstant("Q23", null));
+        hasValidationError("Invalid entity id format: 'invalid format'", new WbItemConstant("invalid format", "my label"));
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbItemEditExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbItemEditExprTest.java
@@ -65,18 +65,18 @@ public class WbItemEditExprTest extends WbExpressionTest<ItemEdit> {
                 + "\"value\":{\"type\":\"wbstringvariable\",\"columnName\":\"column D\"}}}" + "],\"statementGroups\":["
                 + sgt.jsonRepresentation + "]}";
     }
-    
+
     @Test
     public void testValidate() throws ModelException {
-    	ColumnModel columnModel = new ColumnModel();
-    	columnModel.addColumn(0, new Column(0, "column A"), false);
-    	columnModel.addColumn(0, new Column(0, "column B"), false);
-    	columnModel.addColumn(0, new Column(0, "column C"), false);
-    	columnModel.addColumn(0, new Column(0, "column D"), false);
-    	columnModel.addColumn(0, new Column(0, "column E"), false);
-    	
-    	hasNoValidationError(expr, columnModel);
-    	hasValidationError("No subject item id provided", new WbItemEditExpr(null, null, null), columnModel);
+        ColumnModel columnModel = new ColumnModel();
+        columnModel.addColumn(0, new Column(0, "column A"), false);
+        columnModel.addColumn(0, new Column(0, "column B"), false);
+        columnModel.addColumn(0, new Column(0, "column C"), false);
+        columnModel.addColumn(0, new Column(0, "column D"), false);
+        columnModel.addColumn(0, new Column(0, "column E"), false);
+
+        hasNoValidationError(expr, columnModel);
+        hasValidationError("No subject item id provided", new WbItemEditExpr(null, null, null), columnModel);
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbItemEditExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbItemEditExprTest.java
@@ -37,6 +37,10 @@ import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 
+import com.google.refine.model.Column;
+import com.google.refine.model.ColumnModel;
+import com.google.refine.model.ModelException;
+
 public class WbItemEditExprTest extends WbExpressionTest<ItemEdit> {
 
     public WbItemEditExpr expr;
@@ -60,6 +64,19 @@ public class WbItemEditExprTest extends WbExpressionTest<ItemEdit> {
                 + "{\"type\":\"wblanguageconstant\",\"id\":\"en\",\"label\":\"English\"},"
                 + "\"value\":{\"type\":\"wbstringvariable\",\"columnName\":\"column D\"}}}" + "],\"statementGroups\":["
                 + sgt.jsonRepresentation + "]}";
+    }
+    
+    @Test
+    public void testValidate() throws ModelException {
+    	ColumnModel columnModel = new ColumnModel();
+    	columnModel.addColumn(0, new Column(0, "column A"), false);
+    	columnModel.addColumn(0, new Column(0, "column B"), false);
+    	columnModel.addColumn(0, new Column(0, "column C"), false);
+    	columnModel.addColumn(0, new Column(0, "column D"), false);
+    	columnModel.addColumn(0, new Column(0, "column E"), false);
+    	
+    	hasNoValidationError(expr, columnModel);
+    	hasValidationError("No subject item id provided", new WbItemEditExpr(null, null, null), columnModel);
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbLanguageConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbLanguageConstantTest.java
@@ -60,12 +60,12 @@ public class WbLanguageConstantTest extends WbExpressionTest<String> {
     public void testFallbackLangCodes() {
         assertEquals("de", WbLanguageConstant.normalizeLanguageCode("de", "http://not.exist/w/api.php"));
     }
-    
+
     @Test
     public void testValidate() {
-    	hasNoValidationError(constant);
-    	hasValidationError("Empty language field", new WbLanguageConstant(null, "Deutsch"));
-    	hasValidationError("Empty text field", new WbLanguageConstant("de", null));
-    	hasValidationError("Invalid language code 'invalid_code'", new WbLanguageConstant("invalid_code", "unknown language"));
+        hasNoValidationError(constant);
+        hasValidationError("Empty language field", new WbLanguageConstant(null, "Deutsch"));
+        hasValidationError("Empty text field", new WbLanguageConstant("de", null));
+        hasValidationError("Invalid language code 'invalid_code'", new WbLanguageConstant("invalid_code", "unknown language"));
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbLanguageConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbLanguageConstantTest.java
@@ -60,4 +60,12 @@ public class WbLanguageConstantTest extends WbExpressionTest<String> {
     public void testFallbackLangCodes() {
         assertEquals("de", WbLanguageConstant.normalizeLanguageCode("de", "http://not.exist/w/api.php"));
     }
+    
+    @Test
+    public void testValidate() {
+    	hasNoValidationError(constant);
+    	hasValidationError("Empty language field", new WbLanguageConstant(null, "Deutsch"));
+    	hasValidationError("Empty text field", new WbLanguageConstant("de", null));
+    	hasValidationError("Invalid language code 'invalid_code'", new WbLanguageConstant("invalid_code", "unknown language"));
+    }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbLocationConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbLocationConstantTest.java
@@ -57,13 +57,13 @@ public class WbLocationConstantTest extends WbExpressionTest<GlobeCoordinatesVal
             throws ParseException {
         WbLocationConstant.parse("some bad value");
     }
-    
+
     @Test
     public void testValidate() {
-    	hasNoValidationError(new WbLocationConstant(input));
-    	hasValidationError("Invalid geographical coordinates: 'some bad value'", new WbLocationConstant("some bad value"));
-    	hasValidationError("Invalid geographical coordinates: 'lat,lng'", new WbLocationConstant("lat,lng"));
-    	hasValidationError("Invalid geographical coordinates: '0.1,2.3,4.5,6.7'", new WbLocationConstant("0.1,2.3,4.5,6.7"));
+        hasNoValidationError(new WbLocationConstant(input));
+        hasValidationError("Invalid geographical coordinates: 'some bad value'", new WbLocationConstant("some bad value"));
+        hasValidationError("Invalid geographical coordinates: 'lat,lng'", new WbLocationConstant("lat,lng"));
+        hasValidationError("Invalid geographical coordinates: '0.1,2.3,4.5,6.7'", new WbLocationConstant("0.1,2.3,4.5,6.7"));
     }
 
     @Test
@@ -71,7 +71,7 @@ public class WbLocationConstantTest extends WbExpressionTest<GlobeCoordinatesVal
             throws ParseException {
         WbLocationConstant expression = new WbLocationConstant(input);
         expression.validate(new ValidationState(new ColumnModel()));
-		evaluatesTo(loc, expression);
+        evaluatesTo(loc, expression);
     }
 
     @Test
@@ -79,7 +79,7 @@ public class WbLocationConstantTest extends WbExpressionTest<GlobeCoordinatesVal
             throws ParseException {
         WbLocationConstant expression = new WbLocationConstant(inputWithPrecision);
         expression.validate(new ValidationState(new ColumnModel()));
-		evaluatesTo(locWithPrecision, expression);
+        evaluatesTo(locWithPrecision, expression);
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbLocationConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbLocationConstantTest.java
@@ -28,10 +28,13 @@ import static org.testng.Assert.assertEquals;
 
 import java.text.ParseException;
 
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.testing.JacksonSerializationTest;
 import org.testng.annotations.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
+
+import com.google.refine.model.ColumnModel;
 
 public class WbLocationConstantTest extends WbExpressionTest<GlobeCoordinatesValue> {
 
@@ -42,6 +45,7 @@ public class WbLocationConstantTest extends WbExpressionTest<GlobeCoordinatesVal
     private String input = "1.2345,6.7890";
     private String inputWithPrecision = "1.2345,6.7890,0.1";
 
+    @Test
     public void testParseValid()
             throws ParseException {
         assertEquals(loc, WbLocationConstant.parse(input));
@@ -53,35 +57,29 @@ public class WbLocationConstantTest extends WbExpressionTest<GlobeCoordinatesVal
             throws ParseException {
         WbLocationConstant.parse("some bad value");
     }
+    
+    @Test
+    public void testValidate() {
+    	hasNoValidationError(new WbLocationConstant(input));
+    	hasValidationError("Invalid geographical coordinates: 'some bad value'", new WbLocationConstant("some bad value"));
+    	hasValidationError("Invalid geographical coordinates: 'lat,lng'", new WbLocationConstant("lat,lng"));
+    	hasValidationError("Invalid geographical coordinates: '0.1,2.3,4.5,6.7'", new WbLocationConstant("0.1,2.3,4.5,6.7"));
+    }
 
     @Test
     public void testEvaluate()
             throws ParseException {
-        evaluatesTo(loc, new WbLocationConstant(input));
+        WbLocationConstant expression = new WbLocationConstant(input);
+        expression.validate(new ValidationState(new ColumnModel()));
+		evaluatesTo(loc, expression);
     }
 
     @Test
     public void testEvaluateWithPrecision()
             throws ParseException {
-        evaluatesTo(locWithPrecision, new WbLocationConstant(inputWithPrecision));
-    }
-
-    @Test(expectedExceptions = ParseException.class)
-    public void constructInvalid()
-            throws ParseException {
-        new WbLocationConstant("some bad value");
-    }
-
-    @Test(expectedExceptions = ParseException.class)
-    public void constructNotNumber()
-            throws ParseException {
-        new WbLocationConstant("lat,lng");
-    }
-
-    @Test(expectedExceptions = ParseException.class)
-    public void constructtooManyParts()
-            throws ParseException {
-        new WbLocationConstant("0.1,2.3,4.5,6.7");
+        WbLocationConstant expression = new WbLocationConstant(inputWithPrecision);
+        expression.validate(new ValidationState(new ColumnModel()));
+		evaluatesTo(locWithPrecision, expression);
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbMediaInfoEditExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbMediaInfoEditExprTest.java
@@ -75,23 +75,22 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
                 .build();
         evaluatesTo(result, expr);
     }
-    
+
     @Test
     public void testValidate() throws ModelException {
-    	ColumnModel columnModel = new ColumnModel();
-    	columnModel.addColumn(0, new Column(0, "column A"), false);
-    	columnModel.addColumn(0, new Column(0, "column B"), false);
-    	columnModel.addColumn(0, new Column(0, "column C"), false);
-    	columnModel.addColumn(0, new Column(0, "column D"), false);
-    	columnModel.addColumn(0, new Column(0, "column E"), false);
+        ColumnModel columnModel = new ColumnModel();
+        columnModel.addColumn(0, new Column(0, "column A"), false);
+        columnModel.addColumn(0, new Column(0, "column B"), false);
+        columnModel.addColumn(0, new Column(0, "column C"), false);
+        columnModel.addColumn(0, new Column(0, "column D"), false);
+        columnModel.addColumn(0, new Column(0, "column E"), false);
 
-    	
-    	hasNoValidationError(expr, columnModel);
-    	hasValidationError("No subject provided", new WbMediaInfoEditExpr(null, null, null, null, null, null));
-    	hasValidationError("Null term in MediaInfo entity", new WbMediaInfoEditExpr(new WbEntityVariable("column E"),
-    			Collections.singletonList(null), null, null, null, null), columnModel);
-    	hasValidationError("Null statement in MediaInfo entity", new WbMediaInfoEditExpr(new WbEntityVariable("column E"),
-    			null, Collections.singletonList(null), null, null, null), columnModel);
+        hasNoValidationError(expr, columnModel);
+        hasValidationError("No subject provided", new WbMediaInfoEditExpr(null, null, null, null, null, null, false));
+        hasValidationError("Null term in MediaInfo entity", new WbMediaInfoEditExpr(new WbEntityVariable("column E"),
+                Collections.singletonList(null), null, null, null, null, false), columnModel);
+        hasValidationError("Null statement in MediaInfo entity", new WbMediaInfoEditExpr(new WbEntityVariable("column E"),
+                null, Collections.singletonList(null), null, null, null, false), columnModel);
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbMediaInfoEditExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbMediaInfoEditExprTest.java
@@ -23,6 +23,9 @@ import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 
 import com.google.refine.model.Cell;
+import com.google.refine.model.Column;
+import com.google.refine.model.ColumnModel;
+import com.google.refine.model.ModelException;
 import com.google.refine.util.TestUtils;
 
 public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
@@ -71,6 +74,24 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
         MediaInfoEdit result = new MediaInfoEditBuilder(subject).addLabel(label, true).addStatement(fullStatement)
                 .build();
         evaluatesTo(result, expr);
+    }
+    
+    @Test
+    public void testValidate() throws ModelException {
+    	ColumnModel columnModel = new ColumnModel();
+    	columnModel.addColumn(0, new Column(0, "column A"), false);
+    	columnModel.addColumn(0, new Column(0, "column B"), false);
+    	columnModel.addColumn(0, new Column(0, "column C"), false);
+    	columnModel.addColumn(0, new Column(0, "column D"), false);
+    	columnModel.addColumn(0, new Column(0, "column E"), false);
+
+    	
+    	hasNoValidationError(expr, columnModel);
+    	hasValidationError("No subject provided", new WbMediaInfoEditExpr(null, null, null, null, null, null));
+    	hasValidationError("Null term in MediaInfo entity", new WbMediaInfoEditExpr(new WbEntityVariable("column E"),
+    			Collections.singletonList(null), null, null, null, null), columnModel);
+    	hasValidationError("Null statement in MediaInfo entity", new WbMediaInfoEditExpr(new WbEntityVariable("column E"),
+    			null, Collections.singletonList(null), null, null, null), columnModel);
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbMonolingualExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbMonolingualExprTest.java
@@ -38,6 +38,13 @@ public class WbMonolingualExprTest extends WbExpressionTest<MonolingualTextValue
         evaluatesTo(Datamodel.makeMonolingualTextValue("hello", "en"),
                 new WbMonolingualExpr(new WbLanguageConstant("en", "English"), new WbStringConstant("hello")));
     }
+    
+    @Test
+    public void testValidate() {
+    	hasNoValidationError(new WbMonolingualExpr(new WbLanguageConstant("en", "English"), new WbStringConstant("hello")));
+    	hasValidationError("No language provided", new WbMonolingualExpr(null, new WbStringConstant("hello")));
+    	hasValidationError("No text value provided", new WbMonolingualExpr(new WbLanguageConstant("en", "English"), null));
+    }
 
     @Test
     public void testEvaluateVariable() {

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbMonolingualExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbMonolingualExprTest.java
@@ -38,12 +38,12 @@ public class WbMonolingualExprTest extends WbExpressionTest<MonolingualTextValue
         evaluatesTo(Datamodel.makeMonolingualTextValue("hello", "en"),
                 new WbMonolingualExpr(new WbLanguageConstant("en", "English"), new WbStringConstant("hello")));
     }
-    
+
     @Test
     public void testValidate() {
-    	hasNoValidationError(new WbMonolingualExpr(new WbLanguageConstant("en", "English"), new WbStringConstant("hello")));
-    	hasValidationError("No language provided", new WbMonolingualExpr(null, new WbStringConstant("hello")));
-    	hasValidationError("No text value provided", new WbMonolingualExpr(new WbLanguageConstant("en", "English"), null));
+        hasNoValidationError(new WbMonolingualExpr(new WbLanguageConstant("en", "English"), new WbStringConstant("hello")));
+        hasValidationError("No language provided", new WbMonolingualExpr(null, new WbStringConstant("hello")));
+        hasValidationError("No text value provided", new WbMonolingualExpr(new WbLanguageConstant("en", "English"), null));
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbNameDescExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbNameDescExprTest.java
@@ -103,13 +103,13 @@ public class WbNameDescExprTest extends WbExpressionTest<MonolingualTextValue> {
     public void testSerialization() {
         JacksonSerializationTest.canonicalSerialization(WbNameDescExpr.class, expr, jsonRepresentation);
     }
-    
+
     @Test
     public void testValidate() throws ModelException {
-    	ColumnModel columnModel = new ColumnModel();
-    	columnModel.addColumn(0, new Column(0, "column A"), true);
-    	ValidationState validationState = new ValidationState(columnModel);
-    	expr.validate(validationState);
-    	Assert.assertTrue(validationState.getValidationErrors().isEmpty());
+        ColumnModel columnModel = new ColumnModel();
+        columnModel.addColumn(0, new Column(0, "column A"), true);
+        ValidationState validationState = new ValidationState(columnModel);
+        expr.validate(validationState);
+        Assert.assertTrue(validationState.getValidationErrors().isEmpty());
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbNameDescExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbNameDescExprTest.java
@@ -29,13 +29,19 @@ import static org.testng.Assert.assertEquals;
 import java.util.Collections;
 
 import org.openrefine.wikidata.schema.exceptions.QAWarningException;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.testing.JacksonSerializationTest;
 import org.openrefine.wikidata.testing.TestingData;
 import org.openrefine.wikidata.updates.ItemEditBuilder;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+
+import com.google.refine.model.Column;
+import com.google.refine.model.ColumnModel;
+import com.google.refine.model.ModelException;
 
 public class WbNameDescExprTest extends WbExpressionTest<MonolingualTextValue> {
 
@@ -96,5 +102,14 @@ public class WbNameDescExprTest extends WbExpressionTest<MonolingualTextValue> {
     @Test
     public void testSerialization() {
         JacksonSerializationTest.canonicalSerialization(WbNameDescExpr.class, expr, jsonRepresentation);
+    }
+    
+    @Test
+    public void testValidate() throws ModelException {
+    	ColumnModel columnModel = new ColumnModel();
+    	columnModel.addColumn(0, new Column(0, "column A"), true);
+    	ValidationState validationState = new ValidationState(columnModel);
+    	expr.validate(validationState);
+    	Assert.assertTrue(validationState.getValidationErrors().isEmpty());
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbPropConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbPropConstantTest.java
@@ -43,9 +43,9 @@ public class WbPropConstantTest extends WbExpressionTest<PropertyIdValue> {
         JacksonSerializationTest.canonicalSerialization(WbExpression.class, constant,
                 "{\"type\":\"wbpropconstant\",\"pid\":\"P48\",\"label\":\"my ID\",\"datatype\":\"external-id\"}");
     }
-    
+
     @Test
     public void testValidate() {
-    	hasNoValidationError(constant);
+        hasNoValidationError(constant);
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbPropConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbPropConstantTest.java
@@ -43,4 +43,9 @@ public class WbPropConstantTest extends WbExpressionTest<PropertyIdValue> {
         JacksonSerializationTest.canonicalSerialization(WbExpression.class, constant,
                 "{\"type\":\"wbpropconstant\",\"pid\":\"P48\",\"label\":\"my ID\",\"datatype\":\"external-id\"}");
     }
+    
+    @Test
+    public void testValidate() {
+    	hasNoValidationError(constant);
+    }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbQuantityExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbQuantityExprTest.java
@@ -96,17 +96,17 @@ public class WbQuantityExprTest extends WbExpressionTest<QuantityValue> {
         assertEquals("38350", val.getLowerBound().toString());
         assertEquals("38450", val.getUpperBound().toString());
     }
-    
+
     @Test
     public void testValidate() throws ModelException {
-    	ColumnModel columnModel = new ColumnModel();
-    	columnModel.addColumn(0, new Column(0, "column A"), true);
-    	columnModel.addColumn(0, new Column(0, "column B"), true);
+        ColumnModel columnModel = new ColumnModel();
+        columnModel.addColumn(0, new Column(0, "column A"), true);
+        columnModel.addColumn(0, new Column(0, "column B"), true);
 
-    	hasNoValidationError(exprWithUnit, columnModel);
-    	hasNoValidationError(exprWithoutUnit, columnModel);
-    	hasValidationError("No quantity amount provided", new WbQuantityExpr(null,
-            new WbItemVariable("column B")), columnModel);
+        hasNoValidationError(exprWithUnit, columnModel);
+        hasNoValidationError(exprWithoutUnit, columnModel);
+        hasValidationError("No quantity amount provided", new WbQuantityExpr(null,
+                new WbItemVariable("column B")), columnModel);
     }
 
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbQuantityExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbQuantityExprTest.java
@@ -35,6 +35,9 @@ import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.refine.model.Column;
+import com.google.refine.model.ColumnModel;
+import com.google.refine.model.ModelException;
 
 public class WbQuantityExprTest extends WbExpressionTest<QuantityValue> {
 
@@ -92,6 +95,18 @@ public class WbQuantityExprTest extends WbExpressionTest<QuantityValue> {
         assertEquals("38400", val.getNumericValue().toString());
         assertEquals("38350", val.getLowerBound().toString());
         assertEquals("38450", val.getUpperBound().toString());
+    }
+    
+    @Test
+    public void testValidate() throws ModelException {
+    	ColumnModel columnModel = new ColumnModel();
+    	columnModel.addColumn(0, new Column(0, "column A"), true);
+    	columnModel.addColumn(0, new Column(0, "column B"), true);
+
+    	hasNoValidationError(exprWithUnit, columnModel);
+    	hasNoValidationError(exprWithoutUnit, columnModel);
+    	hasValidationError("No quantity amount provided", new WbQuantityExpr(null,
+            new WbItemVariable("column B")), columnModel);
     }
 
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbReferenceExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbReferenceExprTest.java
@@ -87,15 +87,15 @@ public class WbReferenceExprTest extends WbExpressionTest<Reference> {
     public void testUnmodifiableList() {
         expr.getSnaks().clear();
     }
-    
+
     @Test
     public void testValidate() throws ModelException {
-    	ColumnModel columnModel = new ColumnModel();
-    	columnModel.addColumn(0, new Column(0, "column A"), false);
-    	columnModel.addColumn(0, new Column(0, "column B"), false);
-    	hasNoValidationError(expr, columnModel);
-    	hasValidationError("Null snak in reference", new WbReferenceExpr(Arrays.asList(
-            null,
-            new WbSnakExpr(new WbPropConstant("P347", "reference URL", "url"), new WbStringVariable("column B")))), columnModel);
+        ColumnModel columnModel = new ColumnModel();
+        columnModel.addColumn(0, new Column(0, "column A"), false);
+        columnModel.addColumn(0, new Column(0, "column B"), false);
+        hasNoValidationError(expr, columnModel);
+        hasValidationError("Null snak in reference", new WbReferenceExpr(Arrays.asList(
+                null,
+                new WbSnakExpr(new WbPropConstant("P347", "reference URL", "url"), new WbStringVariable("column B")))), columnModel);
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbReferenceExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbReferenceExprTest.java
@@ -26,10 +26,8 @@ package org.openrefine.wikidata.schema;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import org.openrefine.wikidata.testing.JacksonSerializationTest;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.Reference;
@@ -37,6 +35,9 @@ import org.wikidata.wdtk.datamodel.interfaces.Snak;
 import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.refine.model.Column;
+import com.google.refine.model.ColumnModel;
+import com.google.refine.model.ModelException;
 
 public class WbReferenceExprTest extends WbExpressionTest<Reference> {
 
@@ -85,5 +86,16 @@ public class WbReferenceExprTest extends WbExpressionTest<Reference> {
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testUnmodifiableList() {
         expr.getSnaks().clear();
+    }
+    
+    @Test
+    public void testValidate() throws ModelException {
+    	ColumnModel columnModel = new ColumnModel();
+    	columnModel.addColumn(0, new Column(0, "column A"), false);
+    	columnModel.addColumn(0, new Column(0, "column B"), false);
+    	hasNoValidationError(expr, columnModel);
+    	hasValidationError("Null snak in reference", new WbReferenceExpr(Arrays.asList(
+            null,
+            new WbSnakExpr(new WbPropConstant("P347", "reference URL", "url"), new WbStringVariable("column B")))), columnModel);
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbSnakExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbSnakExprTest.java
@@ -56,15 +56,15 @@ public class WbSnakExprTest extends WbExpressionTest<Snak> {
             throws JsonProcessingException {
         JacksonSerializationTest.canonicalSerialization(WbSnakExpr.class, expr, jsonRepresentation);
     }
-    
+
     @Test
     public void testValidate() throws ModelException {
-    	ColumnModel columnModel = new ColumnModel();
-    	columnModel.addColumn(0, new Column(0, "column A"), true);
-    	
-    	hasNoValidationError(expr, columnModel);
-    	WbSnakExpr missingValue = new WbSnakExpr(propStringExpr, null);
-    	hasValidationError("Missing value", missingValue, columnModel);
+        ColumnModel columnModel = new ColumnModel();
+        columnModel.addColumn(0, new Column(0, "column A"), true);
+
+        hasNoValidationError(expr, columnModel);
+        WbSnakExpr missingValue = new WbSnakExpr(propStringExpr, null);
+        hasValidationError("Missing value", missingValue, columnModel);
     }
 
     // TODO check that the datatype of the property matches that of the datavalue

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbSnakExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbSnakExprTest.java
@@ -31,6 +31,9 @@ import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.refine.model.Column;
+import com.google.refine.model.ColumnModel;
+import com.google.refine.model.ModelException;
 
 public class WbSnakExprTest extends WbExpressionTest<Snak> {
 
@@ -52,6 +55,16 @@ public class WbSnakExprTest extends WbExpressionTest<Snak> {
     public void testSerialize()
             throws JsonProcessingException {
         JacksonSerializationTest.canonicalSerialization(WbSnakExpr.class, expr, jsonRepresentation);
+    }
+    
+    @Test
+    public void testValidate() throws ModelException {
+    	ColumnModel columnModel = new ColumnModel();
+    	columnModel.addColumn(0, new Column(0, "column A"), true);
+    	
+    	hasNoValidationError(expr, columnModel);
+    	WbSnakExpr missingValue = new WbSnakExpr(propStringExpr, null);
+    	hasValidationError("Missing value", missingValue, columnModel);
     }
 
     // TODO check that the datatype of the property matches that of the datavalue

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStatementExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStatementExprTest.java
@@ -36,6 +36,7 @@ import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
 import org.openrefine.wikidata.schema.strategies.PropertyOnlyStatementMerger;
 import org.openrefine.wikidata.schema.strategies.StatementEditingMode;
 import org.openrefine.wikidata.schema.strategies.StatementMerger;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.testing.JacksonSerializationTest;
 import org.openrefine.wikidata.updates.StatementEdit;
 import org.testng.annotations.Test;
@@ -53,6 +54,9 @@ import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.google.refine.model.Column;
+import com.google.refine.model.ColumnModel;
+import com.google.refine.model.ModelException;
 import com.google.refine.util.ParsingUtilities;
 
 public class WbStatementExprTest extends WbExpressionTest<StatementEdit> {
@@ -126,6 +130,11 @@ public class WbStatementExprTest extends WbExpressionTest<StatementEdit> {
                 throws SkipSchemaExpressionException, QAWarningException {
             return expr.evaluate(ctxt, subject, property);
         }
+
+		@Override
+		public void validate(ValidationState validation) {
+			expr.validate(validation);
+		}
     }
 
     public String jsonRepresentation = "{"
@@ -164,16 +173,6 @@ public class WbStatementExprTest extends WbExpressionTest<StatementEdit> {
         WbStatementExpr withNulls = new WbStatementExpr(
                 q5, null, null, null, null);
         assertEquals(empty, withNulls);
-    }
-
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testNoMainValue() {
-        new WbStatementExpr(
-                null,
-                Collections.emptyList(),
-                Collections.emptyList(),
-                StatementMerger.FORMER_DEFAULT_STRATEGY,
-                StatementEditingMode.ADD_OR_MERGE);
     }
 
     @Test
@@ -271,5 +270,32 @@ public class WbStatementExprTest extends WbExpressionTest<StatementEdit> {
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testUnmodifiableReferencesList() {
         statementExpr.getReferences().clear();
+    }
+    
+    @Test
+    public void testValidate() throws ModelException {
+    	ColumnModel columnModel = new ColumnModel();
+    	columnModel.addColumn(0, new Column(0, "column A"), true);
+    	columnModel.addColumn(1, new Column(1, "column B"), true);
+    	columnModel.addColumn(2, new Column(2, "column C"), true);
+    	
+    	hasNoValidationError(new Wrapper(statementExpr), columnModel);
+    	hasNoValidationError(new Wrapper(statementDeleteExpr), columnModel);
+    	
+    	WbStatementExpr missingMainValue = new WbStatementExpr(
+                null,
+                Collections.singletonList(qualifierExpr),
+                Collections.singletonList(refExpr),
+                StatementMerger.FORMER_DEFAULT_STRATEGY,
+                StatementEditingMode.ADD_OR_MERGE);
+    	hasValidationError("Missing main statement value", new Wrapper(missingMainValue), columnModel);
+    	
+    	WbStatementExpr nullQualifier = new WbStatementExpr(
+                mainValueExpr,
+                Collections.singletonList(null),
+                Collections.singletonList(refExpr),
+                StatementMerger.FORMER_DEFAULT_STRATEGY,
+                StatementEditingMode.ADD_OR_MERGE);
+    	hasValidationError("Empty qualifier in statement", new Wrapper(nullQualifier), columnModel);
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStatementExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStatementExprTest.java
@@ -131,10 +131,10 @@ public class WbStatementExprTest extends WbExpressionTest<StatementEdit> {
             return expr.evaluate(ctxt, subject, property);
         }
 
-		@Override
-		public void validate(ValidationState validation) {
-			expr.validate(validation);
-		}
+        @Override
+        public void validate(ValidationState validation) {
+            expr.validate(validation);
+        }
     }
 
     public String jsonRepresentation = "{"
@@ -271,31 +271,31 @@ public class WbStatementExprTest extends WbExpressionTest<StatementEdit> {
     public void testUnmodifiableReferencesList() {
         statementExpr.getReferences().clear();
     }
-    
+
     @Test
     public void testValidate() throws ModelException {
-    	ColumnModel columnModel = new ColumnModel();
-    	columnModel.addColumn(0, new Column(0, "column A"), true);
-    	columnModel.addColumn(1, new Column(1, "column B"), true);
-    	columnModel.addColumn(2, new Column(2, "column C"), true);
-    	
-    	hasNoValidationError(new Wrapper(statementExpr), columnModel);
-    	hasNoValidationError(new Wrapper(statementDeleteExpr), columnModel);
-    	
-    	WbStatementExpr missingMainValue = new WbStatementExpr(
+        ColumnModel columnModel = new ColumnModel();
+        columnModel.addColumn(0, new Column(0, "column A"), true);
+        columnModel.addColumn(1, new Column(1, "column B"), true);
+        columnModel.addColumn(2, new Column(2, "column C"), true);
+
+        hasNoValidationError(new Wrapper(statementExpr), columnModel);
+        hasNoValidationError(new Wrapper(statementDeleteExpr), columnModel);
+
+        WbStatementExpr missingMainValue = new WbStatementExpr(
                 null,
                 Collections.singletonList(qualifierExpr),
                 Collections.singletonList(refExpr),
                 StatementMerger.FORMER_DEFAULT_STRATEGY,
                 StatementEditingMode.ADD_OR_MERGE);
-    	hasValidationError("Missing main statement value", new Wrapper(missingMainValue), columnModel);
-    	
-    	WbStatementExpr nullQualifier = new WbStatementExpr(
+        hasValidationError("Missing main statement value", new Wrapper(missingMainValue), columnModel);
+
+        WbStatementExpr nullQualifier = new WbStatementExpr(
                 mainValueExpr,
                 Collections.singletonList(null),
                 Collections.singletonList(refExpr),
                 StatementMerger.FORMER_DEFAULT_STRATEGY,
                 StatementEditingMode.ADD_OR_MERGE);
-    	hasValidationError("Empty qualifier in statement", new Wrapper(nullQualifier), columnModel);
+        hasValidationError("Empty qualifier in statement", new Wrapper(nullQualifier), columnModel);
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStatementGroupExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStatementGroupExprTest.java
@@ -63,10 +63,10 @@ public class WbStatementGroupExprTest extends WbExpressionTest<StatementGroupEdi
             return expr.evaluate(ctxt, subject);
         }
 
-		@Override
-		public void validate(ValidationState validation) {
-			expr.validate(validation);
-		}
+        @Override
+        public void validate(ValidationState validation) {
+            expr.validate(validation);
+        }
     }
 
     public WbStatementGroupExprTest() {
@@ -105,14 +105,14 @@ public class WbStatementGroupExprTest extends WbExpressionTest<StatementGroupEdi
     public void testUnmodifiableList() {
         expr.getStatements().clear();
     }
-    
+
     @Test
     public void testValidate() throws ModelException {
-    	ColumnModel columnModel = new ColumnModel();
-    	columnModel.addColumn(0, new Column(0, "column A"), true);
-    	columnModel.addColumn(1, new Column(1, "column B"), true);
-    	columnModel.addColumn(2, new Column(2, "column C"), true);
-    	
-    	hasNoValidationError(new Wrapper(expr), columnModel);
+        ColumnModel columnModel = new ColumnModel();
+        columnModel.addColumn(0, new Column(0, "column A"), true);
+        columnModel.addColumn(1, new Column(1, "column B"), true);
+        columnModel.addColumn(2, new Column(2, "column C"), true);
+
+        hasNoValidationError(new Wrapper(expr), columnModel);
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStatementGroupExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStatementGroupExprTest.java
@@ -28,12 +28,16 @@ import java.util.Collections;
 
 import org.openrefine.wikidata.schema.exceptions.QAWarningException;
 import org.openrefine.wikidata.schema.exceptions.SkipSchemaExpressionException;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.testing.JacksonSerializationTest;
 import org.openrefine.wikidata.updates.StatementGroupEdit;
 import org.testng.annotations.Test;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.refine.model.Column;
+import com.google.refine.model.ColumnModel;
+import com.google.refine.model.ModelException;
 
 public class WbStatementGroupExprTest extends WbExpressionTest<StatementGroupEdit> {
 
@@ -58,6 +62,11 @@ public class WbStatementGroupExprTest extends WbExpressionTest<StatementGroupEdi
                 throws SkipSchemaExpressionException, QAWarningException {
             return expr.evaluate(ctxt, subject);
         }
+
+		@Override
+		public void validate(ValidationState validation) {
+			expr.validate(validation);
+		}
     }
 
     public WbStatementGroupExprTest() {
@@ -95,5 +104,15 @@ public class WbStatementGroupExprTest extends WbExpressionTest<StatementGroupEdi
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void testUnmodifiableList() {
         expr.getStatements().clear();
+    }
+    
+    @Test
+    public void testValidate() throws ModelException {
+    	ColumnModel columnModel = new ColumnModel();
+    	columnModel.addColumn(0, new Column(0, "column A"), true);
+    	columnModel.addColumn(1, new Column(1, "column B"), true);
+    	columnModel.addColumn(2, new Column(2, "column C"), true);
+    	
+    	hasNoValidationError(new Wrapper(expr), columnModel);
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStringConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStringConstantTest.java
@@ -26,8 +26,13 @@ public class WbStringConstantTest extends WbExpressionTest<StringValue> {
         evaluatesTo(Datamodel.makeStringValue("hello world"), new WbStringConstant(" hello world "));
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
+    @Test
     public void testEmpty() {
-        new WbStringConstant("");
+        hasValidationError("Empty value", new WbStringConstant(""));
+    }
+    
+    @Test
+    public void testValidate() {
+    	hasNoValidationError(constant);
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStringConstantTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbStringConstantTest.java
@@ -30,9 +30,9 @@ public class WbStringConstantTest extends WbExpressionTest<StringValue> {
     public void testEmpty() {
         hasValidationError("Empty value", new WbStringConstant(""));
     }
-    
+
     @Test
     public void testValidate() {
-    	hasNoValidationError(constant);
+        hasNoValidationError(constant);
     }
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbVariableExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbVariableExprTest.java
@@ -1,0 +1,23 @@
+package org.openrefine.wikidata.schema;
+
+import org.testng.annotations.Test;
+import org.wikidata.wdtk.datamodel.interfaces.StringValue;
+
+import com.google.refine.model.Column;
+import com.google.refine.model.ColumnModel;
+import com.google.refine.model.ModelException;
+
+public class WbVariableExprTest extends WbExpressionTest<StringValue> {
+
+	@Test
+	public void testValidate() throws ModelException {
+		ColumnModel columnModel = new ColumnModel();
+    	columnModel.addColumn(0, new Column(0, "column A"), true);
+    	columnModel.addColumn(1, new Column(1, "column B"), true);
+    	columnModel.addColumn(2, new Column(2, "column C"), true);
+    	
+    	hasNoValidationError(new WbStringVariable("column A"), columnModel);
+    	hasValidationError("Column 'foo' does not exist", new WbStringVariable("foo"), columnModel);
+	}
+
+}

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbVariableExprTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WbVariableExprTest.java
@@ -1,3 +1,4 @@
+
 package org.openrefine.wikidata.schema;
 
 import org.testng.annotations.Test;
@@ -9,15 +10,15 @@ import com.google.refine.model.ModelException;
 
 public class WbVariableExprTest extends WbExpressionTest<StringValue> {
 
-	@Test
-	public void testValidate() throws ModelException {
-		ColumnModel columnModel = new ColumnModel();
-    	columnModel.addColumn(0, new Column(0, "column A"), true);
-    	columnModel.addColumn(1, new Column(1, "column B"), true);
-    	columnModel.addColumn(2, new Column(2, "column C"), true);
-    	
-    	hasNoValidationError(new WbStringVariable("column A"), columnModel);
-    	hasValidationError("Column 'foo' does not exist", new WbStringVariable("foo"), columnModel);
-	}
+    @Test
+    public void testValidate() throws ModelException {
+        ColumnModel columnModel = new ColumnModel();
+        columnModel.addColumn(0, new Column(0, "column A"), true);
+        columnModel.addColumn(1, new Column(1, "column B"), true);
+        columnModel.addColumn(2, new Column(2, "column C"), true);
+
+        hasNoValidationError(new WbStringVariable("column A"), columnModel);
+        hasValidationError("Column 'foo' does not exist", new WbStringVariable("foo"), columnModel);
+    }
 
 }

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WikibaseSchemaTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WikibaseSchemaTest.java
@@ -25,6 +25,7 @@
 package org.openrefine.wikidata.schema;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,12 +35,16 @@ import java.util.List;
 
 import org.openrefine.wikidata.schema.strategies.StatementEditingMode;
 import org.openrefine.wikidata.schema.strategies.StatementMerger;
+import org.openrefine.wikidata.schema.validation.PathElement;
+import org.openrefine.wikidata.schema.validation.PathElement.Type;
+import org.openrefine.wikidata.schema.validation.ValidationError;
+import org.openrefine.wikidata.schema.validation.ValidationState;
 import org.openrefine.wikidata.testing.TestingData;
 import org.openrefine.wikidata.testing.WikidataRefineTest;
-import org.openrefine.wikidata.updates.StatementEdit;
-import org.openrefine.wikidata.updates.TermedStatementEntityEdit;
 import org.openrefine.wikidata.updates.EntityEdit;
 import org.openrefine.wikidata.updates.ItemEditBuilder;
+import org.openrefine.wikidata.updates.StatementEdit;
+import org.openrefine.wikidata.updates.TermedStatementEntityEdit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
@@ -136,6 +141,12 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
             throws IOException {
         String serialized = TestingData.jsonFromFile("schema/inception.json");
         WikibaseSchema schema = WikibaseSchema.reconstruct(serialized);
+        
+        // Validate the schema
+        ValidationState validation = new ValidationState(project.columnModel);
+        schema.validate(validation);
+        assertTrue(validation.getValidationErrors().isEmpty());
+        
         Engine engine = new Engine(project);
         List<EntityEdit> updates = schema.evaluate(project, engine);
         List<EntityEdit> expected = new ArrayList<>();
@@ -144,6 +155,32 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
         TermedStatementEntityEdit update2 = new ItemEditBuilder(qid2).addStatement(statementUpdate2).build();
         expected.add(update2);
         assertEquals(expected, updates);
+    }
+    
+    @Test
+    public void testValidate() throws IOException {
+    	String serialized = TestingData.jsonFromFile("schema/inception_with_errors.json");
+    	WikibaseSchema schema = WikibaseSchema.reconstruct(serialized);
+    	
+    	// Validate the schema
+        ValidationState validation = new ValidationState(project.columnModel);
+        schema.validate(validation);
+        
+        List<ValidationError> expectedErrors = new ArrayList<>();
+        expectedErrors.add(new ValidationError(Arrays.asList(
+        		new PathElement(Type.ENTITY, 0),
+        		new PathElement(Type.STATEMENT, "inception (P571)"),
+        		new PathElement(Type.REFERENCE, 0),
+        		new PathElement(Type.VALUE, "reference URL (P854)")),
+        		"Column 'nonexisting_column_name' does not exist"));
+        expectedErrors.add(new ValidationError(Arrays.asList(
+        		new PathElement(Type.ENTITY, 0),
+        		new PathElement(Type.STATEMENT, "inception (P571)"),
+        		new PathElement(Type.REFERENCE, 0),
+        		new PathElement(Type.VALUE, "retrieved (P813)")),
+        		"Empty date field"));
+        
+        assertEquals(validation.getValidationErrors(), expectedErrors);
     }
 
     @Test(expectedExceptions = IOException.class)
@@ -158,6 +195,12 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
             throws IOException {
         String serialized = TestingData.jsonFromFile("schema/inception.json");
         WikibaseSchema schema = WikibaseSchema.reconstruct(serialized);
+        
+        // Validate the schema
+        ValidationState validation = new ValidationState(project.columnModel);
+        schema.validate(validation);
+        assertTrue(validation.getValidationErrors().isEmpty());
+        
         Engine engine = new Engine(project);
         EngineConfig engineConfig = EngineConfig.reconstruct("{\n"
                 + "      \"mode\": \"row-based\",\n"

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WikibaseSchemaTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/WikibaseSchemaTest.java
@@ -141,12 +141,12 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
             throws IOException {
         String serialized = TestingData.jsonFromFile("schema/inception.json");
         WikibaseSchema schema = WikibaseSchema.reconstruct(serialized);
-        
+
         // Validate the schema
         ValidationState validation = new ValidationState(project.columnModel);
         schema.validate(validation);
         assertTrue(validation.getValidationErrors().isEmpty());
-        
+
         Engine engine = new Engine(project);
         List<EntityEdit> updates = schema.evaluate(project, engine);
         List<EntityEdit> expected = new ArrayList<>();
@@ -156,30 +156,30 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
         expected.add(update2);
         assertEquals(expected, updates);
     }
-    
+
     @Test
     public void testValidate() throws IOException {
-    	String serialized = TestingData.jsonFromFile("schema/inception_with_errors.json");
-    	WikibaseSchema schema = WikibaseSchema.reconstruct(serialized);
-    	
-    	// Validate the schema
+        String serialized = TestingData.jsonFromFile("schema/inception_with_errors.json");
+        WikibaseSchema schema = WikibaseSchema.reconstruct(serialized);
+
+        // Validate the schema
         ValidationState validation = new ValidationState(project.columnModel);
         schema.validate(validation);
-        
+
         List<ValidationError> expectedErrors = new ArrayList<>();
         expectedErrors.add(new ValidationError(Arrays.asList(
-        		new PathElement(Type.ENTITY, 0),
-        		new PathElement(Type.STATEMENT, "inception (P571)"),
-        		new PathElement(Type.REFERENCE, 0),
-        		new PathElement(Type.VALUE, "reference URL (P854)")),
-        		"Column 'nonexisting_column_name' does not exist"));
+                new PathElement(Type.ENTITY, 0),
+                new PathElement(Type.STATEMENT, "inception (P571)"),
+                new PathElement(Type.REFERENCE, 0),
+                new PathElement(Type.VALUE, "reference URL (P854)")),
+                "Column 'nonexisting_column_name' does not exist"));
         expectedErrors.add(new ValidationError(Arrays.asList(
-        		new PathElement(Type.ENTITY, 0),
-        		new PathElement(Type.STATEMENT, "inception (P571)"),
-        		new PathElement(Type.REFERENCE, 0),
-        		new PathElement(Type.VALUE, "retrieved (P813)")),
-        		"Empty date field"));
-        
+                new PathElement(Type.ENTITY, 0),
+                new PathElement(Type.STATEMENT, "inception (P571)"),
+                new PathElement(Type.REFERENCE, 0),
+                new PathElement(Type.VALUE, "retrieved (P813)")),
+                "Empty date field"));
+
         assertEquals(validation.getValidationErrors(), expectedErrors);
     }
 
@@ -195,12 +195,12 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
             throws IOException {
         String serialized = TestingData.jsonFromFile("schema/inception.json");
         WikibaseSchema schema = WikibaseSchema.reconstruct(serialized);
-        
+
         // Validate the schema
         ValidationState validation = new ValidationState(project.columnModel);
         schema.validate(validation);
         assertTrue(validation.getValidationErrors().isEmpty());
-        
+
         Engine engine = new Engine(project);
         EngineConfig engineConfig = EngineConfig.reconstruct("{\n"
                 + "      \"mode\": \"row-based\",\n"

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/validation/ValidationErrorTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/validation/ValidationErrorTest.java
@@ -1,0 +1,44 @@
+package org.openrefine.wikidata.schema.validation;
+
+import java.util.Arrays;
+
+import org.openrefine.wikidata.schema.validation.PathElement.Type;
+import org.testng.annotations.Test;
+
+import com.google.refine.util.TestUtils;
+
+public class ValidationErrorTest {
+
+	@Test
+	public void testSerialize() {
+		String expectedJson = "{\n"
+				+ "       \"message\" : \"Empty date field\",\n"
+				+ "       \"path\" : [ {\n"
+				+ "         \"name\" : null,\n"
+				+ "         \"position\" : 0,\n"
+				+ "         \"type\" : \"entity\"\n"
+				+ "       }, {\n"
+				+ "         \"name\" : \"inception (P571)\",\n"
+				+ "         \"position\" : -1,\n"
+				+ "         \"type\" : \"statement\"\n"
+				+ "       }, {\n"
+				+ "         \"name\" : null,\n"
+				+ "         \"position\" : 0,\n"
+				+ "         \"type\" : \"reference\"\n"
+				+ "       }, {\n"
+				+ "         \"name\" : \"retrieved (P813)\",\n"
+				+ "         \"position\" : -1,\n"
+				+ "         \"type\" : \"value\"\n"
+				+ "       } ]\n"
+				+ "     }";
+		
+		ValidationError validation = new ValidationError(Arrays.asList(
+        		new PathElement(Type.ENTITY, 0),
+        		new PathElement(Type.STATEMENT, "inception (P571)"),
+        		new PathElement(Type.REFERENCE, 0),
+        		new PathElement(Type.VALUE, "retrieved (P813)")),
+        		"Empty date field");
+		
+		TestUtils.isSerializedTo(validation, expectedJson);
+	}
+}

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/validation/ValidationErrorTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/schema/validation/ValidationErrorTest.java
@@ -1,3 +1,4 @@
+
 package org.openrefine.wikidata.schema.validation;
 
 import java.util.Arrays;
@@ -9,36 +10,36 @@ import com.google.refine.util.TestUtils;
 
 public class ValidationErrorTest {
 
-	@Test
-	public void testSerialize() {
-		String expectedJson = "{\n"
-				+ "       \"message\" : \"Empty date field\",\n"
-				+ "       \"path\" : [ {\n"
-				+ "         \"name\" : null,\n"
-				+ "         \"position\" : 0,\n"
-				+ "         \"type\" : \"entity\"\n"
-				+ "       }, {\n"
-				+ "         \"name\" : \"inception (P571)\",\n"
-				+ "         \"position\" : -1,\n"
-				+ "         \"type\" : \"statement\"\n"
-				+ "       }, {\n"
-				+ "         \"name\" : null,\n"
-				+ "         \"position\" : 0,\n"
-				+ "         \"type\" : \"reference\"\n"
-				+ "       }, {\n"
-				+ "         \"name\" : \"retrieved (P813)\",\n"
-				+ "         \"position\" : -1,\n"
-				+ "         \"type\" : \"value\"\n"
-				+ "       } ]\n"
-				+ "     }";
-		
-		ValidationError validation = new ValidationError(Arrays.asList(
-        		new PathElement(Type.ENTITY, 0),
-        		new PathElement(Type.STATEMENT, "inception (P571)"),
-        		new PathElement(Type.REFERENCE, 0),
-        		new PathElement(Type.VALUE, "retrieved (P813)")),
-        		"Empty date field");
-		
-		TestUtils.isSerializedTo(validation, expectedJson);
-	}
+    @Test
+    public void testSerialize() {
+        String expectedJson = "{\n"
+                + "       \"message\" : \"Empty date field\",\n"
+                + "       \"path\" : [ {\n"
+                + "         \"name\" : null,\n"
+                + "         \"position\" : 0,\n"
+                + "         \"type\" : \"entity\"\n"
+                + "       }, {\n"
+                + "         \"name\" : \"inception (P571)\",\n"
+                + "         \"position\" : -1,\n"
+                + "         \"type\" : \"statement\"\n"
+                + "       }, {\n"
+                + "         \"name\" : null,\n"
+                + "         \"position\" : 0,\n"
+                + "         \"type\" : \"reference\"\n"
+                + "       }, {\n"
+                + "         \"name\" : \"retrieved (P813)\",\n"
+                + "         \"position\" : -1,\n"
+                + "         \"type\" : \"value\"\n"
+                + "       } ]\n"
+                + "     }";
+
+        ValidationError validation = new ValidationError(Arrays.asList(
+                new PathElement(Type.ENTITY, 0),
+                new PathElement(Type.STATEMENT, "inception (P571)"),
+                new PathElement(Type.REFERENCE, 0),
+                new PathElement(Type.VALUE, "retrieved (P813)")),
+                "Empty date field");
+
+        TestUtils.isSerializedTo(validation, expectedJson);
+    }
 }


### PR DESCRIPTION
This is first step towards those two issues:
* #5043
* #4724 

It decouples the parsing of the schema (done by the Jackson library, which calls constructors of our classes which make up the schema) and its validation. So far, the constructors of each of those classes were checking that they had valid (non-empty) arguments.

By delaying this to an explicit validation step, we are enabling two things:
* to return better error messages which can point to the location in the schema where a value is missing. I plan to expose this in the frontend in a follow-up PR (which will also tackle related issues in the schema UI)
* to make is possible to represent "schemas with holes", also known as "schema templates". The alternative would have been to declare another tree of classes to represent templates, but that feels overkill to me. Some follow-up PRs will expose this in the frontend (saving, loading, deleting those schema templates).

Since this PR is already rather big I am submitting it as is (although it does not address any of the issues yet), to make it easier for anyone who would want to review this to do so.
