### PR TITLE
Add Caution about JAVA_HOME error to Windows tab

### DIFF
--- a/docs/versioned_docs/version-3.6/manual/running.md
+++ b/docs/versioned_docs/version-3.6/manual/running.md
@@ -49,6 +49,13 @@ On Windows, OpenRefine can also be run by using the file `refine.bat` in the pro
 If you call `refine.bat` from the command line, you can [start OpenRefine with modifications](#starting-with-modifications). 
 If you want to modify the way `refine.bat` opens through double-clicking or using a shortcut, you can edit the `refine.ini` file. 
 
+:::caution Did you get a JAVA_HOME error?
+“Error: Could not find the ‘java’ executable at ‘’, are you sure your JAVA_HOME environment variable is pointing to a proper java installation?”
+
+If you see this error, you need to [install and configure a JDK package](installing#linux), including setting up `JAVA_HOME`.
+Alternatively, you can download our "Windows Kit with embedded Java" version and skip worrying about setting up Java.
+:::
+
 #### Exiting {#exiting}
 
 To exit OpenRefine, close all the browser tabs or windows, then navigate to the command line window. To close this window and ensure OpenRefine exits properly, hold down `Control` and press `C` on your keyboard. This will save any last changes to your projects. 

--- a/docs/versioned_docs/version-3.6/manual/running.md
+++ b/docs/versioned_docs/version-3.6/manual/running.md
@@ -52,7 +52,7 @@ If you want to modify the way `refine.bat` opens through double-clicking or usin
 :::caution Did you get a JAVA_HOME error?
 “Error: Could not find the ‘java’ executable at ‘’, are you sure your JAVA_HOME environment variable is pointing to a proper java installation?”
 
-If you see this error, you need to [install and configure a JDK package](installing#java), including setting up `JAVA_HOME`.
+If you see this error, you need to [install and configure Java](installing#java), including setting up `JAVA_HOME`.
 :::
 
 #### Exiting {#exiting}

--- a/docs/versioned_docs/version-3.6/manual/running.md
+++ b/docs/versioned_docs/version-3.6/manual/running.md
@@ -52,8 +52,7 @@ If you want to modify the way `refine.bat` opens through double-clicking or usin
 :::caution Did you get a JAVA_HOME error?
 “Error: Could not find the ‘java’ executable at ‘’, are you sure your JAVA_HOME environment variable is pointing to a proper java installation?”
 
-If you see this error, you need to [install and configure a JDK package](installing#linux), including setting up `JAVA_HOME`.
-Alternatively, you can download our "Windows Kit with embedded Java" version and skip worrying about setting up Java.
+If you see this error, you need to [install and configure a JDK package](installing#java), including setting up `JAVA_HOME`.
 :::
 
 #### Exiting {#exiting}


### PR DESCRIPTION
fixes #5137

@trnstlntk Does the Netlify preview look OK and show a similar Caution banner text for the Windows tab under "Starting and exiting" as it does for the Linux tab?
I also expanded and mentioned we have a Windows Kit with embedded Java that folks can download and skip worrying about Java setup.
