### PR TITLE
Adjusted memory usage display to show the memory in use

### DIFF
--- a/main/src/com/google/refine/importing/ImportingJob.java
+++ b/main/src/com/google/refine/importing/ImportingJob.java
@@ -121,8 +121,8 @@ public class ImportingJob {
             }
             JSONUtilities.safePut(progress, "message", message);
             JSONUtilities.safePut(progress, "percent", percent);
-            JSONUtilities.safePut(progress, "memory", Runtime.getRuntime().totalMemory() / 1000000);
-            JSONUtilities.safePut(progress, "maxmemory", Runtime.getRuntime().maxMemory() / 1000000);
+            JSONUtilities.safePut(progress, "memory", Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() / 1048576);
+            JSONUtilities.safePut(progress, "maxmemory", Runtime.getRuntime().maxMemory() / 1048576);
         }
     }
 


### PR DESCRIPTION
Fixes #5218

Changes proposed in this pull request:
- Adjusted memory usage display to show the memory used instead of memory total.
- Adjusted display to use base 2 instead of base 10 for the conversion to show the correct amount of memory.

After:
![java-memory-after](https://user-images.githubusercontent.com/42903164/187581386-7f8874c3-4870-4bc2-83d3-908dbd1a7854.gif)
