### PR TITLE
Support for file upload to Wikibase instances without structured data support

### DIFF
--- a/docs/docs/manual/wikibase/configuration.md
+++ b/docs/docs/manual/wikibase/configuration.md
@@ -71,6 +71,7 @@ Here is the manifest of Wikimedia Commons:
        "reconciliation_endpoint": "https://commonsreconcile.toolforge.org/${lang}/api"
     }
   },
+  "hide_structured_fields_in_mediainfo": false,
   "editgroups": {
     "url_schema": "([[:toollabs:editgroups-commons/b/OR/${batch_id}|details]])"
   }
@@ -155,7 +156,7 @@ The Wikibase instance must have at least a reconciliation service endpoint linke
 
 ##### reconciliation_endpoint {#reconciliation_endpoint}
 
-The default reconciliation service endpoint for entities of this type. The endpoint must contain the "${lang}" variable such as "https://wikidata.reconci.link/${lang}/api", since the reconciliation service is expected to work for different languages. For the `item` entity type, you can get such a reconciliation service with [openrefine-wikibase](https://github.com/wetneb/openrefine-wikibase).
+The default reconciliation service endpoint for entities of this type. The endpoint must contain the "${lang}" variable such as "https://wikidata.reconci.link/${lang}/api", since the reconciliation service is expected to work for different languages. For the `item` entity type, you can get such a reconciliation service with [openrefine-wikibase](https://github.com/wetneb/openrefine-wikibase). For the `mediainfo` entity type, you can use the [commons-recon-service](https://gerrit.wikimedia.org/g/labs/tools/commons-recon-service) which can be configured to run for other Wikibase instances.
 
 This parameter is optional: you do not need to run a reconciliation for all entity types available in your Wikibase instance. However, it is a prerequisite for being able to do edits to those entity types via OpenRefine.
 
@@ -166,6 +167,11 @@ The base IRI for the entities of this type. This property is required. By defaul
 ##### mediawiki_api {#mediawiki_api}
 
 The URL of the MediaWiki API to use with entities of this type. If not provided, it is expected to be the same as the MediaWiki API endpoint for this instance, but if entities of this type are federated from another instance, then this should be set to the MediaWiki API endpoint of that Wikibase instance.
+
+#### hide_structured_fields_in_mediainfo
+
+Not required. Set this flag to true if your Wikibase instance supports file uploads (in which case it should have a `mediainfo` section in the `entity_types` object above), but it does not support adding captions and statements directly on the files themselves (unlike
+Wikimedia Commons).
 
 #### editgroups {#editgroups}
 

--- a/extensions/wikidata/module/scripts/schema-alignment.js
+++ b/extensions/wikidata/module/scripts/schema-alignment.js
@@ -604,50 +604,52 @@ SchemaAlignment._addMediaInfo = function(json) {
     SchemaAlignment._hasChanged();
   });
 
-  // Captions
-  $('<span></span>').addClass('wbs-namedesc-header')
-       .text($.i18n('wikibase-schema/captions-header')).appendTo(right);
-  $('<div></div>').addClass('wbs-namedesc-container')
-        .attr('data-emptyplaceholder', $.i18n('wikibase-schema/empty-captions'))
-        .appendTo(right);
-  var termToolbar = $('<div></div>').addClass('wbs-toolbar').appendTo(right);
-  var addNamedescButton = $('<a></a>').addClass('wbs-add-namedesc')
-  .on('click',function(e) {
-     SchemaAlignment._addNameDesc(item, {name_type: 'LABEL_IF_NEW', value: null});
-     e.preventDefault();
-  }).appendTo(termToolbar);
-  SchemaAlignment._plusButton(
-         $.i18n('wikibase-schema/add-caption'), addNamedescButton);
+  if (!WikibaseManager.areStructuredMediaInfoFieldsDisabledForSelectedWikibase()) {
+    // Captions
+    $('<span></span>').addClass('wbs-namedesc-header')
+        .text($.i18n('wikibase-schema/captions-header')).appendTo(right);
+    $('<div></div>').addClass('wbs-namedesc-container')
+            .attr('data-emptyplaceholder', $.i18n('wikibase-schema/empty-captions'))
+            .appendTo(right);
+    var termToolbar = $('<div></div>').addClass('wbs-toolbar').appendTo(right);
+    var addNamedescButton = $('<a></a>').addClass('wbs-add-namedesc')
+    .on('click',function(e) {
+        SchemaAlignment._addNameDesc(item, {name_type: 'LABEL_IF_NEW', value: null});
+        e.preventDefault();
+    }).appendTo(termToolbar);
+    SchemaAlignment._plusButton(
+            $.i18n('wikibase-schema/add-caption'), addNamedescButton);
 
-  // Clear the float
-  $('<div></div>').attr('style', 'clear: right').appendTo(right);
+    // Clear the float
+    $('<div></div>').attr('style', 'clear: right').appendTo(right);
 
-  // Statements
-  $('<div></div>').addClass('wbs-statements-header')
-        .text($.i18n('wikibase-schema/statements-header')).appendTo(right);
-  $('<div></div>').addClass('wbs-statement-group-container')
-        .attr('data-emptyplaceholder', $.i18n('wikibase-schema/empty-statements'))
-        .appendTo(right);
-  var statementToolbar = $('<div></div>').addClass('wbs-toolbar').appendTo(right);
-  var addStatementButton = $('<a></a>').addClass('wbs-add-statement-group')
-        .on('click',function(e) {
-     SchemaAlignment._addStatementGroup(item, null);
-     e.preventDefault();
-  }).appendTo(statementToolbar);
+    // Statements
+    $('<div></div>').addClass('wbs-statements-header')
+            .text($.i18n('wikibase-schema/statements-header')).appendTo(right);
+    $('<div></div>').addClass('wbs-statement-group-container')
+            .attr('data-emptyplaceholder', $.i18n('wikibase-schema/empty-statements'))
+            .appendTo(right);
+    var statementToolbar = $('<div></div>').addClass('wbs-toolbar').appendTo(right);
+    var addStatementButton = $('<a></a>').addClass('wbs-add-statement-group')
+            .on('click',function(e) {
+        SchemaAlignment._addStatementGroup(item, null);
+        e.preventDefault();
+    }).appendTo(statementToolbar);
 
-  SchemaAlignment._plusButton(
-         $.i18n('wikibase-schema/add-statement'), addStatementButton);
-   
-  if (statementGroups) {
-     for(var i = 0; i != statementGroups.length; i++) {
-        SchemaAlignment._addStatementGroup(item, statementGroups[i]);
-     }
-  }
-  
-  if (nameDescs) {
-     for(var i = 0; i != nameDescs.length; i++) {
-        SchemaAlignment._addNameDesc(item, nameDescs[i]);
-     }
+    SchemaAlignment._plusButton(
+            $.i18n('wikibase-schema/add-statement'), addStatementButton);
+    
+    if (statementGroups) {
+        for(var i = 0; i != statementGroups.length; i++) {
+            SchemaAlignment._addStatementGroup(item, statementGroups[i]);
+        }
+    }
+    
+    if (nameDescs) {
+        for(var i = 0; i != nameDescs.length; i++) {
+            SchemaAlignment._addNameDesc(item, nameDescs[i]);
+        }
+    }
   }
 };
 

--- a/extensions/wikidata/module/scripts/wikibase-manager.js
+++ b/extensions/wikidata/module/scripts/wikibase-manager.js
@@ -124,11 +124,7 @@ WikibaseManager.getSelectedWikibaseAvailableEntityTypes = function () {
 
 
 /**
- * TODO temporary function to be removed once we have proper support
- * for multiple entity types. This one just guesses which item-like
- * entity type we should let the user edit, based on the manifest.
- * - for Wikidata it returns 'item'
- * - for Commons it returns 'mediainfo'
+ * Returns the entity types that can be edited on the current Wikibase instance.
  */
 WikibaseManager.getSelectedWikibaseEditableEntityTypes = function () {
   let manifest = WikibaseManager.getSelectedWikibase();
@@ -146,6 +142,11 @@ WikibaseManager.getSelectedWikibaseEditableEntityTypes = function () {
     return editable;
   }
 };
+
+WikibaseManager.areStructuredMediaInfoFieldsDisabledForSelectedWikibase = function() {
+  let manifest = WikibaseManager.getSelectedWikibase();
+  return manifest.hide_structured_fields_in_mediainfo === true;
+}
 
 WikibaseManager.selectWikibase = function (wikibaseName) {
   if (WikibaseManager.wikibases.hasOwnProperty(wikibaseName)) {
@@ -342,4 +343,5 @@ WikibaseManager.getSelectedWikibaseLogoURL = function(onDone, wikibaseName) {
     onDone("extension/wikidata/images/Wikibase_logo.png");
   }, wikibaseName);
 };
+
 

--- a/extensions/wikidata/module/scripts/wikibase-manifest-schema-v2.js
+++ b/extensions/wikidata/module/scripts/wikibase-manifest-schema-v2.js
@@ -144,6 +144,10 @@ const WikibaseManifestSchemaV2 = {
         },
       },
       "required": ["url_schema"]
+    },
+    "hide_structured_fields_in_mediainfo": {
+      "type": "boolean",
+      "description": "Boolean set to true when the Wikibase instance supports file uploads but does not have structured data associated to them in the form of MediaInfo entities"
     }
   },
   "required": ["version", "mediawiki", "wikibase", "entity_types"]

