### PR TITLE
Initial support for schema templates.

### DIFF
--- a/extensions/wikidata/module/MOD-INF/controller.js
+++ b/extensions/wikidata/module/MOD-INF/controller.js
@@ -66,6 +66,7 @@ function init() {
         "scripts/wikibase-manifest-schema-v1.js",
         "scripts/wikibase-manifest-schema-v2.js",
         "scripts/wikibase-manager.js",
+        "scripts/template-manager.js",
         "scripts/menu-bar-extension.js",
         "scripts/warnings-renderer.js",
         "scripts/lang-suggest.js",
@@ -79,6 +80,7 @@ function init() {
         "scripts/dialogs/import-schema-dialog.js",
         "scripts/dialogs/wikibase-dialog.js",
         "scripts/dialogs/statement-configuration-dialog.js",
+        "scripts/dialogs/save-new-template-dialog.js",
         "scripts/jquery.uls.data.js",
       ]);
 

--- a/extensions/wikidata/module/langs/translation-en.json
+++ b/extensions/wikidata/module/langs/translation-en.json
@@ -310,5 +310,6 @@
     "wikibase-save-new-template/existing-template-label": "Or select an existing template to override",
     "wikibase-save-new-template/select-template": "Select template...",
     "wikibase-save-new-template/save": "Save",
+    "wikibase-save-new-template/empty-name": "Please provide a name for the schema template.",
     "wikibase-schema/template-load-erases-schema": "This will discard the current schema, which has unsaved changes."
 }

--- a/extensions/wikidata/module/langs/translation-en.json
+++ b/extensions/wikidata/module/langs/translation-en.json
@@ -32,6 +32,8 @@
     "wikibase-addition/version-error": "Manifest version $1 is not supported. OpenRefine supports manifest versions 1.x and 2.x only.",
     "wikibase-schema/dialog-header": "Align to Wikibase",
     "wikibase-schema/dialog-explanation": "You are currently working against <a href=\"$1\" target=\"_blank\">$2</a>. You should have your data reconciled to reconciliation services linked to $2 first. The schema below specifies how your tabular data will be transformed into $2 edits. You can drag and drop the column names below in most input boxes: for each row, edits will be generated with the values in these columns.",
+    "wikibase-schema/start-from-a-schema-template": "Start from a schema template:",
+    "wikibase-schema/save-new-template": "Save new...",
     "wikibase-schema/preview-explanation": "This tab shows the first edits (out of $1) that will be made once you upload the changes to <a href=\"$2\" target=\"_blank\">$3</a>. You can use facets to inspect the edits on particular items.",
     "wikibase-schema/schema-tab-header": "Schema",
     "wikibase-schema/warnings-tab-header": "Issues",
@@ -302,5 +304,11 @@
     "wikibase-schema/schema-validation/path-element/reference/with-position": "Reference #$1",
     "wikibase-schema/schema-validation/path-element/filename": "File name",
     "wikibase-schema/schema-validation/path-element/filepath": "File path",
-    "wikibase-schema/schema-validation/path-element/wikitext": "Wikitext"
+    "wikibase-schema/schema-validation/path-element/wikitext": "Wikitext",
+    "wikibase-save-new-template/dialog-header": "Save new schema template",
+    "wikibase-save-new-template/template-name": "New template name",
+    "wikibase-save-new-template/existing-template-label": "Or select an existing template to override",
+    "wikibase-save-new-template/select-template": "Select template...",
+    "wikibase-save-new-template/save": "Save",
+    "wikibase-schema/template-load-erases-schema": "This will discard the current schema, which has unsaved changes."
 }

--- a/extensions/wikidata/module/scripts/dialogs/save-new-template-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/save-new-template-dialog.html
@@ -10,7 +10,7 @@
         </div>
     </div>
     <div class="dialog-footer">
-        <button class="button cancel-button" bind="cancelButton"></button>
+        <button class="button cancel-button" type="button" bind="cancelButton"></button>
         <button class="button button-primary" type="submit" bind="saveButton"></button>
     </div>
   </form>

