### PR TITLE
2443 back end localization final

### DIFF
--- a/main/resources/com/google/refine/messages/OpenRefineMessage.properties
+++ b/main/resources/com/google/refine/messages/OpenRefineMessage.properties
@@ -1,0 +1,1 @@
+importer_utilities_column=Column

--- a/main/resources/com/google/refine/messages/OpenRefineMessage.properties
+++ b/main/resources/com/google/refine/messages/OpenRefineMessage.properties
@@ -1,1 +1,3 @@
 importer_utilities_column=Column
+recon_operation_judgement_facet_name=judgment
+recon_operation_score_facet_name=best candidate''s score

--- a/main/src/com/google/refine/importers/ImporterUtilities.java
+++ b/main/src/com/google/refine/importers/ImporterUtilities.java
@@ -46,6 +46,7 @@ import java.util.Properties;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingUtilities;
+import com.google.refine.messages.OpenRefineMessage;
 import com.google.refine.model.Column;
 import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
@@ -129,7 +130,7 @@ public class ImporterUtilities {
         if (index < currentFileColumnNames.size()) {
             return project.columnModel.getColumnByName(currentFileColumnNames.get(index));
         } else if (index >= currentFileColumnNames.size()) {
-            String prefix = "Column ";
+            String prefix = OpenRefineMessage.importer_utilities_column() + " ";
             int i = index + 1;
             while (true) {
                 String columnName = prefix + i;

--- a/main/src/com/google/refine/operations/recon/ReconOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconOperation.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import com.google.refine.messages.OpenRefineMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,7 +145,7 @@ public class ReconOperation extends EngineDependentOperation {
                 "  \"columnName\" : \"" + _columnName + "\",\n" +
                 "  \"expression\" : \"forNonBlank(cell.recon.judgment, v, v, if(isNonBlank(value), \\\"(unreconciled)\\\", \\\"(blank)\\\"))\",\n"
                 +
-                "    \"name\" : \"" + _columnName + ": judgment\"\n" +
+                "    \"name\" : \"" + _columnName + ": " + OpenRefineMessage.recon_operation_judgement_facet_name() + "\"\n" +
                 "    },\n" +
                 "    \"facetOptions\" : {\n" +
                 "      \"scroll\" : false\n" +
@@ -157,7 +158,7 @@ public class ReconOperation extends EngineDependentOperation {
                 "    \"columnName\" : \"" + _columnName + "\",\n" +
                 "    \"expression\" : \"cell.recon.best.score\",\n" +
                 "    \"mode\" : \"range\",\n" +
-                "    \"name\" : \"" + _columnName + ": best candidate's score\"\n" +
+                "    \"name\" : \"" + _columnName + ": " + OpenRefineMessage.recon_operation_score_facet_name() + "\"\n" +
                 "         },\n" +
                 "         \"facetType\" : \"range\"\n" +
                 "}";


### PR DESCRIPTION
Fixes #2443 

Changes proposed in this pull request:
- transferred the default column name prefix used for headers of separator based files to properties for localisation.
- transferred the facet names (judge and score) to properties for localisation 
- removed the conflicting *_en.properties files for FunctionDescription
