### PR TITLE
Adjust wording of error message mentioned in #5138

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -184,7 +184,7 @@
     "core-dialogs/no-cluster-found": "No clusters were found with the selected method",
     "core-dialogs/try-another-method": "Try selecting another method above or changing its parameters",
     "core-dialogs/clustering": "Clustering…",
-    "core-dialogs/warning-check-boxes": "You must check some Edit? checkboxes for your edits to be applied.",
+    "core-dialogs/warning-check-boxes": "You must check some 'Merge?' checkboxes for your edits to be applied.",
     "core-dialogs/choices-in-cluster": "# Choices in cluster",
     "core-dialogs/rows-in-cluster": "# Rows in cluster",
     "core-dialogs/choice-avg-length": "Average length of choices",


### PR DESCRIPTION
In #5138 the error message that is shown does not quite match the UI:
![Schermafbeelding 2022-08-02 165813](https://user-images.githubusercontent.com/198277/182406282-55f066cd-203a-4f81-9c4b-eff19586b70f.png)

The message mentions the "Edit?" column but it is actually called "Merge?".
This fixes that (but not #5138).