### PR TITLE
Remove 'url' format in Wikibase manifest JSON schema

### DIFF
--- a/extensions/wikidata/module/scripts/wikibase-manifest-schema-v1.js
+++ b/extensions/wikidata/module/scripts/wikibase-manifest-schema-v1.js
@@ -19,18 +19,15 @@ const WikibaseManifestSchemaV1 = {
         },
         "root": {
           "type": "string",
-          "format": "url",
           "pattern": "^.*/$",
           "description": "The URL of the root of the Wikibase, such as 'https://www.wikidata.org/wiki/'. The trailing slash cannot be omitted"
         },
         "main_page": {
           "type": "string",
-          "format": "url",
           "description": "The URL of the main page of the Wikibase, such as 'https://www.wikidata.org/wiki/Wikidata:Main_Page'"
         },
         "api": {
           "type": "string",
-          "format": "url",
           "description": "The MediaWiki API endpoint of the Wikibase, such as 'https://www.wikidata.org/w/api.php'"
         }
       },
@@ -42,7 +39,6 @@ const WikibaseManifestSchemaV1 = {
       "properties": {
         "site_iri": {
           "type": "string",
-          "format": "url",
           "pattern": "^.*/$",
           "description": "The IRI of the Wikibase, such as 'http://www.wikidata.org/entity/'. This should match the IRI prefixes used in RDF serialization. Be careful about using 'http' or 'https', because any variation will break comparisons at various places. The trailing slash cannot be omitted"
         },
@@ -98,7 +94,6 @@ const WikibaseManifestSchemaV1 = {
       "properties": {
         "registration_page": {
           "type": "string",
-          "format": "url",
           "description": "The url of the OAuth consumer registration page, 'https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose' for Wikidata"
         }
       },
@@ -110,7 +105,6 @@ const WikibaseManifestSchemaV1 = {
       "properties": {
         "endpoint": {
           "type": "string",
-          "format": "url",
           "pattern": "^.*\\${lang}.*$",
           "description": "The default reconciliation API endpoint of the Wikibase, the endpoint should include the language variable '${lang}', such as 'https://wikidata.reconci.link/${lang}/api'"
         }

--- a/extensions/wikidata/module/scripts/wikibase-manifest-schema-v2.js
+++ b/extensions/wikidata/module/scripts/wikibase-manifest-schema-v2.js
@@ -19,18 +19,15 @@ const WikibaseManifestSchemaV2 = {
         },
         "root": {
           "type": "string",
-          "format": "url",
           "pattern": "^.*/$",
           "description": "The URL of the root of the Wikibase, such as 'https://www.wikidata.org/wiki/'. The trailing slash cannot be omitted"
         },
         "main_page": {
           "type": "string",
-          "format": "url",
           "description": "The URL of the main page of the Wikibase, such as 'https://www.wikidata.org/wiki/Wikidata:Main_Page'"
         },
         "api": {
           "type": "string",
-          "format": "url",
           "description": "The MediaWiki API endpoint of the Wikibase, such as 'https://www.wikidata.org/w/api.php'"
         }
       },
@@ -42,7 +39,6 @@ const WikibaseManifestSchemaV2 = {
       "properties": {
         "site_iri": {
           "type": "string",
-          "format": "url",
           "pattern": "^.*/$",
           "description": "The IRI of the Wikibase, such as 'http://www.wikidata.org/entity/'. This should match the IRI prefixes used in RDF serialization. Be careful about using 'http' or 'https', because any variation will break comparisons at various places. The trailing slash cannot be omitted"
         },
@@ -98,7 +94,6 @@ const WikibaseManifestSchemaV2 = {
       "properties": {
         "registration_page": {
           "type": "string",
-          "format": "url",
           "description": "The url of the OAuth consumer registration page, 'https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration/propose' for Wikidata"
         }
       },
@@ -114,18 +109,15 @@ const WikibaseManifestSchemaV2 = {
           "properties": {
             "reconciliation_endpoint": {
               "type": "string",
-              "format": "url",
               "pattern": "^.*\\${lang}.*$",
               "description": "The default reconciliation API endpoint of the Wikibase for this entity type, the endpoint should include the language variable '${lang}', such as 'https://wikidata.reconci.link/${lang}/api'"
             },
             "site_iri": {
               "type": "string",
-              "format": "url",
               "description": "The RDF prefix in which URIs for entities of this type are minted. If entities of this type are edited locally, this should be the global site_iri of the Wikibase. If those entities are drawn from another Wikibase instance, it should be the site_iri of that instance."
             },
             "mediawiki_api": {
               "type": "string",
-              "format": "url",
               "description": "The MediaWiki API endpoint of the Wikibase, such as 'https://www.wikidata.org/w/api.php'"
             }
           },


### PR DESCRIPTION
Fixes #5035.

This simply drops the `"format": "url"` parts of the schema because AJV refuses localhost URLs for those fields. All of those URL fields can legitimately point to localhost, in particular in development environments.

Furthermore some fields do not actually hold URLs but URL templates, so the `"format": "url"` was wrong for those in the first place.

It would be more satisfying to keep some sort of validation here, but supplying a regex would bloat the manifest. Fixing the issue in AJV could also be an option, but that requires more work and it should not stand in the way of this (since this is actively preventing people from working with this).