### PR TITLE
Fix failing test assert when locale is set to French.

### DIFF
--- a/main/tests/server/src/com/google/refine/expr/functions/ToStringTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/ToStringTests.java
@@ -75,5 +75,5 @@ public class ToStringTests extends RefineTest {
         assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime), "yyyy-MM-dd hh:mm:ss"), "2013-06-01 01:12:11");
         assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime), "yyyy-MM-dd HH:mm:ss"), "2013-06-01 13:12:11");
     }
-    
+
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/ToStringTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/ToStringTests.java
@@ -38,6 +38,7 @@ import com.google.refine.expr.util.CalendarParser;
 import com.google.refine.expr.util.CalendarParserException;
 
 public class ToStringTests extends RefineTest {
+
     @Test
     public void testToString() throws CalendarParserException {
         assertTrue(invoke("toString") instanceof EvalError);
@@ -74,4 +75,5 @@ public class ToStringTests extends RefineTest {
         assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime), "yyyy-MM-dd hh:mm:ss"), "2013-06-01 01:12:11");
         assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime), "yyyy-MM-dd HH:mm:ss"), "2013-06-01 13:12:11");
     }
+    
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/ToStringTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/ToStringTests.java
@@ -36,18 +36,16 @@ import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.util.CalendarParser;
 import com.google.refine.expr.util.CalendarParserException;
-import com.google.refine.util.TestUtils;
 
 public class ToStringTests extends RefineTest {
-
     @Test
     public void testToString() throws CalendarParserException {
         assertTrue(invoke("toString") instanceof EvalError);
         assertEquals(invoke("toString", (Object) null), "");
-        assertEquals(invoke("toString", Long.valueOf(100)), "100");
-        assertEquals(invoke("toString", Double.valueOf(100.0)), "100.0");
-        assertEquals(invoke("toString", Double.valueOf(100.0), "%.0f"), "100");
-        assertEquals(invoke("toString", Double.valueOf(100.0), "%.1f"), "100.0");
+        assertEquals(invoke("toString", 100L), "100");
+        assertEquals(invoke("toString", 100.0), "100.0");
+        assertEquals(invoke("toString", 100.0, "%.0f"), "100");
+        assertEquals(invoke("toString", 100.0, "%.1f"), String.format("%.1f", 100D));
 
         // test with other radix (2, 8, 10, 16)
         assertEquals(invoke("toString", 100L, "%x"), "64");
@@ -76,5 +74,4 @@ public class ToStringTests extends RefineTest {
         assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime), "yyyy-MM-dd hh:mm:ss"), "2013-06-01 01:12:11");
         assertEquals(invoke("toString", CalendarParser.parseAsOffsetDateTime(inputDateTime), "yyyy-MM-dd HH:mm:ss"), "2013-06-01 13:12:11");
     }
-
 }


### PR DESCRIPTION
Closes #5277

This changes an assert that was failing when the environment locale was set to French.

I considered forcing the locale to be en_US when tests are run but rejected this because in my opinion, tests that require a specific locale to pass are brittle and should ideally be avoided. The actual fix dynamically sets the expected value based on the locale the test is being run in, which is a more resilient solution.

While working on this issue, an inconsistency in the toString method was identified. Ideally, when the function is called on a number, it should always return a string that takes the locale into consideration. However, there is an edge case where this does not happen. The following assert is included in the `testToString` test and succeeds with a French locale when it should fail:
```
assertEquals(invoke("toString", 100.0), "100.0");
```
Fixing this would require changes to the `toString()` method itself. I spent some time looking into this but any changes I made broke the function in other ways. Given that this is a GREL function that users have been using it for some time, I chose not to dig into this further, as they have not reported this as an issue.