--- a/extensions/wikidata/module/scripts/dialogs/save-new-template-dialog.html
+++ b/extensions/wikidata/module/scripts/dialogs/save-new-template-dialog.html
@@ -1,0 +1,17 @@
+<div class="dialog-frame" style="width: 600px;">
+  <div class="dialog-header" bind="dialogHeader"></div>
+  <form bind="form">
+    <div class="dialog-body" bind="dialogBody">
+        <label for="name-input" bind="nameLabel"></label><br/>
+        <input type="text" name="name-input" bind="nameInput" style="width: 100%"></input><br />
+        <div bind="existingTemplateArea">
+        <label for="existing-template-select" bind="existingTemplateLabel"></label><br />
+        <select name="existing-template-select" bind="templateSelect"></select>
+        </div>
+    </div>
+    <div class="dialog-footer">
+        <button class="button cancel-button" bind="cancelButton"></button>
+        <button class="button button-primary" type="submit" bind="saveButton"></button>
+    </div>
+  </form>
+</div>

--- a/extensions/wikidata/module/scripts/dialogs/save-new-template-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/save-new-template-dialog.js
@@ -40,6 +40,7 @@ SaveNewTemplateDialog.launch = function() {
      SaveNewTemplateDialog._elmts.nameInput.val($(this).val());
   });
 
+  elmts.nameInput.focus();
   elmts.nameInput.on('change', function(e) {
      SaveNewTemplateDialog._elmts.templateSelect.val('__placeholder__');
   });
@@ -48,9 +49,14 @@ SaveNewTemplateDialog.launch = function() {
      dismiss();
   });
 
