### PR TITLE
Updated Dependabot to ignore Jetty versions 10 and above

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     versions:
     - "> 1.4.12"
     - "< 2"
+  - dependency-name: jetty-*
+      versions:
+        - ">= 10.0.0"
   target-branch: "master"
     
 # For main webapp


### PR DESCRIPTION
### Changes proposed in this pull request:
- Updated Dependabot to ignore Jetty versions 10 and above.