### PR TITLE
Wikidata extension tests

### DIFF
--- a/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.js
+++ b/extensions/wikidata/module/scripts/dialogs/wikibase-dialog.js
@@ -80,6 +80,7 @@ WikibaseDialog.prototype.populateDialog = function () {
     _elmts.wikibaseName.text(wikibaseName);
     _elmts.wikibaseUrl.text(rootURL);
     _elmts.deleteWikibase.text($.i18n('core-index/delete'));
+    _elmts.deleteWikibase.addClass('wikibase-dialog-selector-delete');
     _elmts.deleteWikibase.on('click', (event) => {
       this.removeWikibase(event, wikibaseName);
     });

--- a/main/tests/cypress/cypress/integration/extensions/wikidata/layout.spec.js
+++ b/main/tests/cypress/cypress/integration/extensions/wikidata/layout.spec.js
@@ -1,0 +1,12 @@
+describe(__filename, function () {
+    it('Ensure the wikidata extension is loaded by default', function () {
+        cy.loadAndVisitProject('food.mini');
+        cy.get('#extension-bar-menu-container').should('to.contain', 'Wikidata');
+        cy.get('#extension-bar-menu-container')
+            .should('to.contain', 'Wikidata')
+            .click();
+
+        // we do only one assertion to ensure the menu appear properly
+        cy.get('.menu-container').should('to.contain', 'Select Wikibase instance');
+    });
+});

--- a/main/tests/cypress/cypress/integration/extensions/wikidata/select_wikibase_instance.spec.js
+++ b/main/tests/cypress/cypress/integration/extensions/wikidata/select_wikibase_instance.spec.js
@@ -12,8 +12,11 @@ function cleanupWikibases() {
         if ($el.text().includes('OpenRefine Wikibase Cypress Test')) {
             cy.wrap($el).contains('Delete').click();
         }
+        if ($el.text().includes('OpenRefine Wikibase Test')) {
+            cy.wrap($el).contains('Delete').click();
+        }
     });
