### PR TITLE
 Changed link in the cluster and edit dialog to point directly to the documentation

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.html
@@ -5,7 +5,7 @@
       <tr>
         <td colspan="4">
           <span bind="or_dialog_descr"></span>
-          <a href="https://github.com/OpenRefine/OpenRefine/wiki/Clustering" target="_blank" bind="or_dialog_findMore"></a>
+          <a href="https://docs.openrefine.org/manual/cellediting#cluster-and-edit" target="_blank" bind="or_dialog_findMore"></a>
         </td>
       </tr>
       <tr>


### PR DESCRIPTION
Changes proposed in this pull request:
- Changed 'Find out more...' link to point directly to the documentation rather than GitHub in the cluster and edit dialog.