### PR TITLE
build(deps): bump jetty.version from 9.4.46.v20220331 to 9.4.48.v20220622

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <butterfly.version>1.2.3</butterfly.version>
     <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.18.0</log4j.version>
-    <jetty.version>9.4.46.v20220331</jetty.version>
+    <jetty.version>9.4.48.v20220622</jetty.version>
     <okhttp.version>4.10.0</okhttp.version>
     <jena.version>4.5.0</jena.version>
     <poi.version>5.2.2</poi.version>


### PR DESCRIPTION
Changes proposed in this pull request:
- Update Jetty from 9.4.46.v20220331 to 9.4.48.v20220622.