### PR TITLE
Cluster and edit display fix

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.html
@@ -1,56 +1,63 @@
 <div class="dialog-frame" style="width: 1000px;">
-  <div class="dialog-header" bind="dialogHeader"></div>
-  <div class="dialog-body" bind="dialogBody">
-    <div class="grid-layout layout-normal layout-full">
+    <div class="dialog-header" bind="dialogHeader"></div>
+    <div class="dialog-body clustering-dialog-body" bind="dialogBody">
         <div>
-          <span bind="or_dialog_descr"></span>
-          <a href="https://docs.openrefine.org/manual/cellediting#cluster-and-edit" target="_blank" bind="or_dialog_findMore"></a>
+            <span bind="or_dialog_descr"></span>
+            <a href="https://docs.openrefine.org/manual/cellediting#cluster-and-edit" target="_blank"
+               bind="or_dialog_findMore"></a>
         </div>
-      <div style="margin: 1em 0em;display: flex; flex-flow: row; justify-content: space-between">
-        <div>
-            <span bind="or_dialog_method"></span><select bind="methodSelector">
-              <option selected="true" bind="or_dialog_keyCollision"></option>
-              <option bind="or_dialog_neighbor"></option>
+        <div class="clustering-dialog-control-row">
+            <div>
+                <span bind="or_dialog_method"></span><select bind="methodSelector">
+                <option selected="true" bind="or_dialog_keyCollision"></option>
+                <option bind="or_dialog_neighbor"></option>
             </select>
+            </div>
+            <div>
+                <div class="binning-controls"><span bind="or_dialog_keying"></span>
+                    <select bind="keyingFunctionSelector"></select>
+                </div>
+                <div class="knn-controls hidden"><span bind="or_dialog_distance"></span>
+                    <select bind="distanceFunctionSelector"></select>
+                </div>
+            </div>
+            <div>
+                <div id="ngram-fingerprint-params" class="function-params hidden">
+                    <span bind="or_dialog_ngramSize"></span>
+                    <input spellcheck="false" type="text" value="2" bind="ngramSize" name="ngram-size" size="2"
+                           class="param" datatype="int">
+                </div>
+                <div class="knn-controls hidden">
+                    <span style="margin-right: 1em">
+                        <span bind="or_dialog_radius"></span>
+                        <input spellcheck="false" type="text" value="1.0" bind="radius" name="radius" size="2"
+                               class="param" datatype="float">
+                    </span>
+                    <span>
+                        <span bind="or_dialog_blockChars"></span>
+                        <input spellcheck="false" type="text" value="6" bind="ngramBlock" name="blocking-ngram-size"
+                               size="2" class="param" datatype="int">
+                    </span>
+                </div>
+            </div>
+            <div bind="resultSummary" style="text-align:right;">
+            </div>
         </div>
-        <div>
-          <div class="binning-controls"><span bind="or_dialog_keying"></span>
-             <select bind="keyingFunctionSelector"></select>
-          </div>
-          <div class="knn-controls hidden"><span bind="or_dialog_distance"></span>
-             <select bind="distanceFunctionSelector"></select>
-          </div>
+        <div class="clustering-dialog-facet-row">
+            <div bind="tableContainer" class="clustering-dialog-table-container"></div>
+            <div bind="facetContainer"></div>
         </div>
-        <div>
-          <div id="ngram-fingerprint-params" class="function-params hidden">
-            <span bind="or_dialog_ngramSize"></span><input spellcheck="false" type="text" value="2" bind="ngramSize" name="ngram-size" size="2" class="param" datatype="int">
-          </div>
-          <div class="knn-controls hidden">
-            <span style="margin-right: 1em"><span bind="or_dialog_radius"></span><input spellcheck="false" type="text" value="1.0" bind="radius" name="radius" size="2" class="param" datatype="float"></span>
-            <span><span bind="or_dialog_blockChars"></span><input spellcheck="false" type="text" value="6" bind="ngramBlock" name="blocking-ngram-size" size="2" class="param" datatype="int"></span>
-          </div>
-        </div>
-        <div bind="resultSummary" style="text-align:right;">
-        </div>
-      </div>
-      <tr>
-        <td colspan="3">
-          <div bind="tableContainer" class="clustering-dialog-table-container"></div>
-        </td>
-        <td colspan="1" bind="facetContainer" width="250"></td>
-      </tr>
     </div>
-  </div>
-  <div class="dialog-footer" bind="dialogFooter" style="justify-content: space-between">
-      <div class="dialog-footer-bg">
-        <button class="button" bind="selectAllButton"></button>
-        <button class="button" bind="deselectAllButton"></button>
-      </div>
-      <div class="dialog-footer-bg">
-        <button class="button" bind="exportClusterButton"></button>
-        <button class="button button-primary" bind="applyReClusterButton"></button>
-        <button class="button" bind="applyCloseButton"></button>
-        <button class="button" bind="closeButton"></button>
-      </div>
-  </div>
+    <div class="dialog-footer" bind="dialogFooter" style="justify-content: space-between">
+        <div class="dialog-footer-bg">
+            <button class="button" bind="selectAllButton"></button>
+            <button class="button" bind="deselectAllButton"></button>
+        </div>
+        <div class="dialog-footer-bg">
+            <button class="button" bind="exportClusterButton"></button>
+            <button class="button button-primary" bind="applyReClusterButton"></button>
+            <button class="button" bind="applyCloseButton"></button>
+            <button class="button" bind="closeButton"></button>
+        </div>
+    </div>
 </div>

