### PR TITLE
Revert "build(deps): bump slf4j-api from 1.7.36 to 2.0.0 (#5206)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <jackson.version>2.13.3</jackson.version>
     <servlet-api.version>4.0.1</servlet-api.version>
     <butterfly.version>1.2.3</butterfly.version>
-    <slf4j.version>2.0.0</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <log4j.version>2.18.0</log4j.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <okhttp.version>4.10.0</okhttp.version>


### PR DESCRIPTION
This update requires migrating to log4j-slf4j18-impl, which has not been updated yet to satisfy the 2.0 SPI.
This closes #5225.

This reverts commit 0ebfccd4f87acc5c8118a5fc228d83034cfc5644.