### PR TITLE
Made text color in tables consistent with the color used in the project table

### DIFF
--- a/main/webapp/modules/core/styles/common.less
+++ b/main/webapp/modules/core/styles/common.less
@@ -188,7 +188,7 @@ a img {
   vertical-align: baseline;
   padding: @padding_tighter @padding_tight;
   font-size: 1.1em;
-  color: @metadata_grey;
+  color: #222;
   border-bottom: dotted 1px @faint_grey;
   }
 


### PR DESCRIPTION

Changes proposed in this pull request:
- Made text color in tables consistent with the color used in the project table to improve readability of the table data (Going from gray to almost black).

After (Open Project) :
![image](https://user-images.githubusercontent.com/42903164/180394146-81f542c1-6c23-4c56-8f35-193ad49ed31c.png)

After (About/Project Metadata) :
![image](https://user-images.githubusercontent.com/42903164/180394504-5ef1efac-d004-4844-bbd6-2453c5414f5d.png)

