### PR TITLE
Fixed flaky cluster and edit Cypress test

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/column/edit-cells/cluster-and-edit.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/edit-cells/cluster-and-edit.spec.js
@@ -111,11 +111,11 @@ describe(__filename, function () {
         cy.get('.dialog-container').within(() => {
             // check lines to be merged
             cy.get(
-                '.clustering-dialog-entry-table tr.odd input[type="checkbox"]'
+                '.clustering-dialog-entry-table tbody tr:nth-child(2) input[type="checkbox"]'
             ).check();
 
             // enter a new cell value
-            cy.get('.clustering-dialog-entry-table tr.odd input[type="text"]').type(
+            cy.get('.clustering-dialog-entry-table tbody tr:nth-child(2) input[type="text"]').type(
                 'testing'
             );
 
@@ -133,18 +133,18 @@ describe(__filename, function () {
         ]);
     });
 
-    it('Merge Select & Re Cluster', function () {
+    it.only('Merge Select & Re Cluster', function () {
         cy.loadAndVisitProject(fixture);
         cy.columnActionClick('location', ['Edit cells', 'Cluster and edit']);
 
         cy.get('.dialog-container').within(() => {
             // Merge BALLARDS RIVER
             cy.get(
-                '.clustering-dialog-entry-table tr.odd input[type="checkbox"]'
+                '.clustering-dialog-entry-table tbody tr:nth-child(2) input[type="checkbox"]'
             ).check();
 
             // enter a new cell value
-            cy.get('.clustering-dialog-entry-table tr.odd input[type="text"]').type(
+            cy.get('.clustering-dialog-entry-table tbody tr:nth-child(2) input[type="text"]').type(
                 ' TESTING A'
             );
 
@@ -154,11 +154,11 @@ describe(__filename, function () {
 
             // Merge Swabbys
             cy.get(
-                '.clustering-dialog-entry-table tr.odd input[type="checkbox"]'
+                '.clustering-dialog-entry-table tbody tr:nth-child(2) input[type="checkbox"]'
             ).check();
 
             // enter a new cell value
-            cy.get('.clustering-dialog-entry-table tr.odd input[type="text"]').type(
+            cy.get('.clustering-dialog-entry-table tbody tr:nth-child(2) input[type="text"]').type(
                 ' TESTING B'
             );
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed flakiest Cypress test in cluster and edit:
![image](https://user-images.githubusercontent.com/42903164/194671688-2fcf9003-5538-4618-a65d-7ba36b46856b.png)
