### PR TITLE
Cleaned up duplicate i18n code

### DIFF
--- a/extensions/database/module/scripts/index/database-import-controller.js
+++ b/extensions/database/module/scripts/index/database-import-controller.js
@@ -27,24 +27,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-//Internationalization init
-var lang = navigator.language.split("-")[0]
-    || navigator.userLanguage.split("-")[0];
-var dictionary = "";
-$.ajax({
-  url : "command/core/load-language?",
-  type : "POST",
-  async : false,
-  data : {
-    module : "database",
-  },
-  success : function(data) {
-    dictionary = data['dictionary'];
-    lang = data['lang'];
-  }
-});
-$.i18n().load(dictionary, lang);
-// End internationalization
+I18NUtil.init("database");
 
 Refine.DatabaseImportController = function(createProjectUI) {
   this._createProjectUI = createProjectUI;

--- a/extensions/database/module/scripts/project/database-exporters.js
+++ b/extensions/database/module/scripts/project/database-exporters.js
@@ -27,22 +27,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-var dictionary = "";
-$.ajax({
-    url : "command/core/load-language?",
-    type : "POST",
-    async : false,
-    data : {
-      module : "database",
-
-    },
-    success : function(data) {
-        dictionary = data['dictionary'];
-        lang = data['lang'];
-    }
-});
-$.i18n().load(dictionary, lang);
-// End internationalization
+I18NUtil.init("database");
 
 (function() {
 

--- a/extensions/gdata/module/scripts/index/importing-controller.js
+++ b/extensions/gdata/module/scripts/index/importing-controller.js
@@ -31,25 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  */
 
-//Internationalization init
-var lang = navigator.language.split("-")[0]
-		|| navigator.userLanguage.split("-")[0];
-var dictionary = "";
-$.ajax({
-	url : "command/core/load-language?",
-	type : "POST",
-	async : false,
-	data : {
-	  module : "gdata",
-//		lang : lang
-	},
-	success : function(data) {
-		dictionary = data['dictionary'];
-                lang = data['lang'];
-	}
-});
-$.i18n().load(dictionary, lang);
-// End internationalization
+I18NUtil.init("gdata");
 
 Refine.GDataImportingController = function(createProjectUI) {
   this._createProjectUI = createProjectUI;

--- a/extensions/gdata/module/scripts/project/exporters.js
+++ b/extensions/gdata/module/scripts/project/exporters.js
@@ -31,22 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  */
 
-var dictionary = "";
-$.ajax({
-	url : "command/core/load-language?",
-	type : "POST",
-	async : false,
-	data : {
-	  module : "gdata",
-//		lang : lang
-	},
-	success : function(data) {
-		dictionary = data['dictionary'];
-                lang = data['lang'];
-	}
-});
-$.i18n().load(dictionary, lang);
-// End internationalization
+I18NUtil.init("gdata");
 
 ExporterManager.MenuItems.push({});
 ExporterManager.MenuItems.push(

--- a/extensions/pc-axis/module/scripts/pc-axis-parser-ui.js
+++ b/extensions/pc-axis/module/scripts/pc-axis-parser-ui.js
@@ -31,23 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
  */
 
-//Internationalization init
-
-var dictionary = {};
-$.ajax({
-url : "command/core/load-language?",
-type : "POST",
-async : false,
-data : {
-module : "pc-axis",
-},
-success : function(data) {
-dictionary = data['dictionary'];
-lang = data['lang'];
-}
-});
-$.i18n().load(dictionary, lang);
-// End internationalization
+I18NUtil.init("pc-axis");
 
 Refine.PCAxisParserUI = function(controller, jobID, job, format, config,
     dataContainerElmt, progressContainerElmt, optionContainerElmt) {

--- a/extensions/phonetic/module/scripts/load-language.js
+++ b/extensions/phonetic/module/scripts/load-language.js
@@ -1,19 +1,3 @@
-// Load the localization file
-var dictionary = {};
-$.ajax({
-	url : "command/core/load-language?",
-	type : "POST",
-	async : false,
-	data : {
-	  module : "phonetic",
-//		lang : lang
-	},
-	success : function(data) {
-		dictionary = data['dictionary'];
-		lang = data['lang'];
-	}
-});
-$.i18n().load(dictionary, lang);
-
+I18NUtil.init("phonetic");
 
 

--- a/extensions/wikidata/module/scripts/menu-bar-extension.js
+++ b/extensions/wikidata/module/scripts/menu-bar-extension.js
@@ -1,20 +1,4 @@
-// Load the localization file
-var dictionary = {};
-$.ajax({
-  url: "command/core/load-language?",
-  type: "POST",
-  async: false,
-  data: {
-    module: "wikidata",
-//		lang : lang
-  },
-  success: function (data) {
-    dictionary = data['dictionary'];
-    lang = data['lang'];
-  }
-});
-$.i18n().load(dictionary, lang);
-
+I18NUtil.init("wikidata");
 
 ExporterManager.MenuItems.push({});
 ExporterManager.MenuItems.push({

--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -365,6 +365,7 @@ function init() {
       "scripts/util/url.js",
       "scripts/util/string.js",
       "scripts/util/ajax.js",
+      "scripts/util/i18n.js",
       "scripts/util/menu.js",
       "scripts/util/dialog.js",
       "scripts/util/dom.js",
@@ -436,9 +437,8 @@ function init() {
     commonModules.concat([
       "externals/suggest/suggest-4_3a.js",
       "3rdparty/date.js",
-
+      "scripts/util/i18n.js",
       "scripts/project.js",
-
       "scripts/util/misc.js",
       "scripts/util/url.js",
       "scripts/util/string.js",
@@ -540,6 +540,7 @@ function init() {
     "preferences/scripts",
     module,
     commonModules.concat([
+      "scripts/util/i18n.js",
       "scripts/preferences.js",
     ])
   );

--- a/main/webapp/modules/core/about.html
+++ b/main/webapp/modules/core/about.html
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <script type="text/javascript" src="3rdparty/jquery.i18n/jquery.i18n.language.js"></script>
     <script type="text/javascript" src="3rdparty/jquery.i18n/languages/fi.js"></script>
     <script type="text/javascript" src="3rdparty/jquery.i18n/languages/ru.js"></script>
+    <script type="text/javascript" src="scripts/util/i18n.js"></script>
     <script type="text/javascript" src="scripts/index.js"></script>
 
   </head>

--- a/main/webapp/modules/core/scripts/index.js
+++ b/main/webapp/modules/core/scripts/index.js
@@ -68,24 +68,7 @@ Refine.postCSRF = function(url, data, success, dataType, failCallback) {
    });
 };
 
-var lang = (navigator.language|| navigator.userLanguage).split("-")[0];
-var dictionary = "";
-$.ajax({
-	url : "command/core/load-language?",
-	type : "POST",
-	async : false,
-	data : {
-	  module : "core",
-//		lang : lang
-	},
-	success : function(data) {
-		dictionary = data['dictionary'];
-        lang = data['lang'];
-	}
-});
-$.i18n().load(dictionary, lang);
-$.i18n({ locale: lang });
-// End internationalization
+I18NUtil.init();
 
 Refine.selectActionArea = function(id) {
   $('.action-area-tab').removeClass('selected');

--- a/main/webapp/modules/core/scripts/index.js
+++ b/main/webapp/modules/core/scripts/index.js
@@ -68,7 +68,7 @@ Refine.postCSRF = function(url, data, success, dataType, failCallback) {
    });
 };
 
-I18NUtil.init();
+I18NUtil.init("core");
 
 Refine.selectActionArea = function(id) {
   $('.action-area-tab').removeClass('selected');

--- a/main/webapp/modules/core/scripts/preferences.js
+++ b/main/webapp/modules/core/scripts/preferences.js
@@ -67,33 +67,7 @@ Refine.postCSRF = function(url, data, success, dataType, failCallback) {
    });
 };
 
-
-var lang = (navigator.language|| navigator.userLanguage).split("-")[0];
-var dictionary = "";
-$.ajax({
-  url : "command/core/load-language?",
-  type : "POST",
-  async : false,
-  data : {
-    module : "core",
-    //lang : lang
-  },
-  success : function(data) {
-    dictionary = data['dictionary'];
-    lang = data['lang'];
-  }
-}).fail(function( jqXhr, textStatus, errorThrown ) {
-  var errorMessage = $.i18n('core-index/prefs-loading-failed');
-  if(errorMessage != "" && errorMessage != 'core-index/prefs-loading-failed') {
-    alert(errorMessage); 
-  } else {
-    alert( textStatus + ':' + errorThrown );
-  }
-});
-
-$.i18n().load(dictionary, lang);
-$.i18n().locale = lang;
-//End internationalization
+I18NUtil.init();
 
 function deDupUserMetaData(arrObj)  {
     var result = _.uniq(JSON.parse(arrObj), function(x){

--- a/main/webapp/modules/core/scripts/preferences.js
+++ b/main/webapp/modules/core/scripts/preferences.js
@@ -67,7 +67,7 @@ Refine.postCSRF = function(url, data, success, dataType, failCallback) {
    });
 };
 
-I18NUtil.init();
+I18NUtil.init("core");
 
 function deDupUserMetaData(arrObj)  {
     var result = _.uniq(JSON.parse(arrObj), function(x){

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -35,7 +35,7 @@ var theProject;
 var thePreferences;
 var ui = {};
 
-I18NUtil.init();
+I18NUtil.init("core");
 
 var Refine = {};
 

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -35,24 +35,7 @@ var theProject;
 var thePreferences;
 var ui = {};
 
-var lang = (navigator.language|| navigator.userLanguage).split("-")[0];
-var dictionary = "";
-$.ajax({
-	url : "command/core/load-language?",
-	type : "POST",
-	async : false,
-	data : {
-	  module : "core",
-//		lang : lang
-	},
-	success : function(data) {
-		dictionary = data['dictionary'];
-        lang = data['lang'];
-	}
-});
-$.i18n().load(dictionary, lang);
-$.i18n({ locale: lang });
-// End internationalization
+I18NUtil.init();
 
 var Refine = {};
 

--- a/main/webapp/modules/core/scripts/util/i18n.js
+++ b/main/webapp/modules/core/scripts/util/i18n.js
@@ -6,7 +6,7 @@ var dictionary = "";
 /*
    Initialize i18n and load message translation file from the server.
 
-   Note that the language is set by the 'userLang' user preference setting.  You can chnage that by
+   Note that the language is set by the 'userLang' user preference setting.  You can change that by
    clicking on 'Language Settings' on the landing page.
 */
 I18NUtil.init = function (module) {
@@ -15,8 +15,7 @@ I18NUtil.init = function (module) {
         type: "POST",
         async: false,
         data: {
-            module: module,
-            lang: lang
+            module: module
         },
         success: function (data) {
             dictionary = data['dictionary'];

--- a/main/webapp/modules/core/scripts/util/i18n.js
+++ b/main/webapp/modules/core/scripts/util/i18n.js
@@ -1,0 +1,38 @@
+I18NUtil = {};
+
+var lang = (navigator.language || navigator.userLanguage).split("-")[0];
+var dictionary = "";
+
+/*
+   Initialize i18n and load message translation file from the server.
+
+   Note that the language is set by the 'userLang' user preference setting.  You can chnage that by
+   clicking on 'Language Settings' on the landing page.
+*/
+I18NUtil.init = function () {
+    $.ajax({
+        url: "command/core/load-language?",
+        type: "POST",
+        async: false,
+        data: {
+            module: "core"
+        },
+        success: function (data) {
+            dictionary = data['dictionary'];
+            var langFromServer = data['lang'];
+            if (lang !== langFromServer) {
+                console.warn('Language \'' + lang + '\' missing translation. Defaulting to \''+langFromServer+'\'.');
+                lang = langFromServer;
+            }
+        }
+    }).fail(function( jqXhr, textStatus, errorThrown ) {
+        var errorMessage = $.i18n('core-index/prefs-loading-failed');
+        if(errorMessage != "" && errorMessage != 'core-index/prefs-loading-failed') {
+            alert(errorMessage);
+        } else {
+            alert( textStatus + ':' + errorThrown );
+        }
+    });
+    $.i18n().load(dictionary, lang);
+    $.i18n({locale: lang});
+}

--- a/main/webapp/modules/core/scripts/util/i18n.js
+++ b/main/webapp/modules/core/scripts/util/i18n.js
@@ -1,6 +1,6 @@
 I18NUtil = {};
 
-var lang = (navigator.language || navigator.userLanguage).split("-")[0];
+var lang = (navigator.language).split("-")[0];
 var dictionary = "";
 
 /*
@@ -9,13 +9,14 @@ var dictionary = "";
    Note that the language is set by the 'userLang' user preference setting.  You can chnage that by
    clicking on 'Language Settings' on the landing page.
 */
-I18NUtil.init = function () {
+I18NUtil.init = function (module) {
     $.ajax({
         url: "command/core/load-language?",
         type: "POST",
         async: false,
         data: {
-            module: "core"
+            module: module,
+            lang: lang
         },
         success: function (data) {
             dictionary = data['dictionary'];


### PR DESCRIPTION
Changes proposed in this pull request:
- Move duplicate code to initialize the i18n system to i18n.js so it can be used by the index.vt, preferences.vt, and project.vt templates.  
- Removed duplicate code in extensions.
- Updated controller.js to include i18n.js in the script bundles for each template.
- Added check to compare the browser's language to the one returned by the load-language command, and print a warning if they are different.  Requested in Issue #5118.