### PR TITLE
Make respondException print the exception stacktrace

### DIFF
--- a/main/src/com/google/refine/commands/Command.java
+++ b/main/src/com/google/refine/commands/Command.java
@@ -346,6 +346,7 @@ public abstract class Command {
             throws IOException, ServletException {
 
         logger.warn("Exception caught", e);
+        e.printStackTrace();
 
         if (response == null) {
             throw new ServletException("Response object can't be null");


### PR DESCRIPTION
When errors happen in the API it can be rather opaque to the end user as the error is only printed in the resulting JSON response. This change ensures that the stacktrace is also natively printed.