### PR TITLE
Added fix so the gdata importer gets the date properly

### DIFF
--- a/extensions/gdata/module/scripts/index/gdata-source-ui.js
+++ b/extensions/gdata/module/scripts/index/gdata-source-ui.js
@@ -135,44 +135,50 @@ Refine.GDataSourceUI.prototype._renderDocuments = function(o) {
   
   var renderDocument = function(doc) {
     var tr = table.insertRow(table.rows.length);
-    
-    var td = tr.insertCell(tr.cells.length);
-    if (doc.isStarred) {
-      $('<img>').attr('src', 'images/star.png').appendTo(td);
+
+    try {
+      var td = tr.insertCell(tr.cells.length);
+      if (doc.isStarred) {
+        $('<img>').attr('src', 'images/star.png').appendTo(td);
+      }
+
+      td = tr.insertCell(tr.cells.length);
+      $('<span>').text(doc.type).appendTo(td);
+
+      td = tr.insertCell(tr.cells.length);
+      $('<a>')
+          .addClass('gdata-doc-title')
+          .attr('href', 'javascript:{}')
+          .text(doc.title)
+          .appendTo(td)
+          .on('click', function (evt) {
+            self._controller.startImportingDocument(doc);
+          });
+
+      $('<a>')
+          .addClass('gdata-doc-preview')
+          .attr('href', doc.docLink)
+          .attr('target', '_blank')
+          .text('preview')
+          .appendTo(td);
+
+      td = tr.insertCell(tr.cells.length);
+      $('<span>')
+          .addClass('gdata-doc-authors')
+          .text((doc.authors) ? doc.authors.join(', ') : '<unknown>')
+          .appendTo(td);
+
+      td = tr.insertCell(tr.cells.length);
+      $('<span>')
+          .addClass('gdata-doc-date')
+          .text((doc.updated) ? formatRelativeDate(doc.updated) : '<unknown>')
+          .attr('title', (doc.updated) ? doc.updated : '<unknown>')
+          .appendTo(td);
+    } catch (e) {
+      console.log(e);
+      console.log('Error rendering Google Document "'+doc.title+'". Skipping...');
+      tr.remove();
     }
-    
-    td = tr.insertCell(tr.cells.length);
-    $('<span>').text(doc.type).appendTo(td);
-    
-    td = tr.insertCell(tr.cells.length);
-    $('<a>')
-    .addClass('gdata-doc-title')
-    .attr('href', 'javascript:{}')
-    .text(doc.title)
-    .appendTo(td)
-    .on('click',function(evt) {
-      self._controller.startImportingDocument(doc);
-    });
-    
-    $('<a>')
-    .addClass('gdata-doc-preview')
-    .attr('href', doc.docLink)
-    .attr('target', '_blank')
-    .text('preview')
-    .appendTo(td);
-    
-    td = tr.insertCell(tr.cells.length);
-    $('<span>')
-    .addClass('gdata-doc-authors')
-    .text((doc.authors) ? doc.authors.join(', ') : '<unknown>')
-    .appendTo(td);
-    
-    td = tr.insertCell(tr.cells.length);
-    $('<span>')
-    .addClass('gdata-doc-date')
-    .text((doc.updated) ? formatRelativeDate(doc.updated) : '<unknown>')
-    .attr('title', (doc.updated) ? doc.updated : '<unknown>')
-    .appendTo(td);
   };
   
   if (o.status === 'error') {

--- a/main/webapp/modules/core/scripts/util/misc.js
+++ b/main/webapp/modules/core/scripts/util/misc.js
@@ -66,12 +66,12 @@ function formatRelativeDate(d) {
   if (d.between(today, tomorrow)) {
     return $.i18n('core-util-enc/today', d.toString("h:mm tt"));
   } else if (d.between(last_week, today)) {
-    var diff = Math.floor(today.getDayOfYear() - d.getDayOfYear());
+    var diff = Math.floor(daysIntoYear(today) - daysIntoYear(d));
     return (diff <= 1) ? ($.i18n('core-util-enc/yesterday', d.toString("h:mm tt"))) : $.i18n('core-util-enc/days-ago', diff);
   } else if (d.between(last_month, today)) {
-    var diff = Math.floor((today.getDayOfYear() - d.getDayOfYear()) / 7);
+    var diff = Math.floor((daysIntoYear(today) - daysIntoYear(d)) / 7);
     if (diff < 1) {diff += 52};
-    return $.i18n('core-util-enc/week-agos', diff) ;
+    return $.i18n('core-util-enc/weeks-ago', diff) ;
   } else if (d.between(almost_last_year, today)) {
     var diff = today.getMonth() - d.getMonth();
     if (diff < 1) {
@@ -82,4 +82,8 @@ function formatRelativeDate(d) {
     var diff = Math.floor(today.getYear() - d.getYear());
     return $.i18n('core-util-enc/years-ago', diff);
   }
+}
+
+function daysIntoYear(date){
+  return (Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) - Date.UTC(date.getFullYear(), 0, 0)) / 24 / 60 / 60 / 1000;
 }


### PR DESCRIPTION
Fixes #5107

Changes proposed in this pull request:
- Added fix for gdata importer login to get the date properly so the documents show up on login (Last screenshot).
- Fixed i18n typo.
- Added a try catch block around the code that processes each document. If any document causes an exception, an error is displayed in the console, but the other documents are displayed:
![image](https://user-images.githubusercontent.com/42903164/180675554-e1bb6843-1dcb-4b57-8482-bdbabbafe122.png)

![image](https://user-images.githubusercontent.com/42903164/180675524-55ffa0aa-4f1d-4616-a75e-fcc7f966dd7e.png)
