### PR TITLE
Save schema templates when adding a wikibase.

### DIFF
--- a/extensions/wikidata/module/scripts/wikibase-manager.js
+++ b/extensions/wikidata/module/scripts/wikibase-manager.js
@@ -174,6 +174,7 @@ WikibaseManager.addWikibase = function (manifest) {
     for (let template of manifest.schema_templates) {
       WikibaseTemplateManager.addTemplate(manifest.mediawiki.name, template.name, template.schema);
     }
+    WikibaseTemplateManager.saveTemplates();
   }
   WikibaseManager.saveWikibases();
 };


### PR DESCRIPTION
Small improvement, to make sure that the schema templates are not lost if OpenRefine is closed immediately after adding a new Wikibase instance with templates in its manifest.
