### PR TITLE
Dark mode and theming support #3017

### DIFF
--- a/extensions/database/module/styles/database-import.less
+++ b/extensions/database/module/styles/database-import.less
@@ -53,7 +53,7 @@
 
 .database-importing-wizard-header {
   font-size: 1.3em;
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   padding: @padding_tight;
   }
 
@@ -76,7 +76,7 @@
   font-size: 1.3em;
   position: absolute;
   overflow: auto;
-  border-top: 5px solid @chrome_primary;
+  border-top: 5px solid var(--chrome-primary);
   background: white;
   padding: @padding_looser;
   }

--- a/extensions/gdata/module/styles/importing-controller.less
+++ b/extensions/gdata/module/styles/importing-controller.less
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 .gdata-document-container > table {
-  color: var(--metadata-grey);
+  color: var(--text-tertiary);
 }
 
 a.gdata-doc-title {

--- a/extensions/gdata/module/styles/importing-controller.less
+++ b/extensions/gdata/module/styles/importing-controller.less
@@ -48,11 +48,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 .gdata-document-container > table {
-  color: @metadata_grey;
+  color: var(--metadata-grey);
 }
 
 a.gdata-doc-title {
-  color: @link_primary;
+  color: var(--link-primary);
   text-decoration: none;
   }
 a.gdata-doc-title:hover {
@@ -66,7 +66,7 @@ a.gdata-doc-preview {
   font-size: 80%;
   text-decoration: none;
   vertical-align: super;
-  color: @link_secondary;
+  color: var(--link-secondary);
   margin-left: 0.5em;
   }
 a.gdata-doc-preview:hover {
@@ -81,7 +81,7 @@ a.gdata-doc-preview:hover {
 
 .gdata-importing-wizard-header {
   font-size: 1.3em;
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   padding: @padding_tight;
   }
 
@@ -104,7 +104,7 @@ a.gdata-doc-preview:hover {
   font-size: 1.3em;
   position: absolute;
   overflow: auto;
-  border-top: 5px solid @chrome_primary;
+  border-top: 5px solid var(--chrome-primary);
   background: white;
   padding: @padding_looser;
   }

--- a/extensions/wikidata/module/styles/dialogs/wikibase-dialog.less
+++ b/extensions/wikidata/module/styles/dialogs/wikibase-dialog.less
@@ -34,7 +34,7 @@
 }
 
 .wikibase-list li:not(.selected):hover {
-  background: @dialog_footer;
+  background: var(--dialog-footer);
 }
 
 .wikibase-list li img {

--- a/main/webapp/modules/core/styles/common.less
+++ b/main/webapp/modules/core/styles/common.less
@@ -34,6 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 @import-less url("theme.less");
 
 :root {
+  --text-primary: black;
+  --text-secondary: #222;
   --link-primary: #11c;
   --link-secondary: #4272db;
   --chrome-primary: #bcf;
@@ -56,6 +58,32 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   --dialog-footer: #eee;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --text-primary: white;
+    --text-secondary: #e3e3e3;
+    --background-primary: #0e2439;
+    --chrome-primary: #015ca3;
+    --chrome-secondary: #037ede;
+    --fill-primary: #06325d;
+    --fill-secondary: #0a4f8e;
+    --link-primary: #bdbdff;
+    --link-secondary: #8b8bff;
+    --dialog-header: #072038;
+    --dialog-border: #0a2136;
+    --dialog-footer: #09233b;
+  }
+
+  textarea,
+  input[type="text"],
+  input[type="number"],
+  input[type="url"] {
+    background-color: var(--fill-primary);
+    border-color: var(--chrome-primary);
+  }
+}
+
+
 
 html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, abbr, address, cite, code, del, dfn, em, img, ins, kbd, q, samp, small, strong, sub, sup, var, b, i, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, figure, footer, header, hgroup, menu, nav, section, menu, time, mark, audio, video { margin: 0; padding: 0; border: 0; outline: 0; font-size: 100%; vertical-align: baseline; background: transparent; }
 article, aside, figure, footer, header, hgroup, nav, section { display: block; }
@@ -64,11 +92,12 @@ a { margin: 0; padding: 0; font-size: 100%; vertical-align: baseline; background
 table { border-collapse: collapse; border-spacing: 0; }
 input, select { vertical-align: middle; }
 
-body { 
+body {
+  color: var(--text-primary);
   font-size: 62.5%; 
   font-family: Arial, sans-serif; 
   background: var(--background-primary);
-  }
+}
 
 h1 { 
   font-size: 1.8em; 

--- a/main/webapp/modules/core/styles/common.less
+++ b/main/webapp/modules/core/styles/common.less
@@ -51,7 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   --notification-primary: #fe8;
   --faint-grey: #ddd;
   --light-grey: #999;
-  --near-black: #444;
   --dialog-frame: #3a5774;
   --dialog-border: #c1d9ff;
   --dialog-header: #e0edfe;

--- a/main/webapp/modules/core/styles/common.less
+++ b/main/webapp/modules/core/styles/common.less
@@ -33,6 +33,29 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 @import-less url("theme.less");
 
+:root {
+  --link-primary: #11c;
+  --link-secondary: #4272db;
+  --chrome-primary: #bcf;
+  --chrome-secondary: #e3e9ff;
+  --fill-primary: #ebeef8;
+  --fill-secondary: #f2f2f2;
+  --fill-editable: #ffffd6;
+  --selected-primary: #68e;
+  --green-primary: #282;
+  --green-secondary: #3d3;
+  --notification-primary: #fe8;
+  --faint-grey: #ddd;
+  --light-grey: #999;
+  --metadata-grey: #777;
+  --near-black: #444;
+  --dialog-frame: #3a5774;
+  --dialog-border: #c1d9ff;
+  --dialog-header: #e0edfe;
+  --dialog-footer: #eee;
+}
+
+
 html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, abbr, address, cite, code, del, dfn, em, img, ins, kbd, q, samp, small, strong, sub, sup, var, b, i, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, figure, footer, header, hgroup, menu, nav, section, menu, time, mark, audio, video { margin: 0; padding: 0; border: 0; outline: 0; font-size: 100%; vertical-align: baseline; background: transparent; }
 article, aside, figure, footer, header, hgroup, nav, section { display: block; }
 ul { list-style-position: inside; }
@@ -69,7 +92,7 @@ input[type=text] {
   }
 
 a {
-  color: @link_primary;
+  color: var(--link-primary);
   text-decoration: none;
   }
 
@@ -78,7 +101,7 @@ a:hover {
   }
   
 a.secondary {
-  color: @link_secondary;
+  color: var(--link-secondary);
   }
 
 a.action, a.selected, a.inaction {
@@ -92,7 +115,7 @@ a.selected {
   }
 
 a.inaction {
-  color: @light_grey;
+  color: var(--light-grey);
   }
 
 a.selected:hover, a.inaction:hover {
@@ -189,7 +212,7 @@ a img {
   padding: @padding_tighter @padding_tight;
   font-size: 1.1em;
   color: #222;
-  border-bottom: dotted 1px @faint_grey;
+  border-bottom: dotted 1px var(--faint-grey);
   }
 
 .list-table th {
@@ -205,7 +228,7 @@ a img {
 #loading-message {
   text-align: center;
   font-size: 300%;
-  color: @light_grey;
+  color: var(--light-grey);
   padding: 3em .5em;
   }
 
@@ -229,7 +252,7 @@ a img {
   font-size: 1.3em;
   text-align: left;
   font-weight: bold;
-  background: @notification_primary;
+  background: var(--notification-primary);
   .rounded_corners(2px);
   }
   
@@ -275,7 +298,7 @@ a img {
 #body-info h1 {
   font-size: 3.0em;
   font-weight: normal;
-  color: @metadata_grey;
+  color: var(--metadata-grey);
   }
 
 #body-info h2 {
@@ -315,8 +338,8 @@ input[type='text'].inline {
 input.lightweight {
   vertical-align: baseline;
   border: none;
-  border-bottom: 1px solid @faint_grey;
-  background-color: @fainter_grey;
+  border-bottom: 1px solid var(--faint-grey);
+  background-color: var(--fainter-grey);
   padding: 0px 2px 1px 2px;
   }
 

--- a/main/webapp/modules/core/styles/common.less
+++ b/main/webapp/modules/core/styles/common.less
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   --link-secondary: #4272db;
   --chrome-primary: #bcf;
   --chrome-secondary: #e3e9ff;
+  --background-primary: #fff;
   --fill-primary: #ebeef8;
   --fill-secondary: #f2f2f2;
   --fill-editable: #ffffd6;
@@ -66,7 +67,7 @@ input, select { vertical-align: middle; }
 body { 
   font-size: 62.5%; 
   font-family: Arial, sans-serif; 
-  background: #fff;
+  background: var(--background-primary);
   }
 
 h1 { 

--- a/main/webapp/modules/core/styles/common.less
+++ b/main/webapp/modules/core/styles/common.less
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 :root {
   --text-primary: black;
   --text-secondary: #222;
+  --text-tertiary: #777;
   --link-primary: #11c;
   --link-secondary: #4272db;
   --chrome-primary: #bcf;
@@ -50,7 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   --notification-primary: #fe8;
   --faint-grey: #ddd;
   --light-grey: #999;
-  --metadata-grey: #777;
   --near-black: #444;
   --dialog-frame: #3a5774;
   --dialog-border: #c1d9ff;
@@ -62,6 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   :root {
     --text-primary: white;
     --text-secondary: #e3e3e3;
+    --text-tertiary: #c6c6c6;
     --background-primary: #0e2439;
     --chrome-primary: #015ca3;
     --chrome-secondary: #037ede;
@@ -328,7 +329,7 @@ a img {
 #body-info h1 {
   font-size: 3.0em;
   font-weight: normal;
-  color: var(--metadata-grey);
+  color: var(--text-tertiary);
   }
 
 #body-info h2 {

--- a/main/webapp/modules/core/styles/dialogs/custom-tabular-exporter-dialog.less
+++ b/main/webapp/modules/core/styles/dialogs/custom-tabular-exporter-dialog.less
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 .custom-tabular-exporter-columns, .custom-tabular-exporter-column-options {
-  border: 1px solid @chrome_primary;
+  border: 1px solid var(--chrome-primary);
   height: 22em;
   padding: @padding_loose;
   }
@@ -47,27 +47,27 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 .custom-tabular-exporter-selected-column {
   font-weight: bold;
-  border: 1px solid @chrome_primary;
-  background: @chrome_primary;
+  border: 1px solid var(--chrome-primary);
+  background: var(--chrome-primary);
   padding: @padding_tighter;
   .rounded_corners();
   }
 
 .custom-tabular-exporter-dialog-column {
-  border: 1px solid @chrome_primary;
-  background: @fill_secondary;
+  border: 1px solid var(--chrome-primary);
+  background: var(--fill-secondary);
   padding: @padding_tighter;
   margin: @padding_tight;
   cursor: move;
   .rounded_corners();
   }
 .custom-tabular-exporter-dialog-column.selected {
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   font-weight: bold;
   }
   
 textarea.custom-tabular-exporter-code {
   width: 100%;
-  border: 1px solid @chrome_primary;
+  border: 1px solid var(--chrome-primary);
   height: 25em;
   }

--- a/main/webapp/modules/core/styles/dialogs/expression-preview-dialog.less
+++ b/main/webapp/modules/core/styles/dialogs/expression-preview-dialog.less
@@ -85,9 +85,9 @@ textarea.expression-preview-code {
 
 td.expression-preview-heading {
   border-top: none;
-  background: #ddd;
+  background: var(--faint-grey);
   font-weight: bold;
-  }
+}
 
 td.expression-preview-value {
   max-width: 250px !important;

--- a/main/webapp/modules/core/styles/dialogs/expression-preview-dialog.less
+++ b/main/webapp/modules/core/styles/dialogs/expression-preview-dialog.less
@@ -44,7 +44,7 @@ textarea.expression-preview-code {
   }
 
 .expression-preview-parsing-status {
-  color: @light_grey;
+  color: var(--light-grey);
   }
 .expression-preview-parsing-status.error {
   color: red;
@@ -102,7 +102,7 @@ td.expression-preview-value {
 .expression-preview-help-container h3 {
   margin-top: @padding_looser;
   margin-bottom: @padding_normal;
-  border-bottom: 1px solid @light_grey;
+  border-bottom: 1px solid var(--light-grey);
   }
 
 .expression-preview-doc-item-title {

--- a/main/webapp/modules/core/styles/dialogs/sql-exporter-dialog.less
+++ b/main/webapp/modules/core/styles/dialogs/sql-exporter-dialog.less
@@ -41,7 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	
 }
 .sql-exporter-columns, .sql-exporter-column-options {
-  /*border: 1px solid @chrome_primary;*/
+  /*border: 1px solid var(--chrome-primary);*/
   height: 8em;
   padding: @padding_loose;
  }
@@ -51,28 +51,28 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  }
 .sql-exporter-selected-column {
   font-weight: bold;
-  border: 1px solid @chrome_primary;
-  background: @chrome_primary;
+  border: 1px solid var(--chrome-primary);
+  background: var(--chrome-primary);
   padding: @padding_tighter;
   .rounded_corners();
  }
 
 .sql-exporter-dialog-column {
- /* border: 1px solid @chrome_primary;*/
-  background: @fill_secondary;
+ /* border: 1px solid var(--chrome-primary);*/
+  background: var(--fill-secondary);
   padding: @padding_tighter;
   margin: @padding_tight;
   cursor: move;
   .rounded_corners();
  }
 .sql-exporter-dialog-column.selected {
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   font-weight: bold;
  }
   
 textarea.sql-exporter-code {
   width: 100%;
-  border: 1px solid @chrome_primary;
+  border: 1px solid var(--chrome-primary);
   height: 25em;
  }
 .sql-exporter-dialog-row {	

--- a/main/webapp/modules/core/styles/index.less
+++ b/main/webapp/modules/core/styles/index.less
@@ -97,7 +97,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #openrefine-version {
   margin: @padding_normal 0 0 0;
-  color: var(--metadata-grey);
+  color: var(--text-tertiary);
   font-size: 80%;
   }
 

--- a/main/webapp/modules/core/styles/index.less
+++ b/main/webapp/modules/core/styles/index.less
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   margin: 0 1em;
   font-style: italic;
   font-size: 110%;
-  color: var(--near-black);
+  color: var(--text-secondary);
   }
 
 #left-panel-body {

--- a/main/webapp/modules/core/styles/index.less
+++ b/main/webapp/modules/core/styles/index.less
@@ -113,7 +113,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .action-area-tab-body {
   visibility: hidden;
   position: absolute;
-  background: white;
+  background: var(--background-primary);
   top: 0;
   left: 0;
   width: 100%;

--- a/main/webapp/modules/core/styles/index.less
+++ b/main/webapp/modules/core/styles/index.less
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   margin: 0 1em;
   font-style: italic;
   font-size: 110%;
-  color: @near_black;
+  color: var(--near-black);
   }
 
 #left-panel-body {
@@ -68,7 +68,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   cursor: pointer;
   }
 #action-area-tabs > li.selected {
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   .rounded_corners_left();
   }
 
@@ -97,12 +97,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #openrefine-version {
   margin: @padding_normal 0 0 0;
-  color: @metadata_grey;
+  color: var(--metadata-grey);
   font-size: 80%;
   }
 
 #right-panel {
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   }
 
 #right-panel-body {

--- a/main/webapp/modules/core/styles/index/create-project-ui.less
+++ b/main/webapp/modules/core/styles/index/create-project-ui.less
@@ -40,7 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #create-project-ui-source-selection-message {
   padding: @padding_loose;
-  border-bottom: 1px solid @chrome_primary;
+  border-bottom: 1px solid var(--chrome-primary);
   background: white;
   }
 #create-project-ui-source-selection-message > h3 {
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #create-project-ui-source-selection-layout {
   width: 100%;
   border-collapse: collapse;
-  border-bottom: 1px solid @chrome_primary;
+  border-bottom: 1px solid var(--chrome-primary);
   }
 #create-project-ui-source-selection-layout > tbody > tr > td {
   vertical-align: top;
@@ -63,7 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #create-project-ui-source-selection-tabs {
   width: 15em;
-  background: @fill_primary;
+  background: var(--fill-primary);
   padding-left: @padding_looser;
   padding-bottom: @padding_looser;
   }
@@ -78,7 +78,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .create-project-ui-source-selection-tab {
   cursor: pointer;
-  color: @link_primary;
+  color: var(--link-primary);
   }
 .create-project-ui-source-selection-tab.selected {
   cursor: default;
@@ -104,13 +104,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 #create-project-progress-bar-frame {
-  border: 1px solid @chrome_primary;
+  border: 1px solid var(--chrome-primary);
   padding: @padding_tighter;
   width: 300px;
   }
 
 #create-project-progress-bar-body {
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   height: 1em;
   position: relative;
   width: 30%;
@@ -142,5 +142,5 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   font-family: monospace;
   white-space: pre;
   padding: @padding_normal;
-  border: 1px solid @chrome_primary;
+  border: 1px solid var(--chrome-primary);
   }

--- a/main/webapp/modules/core/styles/index/create-project-ui.less
+++ b/main/webapp/modules/core/styles/index/create-project-ui.less
@@ -35,13 +35,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #create-project-ui-source-selection {
   font-size: 1.3em;
-  background: white;
+  background: var(--background-primary);
   }
 
 #create-project-ui-source-selection-message {
   padding: @padding_loose;
   border-bottom: 1px solid var(--chrome-primary);
-  background: white;
+  background: var(--background-primary);
   }
 #create-project-ui-source-selection-message > h3 {
   margin-bottom: @padding_normal;
@@ -57,7 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 #create-project-ui-source-selection-tab-bodies {
-  background: white;
+  background: var(--background-primary);
   .rounded_corners_left();
   }
 
@@ -83,13 +83,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .create-project-ui-source-selection-tab.selected {
   cursor: default;
   color: black;
-  background: white;
+  background: var(--background-primary);
   font-weight: bold;
   .rounded_corners_left();
   }
 
 .create-project-ui-panel {
-  background: white;
+  background: var(--background-primary);
   position: absolute;
   left: 0;
   top: 0;

--- a/main/webapp/modules/core/styles/index/default-importing-controller.less
+++ b/main/webapp/modules/core/styles/index/default-importing-controller.less
@@ -35,6 +35,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .default-importing-wizard-header {
   font-size: 1.3em;
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   padding: @padding_tight;
   }

--- a/main/webapp/modules/core/styles/index/default-importing-file-selection-panel.less
+++ b/main/webapp/modules/core/styles/index/default-importing-file-selection-panel.less
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .default-importing-file-selection-file-panel {
   font-size: 1.3em;
   position: absolute;
-  background: white;
+  background: var(--background-primary);
   overflow: auto;
   }
 .default-importing-file-selection-file-panel > table {

--- a/main/webapp/modules/core/styles/index/default-importing-file-selection-panel.less
+++ b/main/webapp/modules/core/styles/index/default-importing-file-selection-panel.less
@@ -36,9 +36,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .default-importing-file-selection-control-panel {
   font-size: 1.3em;
   position: absolute;
-  background: @chrome_secondary;
+  background: var(--chrome-secondary);
   padding: @padding_looser;
-  border-right: 1px solid @chrome_primary;
+  border-right: 1px solid var(--chrome-primary);
   }
 .default-importing-file-selection-file-panel {
   font-size: 1.3em;
@@ -53,11 +53,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .default-importing-file-selection-file-panel > table > tbody > tr > th {
   text-align: left;
   padding: @padding_tight @padding_normal;
-  background: @chrome_secondary;
+  background: var(--chrome-secondary);
   }
 .default-importing-file-selection-file-panel > table > tbody > tr > td {
   padding: 0;
-  border-bottom: 1px solid @chrome_secondary;
+  border-bottom: 1px solid var(--chrome-secondary);
   }
 .default-importing-file-selection-file-panel > table > tbody > tr > td > label {
   display: block;
@@ -72,5 +72,5 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .default-importing-file-selection-file-panel > table > tbody > tr >
     td.default-importing-file-selection-filename.highlighted {
-  background: @fill_editable;
+  background: var(--fill-editable);
   }

--- a/main/webapp/modules/core/styles/index/default-importing-parsing-panel.less
+++ b/main/webapp/modules/core/styles/index/default-importing-parsing-panel.less
@@ -86,7 +86,7 @@ td.default-importing-parsing-control-panel-formats {
   }
 
 td.default-importing-parsing-control-panel-options-panel {
-  background: white;
+  background: var(--background-primary);
   padding: @padding_looser;
   .rounded_corners_left();
   }

--- a/main/webapp/modules/core/styles/index/default-importing-parsing-panel.less
+++ b/main/webapp/modules/core/styles/index/default-importing-parsing-panel.less
@@ -52,8 +52,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   font-size: 1.3em;
   position: absolute;
   overflow: auto;
-  border-top: 5px solid @chrome_primary;
-  background: @chrome_secondary;
+  border-top: 5px solid var(--chrome-primary);
+  background: var(--chrome-secondary);
   }
 .default-importing-parsing-control-panel > table {
   width: 100%;
@@ -75,7 +75,7 @@ td.default-importing-parsing-control-panel-formats {
   margin-left: @padding_looser;
   padding: @padding_tight @padding_normal;
   .rounded_corners_left();
-  color: @link_primary;
+  color: var(--link-primary);
   cursor: pointer;
   }
 

--- a/main/webapp/modules/core/styles/index/open-project-ui.less
+++ b/main/webapp/modules/core/styles/index/open-project-ui.less
@@ -161,7 +161,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	margin: 5px;
 	font-size: 130%;
 	border-radius: 5px;
-	background: #bcf;
+	background: var(--fill-primary);
 	min-height: 18px;
 	height: auto;
 	overflow:auto;

--- a/main/webapp/modules/core/styles/index/open-project-ui.less
+++ b/main/webapp/modules/core/styles/index/open-project-ui.less
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   vertical-align: baseline;
   padding: @padding_tighter @padding_tight;
   font-size: 1.1em;
-  color: var(--metadata-grey);
+  color: var(--text-tertiary);
   border-bottom: dotted 1px var(--faint-grey);
   }
   

--- a/main/webapp/modules/core/styles/index/open-project-ui.less
+++ b/main/webapp/modules/core/styles/index/open-project-ui.less
@@ -45,8 +45,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #projects-workspace-controls {
   position: absolute;
   padding: @padding_normal;
-  background: @fill_primary;
-  border-top: 1px solid @chrome_primary;
+  background: var(--fill-primary);
+  border-top: 1px solid var(--chrome-primary);
   font-size: 1.3em;
   }
   
@@ -60,13 +60,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   vertical-align: baseline;
   padding: @padding_tighter @padding_tight;
   font-size: 1.1em;
-  color: @metadata_grey;
-  border-bottom: dotted 1px @faint_grey;
+  color: var(--metadata-grey);
+  border-bottom: dotted 1px var(--faint-grey);
   }
   
 #projects-container > table > tbody > tr > th {
   font-weight: bold;
-  background: @chrome_secondary;
+  background: var(--chrome-secondary);
   }
 
 #projects-container .project .project-name {

--- a/main/webapp/modules/core/styles/index/open-project-ui.less
+++ b/main/webapp/modules/core/styles/index/open-project-ui.less
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 @import-less url("../theme.less");
 
 #projects-container {
-  background: #fff;
+  background: var(--background-primary);
   overflow: auto;
   position: absolute;
   top: 0px;

--- a/main/webapp/modules/core/styles/jquery-ui-overrides.less
+++ b/main/webapp/modules/core/styles/jquery-ui-overrides.less
@@ -70,7 +70,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 .ui-tabs .ui-tabs-nav li a span.count {
-  color: var(--near-black);
+  color: var(--text-secondary);
   font-weight: normal;
   font-size: 80%;
   }

--- a/main/webapp/modules/core/styles/jquery-ui-overrides.less
+++ b/main/webapp/modules/core/styles/jquery-ui-overrides.less
@@ -70,7 +70,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 .ui-tabs .ui-tabs-nav li a span.count {
-  color: #666;
+  color: var(--near-black);
   font-weight: normal;
   font-size: 80%;
   }
@@ -85,7 +85,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .ui-tabs .ui-tabs-nav .ui-state-active a, 
 .ui-tabs .ui-tabs-nav .ui-state-active a:link, 
 .ui-tabs .ui-tabs-nav .ui-state-active a:visited {
-  color: black;
+  color: var(--text-primary);
   font-weight: bold;
   }
 
@@ -104,3 +104,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .ui-widget-content a {
   color: var(--link-primary);
   }
+
+.ui-widget.ui-widget-content {
+  border: none;
+}

--- a/main/webapp/modules/core/styles/jquery-ui-overrides.less
+++ b/main/webapp/modules/core/styles/jquery-ui-overrides.less
@@ -65,7 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .ui-tabs .ui-tabs-nav .ui-state-default a, 
 .ui-tabs .ui-tabs-nav .ui-state-default a:link, 
 .ui-tabs .ui-tabs-nav .ui-state-default a:visited {
-  color: @link_primary;
+  color: var(--link-primary);
   font-weight: normal;
   }
 
@@ -77,7 +77,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .ui-tabs .ui-tabs-nav .ui-state-active, 
 .ui-tabs .ui-tabs-nav .ui-widget-content .ui-state-active {
-  border: 1px solid @chrome_primary;
+  border: 1px solid var(--chrome-primary);
   border-bottom: none;
   background: white;
   }
@@ -97,10 +97,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .ui-tabs .ui-tabs-panel {
   margin: 0;
   padding: @padding_normal;
-  border: 1px solid @chrome_primary;
+  border: 1px solid var(--chrome-primary);
   background: white;
   }
   
 .ui-widget-content a {
-  color: @link_primary;
+  color: var(--link-primary);
   }

--- a/main/webapp/modules/core/styles/jquery-ui-overrides.less
+++ b/main/webapp/modules/core/styles/jquery-ui-overrides.less
@@ -79,7 +79,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .ui-tabs .ui-tabs-nav .ui-widget-content .ui-state-active {
   border: 1px solid var(--chrome-primary);
   border-bottom: none;
-  background: white;
+  background: var(--background-primary);
   }
 
 .ui-tabs .ui-tabs-nav .ui-state-active a, 
@@ -98,7 +98,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   margin: 0;
   padding: @padding_normal;
   border: 1px solid var(--chrome-primary);
-  background: white;
+  background: var(--background-primary);
   }
   
 .ui-widget-content a {

--- a/main/webapp/modules/core/styles/project.less
+++ b/main/webapp/modules/core/styles/project.less
@@ -129,7 +129,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 #view-panel {
-  background: white;
+  background: var(--background-primary);
   overflow: hidden;
   }
 

--- a/main/webapp/modules/core/styles/project.less
+++ b/main/webapp/modules/core/styles/project.less
@@ -62,7 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 #project-name-button:hover {
-  background: @fill_editable;
+  background: var(--fill-editable);
   border: 1px solid #ccc;
   border-top: 1px solid #aaa;
   }