--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.html
@@ -1,29 +1,27 @@
 <div class="dialog-frame" style="width: 1000px;">
   <div class="dialog-header" bind="dialogHeader"></div>
   <div class="dialog-body" bind="dialogBody">
-    <div class="grid-layout layout-normal layout-full"><table>
-      <tr>
-        <td colspan="4">
+    <div class="grid-layout layout-normal layout-full">
+        <div>
           <span bind="or_dialog_descr"></span>
           <a href="https://docs.openrefine.org/manual/cellediting#cluster-and-edit" target="_blank" bind="or_dialog_findMore"></a>
-        </td>
-      </tr>
-      <tr>
-        <td>
+        </div>
+      <div style="margin: 1em 0em;display: flex; flex-flow: row; justify-content: space-between">
+        <div>
             <span bind="or_dialog_method"></span><select bind="methodSelector">
               <option selected="true" bind="or_dialog_keyCollision"></option>
               <option bind="or_dialog_neighbor"></option>
             </select>
-        </td>
-        <td>
+        </div>
+        <div>
           <div class="binning-controls"><span bind="or_dialog_keying"></span>
              <select bind="keyingFunctionSelector"></select>
           </div>
           <div class="knn-controls hidden"><span bind="or_dialog_distance"></span>
              <select bind="distanceFunctionSelector"></select>
           </div>
-        </td>
-        <td>
+        </div>
+        <div>
           <div id="ngram-fingerprint-params" class="function-params hidden">
             <span bind="or_dialog_ngramSize"></span><input spellcheck="false" type="text" value="2" bind="ngramSize" name="ngram-size" size="2" class="param" datatype="int">
           </div>
@@ -31,17 +29,17 @@
             <span style="margin-right: 1em"><span bind="or_dialog_radius"></span><input spellcheck="false" type="text" value="1.0" bind="radius" name="radius" size="2" class="param" datatype="float"></span>
             <span><span bind="or_dialog_blockChars"></span><input spellcheck="false" type="text" value="6" bind="ngramBlock" name="blocking-ngram-size" size="2" class="param" datatype="int"></span>
           </div>
-        </td>
-        <td bind="resultSummary" style="text-align:right;">
-        </td>
-      </tr>
+        </div>
+        <div bind="resultSummary" style="text-align:right;">
+        </div>
+      </div>
       <tr>
         <td colspan="3">
           <div bind="tableContainer" class="clustering-dialog-table-container"></div>
         </td>
         <td colspan="1" bind="facetContainer" width="250"></td>
       </tr>
-    </table></div>
+    </div>
   </div>
   <div class="dialog-footer" bind="dialogFooter" style="justify-content: space-between">
       <div class="dialog-footer-bg">

--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
@@ -610,18 +610,18 @@ ClusteringDialog.Facet.prototype.update = function(clusters) {
 
     var bins = this._computeDistribution(clusters);
 
+    this._histogram.update(
+        this._min,
+        this._max,
+        this._step,
+        [ this._baseBins, bins ]
+    );
     this._sliderWidget.update(
         this._min,
         this._max,
         this._step,
         this._from,
         this._to
-    );
-    this._histogram.update(
-        this._min,
-        this._max,
-        this._step,
-        [ this._baseBins, bins ]
     );
 };
 

--- a/main/webapp/modules/core/styles/dialogs/clustering-dialog.less
+++ b/main/webapp/modules/core/styles/dialogs/clustering-dialog.less
@@ -23,8 +23,8 @@ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -33,8 +33,27 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 @import-less url("../theme.less");
 
+.clustering-dialog-body {
+  padding: 15px 15px 0 15px;
+  }
+
+.clustering-dialog-control-row {
+  margin: 1em 0;
+  display: flex;
+  flex-flow: row;
+  justify-content: space-between;
+  }
+
+.clustering-dialog-facet-row {
+  margin: 1em 0;
+  display: flex;
+  flex-flow: row;
+  column-gap: 5px;
+  }
+
 .clustering-dialog-table-container {
   height: 450px;
+  width: 650px;
   overflow: auto;
   border: 1px solid #aaa;
   }
@@ -71,7 +90,7 @@ table.clustering-dialog-entry-table a {
   }
 
 table.clustering-dialog-entry-table ul {
-  margin: 1em 0em 0em 0em;
+  margin: 1em 0 0 0;
   }
 
 table.clustering-dialog-entry-table a:hover {


### PR DESCRIPTION
Fixes #5210, #1141, #938

Changes proposed in this pull request:
- Adjusted control part of the cluster and edit dialog.
- Adjusted the width and spacing of elements in the dialog body. 

After:
![image](https://user-images.githubusercontent.com/42903164/187003510-4021af17-77c2-4a4d-95f5-e77140326f16.png)