-  elmts.form.on('submit',function() {
+  elmts.form.on('submit',function(e) {
+    e.preventDefault();
     let wikibaseName = WikibaseManager.getSelectedWikibaseName();
     let templateName = elmts.nameInput.val();
+    if (templateName.trim().length === 0) {
+      alert($.i18n('wikibase-save-new-template/empty-name'));
+      return;
+    }
     let schema = SchemaAlignment.getJSON();
     WikibaseTemplateManager.addTemplate(wikibaseName, templateName, schema);
     WikibaseTemplateManager.saveTemplates();

--- a/extensions/wikidata/module/scripts/dialogs/save-new-template-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/save-new-template-dialog.js
@@ -1,0 +1,61 @@
+var SaveNewTemplateDialog = {};
+
+SaveNewTemplateDialog.launch = function() {
+  var self = this;
+  var frame = $(DOM.loadHTML("wikidata", "scripts/dialogs/save-new-template-dialog.html"));
+  var elmts = this._elmts = DOM.bind(frame);
+
+  this._elmts.dialogHeader.text($.i18n('wikibase-save-new-template/dialog-header'));
+  this._elmts.nameLabel.html($.i18n('wikibase-save-new-template/template-name'));
+  this._elmts.existingTemplateLabel.text($.i18n('wikibase-save-new-template/existing-template-label'));
+  this._elmts.cancelButton.text($.i18n('core-buttons/cancel'));
+  this._elmts.saveButton.text($.i18n('wikibase-save-new-template/save'));
+
+  this._level = DialogSystem.showDialog(frame);
+
+  var dismiss = function() {
+    DialogSystem.dismissUntil(self._level - 1);
+  };
+
+  // populate the list of existing templates
+  let wikibaseName = WikibaseManager.getSelectedWikibaseName();
+  let templates = WikibaseTemplateManager.getTemplates(wikibaseName);
+  if (templates.length === 0) {
+     this._elmts.existingTemplateArea.hide();
+  } else {
+    $('<option></option>')
+        .attr('selected', 'selected')
+        .attr('value', '__placeholder__')
+        .addClass('placeholder')
+        .text($.i18n('wikibase-save-new-template/select-template'))
+        .appendTo(elmts.templateSelect);
+    templates.forEach(template =>
+      $('<option></option>')
+        .attr('value', template.name)
+        .text(template.name)
+        .appendTo(elmts.templateSelect));
+  }
+
+  elmts.templateSelect.on('change', function(e) {
+     SaveNewTemplateDialog._elmts.nameInput.val($(this).val());
+  });
+
+  elmts.nameInput.on('change', function(e) {
+     SaveNewTemplateDialog._elmts.templateSelect.val('__placeholder__');
+  });
+
+  elmts.cancelButton.on('click',function() {
+     dismiss();
+  });
+
+  elmts.form.on('submit',function() {
+    let wikibaseName = WikibaseManager.getSelectedWikibaseName();
+    let templateName = elmts.nameInput.val();
+    let schema = SchemaAlignment.getJSON();
+    WikibaseTemplateManager.addTemplate(wikibaseName, templateName, schema);
+    WikibaseTemplateManager.saveTemplates();
+    SchemaAlignment.updateAvailableTemplates();
+    dismiss();
+  });
+};
+

--- a/extensions/wikidata/module/scripts/schema-alignment-tab.html
+++ b/extensions/wikidata/module/scripts/schema-alignment-tab.html
@@ -2,6 +2,11 @@
     <div bind="schemaHeader">
         <div class="schema-alignment-save"><button class="button button-primary" bind="saveButton"></button><button class="button button-primary" bind="discardButton"></button></div>
         <p class="panel-explanation" bind="dialogExplanation"></p>
+        <div class="panel-explanation">
+          <label bind="templateLabel" for="wikibase-template-select"></label>
+          <select bind="templateSelect" name="wikibase-template-select" id="wikibase-template-select"></select>
+          <button bind="saveNewTemplateButton" class="button button-primary"></button>
+        </div>
         <div style="clear: right"></div>
         <div class="schema-alignment-dialog-columns-area" bind="columnsArea">
         </div>

--- a/extensions/wikidata/module/scripts/template-manager.js
+++ b/extensions/wikidata/module/scripts/template-manager.js
@@ -1,0 +1,95 @@
+/**
+ * Manages schema templates
+ */
+
+const WikibaseTemplateManager = {
+  /**
+   * Keys: Wikibase instance names
+   * Values: Array of objects, with two keys:
+   *   - 'name': the name of the template
+   *   - 'schema': the (potentially incomplete) Wikibase schema
+   */
+  templates: {}
+};
+
+// returns all the templates for a given Wikibase, in the form of an array 
+WikibaseTemplateManager.getTemplates = function (wikibaseName) {
+  let templates = WikibaseTemplateManager.templates[wikibaseName];
+  return templates === undefined ? [] : templates;
+}
+
+// returns the template identified by the user-supplied name
+WikibaseTemplateManager.getTemplate = function (wikibaseName, templateName) {
+  let templates = WikibaseTemplateManager.getTemplates(wikibaseName);
+  let matching = templates.filter(t => t.name === templateName);
+  if (matching.length > 0) {
+    return matching[0];
+  } else {
+    return undefined;
+  }
+}
+
+// adds a new template for the given Wikibase instance 
+WikibaseTemplateManager.addTemplate = function (wikibaseName, templateName, schema) {
+  let template = {
+      name: templateName,
+      schema: schema
+  };
+  let templates = WikibaseTemplateManager.templates[wikibaseName];
+  if (templates === undefined) {
+     templates = [];
+  }
+  templates = templates.filter(existingTemplate => existingTemplate.name !== templateName);
+  templates.push(template);
+  WikibaseTemplateManager.templates[wikibaseName] = templates;
+}
+
+// deletes a template
+WikibaseTemplateManager.deleteTemplate = function (wikibaseName, templateName) {
+  let templates = WikibaseTemplateManager.getTemplates(wikibaseName);
+  let newTemplates = templates.filter(template => template.name !== templateName);
+  WikibaseTemplateManager.templates[wikibaseName] = newTemplates;
+}
+
+// loads all the templates from the backend
+WikibaseTemplateManager.loadTemplates = function(onDone) {
+  $.ajax({
+    url: "command/core/get-preference?" + $.param({
+      name: "wikibase.templates"
+    }),
+    success: function (data) {
+      WikibaseTemplateManager.templates = {};
+      if (data.value && data.value !== "null" && data.value !== "[]") {
+        // the object is wrapped into an array because the backend does not
+        // allow storing arbitrary JSON objects otherwise (sigh...)
+        let dummyList = JSON.parse(data.value);
+        if (dummyList.length === 1) {
+          WikibaseTemplateManager.templates = dummyList[0];
+        } 
+      }
+      if (onDone) {
+        onDone();
+      }
+    },
+    dataType: "json"
+  });
+}
+
+// saves all the templates to the backend
+WikibaseTemplateManager.saveTemplates = function() {
+  Refine.wrapCSRF(function (token) {
+    $.ajax({
+      async: false,
+      type: "POST",
+      url: "command/core/set-preference?" + $.param({
+        name: "wikibase.templates"
+      }),
+      data: {
+        "value": JSON.stringify([WikibaseTemplateManager.templates]),
+        csrf_token: token
+      },
+      dataType: "json"
+    });
+  });
+
+}

--- a/extensions/wikidata/module/scripts/wikibase-manager.js
+++ b/extensions/wikidata/module/scripts/wikibase-manager.js
@@ -170,11 +170,17 @@ WikibaseManager.getAllWikibaseManifests = function () {
 
 WikibaseManager.addWikibase = function (manifest) {
   WikibaseManager.wikibases[manifest.mediawiki.name] = manifest;
+  if (manifest.schema_templates !== undefined) {
+    for (let template of manifest.schema_templates) {
+      WikibaseTemplateManager.addTemplate(manifest.mediawiki.name, template.name, template.schema);
+    }
+  }
   WikibaseManager.saveWikibases();
 };
 
 WikibaseManager.removeWikibase = function (wikibaseName) {
   delete WikibaseManager.wikibases[wikibaseName];
+  // we do not delete templates associated with this wikibase because some of them might be user-defined
   WikibaseManager.saveWikibases();
 };
 

--- a/extensions/wikidata/module/scripts/wikibase-manifest-schema-v2.js
+++ b/extensions/wikidata/module/scripts/wikibase-manifest-schema-v2.js
@@ -145,6 +145,24 @@ const WikibaseManifestSchemaV2 = {
       },
       "required": ["url_schema"]
     },
+    "schema_templates": {
+      "type": "array",
+      "description": "A list of predefined schema templates to be offered to the user",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the template to be displayed to the user"
+          },
+          "schema": {
+            "type": "object",
+            "description": "The schema, potentially incomplete, to be loaded with this template"
+          }
+        },
+        "required": ["name", "schema"]
+      }
+    },
     "hide_structured_fields_in_mediainfo": {
       "type": "boolean",
       "description": "Boolean set to true when the Wikibase instance supports file uploads but does not have structured data associated to them in the form of MediaInfo entities"

--- a/extensions/wikidata/module/styles/schema-alignment.less
+++ b/extensions/wikidata/module/styles/schema-alignment.less
@@ -640,3 +640,9 @@ div.schema-alignment-dialog-preview {
 .schema-validation-error {
     margin-left: 2px;
 }
+
+/** Template selection **/
+
+select:focus option.placeholder {
+  display: none;
+}


### PR DESCRIPTION
Closes #5043.

This adds the ability to start a schema from a previously saved schema template.
A schema template is a schema with some missing values.
It is also possible to pre-define some templates in the Wikibase manifest, so that those are added to OpenRefine when the manifest is first loaded.

I think it would be useful to add an interface to list existing schema templates, which would enable:
* deleting schema templates
* exporting a schema template to JSON (useful to add it to the manifest afterwards)