@@ -78,7 +78,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   padding: 0px;
   padding-top: 0px;
   font-size: 1.3em;
-  background: @chrome_secondary;  
+  background: var(--chrome-secondary);  
   border-top-right-radius: 7px;
   }
   
@@ -94,7 +94,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   overflow: hidden;
   padding: 0px;
   padding-left: @padding_tight;
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   border-top-left-radius: 7px;
   }
 

--- a/main/webapp/modules/core/styles/project/facets.less
+++ b/main/webapp/modules/core/styles/project/facets.less
@@ -149,7 +149,7 @@ li.facet-state-minimize a.facet-title-minimize:hover {
   }
 
 .facet-body-inner {
-  background: #fff;
+  background: var(--background-primary);
   }
   
 .facet-body-scrollable .facet-body-inner {

--- a/main/webapp/modules/core/styles/project/facets.less
+++ b/main/webapp/modules/core/styles/project/facets.less
@@ -42,17 +42,17 @@ li.facet-container {
   display: block;
   clear: both;
   margin: 0 5px 7px;
-  background: @chrome_secondary;  
-  border: 1px solid @chrome_primary;
+  background: var(--chrome-secondary);  
+  border: 1px solid var(--chrome-primary);
   .rounded_corners(7px);
   }
 
 .facet-title {
   padding: 3px 5px;
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   font-weight: bold;
   cursor: move;
-  border-bottom: 1px solid @chrome_primary;
+  border-bottom: 1px solid var(--chrome-primary);
   .rounded_corners_top(6px);
   
   }
@@ -110,11 +110,11 @@ li.facet-state-minimize a.facet-title-minimize:hover {
   font-family: monospace;
   background: #fff;
   cursor: text;
-  border-bottom: 1px solid @chrome_primary;
+  border-bottom: 1px solid var(--chrome-primary);
   }
 
 .facet-expression:hover {
-  background: @fill_editable;
+  background: var(--fill-editable);
   }
 
 .facet-status {
@@ -126,8 +126,8 @@ li.facet-state-minimize a.facet-title-minimize:hover {
   position: relative;
   font-size: 0.9em;
   padding: 7px 3px;
-  background: @chrome_secondary;
-  border-bottom: 1px solid @chrome_primary;
+  background: var(--chrome-secondary);
+  border-bottom: 1px solid var(--chrome-primary);
   }
 
 .facet-controls-button {
@@ -138,7 +138,7 @@ li.facet-state-minimize a.facet-title-minimize:hover {
   
 .facet-body-message {
   margin: 1em;
-  color: @metadata_grey;
+  color: var(--metadata-grey);
   text-align: center;
   }
 
@@ -153,7 +153,7 @@ li.facet-state-minimize a.facet-title-minimize:hover {
   }
   
 .facet-body-scrollable .facet-body-inner {
-  border-bottom: 1px solid @chrome_primary;
+  border-bottom: 1px solid var(--chrome-primary);
   }
 
 .facet-body.facet-body-scrollable .ui-resizable-s {
@@ -178,7 +178,7 @@ li.facet-state-minimize a.facet-title-minimize:hover {
   }
 
 .facet-choice:hover {
-  background: @fill_secondary;
+  background: var(--fill-secondary);
   }
 
 .facet-choice-selected .facet-choice-label {
@@ -197,14 +197,14 @@ li.facet-state-minimize a.facet-title-minimize:hover {
 .facet-choice-count, .facet-range-choice-count {
   padding-left: 5px;
   font-size: 0.85em;
-  color: @light_grey;
+  color: var(--light-grey);
   }
 
 a.facet-choice-link {
   float: right;
   padding-left: 5px;
   font-size: 0.85em;
-  color: @link_secondary;
+  color: var(--link-secondary);
   font-weight: normal;
   }
 
@@ -220,7 +220,7 @@ img.facet-choice-link {
   }
 
 .facet-range-message {
-  color: @metadata_grey;
+  color: var(--metadata-grey);
   }
 
 .facet-range-histogram {

--- a/main/webapp/modules/core/styles/project/facets.less
+++ b/main/webapp/modules/core/styles/project/facets.less
@@ -138,7 +138,7 @@ li.facet-state-minimize a.facet-title-minimize:hover {
   
 .facet-body-message {
   margin: 1em;
-  color: var(--metadata-grey);
+  color: var(--text-tertiary);
   text-align: center;
   }
 
@@ -220,7 +220,7 @@ img.facet-choice-link {
   }
 
 .facet-range-message {
-  color: var(--metadata-grey);
+  color: var(--text-tertiary);
   }
 
 .facet-range-histogram {

--- a/main/webapp/modules/core/styles/project/sidebar.less
+++ b/main/webapp/modules/core/styles/project/sidebar.less
@@ -87,7 +87,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   padding: 0 0 13px 0;
   background: var(--fill-primary);
   border: 1px solid var(--chrome-primary);
-  color: var(--near-black);
+  color: var(--text-secondary);
   .rounded_corners();
   }
   

--- a/main/webapp/modules/core/styles/project/sidebar.less
+++ b/main/webapp/modules/core/styles/project/sidebar.less
@@ -85,9 +85,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .browsing-panel-help, .history-panel-help {
   margin: 1em;
   padding: 0 0 13px 0;
-  background: @fill_primary;
-  border: 1px solid @chrome_primary;
-  color: @near_black;
+  background: var(--fill-primary);
+  border: 1px solid var(--chrome-primary);
+  color: var(--near-black);
   .rounded_corners();
   }
   
@@ -146,7 +146,7 @@ div#body div#left-panel a#hide-left-panel-button:hover {
 }
 
 @history_done_background: #fff;
-@history_undone_background: @chrome_secondary;
+@history_undone_background: var(--chrome-secondary);
 @history_entry_index_width: 30px;
 
 a.history-entry {
@@ -186,8 +186,8 @@ a.history-entry.filtered-out > * {
 
 .history-panel-filter {
   padding: @padding_tighter @padding_normal;
-  background: @chrome_secondary;
-  border: 1px solid @chrome_primary;
+  background: var(--chrome-secondary);
+  border: 1px solid var(--chrome-primary);
   border-left: 0;  
   border-right: 0;
   }
@@ -207,7 +207,7 @@ a.history-entry.filtered-out > * {
   }
 
 .history-now {
-  background: @selected_primary;
+  background: var(--selected-primary);
   }
 
 .history-future {
@@ -233,7 +233,7 @@ a.history-entry.filtered-out > * {
   }
 
 .history-future a.history-entry, .history-future a.history-entry-index {
-  color: @light_grey;
+  color: var(--light-grey);
   }
 
 .history-now a.history-entry, .history-now a.history-entry-index {
@@ -241,11 +241,11 @@ a.history-entry.filtered-out > * {
   }
   
 .history-past a.history-entry:hover, .history-future a.history-entry:hover {
-  border-bottom: 1px solid @selected_primary;
+  border-bottom: 1px solid var(--selected-primary);
   }
 
 .history-extract-dialog-panel {
-  border: 1px solid @chrome_primary;
+  border: 1px solid var(--chrome-primary);
   height: 400px;
   overflow: auto;
   }

--- a/main/webapp/modules/core/styles/project/sidebar.less
+++ b/main/webapp/modules/core/styles/project/sidebar.less
@@ -59,7 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   top: 0em;
   left: 20%;
   text-align: center;
-  background-color: #fff;
+  background-color: var(--background-primary);
   padding: 4px 4px;
   border-radius: 4px;
   border: 1px solid #ccc;

--- a/main/webapp/modules/core/styles/theme.less
+++ b/main/webapp/modules/core/styles/theme.less
@@ -31,25 +31,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-@link_primary: #11c;
-@link_secondary: #4272db;
-@chrome_primary: #bcf;
-@chrome_secondary: #e3e9ff;
-@fill_primary: #ebeef8;
-@fill_secondary: #f2f2f2;
-@fill_editable: #ffffd6;
-@selected_primary: #68e;
-@green_primary: #282;
-@green_secondary: #3d3;
-@notification_primary: #fe8;
-@faint_grey: #ddd;
-@light_grey: #999;
-@metadata_grey: #777;
-@near_black: #444;
-@dialog_frame: #3a5774;
-@dialog_border: #c1d9ff;
-@dialog_header: #e0edfe;
-@dialog_footer: #eee;
 
 @padding_tighter: 3px;
 @padding_tight: 5px;

--- a/main/webapp/modules/core/styles/util/dialog.less
+++ b/main/webapp/modules/core/styles/util/dialog.less
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .dialog-frame {
   margin: 0 auto;
   text-align: left;
-  background: white;
+  background: var(--background-primary);
   border: 1px solid var(--dialog-frame);
   display: inline-block;
   }
@@ -66,7 +66,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   padding: @padding_loose;
   font-weight: bold;
   font-size: 1.6em;
-  color: #000;
+  color: var(--text-primary);
   cursor: move;
   }
 

--- a/main/webapp/modules/core/styles/util/dialog.less
+++ b/main/webapp/modules/core/styles/util/dialog.less
@@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   margin: 0 auto;
   text-align: left;
   background: white;
-  border: 1px solid @dialog_frame;
+  border: 1px solid var(--dialog-frame);
   display: inline-block;
   }
 
@@ -62,7 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 .dialog-header {
-  background: @dialog_header;
+  background: var(--dialog-header);
   padding: @padding_loose;
   font-weight: bold;
   font-size: 1.6em;
@@ -84,7 +84,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   display: flex;
   column-gap: 5px;
   justify-content: right;
-  background: @dialog_footer;
+  background: var(--dialog-footer);
   padding: @padding_loose;
   }
 

--- a/main/webapp/modules/core/styles/util/menu.less
+++ b/main/webapp/modules/core/styles/util/menu.less
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .menu-container {
   position: absolute;
   width: 250px;
-  background: white;
+  background: var(--background-primary);
   padding: 1px;
   border: 1px solid #ccc;
   border-right: 1px solid #666;

--- a/main/webapp/modules/core/styles/util/menu.less
+++ b/main/webapp/modules/core/styles/util/menu.less
@@ -65,11 +65,11 @@ a.menu-item {
   display: block;
   padding: 5px 7px;
   text-decoration: none;
-  color: #000;
-  }
+  color: var(--text-primary);
+}
 
 a.menu-item:hover, a.menu-item.menu-expanded {
-  background: #dbe8f8;
+  background: var(--fill-primary);
   }
 
 a.menu-item img {

--- a/main/webapp/modules/core/styles/views/column-join.less
+++ b/main/webapp/modules/core/styles/views/column-join.less
@@ -48,7 +48,7 @@ Same properties as dialogs/custom-tabular-exporter-dialog.less, applied to the c
 }
 
 .column-join-inner-left-pane,.column-join-inner-right-pane {
-  border: 1px solid @chrome_primary;
+  border: 1px solid var(--chrome-primary);
   height: 24em;
   padding: @padding_loose;
   }
@@ -64,15 +64,15 @@ Same properties as dialogs/custom-tabular-exporter-dialog.less, applied to the c
 }
 
 .column-join-column {
-  border: 1px solid @chrome_primary;
-  background: @fill_secondary;
+  border: 1px solid var(--chrome-primary);
+  background: var(--fill-secondary);
   padding: @padding_tighter;
   margin: @padding_tight;
   cursor: move;
   .rounded_corners();
   }
 .column-join-column.selected {
-  background: @chrome_primary;
+  background: var(--chrome-primary);
   font-weight: bold;
   }
 

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -117,8 +117,8 @@ div.viewpanel-pagesize span:first-of-type {
   }
 
 .data-table td {
-  border-bottom: 0.02rem dotted #ddd;
-  border-right: 0.02rem solid #ddd;
+  border-bottom: 0.02rem dotted var(--faint-grey);
+  border-right: 0.02rem solid var(--faint-grey);
   }
 
 .data-table-header td, .data-table-header th {

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -264,7 +264,7 @@ div.data-table-cell-content-numeric > a.data-table-cell-edit {
 div.data-table-recon-candidates {
   padding: 1px 0;
   min-width: 15em;
-  color: var(--metadata-grey);
+  color: var(--text-tertiary);
   }
   
 div.data-table-recon-candidate {

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -35,7 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .viewpanel-header {
   position: relative;
-  background: @fill_secondary;
+  background: var(--fill-secondary);
   font-size: 1.3em;
   padding: @padding_normal;
   overflow: hidden;
@@ -56,14 +56,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   }
 
 .viewpanel-rowrecord a {
-  background-color: @fill_primary;
+  background-color: var(--fill-primary);
   margin: 0px 1px 0px 1px;
   padding: 2px 5px 2px 5px;
   .rounded_corners(4px);
   }
 
 .viewpanel-pagesize a {
-  background-color: @fill_primary;
+  background-color: var(--fill-primary);
   margin: 0px 2px 0px 2px;
   padding: 2px 3px 2px 3px;
   .rounded_corners(4px);
@@ -74,7 +74,7 @@ div.viewpanel-pagesize span:first-of-type {
 }
 
 .viewpanel-paging a {
-  background-color: @fill_primary;
+  background-color: var(--fill-primary);
   margin: 0px 4px 0px 4px;
   padding: 2px 10px 2px 10px;
   .rounded_corners(4px);
@@ -97,12 +97,12 @@ div.viewpanel-pagesize span:first-of-type {
 .data-table-header {
   width: 1px;
   position: relative;
-  background: @fill_primary;
+  background: var(--fill-primary);
   }
   
 .data-table-container {
   overflow: auto;
-  border-top: 1px solid @chrome_primary;
+  border-top: 1px solid var(--chrome-primary);
   }
 
 .data-table-header, .data-table {
@@ -122,8 +122,8 @@ div.viewpanel-pagesize span:first-of-type {
   }
 
 .data-table-header td, .data-table-header th {
-  border-bottom: 0.02rem dotted @chrome_primary;
-  border-right: 0.02rem solid @chrome_primary;
+  border-bottom: 0.02rem dotted var(--chrome-primary);
+  border-right: 0.02rem solid var(--chrome-primary);
   }
 
 table {
@@ -150,7 +150,7 @@ table > thead > tr > th {
   }
 
 table.data-table > tbody > tr.odd > td {
-  background: @fill_secondary;
+  background: var(--fill-secondary);
   }
 
 table.data-table > tbody > tr.contextual > td > div {
@@ -169,8 +169,8 @@ table.data-table td.column-header, table.data-table th.column-header {
 
 /* For the preview in the importing stage */
 table.data-table td.column-header, table.data-table th.column-header {
-  background: @fill_primary;
-  border-bottom: 0.12rem solid @chrome_primary;
+  background: var(--fill-primary);
+  border-bottom: 0.12rem solid var(--chrome-primary);
   }
 
 .column-header-name {
@@ -206,13 +206,13 @@ a.column-header-menu:hover {
 .column-header-recon-stats-matched {
   position: absolute;
   height: 100%;
-  background: @green_primary;
+  background: var(--green-primary);
   }
   
 .column-header-recon-stats-blanks {
   position: absolute;
   height: 100%;
-  background: @green_secondary;
+  background: var(--green-secondary);
   }
 
 div.data-table-cell-content {
@@ -264,7 +264,7 @@ div.data-table-cell-content-numeric > a.data-table-cell-edit {
 div.data-table-recon-candidates {
   padding: 1px 0;
   min-width: 15em;
-  color: @metadata_grey;
+  color: var(--metadata-grey);
   }
   
 div.data-table-recon-candidate {
@@ -273,7 +273,7 @@ div.data-table-recon-candidate {
   }
 
 a.data-table-recon-topic {
-  color: @link_secondary;
+  color: var(--link-secondary);
   }
 
 .data-table-recon-score, .data-table-recon-new {
@@ -283,7 +283,7 @@ a.data-table-recon-topic {
 
 a.data-table-recon-action, .data-table-recon-extra > a {
   text-decoration: none;
-  color: @link_secondary;
+  color: var(--link-secondary);
   }
   
 a.data-table-recon-action, .data-table-recon-extra {
@@ -344,8 +344,8 @@ a.data-table-flag-off {
   }
 
 .data-table-cell-editor, .data-table-topic-popup {
-  border: 1px solid @chrome_primary;
-  background: @chrome_secondary;
+  border: 1px solid var(--chrome-primary);
+  background: var(--chrome-secondary);
   padding: @padding_tight;
   .rounded_corners();
   }
@@ -377,7 +377,7 @@ a.data-table-flag-off {
 
 .data-table-cell-editor-key {
   font-size: 0.8em;
-  color: @light_grey;
+  color: var(--light-grey);
   }
 
 .set-httpheaders-container {


### PR DESCRIPTION
**This is very much a work in progress and has a long way to go.**

The intent of this pull request is to bring theming and in particular dark-mode support(#3017) to the OpenRefine GUI.

 - [x] migrate LESS variables to CSS
 - [ ] consolidate and reduce shades and colors used in OpenRefine (*wip* / *input wanted*)
 - [ ] rename and make variable names color independent (*wip*)
 - [ ] ensure all colors are exposed as CSS variables (*wip*)
 - [ ] migrate raster images to vectors (*help wanted*) 
 - [ ] decide on a color scheme for dark mode (*help wanted*)
 - [ ] migrate extensions to use the built-in theme options (*not started*)

Expected side effects:

 - changes to GUI colors as a result of consolidating the 10+ shades of greys, 10+ shades of blue/white, etc
 - a period in between versions in which non-core extensions might not adhere to theming
 - improved contrast and overall accessibility
 - ...

**Note that the dark-mode theme in place as of the opening of this pull request is only a proof of concept.**