--- a/extensions/wikidata/pom.xml
+++ b/extensions/wikidata/pom.xml
@@ -15,7 +15,7 @@
   </parent>
 
   <properties>
-    <wdtk.version>0.14.0</wdtk.version>
+    <wdtk.version>0.14.1</wdtk.version>
   </properties>
 
   <build>

--- a/extensions/wikidata/src/org/openrefine/wikidata/manifests/Manifest.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/manifests/Manifest.java
@@ -105,10 +105,9 @@ public interface Manifest {
     List<String> getAvailableEntityTypes();
 
     /**
-     * Only useful for Wikibase instances to which one can upload files:
-     * this is set to true when the Wikibase instance does not support structured
-     * data in the form of MediaInfo entities. In this case, OpenRefine will
-     * still offer editing those files, but hide the Captions and Statements fields.
+     * Only useful for Wikibase instances to which one can upload files: this is set to true when the Wikibase instance
+     * does not support structured data in the form of MediaInfo entities. In this case, OpenRefine will still offer
+     * editing those files, but hide the Captions and Statements fields.
      */
     boolean hideStructuredFieldsInMediaInfo();
 

--- a/extensions/wikidata/src/org/openrefine/wikidata/manifests/Manifest.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/manifests/Manifest.java
@@ -105,6 +105,14 @@ public interface Manifest {
     List<String> getAvailableEntityTypes();
 
     /**
+     * Only useful for Wikibase instances to which one can upload files:
+     * this is set to true when the Wikibase instance does not support structured
+     * data in the form of MediaInfo entities. In this case, OpenRefine will
+     * still offer editing those files, but hide the Captions and Statements fields.
+     */
+    boolean hideStructuredFieldsInMediaInfo();
+
+    /**
      * Returns an entity or property id used in the WikibaseQualityConstraints extension.
      * 
      * @param name

--- a/extensions/wikidata/src/org/openrefine/wikidata/manifests/ManifestV1.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/manifests/ManifestV1.java
@@ -135,6 +135,11 @@ public class ManifestV1 implements Manifest {
     }
 
     @Override
+    public boolean hideStructuredFieldsInMediaInfo() {
+        return false;
+    }
+
+    @Override
     public String getTagTemplate() {
         return tagTemplate;
     }

--- a/extensions/wikidata/src/org/openrefine/wikidata/manifests/ManifestV2.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/manifests/ManifestV2.java
@@ -28,6 +28,7 @@ public class ManifestV2 implements Manifest {
     private String mediaWikiApiEndpoint;
     private String editGroupsUrlSchema;
     private String tagTemplate;
+    private boolean hideStructuredFieldsInMediaInfo;
 
     private Map<String, EntityTypeSettings> entityTypeSettings;
 
@@ -66,6 +67,7 @@ public class ManifestV2 implements Manifest {
                 });
         JsonNode editGroups = manifest.path("editgroups");
         editGroupsUrlSchema = editGroups.path("url_schema").textValue();
+        hideStructuredFieldsInMediaInfo = editGroups.path("hide_structured_fields_in_mediainfo").asBoolean(false);
     }
 
     private static class EntityTypeSettings {
@@ -165,6 +167,11 @@ public class ManifestV2 implements Manifest {
     @Override
     public List<String> getAvailableEntityTypes() {
         return entityTypeSettings.keySet().stream().collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean hideStructuredFieldsInMediaInfo() {
+        return hideStructuredFieldsInMediaInfo;
     }
 
     @Override

--- a/extensions/wikidata/src/org/openrefine/wikidata/updates/EntityEdit.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/updates/EntityEdit.java
@@ -36,6 +36,11 @@ public interface EntityEdit {
     /**
      * In case the subject id is not new, returns the corresponding update given the current state of the entity. Throws
      * a validation exception otherwise.
+     *
+     * @param entityDocument
+     *              The current state of the entity.
+     *              If {@link #requiresFetchingExistingState()} returns false, then this parameter may be null,
+     *              as it should not be required to compute the {@link EntityUpdate}.
      */
     EntityUpdate toEntityUpdate(EntityDocument entityDocument);
 
@@ -102,4 +107,13 @@ public interface EntityEdit {
         return isEmpty() && !isNew();
     }
 
+    /**
+     * @return true when performing this edit requires fetching the current contents of the entity
+     * before making the edit. By default, this is true when making non-empty edits on existing entities.
+     * But implementations may override this, to spare the request to fetch the current entity, if
+     * that information is not necessary to compute the update.
+     */
+    public default boolean requiresFetchingExistingState() {
+        return !isEmpty() && !isNew();
+    }
 }

--- a/extensions/wikidata/src/org/openrefine/wikidata/updates/EntityEdit.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/updates/EntityEdit.java
@@ -38,9 +38,8 @@ public interface EntityEdit {
      * a validation exception otherwise.
      *
      * @param entityDocument
-     *              The current state of the entity.
-     *              If {@link #requiresFetchingExistingState()} returns false, then this parameter may be null,
-     *              as it should not be required to compute the {@link EntityUpdate}.
+     *            The current state of the entity. If {@link #requiresFetchingExistingState()} returns false, then this
+     *            parameter may be null, as it should not be required to compute the {@link EntityUpdate}.
      */
     EntityUpdate toEntityUpdate(EntityDocument entityDocument);
 
@@ -108,10 +107,10 @@ public interface EntityEdit {
     }
 
     /**
-     * @return true when performing this edit requires fetching the current contents of the entity
-     * before making the edit. By default, this is true when making non-empty edits on existing entities.
-     * But implementations may override this, to spare the request to fetch the current entity, if
-     * that information is not necessary to compute the update.
+     * @return true when performing this edit requires fetching the current contents of the entity before making the
+     *         edit. By default, this is true when making non-empty edits on existing entities. But implementations may
+     *         override this, to spare the request to fetch the current entity, if that information is not necessary to
+     *         compute the update.
      */
     public default boolean requiresFetchingExistingState() {
         return !isEmpty() && !isNew();

--- a/extensions/wikidata/src/org/openrefine/wikidata/updates/FullMediaInfoUpdate.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/updates/FullMediaInfoUpdate.java
@@ -61,7 +61,10 @@ public class FullMediaInfoUpdate extends MediaInfoUpdateImpl implements MediaInf
 
     @Override
     public boolean isEmpty() {
-        return (filePath == null && fileName == null && wikitext == null && super.isEmpty());
+        // intentionally ignoring our custom fields filePath, fileName and wikitext,
+        // because we want to preserve the meaning of isEmpty to only cover the wikibase part of
+        // the update.
+        return super.isEmpty();
     }
 
     /**

--- a/extensions/wikidata/src/org/openrefine/wikidata/updates/MediaInfoEdit.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/updates/MediaInfoEdit.java
@@ -148,6 +148,18 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
 
     @Override
     public FullMediaInfoUpdate toEntityUpdate(EntityDocument entityDocument) {
+        if (entityDocument == null) {
+            Validate.isFalse(requiresFetchingExistingState(), "No existing entity state provided");
+            return new FullMediaInfoUpdate(
+                    (MediaInfoIdValue) id,
+                    0L,
+                    Datamodel.makeTermUpdate(Collections.emptyList(), Collections.emptyList()),
+                    Datamodel.makeStatementUpdate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
+                    filePath,
+                    fileName,
+                    wikitext,
+                    overrideWikitext);
+        }
         MediaInfoDocument mediaInfoDocument = (MediaInfoDocument) entityDocument;
 
         // Labels (captions)
@@ -269,6 +281,19 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
                 filePath == null &&
                 fileName == null &&
                 wikitext == null);
+    }
+
+    @Override
+    public boolean requiresFetchingExistingState() {
+        /*
+        If all the Wikibase-related fields are empty, then
+        we can skip fetching the current entity from the wiki.
+        This makes it possible to use the wikitext editing feature
+        for Wikibases which do not use MediaInfo.
+         */
+        return !(statements.isEmpty() &&
+                labels.isEmpty() &&
+                labelsIfNew.isEmpty());
     }
 
     @Override

--- a/extensions/wikidata/src/org/openrefine/wikidata/updates/MediaInfoEdit.java
+++ b/extensions/wikidata/src/org/openrefine/wikidata/updates/MediaInfoEdit.java
@@ -286,10 +286,8 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
     @Override
     public boolean requiresFetchingExistingState() {
         /*
-        If all the Wikibase-related fields are empty, then
-        we can skip fetching the current entity from the wiki.
-        This makes it possible to use the wikitext editing feature
-        for Wikibases which do not use MediaInfo.
+         * If all the Wikibase-related fields are empty, then we can skip fetching the current entity from the wiki.
+         * This makes it possible to use the wikitext editing feature for Wikibases which do not use MediaInfo.
          */
         return !(statements.isEmpty() &&
                 labels.isEmpty() &&

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/manifests/ManifestTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/manifests/ManifestTest.java
@@ -3,6 +3,8 @@ package org.openrefine.wikidata.manifests;
 
 import org.openrefine.wikidata.testing.TestingData;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -57,6 +59,7 @@ public class ManifestTest {
         assertEquals("https://commons.wikimedia.org/entity/", manifest.getEntityTypeSiteIri(Manifest.MEDIAINFO_TYPE));
         assertEquals("P2302", manifest.getConstraintsRelatedId("property_constraint_pid"));
         assertEquals("([[:toollabs:editgroups-commons/b/OR/${batch_id}|details]])", manifest.getEditGroupsUrlSchema());
+        assertFalse(manifest.hideStructuredFieldsInMediaInfo());
     }
 
     @Test

--- a/extensions/wikidata/tests/src/org/openrefine/wikidata/updates/MediaInfoEditTest.java
+++ b/extensions/wikidata/tests/src/org/openrefine/wikidata/updates/MediaInfoEditTest.java
@@ -105,6 +105,8 @@ public class MediaInfoEditTest {
                 .addFileName("Foo.png")
                 .addFilePath("C:\\Foo.png")
                 .build();
+        assertTrue(edit.requiresFetchingExistingState());
+
         FullMediaInfoUpdate update = edit.toEntityUpdate(Datamodel.makeMediaInfoDocument(existingSubject));
         assertEquals(update.getStatements().getAdded(), Arrays.asList(statement1));
         assertEquals(update.getFileName(), "Foo.png");
@@ -117,7 +119,9 @@ public class MediaInfoEditTest {
                 .addWikitext("my new wikitext")
                 .setOverrideWikitext(true)
                 .build();
-        FullMediaInfoUpdate update = edit.toEntityUpdate(Datamodel.makeMediaInfoDocument(existingSubject));
+        assertFalse(edit.requiresFetchingExistingState());
+
+        FullMediaInfoUpdate update = edit.toEntityUpdate(null);
         assertEquals(update.getStatements().getAdded(), Collections.emptyList());
         assertEquals(update.getFileName(), null);
         assertEquals(update.getFilePath(), null);
@@ -134,6 +138,7 @@ public class MediaInfoEditTest {
                 .addFilePath(url)
                 .addWikitext("{{wikitext}}")
                 .build();
+        assertTrue(edit.requiresFetchingExistingState());
 
         // set up dependencies
         WikibaseDataEditor editor = mock(WikibaseDataEditor.class);


### PR DESCRIPTION
Fixes #5039.

Changes proposed in this pull request:
- Rework the backend to avoid trying to fetch MediaInfo entities when we are not uploading any structured data. This enables working with the existing Wikibase integration with "virtual" MediaInfo entities, even when the target Wikibase instance does not actually have Wikibase entities of that type, but only plain old MediaWiki files. This is shoehorning a new sort of file upload feature in the Wikibase extension (#5039), even if it does not have anything to do with Wikibase in the end.
- Add a field to the manifest to disable the structured data fields on media files (captions and statements). When this flag is set in the Wikibase manifest, we simply offer the file name, file path and wikitext fields in the schema editor, and nothing else.
- Add documentation of this feature.

This supports both uploading new files and editing the wikitext of existing files.

To test this integration, you need:
- a Wikibase instance which has file upload enabled
- an instance of the [Commons recon service](https://gerrit.wikimedia.org/r/q/project:labs%252Ftools%252Fcommons-recon-service) running for that Wikibase instance, with [this patch](https://gerrit.wikimedia.org/r/c/labs/tools/commons-recon-service/+/820900) applied

I have deployed [a test instance](http://bubbletea.reconci.link/wiki/Main_Page) (which will disappear in 10 days) that you can also use to test this functionality.
