### PR TITLE
Adjusted the colors in range and timerange facet to have more contrast

### DIFF
--- a/main/webapp/modules/core/scripts/facets/range-facet.js
+++ b/main/webapp/modules/core/scripts/facets/range-facet.js
@@ -172,7 +172,7 @@ class RangeFacet extends Facet {
     this._elmts.removeButton.on('click',function() { self._remove(); });
     this._elmts.minimizeButton.on('click',function() { self._minimize(); });
 
-    this._histogram = new HistogramWidget(this._elmts.histogramDiv, { binColors: [ "#bbccff", "#88aaee" ] });
+    this._histogram = new HistogramWidget(this._elmts.histogramDiv, { binColors: [ "#668CFF", "#174092" ] });
     this._sliderWidget = new SliderWidget(this._elmts.sliderWidgetDiv);
 
     this._elmts.sliderWidgetDiv.on("slide", function(evt, data) {

--- a/main/webapp/modules/core/scripts/facets/timerange-facet.js
+++ b/main/webapp/modules/core/scripts/facets/timerange-facet.js
@@ -170,7 +170,7 @@ class TimeRangeFacet extends Facet{
     this._elmts.removeButton.on('click',function() { self._remove(); });
     this._elmts.minimizeButton.on('click',function() { self._minimize(); });
 
-    this._histogram = new HistogramWidget(this._elmts.histogramDiv, { binColors: [ "#ccccff", "#6666ff" ] });
+    this._histogram = new HistogramWidget(this._elmts.histogramDiv, { binColors: [ "#668CFF", "#174092" ] });
     this._sliderWidget = new SliderWidget(this._elmts.sliderWidgetDiv);
 
     this._elmts.sliderWidgetDiv.on("slide", function(evt, data) {


### PR DESCRIPTION
Fixes #3319

Adjusted the numeric and timeline facet histogram bin colors to improve the contrast so that it is 3 to 1 between the three colors: background (white), bin color 1, and bin color 2.

Previously, timeline facet was using a separate color palette. This change makes numeric and timeline use the same colors. See the pictures below to see the difference.

Before and After:
![image](https://user-images.githubusercontent.com/42903164/190029504-bbea4ed3-de19-46d4-a4f8-7e79e5ed7b22.png)

Contrast:
![image](https://user-images.githubusercontent.com/42903164/190029545-bb4b8df8-dcf8-44f1-bc80-e9d7b97f0e1d.png)
