### PR TITLE
Fix reconciliation dialog overflow issue.

### DIFF
--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.html
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.html
@@ -15,24 +15,18 @@
       <td width="50%"><div class="detail-container" bind="detailContainer"></div></td>
     </tr>
     <tr>
-      <td><input type="radio" name="type-choice" id="againstType" value="">
+      <td colspan="2"><input type="radio" name="type-choice" id="againstType" value="">
         <label for="againstType"><span bind="or_proc_againstType"></span></label> <input size="20" bind="typeInput" /></td>
-      <td>
-      </td>
     </tr>
     <tr>
-      <td><input type="radio" name="type-choice" id="noType" value="-">
+      <td colspan="2"><input type="radio" name="type-choice" id="noType" value="-">
         <label for="noType"><span bind="or_proc_noType"></span></label></td>
-      <td>
-      </td>
     </tr>
     <tr>
-      <td><input type="checkbox" checked bind="automatchCheck" /> <span bind="or_proc_autoMatch"></span></td>
-      <td></td>
+      <td colspan="2"><input type="checkbox" checked bind="automatchCheck" /> <span bind="or_proc_autoMatch"></span></td>
     </tr>
     <tr>
-      <td><span bind="or_proc_max_candidates"></span> <input type="number" bind="maxCandidates" min=0 max=9 width=20/> </td> 
-      <td></td>
+      <td colspan="2"><span bind="or_proc_max_candidates"></span> <input type="number" bind="maxCandidates" min=0 max=9 width=20/> </td> 
     </tr>
   </table></div>
 </div>

--- a/main/webapp/modules/core/styles/reconciliation/recon-dialog.less
+++ b/main/webapp/modules/core/styles/reconciliation/recon-dialog.less
@@ -83,6 +83,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   
 .recon-dialog-service-panel-container {
   float: left;
+  min-height: 500px;
   margin-left: 20px;
   width: 850px;
   }

--- a/main/webapp/modules/core/styles/reconciliation/recon-dialog.less
+++ b/main/webapp/modules/core/styles/reconciliation/recon-dialog.less
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 @import-less url("../theme.less");
 
 .recon-dialog-service {
-  height: 500px;
   padding: 0 0 10px;
  }
  
@@ -84,7 +83,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   
 .recon-dialog-service-panel-container {
   float: left;
-  height: 500px;
   margin-left: 20px;
   width: 850px;
   }


### PR DESCRIPTION
We plan to redesign this dialog completely - there are a lot of issues with it. This is just a fairly minimal fix to avoid its contents overflowing and hiding the "Reconcile" and "Cancel" buttons.

Closes #5285.

Changes proposed in this pull request:
- make sure the lower part of the form can expand to the full width of the dialog by uncoupling it with the separation between the two upper parts
- remove the (fairly arbitrary) `height: 500px` set on the dialog so that it can expand further down to fit its contents

New version:

![image](https://user-images.githubusercontent.com/309908/192135151-e7b22688-4aab-4610-81de-b5bd3e0fd4e2.png)

