### PR TITLE
Fix CSS issue in Wikibase extension, affecting the entire application

### DIFF
--- a/extensions/wikidata/module/styles/dialogs/wikibase-dialog.less
+++ b/extensions/wikidata/module/styles/dialogs/wikibase-dialog.less
@@ -65,7 +65,7 @@
   color: gray;
 }
 
-.wikibase-list li a,span {
+.wikibase-list li a, .wikibase-list li span {
   margin: 10px;
   flex: 0 0;
 }


### PR DESCRIPTION
In 8e4dce1ac7df5adf561ea8f912db86e299817ee1 (#5049), we introduced a CSS rule which affects all `span` elements in the entire application, whereas it was meant to only apply to the ones contained in the dialog to manage Wikibase instances.

### Screenshots

Before this fix:
![image](https://user-images.githubusercontent.com/309908/182399437-92415f89-a2d1-4bb9-926f-e58bcb174764.png)


With this fix:
![image](https://user-images.githubusercontent.com/309908/182399157-07e12d8c-fd1f-4331-b5bb-fc3c235a0bce.png)