-    cy.get('.dialog-container .wikibase-dialog button').contains('OK').click();
+    cy.get('.wikibase-dialog .dialog-footer button').contains('OK').click();
 }
 describe(__filename, function () {
     it('Add a wikibase instance, general navigation', function () {
@@ -30,7 +33,7 @@ describe(__filename, function () {
         );
 
         // click add
-        cy.get('.dialog-container .wikibase-dialog button')
+        cy.get('.wikibase-dialog .dialog-footer button')
             .contains('Add Wikibase')
             .click();
 
@@ -47,7 +50,7 @@ describe(__filename, function () {
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
 
-        cy.get('.dialog-container .wikibase-dialog button')
+        cy.get('.wikibase-dialog .dialog-footer button')
             .contains('Add Wikibase')
             .click();
 
@@ -61,8 +64,9 @@ describe(__filename, function () {
         // ensure the new Wikibase is listed
         cy.get('.dialog-container .wikibase-dialog').should(
             'to.contain',
-            'OpenRefine Wikibase Cypress Test'
+            'OpenRefine Wikibase Test'
         );
+        cy.get('.wikibase-dialog .dialog-footer button').contains('OK').click();
         cleanupWikibases();
     });
 
@@ -72,7 +76,7 @@ describe(__filename, function () {
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
 
-        cy.get('.dialog-container .wikibase-dialog button')
+        cy.get('.wikibase-dialog .dialog-footer button')
             .contains('Add Wikibase')
             .click();
 
@@ -112,6 +116,7 @@ describe(__filename, function () {
             'to.contain',
             'OpenRefine Wikibase Cypress Test'
         );
+        cy.get('.wikibase-dialog .dialog-footer button').contains('OK').click();
         cleanupWikibases();
     });
 
@@ -121,7 +126,7 @@ describe(__filename, function () {
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
 
-        cy.get('.dialog-container .wikibase-dialog button')
+        cy.get('.wikibase-dialog .dialog-footer button')
             .contains('Add Wikibase')
             .click();
 
@@ -130,10 +135,12 @@ describe(__filename, function () {
         cy.get('.add-wikibase-dialog p.invalid-manifest')
             .should('be.visible')
             .contains('SyntaxError: Unexpected token \'T\', "This is an"... is not valid JSON');
+        cy.get('.add-wikibase-dialog .dialog-footer button').contains('Cancel').click();
+        cy.get('.wikibase-dialog .dialog-footer button').contains('OK').click();
         cleanupWikibases();
     });
 
-    it('Switch from one wikibase to another', function () {
+    it('Delete wikibase', function () {
         cy.loadAndVisitProject('food.mini');
         cy.addWikibaseInstance(
             'https://raw.githubusercontent.com/OpenRefine/wikibase-manifests/master/openrefine-wikibase-test-manifest.json'
@@ -142,53 +149,19 @@ describe(__filename, function () {
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
 
-        // check that wikidata is selected by default
-        cy.get('.wikibase-dialog li').contains('Wikidata').click();
-        cy.get('.wikibase-dialog li').should(
-            'to.contain',
-            'active'
-        );
-
-        // switch to OpenRefine Wikibase Cypress Test
-        cy.get('.wikibase-dialog li').contains('OpenRefine Wikibase Cypress Test').click();
-        cy.get('.wikibase-dialog li').should(
-            'to.contain',
-            'active'
-        );
-
-        // switch back to Wikidata
-        cy.get('.wikibase-dialog li').contains('Wikidata').click();
-        cy.get('.wikibase-dialog li').should(
-            'to.contain',
-            'active'
-        );
-        cleanupWikibases();
-    });
-
-    it('Remove wikibase', function () {
-        cy.loadAndVisitProject('food.mini');
-        cy.addWikibaseInstance(
-            'https://raw.githubusercontent.com/OpenRefine/wikibase-manifests/master/openrefine-wikibase-test-manifest.json'
-        );
-
-        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
-        cy.get('.menu-container a').contains('Select Wikibase instance').click();
-
-        // Click on the little cross to remove the test wikibase and ensure it's been removed
         cy.get('.wikibase-dialog li')
-            .contains('OpenRefine Wikibase Cypress Test')
-            .parent()
-            .parent()
+            .contains('OpenRefine Wikibase Test')
+            .parents('li')
             .find('.wikibase-dialog-selector-delete')
             .click();
 
         cy.get('.wikibase-dialog').should(
             'not.to.contain',
-            'OpenRefine Wikibase Cypress Test'
+            'OpenRefine Wikibase Test'
         );
 
-        // wikidata should still be there
         cy.get('.wikibase-dialog').should('to.contain', 'Wikidata');
+        cy.get('.wikibase-dialog .dialog-footer button').contains('OK').click();
         cleanupWikibases();
     });
 });

--- a/main/tests/cypress/cypress/integration/extensions/wikidata/select_wikibase_instance.spec.js
+++ b/main/tests/cypress/cypress/integration/extensions/wikidata/select_wikibase_instance.spec.js
@@ -1,0 +1,189 @@
+/**
+ * Delete all previsouly added wikibase instances
+ * They are shared across project, therefore some cleanup is required to ensure a wikibase instance doesn't come from another test
+ */
+function cleanupWikibases() {
+    cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+    cy.get('.menu-container a').contains('Select Wikibase instance').click();
+    cy.get(
+        '.wikibase-dialog table .wikibase-dialog-selector-delete'
+    ).each(($el) => cy.wrap($el).click());
+    cy.get('.dialog-container .wikibase-dialog button').contains('Delete').click();
+}
+
+describe(__filename, function () {
+    it('Add a wikibase instance, general navigation', function () {
+        //
+        cy.loadAndVisitProject('food.mini');
+        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+        cy.get('.menu-container a').contains('Select Wikibase instance').click();
+
+        // check dialog and header
+        cy.get('.dialog-container .wikibase-dialog').should('to.exist');
+        cy.get('.dialog-container .wikibase-dialog .dialog-header').should(
+            'to.contain',
+            'Select Wikibase instance'
+        );
+
+        // click add
+        cy.get('.dialog-container .wikibase-dialog button')
+            .contains('Add Wikibase')
+            .click();
+
+        // check panel
+        cy.get('.add-wikibase-dialog .dialog-header').should(
+            'to.contain',
+            'Add Wikibase manifest'
+        );
+    });
+
+    it('Add a wikibase instance (URL)', function () {
+        cy.loadAndVisitProject('food.mini');
+        cleanupWikibases();
+
+        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+        cy.get('.menu-container a').contains('Select Wikibase instance').click();
+
+        cy.get('.dialog-container .wikibase-dialog button')
+            .contains('Add Wikibase')
+            .click();
+
+        // ad a manifest
+        cy.get('.add-wikibase-dialog input[bind="manifestURLInput"]').invoke(
+            'val',
+            'https://raw.githubusercontent.com/OpenRefine/wikibase-manifests/master/openrefine-wikibase-test-manifest.json'
+        );
+        cy.get('.add-wikibase-dialog button').contains('Add Wikibase').click();
+
+        // ensure the new Wikibase is listed
+        cy.get('.dialog-container .wikibase-dialog').should(
+            'to.contain',
+            'OpenRefine Wikibase Test'
+        );
+    });
+
+    it('Add a wikibase instance (JSON Manifest copy-pasted in the textarea)', function () {
+        cy.loadAndVisitProject('food.mini');
+        cleanupWikibases();
+
+        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+        cy.get('.menu-container a').contains('Select Wikibase instance').click();
+
+        cy.get('.dialog-container .wikibase-dialog button')
+            .contains('Add Wikibase')
+            .click();
+
+        // add a manifest
+        const manifest = {
+            version: '1.0',
+            mediawiki: {
+                name: 'Cypress Testing Wikibase Test',
+                root: 'https://or-wikibase-test.wiki.opencura.com/wiki/',
+                main_page: 'https://or-wikibase-test.wiki.opencura.com/wiki/Main_Page',
+                api: 'https://or-wikibase-test.wiki.opencura.com/w/api.php',
+            },
+            wikibase: {
+                site_iri: 'http://or-wikibase-test.wiki.opencura.com/entity/',
+                maxlag: 5,
+                properties: {
+                    instance_of: 'P1',
+                    subclass_of: 'P2',
+                },
+            },
+            oauth: {
+                registration_page:
+                    'https://or-wikibase-test.wiki.opencura.com/wiki/Special:OAuthConsumerRegistration/propose',
+            },
+            reconciliation: {
+                endpoint: 'https://or-wikibase-test.reconci.link/${lang}/api',
+            },
+        };
+        cy.get('.add-wikibase-dialog textarea').invoke(
+            'val',
+            JSON.stringify(manifest)
+        );
+        cy.get('.add-wikibase-dialog button').contains('Add Wikibase').click();
+
+        // ensure the new Wikibase is listed
+        cy.get('.dialog-container .wikibase-dialog').should(
+            'to.contain',
+            'Cypress Testing Wikibase Test'
+        );
+    });
+
+    it('Add a wikibase instance (Invalid manifest provided)', function () {
+        cy.loadAndVisitProject('food.mini');
+        cleanupWikibases();
+
+        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+        cy.get('.menu-container a').contains('Select Wikibase instance').click();
+
+        cy.get('.dialog-container .wikibase-dialog button')
+            .contains('Add Wikibase')
+            .click();
+
+        cy.get('.add-wikibase-dialog textarea').type('This is an invalid manifest');
+        cy.get('.add-wikibase-dialog button').contains('Add Wikibase').click();
+        cy.get('.add-wikibase-dialog p.invalid-manifest')
+            .should('be.visible')
+            .contains('Invalid Wikibase manifest.');
+    });
+
+    it('Switch from one wikibase to another', function () {
+        cy.loadAndVisitProject('food.mini');
+        cleanupWikibases();
+        cy.addWikibaseInstance(
+            'https://raw.githubusercontent.com/OpenRefine/wikibase-manifests/master/openrefine-wikibase-test-manifest.json'
+        );
+
+        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+        cy.get('.menu-container a').contains('Select Wikibase instance').click();
+
+        // check that wikidata is selected by default
+        cy.get('.wikibase-dialog td').contains('Wikidata').click();
+        cy.get('.wikibase-dialog p[bind="currentSelectedWikibase"] a').should(
+            'to.contain',
+            'Wikidata'
+        );
+
+        // switch to OpenRefine Wikibase Test
+        cy.get('.wikibase-dialog td').contains('OpenRefine Wikibase Test').click();
+        cy.get('.wikibase-dialog p[bind="currentSelectedWikibase"] a').should(
+            'to.contain',
+            'OpenRefine Wikibase Test'
+        );
+
+        // switch back to Wikidata
+        cy.get('.wikibase-dialog td').contains('Wikidata').click();
+        cy.get('.wikibase-dialog p[bind="currentSelectedWikibase"] a').should(
+            'to.contain',
+            'Wikidata'
+        );
+    });
+
+    it('Remove wikibase', function () {
+        cy.loadAndVisitProject('food.mini');
+        cleanupWikibases();
+        cy.addWikibaseInstance(
+            'https://raw.githubusercontent.com/OpenRefine/wikibase-manifests/master/openrefine-wikibase-test-manifest.json'
+        );
+
+        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+        cy.get('.menu-container a').contains('Select Wikibase instance').click();
+
+        // Click on the little cross to remove the test wikibase and ensure it's been removed
+        cy.get('.wikibase-dialog td')
+            .contains('OpenRefine Wikibase Test')
+            .parent()
+            .find('.wikibase-dialog-selector-delete')
+            .click();
+
+        cy.get('.wikibase-dialog').should(
+            'not.to.contain',
+            'OpenRefine Wikibase Test'
+        );
+
+        // wikidata should still be there
+        cy.get('.wikibase-dialog').should('to.contain', 'Wikidata');
+    });
+});

--- a/main/tests/cypress/cypress/integration/extensions/wikidata/select_wikibase_instance.spec.js
+++ b/main/tests/cypress/cypress/integration/extensions/wikidata/select_wikibase_instance.spec.js
@@ -1,6 +1,6 @@
 /**
- * Delete all previously added wikibase test instances
- * They are shared across project, therefore some cleanup is required to ensure a wikibase instance doesn't come from another test
+ * Delete all previously added Wikibase test instances
+ * They are shared across project, therefore some cleanup is required to ensure a Wikibase instance doesn't come from another test
  */
 function cleanupWikibases() {
     cy.get('#extension-bar-menu-container').contains('Wikidata').click();
@@ -20,14 +20,13 @@ function cleanupWikibases() {
 }
 describe(__filename, function () {
     it('Add a wikibase instance, general navigation', function () {
-        //
         cy.loadAndVisitProject('food.mini');
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
 
         // check dialog and header
-        cy.get('.dialog-container .wikibase-dialog').should('to.exist');
-        cy.get('.dialog-container .wikibase-dialog .dialog-header').should(
+        cy.get('.wikibase-dialog').should('to.exist');
+        cy.get('.wikibase-dialog .dialog-header').should(
             'to.contain',
             'Select Wikibase instance'
         );
@@ -54,7 +53,7 @@ describe(__filename, function () {
             .contains('Add Wikibase')
             .click();
 
-        // ad a manifest
+        // add a manifest
         cy.get('.add-wikibase-dialog input[bind="manifestURLInput"]').invoke(
             'val',
             'https://raw.githubusercontent.com/OpenRefine/wikibase-manifests/master/openrefine-wikibase-test-manifest.json'
@@ -62,7 +61,7 @@ describe(__filename, function () {
         cy.get('.add-wikibase-dialog button').contains('Add Wikibase').click();
 
         // ensure the new Wikibase is listed
-        cy.get('.dialog-container .wikibase-dialog').should(
+        cy.get('.wikibase-dialog').should(
             'to.contain',
             'OpenRefine Wikibase Test'
         );
@@ -112,7 +111,7 @@ describe(__filename, function () {
         cy.get('.add-wikibase-dialog button').contains('Add Wikibase').click();
 
         // ensure the new Wikibase is listed
-        cy.get('.dialog-container .wikibase-dialog').should(
+        cy.get('.wikibase-dialog').should(
             'to.contain',
             'OpenRefine Wikibase Cypress Test'
         );

--- a/main/tests/cypress/cypress/integration/extensions/wikidata/select_wikibase_instance.spec.js
+++ b/main/tests/cypress/cypress/integration/extensions/wikidata/select_wikibase_instance.spec.js
@@ -1,16 +1,20 @@
 /**
- * Delete all previsouly added wikibase instances
+ * Delete all previously added wikibase test instances
  * They are shared across project, therefore some cleanup is required to ensure a wikibase instance doesn't come from another test
  */
 function cleanupWikibases() {
     cy.get('#extension-bar-menu-container').contains('Wikidata').click();
     cy.get('.menu-container a').contains('Select Wikibase instance').click();
-    cy.get(
-        '.wikibase-dialog a:visible'
-    ).each(($el) => cy.wrap($el).click());
-    cy.get('div.dialog-container div.dialog-body ol > li > a:visible').contains('Delete').click();
-}
 
+    cy.get(
+        'div.wikibase-dialog ol.wikibase-list > li'
+    ).each(($el) => {
+        if ($el.text().includes('OpenRefine Wikibase Cypress Test')) {
+            cy.wrap($el).contains('Delete').click();
+        }
+    });
+    cy.get('.dialog-container .wikibase-dialog button').contains('OK').click();
+}
 describe(__filename, function () {
     it('Add a wikibase instance, general navigation', function () {
         //
@@ -39,7 +43,6 @@ describe(__filename, function () {
 
     it('Add a wikibase instance (URL)', function () {
         cy.loadAndVisitProject('food.mini');
-        // cleanupWikibases();
 
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
@@ -58,13 +61,13 @@ describe(__filename, function () {
         // ensure the new Wikibase is listed
         cy.get('.dialog-container .wikibase-dialog').should(
             'to.contain',
-            'OpenRefine Wikibase Test'
+            'OpenRefine Wikibase Cypress Test'
         );
+        cleanupWikibases();
     });
 
     it('Add a wikibase instance (JSON Manifest copy-pasted in the textarea)', function () {
         cy.loadAndVisitProject('food.mini');
-        // cleanupWikibases();
 
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
@@ -77,7 +80,7 @@ describe(__filename, function () {
         const manifest = {
             version: '1.0',
             mediawiki: {
-                name: 'OpenRefine Wikibase Test',
+                name: 'OpenRefine Wikibase Cypress Test',
                 root: 'https://or-wikibase-test.wiki.opencura.com/wiki/',
                 main_page: 'https://or-wikibase-test.wiki.opencura.com/wiki/Main_Page',
                 api: 'https://or-wikibase-test.wiki.opencura.com/w/api.php',
@@ -107,13 +110,13 @@ describe(__filename, function () {
         // ensure the new Wikibase is listed
         cy.get('.dialog-container .wikibase-dialog').should(
             'to.contain',
-            'Cypress Testing Wikibase Test'
+            'OpenRefine Wikibase Cypress Test'
         );
+        cleanupWikibases();
     });
 
     it('Add a wikibase instance (Invalid manifest provided)', function () {
         cy.loadAndVisitProject('food.mini');
-        // cleanupWikibases();
 
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
@@ -127,11 +130,11 @@ describe(__filename, function () {
         cy.get('.add-wikibase-dialog p.invalid-manifest')
             .should('be.visible')
             .contains('SyntaxError: Unexpected token \'T\', "This is an"... is not valid JSON');
+        cleanupWikibases();
     });
 
     it('Switch from one wikibase to another', function () {
         cy.loadAndVisitProject('food.mini');
-        // cleanupWikibases();
         cy.addWikibaseInstance(
             'https://raw.githubusercontent.com/OpenRefine/wikibase-manifests/master/openrefine-wikibase-test-manifest.json'
         );
@@ -146,8 +149,8 @@ describe(__filename, function () {
             'active'
         );
 
-        // switch to OpenRefine Wikibase Test
-        cy.get('.wikibase-dialog li').contains('OpenRefine Wikibase Test').click();
+        // switch to OpenRefine Wikibase Cypress Test
+        cy.get('.wikibase-dialog li').contains('OpenRefine Wikibase Cypress Test').click();
         cy.get('.wikibase-dialog li').should(
             'to.contain',
             'active'
@@ -159,11 +162,11 @@ describe(__filename, function () {
             'to.contain',
             'active'
         );
+        cleanupWikibases();
     });
 
     it('Remove wikibase', function () {
         cy.loadAndVisitProject('food.mini');
-        // cleanupWikibases();
         cy.addWikibaseInstance(
             'https://raw.githubusercontent.com/OpenRefine/wikibase-manifests/master/openrefine-wikibase-test-manifest.json'
         );
@@ -173,7 +176,7 @@ describe(__filename, function () {
 
         // Click on the little cross to remove the test wikibase and ensure it's been removed
         cy.get('.wikibase-dialog li')
-            .contains('OpenRefine Wikibase Test')
+            .contains('OpenRefine Wikibase Cypress Test')
             .parent()
             .parent()
             .find('.wikibase-dialog-selector-delete')
@@ -181,10 +184,11 @@ describe(__filename, function () {
 
         cy.get('.wikibase-dialog').should(
             'not.to.contain',
-            'OpenRefine Wikibase Test'
+            'OpenRefine Wikibase Cypress Test'
         );
 
         // wikidata should still be there
         cy.get('.wikibase-dialog').should('to.contain', 'Wikidata');
+        cleanupWikibases();
     });
 });

--- a/main/tests/cypress/cypress/integration/extensions/wikidata/select_wikibase_instance.spec.js
+++ b/main/tests/cypress/cypress/integration/extensions/wikidata/select_wikibase_instance.spec.js
@@ -6,9 +6,9 @@ function cleanupWikibases() {
     cy.get('#extension-bar-menu-container').contains('Wikidata').click();
     cy.get('.menu-container a').contains('Select Wikibase instance').click();
     cy.get(
-        '.wikibase-dialog table .wikibase-dialog-selector-delete'
+        '.wikibase-dialog a:visible'
     ).each(($el) => cy.wrap($el).click());
-    cy.get('.dialog-container .wikibase-dialog button').contains('Delete').click();
+    cy.get('div.dialog-container div.dialog-body ol > li > a:visible').contains('Delete').click();
 }
 
 describe(__filename, function () {
@@ -39,7 +39,7 @@ describe(__filename, function () {
 
     it('Add a wikibase instance (URL)', function () {
         cy.loadAndVisitProject('food.mini');
-        cleanupWikibases();
+        // cleanupWikibases();
 
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
@@ -64,7 +64,7 @@ describe(__filename, function () {
 
     it('Add a wikibase instance (JSON Manifest copy-pasted in the textarea)', function () {
         cy.loadAndVisitProject('food.mini');
-        cleanupWikibases();
+        // cleanupWikibases();
 
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
@@ -77,7 +77,7 @@ describe(__filename, function () {
         const manifest = {
             version: '1.0',
             mediawiki: {
-                name: 'Cypress Testing Wikibase Test',
+                name: 'OpenRefine Wikibase Test',
                 root: 'https://or-wikibase-test.wiki.opencura.com/wiki/',
                 main_page: 'https://or-wikibase-test.wiki.opencura.com/wiki/Main_Page',
                 api: 'https://or-wikibase-test.wiki.opencura.com/w/api.php',
@@ -113,7 +113,7 @@ describe(__filename, function () {
 
     it('Add a wikibase instance (Invalid manifest provided)', function () {
         cy.loadAndVisitProject('food.mini');
-        cleanupWikibases();
+        // cleanupWikibases();
 
         cy.get('#extension-bar-menu-container').contains('Wikidata').click();
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
@@ -126,12 +126,12 @@ describe(__filename, function () {
         cy.get('.add-wikibase-dialog button').contains('Add Wikibase').click();
         cy.get('.add-wikibase-dialog p.invalid-manifest')
             .should('be.visible')
-            .contains('Invalid Wikibase manifest.');
+            .contains('SyntaxError: Unexpected token \'T\', "This is an"... is not valid JSON');
     });
 
     it('Switch from one wikibase to another', function () {
         cy.loadAndVisitProject('food.mini');
-        cleanupWikibases();
+        // cleanupWikibases();
         cy.addWikibaseInstance(
             'https://raw.githubusercontent.com/OpenRefine/wikibase-manifests/master/openrefine-wikibase-test-manifest.json'
         );
@@ -140,30 +140,30 @@ describe(__filename, function () {
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
 
         // check that wikidata is selected by default
-        cy.get('.wikibase-dialog td').contains('Wikidata').click();
-        cy.get('.wikibase-dialog p[bind="currentSelectedWikibase"] a').should(
+        cy.get('.wikibase-dialog li').contains('Wikidata').click();
+        cy.get('.wikibase-dialog li').should(
             'to.contain',
-            'Wikidata'
+            'active'
         );
 
         // switch to OpenRefine Wikibase Test
-        cy.get('.wikibase-dialog td').contains('OpenRefine Wikibase Test').click();
-        cy.get('.wikibase-dialog p[bind="currentSelectedWikibase"] a').should(
+        cy.get('.wikibase-dialog li').contains('OpenRefine Wikibase Test').click();
+        cy.get('.wikibase-dialog li').should(
             'to.contain',
-            'OpenRefine Wikibase Test'
+            'active'
         );
 
         // switch back to Wikidata
-        cy.get('.wikibase-dialog td').contains('Wikidata').click();
-        cy.get('.wikibase-dialog p[bind="currentSelectedWikibase"] a').should(
+        cy.get('.wikibase-dialog li').contains('Wikidata').click();
+        cy.get('.wikibase-dialog li').should(
             'to.contain',
-            'Wikidata'
+            'active'
         );
     });
 
     it('Remove wikibase', function () {
         cy.loadAndVisitProject('food.mini');
-        cleanupWikibases();
+        // cleanupWikibases();
         cy.addWikibaseInstance(
             'https://raw.githubusercontent.com/OpenRefine/wikibase-manifests/master/openrefine-wikibase-test-manifest.json'
         );
@@ -172,8 +172,9 @@ describe(__filename, function () {
         cy.get('.menu-container a').contains('Select Wikibase instance').click();
 
         // Click on the little cross to remove the test wikibase and ensure it's been removed
-        cy.get('.wikibase-dialog td')
+        cy.get('.wikibase-dialog li')
             .contains('OpenRefine Wikibase Test')
+            .parent()
             .parent()
             .find('.wikibase-dialog-selector-delete')
             .click();

--- a/main/tests/cypress/cypress/integration/extensions/wikidata/wikibase_account.spec.js
+++ b/main/tests/cypress/cypress/integration/extensions/wikidata/wikibase_account.spec.js
@@ -1,0 +1,66 @@
+describe(__filename, function () {
+    it('Test the elements of the login panel', function () {
+        cy.loadAndVisitProject('food.mini');
+        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+        cy.get('.menu-container a').contains('Manage Wikibase account').click();
+
+        cy.get('.dialog-container').should('be.visible');
+        cy.get('.dialog-container .dialog-header').should(
+            'to.contain',
+            'Wikidata account'
+        );
+
+        cy.get('.dialog-container input#wb-username').should('be.visible');
+        cy.get('.dialog-container input#wb-password').should('be.visible');
+    });
+
+    it('Login with invalid credentials', function () {
+        cy.loadAndVisitProject('food.mini');
+        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+        cy.get('.menu-container a').contains('Manage Wikibase account').click();
+
+        cy.get('.dialog-container input#wb-username').type('cypress');
+        cy.get('.dialog-container input#wb-password').type('dummy password');
+
+        cy.get('.dialog-container button').contains('Log in').click();
+        cy.get('.dialog-container .wikibase-invalid-credentials').should(
+            'be.visible'
+        );
+    });
+
+    it('Close the panel', function () {
+        cy.loadAndVisitProject('food.mini');
+        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+        cy.get('.menu-container a').contains('Manage Wikibase account').click();
+
+        cy.get('.dialog-container button').contains('Close').click();
+
+        cy.get('.dialog-container').should('not.to.exist');
+    });
+
+    it('Login with owner only consumer credentials (invalid credentials)', function () {
+        cy.loadAndVisitProject('food.mini');
+        cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+        cy.get('.menu-container a').contains('Manage Wikibase account').click();
+
+        cy.get('.dialog-container a')
+            .contains('login with your owner-only consumer')
+            .click();
+
+        cy.get('.dialog-container input#wb-consumer-token').should('be.visible');
+        cy.get('.dialog-container input#wb-consumer-secret').should('be.visible');
+        cy.get('.dialog-container input#wb-access-token').should('be.visible');
+        cy.get('.dialog-container input#wb-access-secret').should('be.visible');
+
+        cy.get('.dialog-container button').contains('Log in').click();
+        cy.get('.dialog-container .wikibase-invalid-credentials').should(
+            'be.visible'
+        );
+
+        // switch back to regular login panel
+        cy.get('.dialog-container a')
+            .contains('login with your username/password')
+            .click();
+        cy.get('.dialog-container input#wb-username').should('be.visible');
+    });
+});

--- a/main/tests/cypress/cypress/support/ext_wikidata.js
+++ b/main/tests/cypress/cypress/support/ext_wikidata.js
@@ -5,7 +5,7 @@ Cypress.Commands.add('addWikibaseInstance', (url) => {
     cy.get('#extension-bar-menu-container').contains('Wikidata').click();
     cy.get('.menu-container a').contains('Select Wikibase instance').click();
 
-    cy.get('.dialog-container .wikibase-dialog button')
+    cy.get('.wikibase-dialog .dialog-footer button')
         .contains('Add Wikibase')
         .click();
 
@@ -16,5 +16,5 @@ Cypress.Commands.add('addWikibaseInstance', (url) => {
     );
     cy.get('.add-wikibase-dialog button').contains('Add Wikibase').click();
 
-    cy.get('.dialog-container .wikibase-dialog button').contains('Cancel').click();
+    cy.get('.wikibase-dialog .dialog-footer button').contains('Cancel').click();
 });

--- a/main/tests/cypress/cypress/support/ext_wikidata.js
+++ b/main/tests/cypress/cypress/support/ext_wikidata.js
@@ -1,0 +1,20 @@
+/**
+ * Return the .facets-container for a given facet name
+ */
+Cypress.Commands.add('addWikibaseInstance', (url) => {
+    cy.get('#extension-bar-menu-container').contains('Wikidata').click();
+    cy.get('.menu-container a').contains('Select Wikibase instance').click();
+
+    cy.get('.dialog-container .wikibase-dialog button')
+        .contains('Add Wikibase')
+        .click();
+
+    // ad a manifest
+    cy.get('.add-wikibase-dialog input[bind="manifestURLInput"]').invoke(
+        'val',
+        url
+    );
+    cy.get('.add-wikibase-dialog button').contains('Add Wikibase').click();
+
+    cy.get('.dialog-container .wikibase-dialog button').contains('Close').click();
+});

--- a/main/tests/cypress/cypress/support/ext_wikidata.js
+++ b/main/tests/cypress/cypress/support/ext_wikidata.js
@@ -16,5 +16,5 @@ Cypress.Commands.add('addWikibaseInstance', (url) => {
     );
     cy.get('.add-wikibase-dialog button').contains('Add Wikibase').click();
 
-    cy.get('.dialog-container .wikibase-dialog button').contains('Close').click();
+    cy.get('.dialog-container .wikibase-dialog button').contains('Cancel').click();
 });

--- a/main/tests/cypress/cypress/support/index.js
+++ b/main/tests/cypress/cypress/support/index.js
@@ -16,6 +16,7 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 import './openrefine_api';
+import './ext_wikidata';
 
 let token;
 


### PR DESCRIPTION
Partial fix for #3430
This PR is adapted from @fgiroud PR #3624

Changes proposed in this pull request:
- Added basic tests for the Wikibase extension that are possible without credentials:
  - Check extension is loaded
  - Check login dialog
  - Select Wikibase instance
  - Add/Delete Wikibase manifests by URL and JSON
