### PR TITLE
Preserve aspect ratio of Wikibase logos

### DIFF
--- a/extensions/wikidata/module/styles/dialogs/wikibase-dialog.less
+++ b/extensions/wikidata/module/styles/dialogs/wikibase-dialog.less
@@ -39,9 +39,7 @@
 
 .wikibase-list li img {
   flex: 0 0;
-  min-height: 60px;
   max-height: 60px;
-  min-width: 60px;
   max-width: 60px;
 }
 


### PR DESCRIPTION
Fixes #5306.
# Before
![image](https://user-images.githubusercontent.com/309908/193421303-55b9f707-c3b7-4e16-8753-2126205bb42e.png)
# After
![image](https://user-images.githubusercontent.com/309908/193421550-b26ae1eb-b78f-4831-9606-8ec1628a114a.png)

