### PR TITLE
Fix caching of Wikibase suggest results

### DIFF
--- a/extensions/wikidata/module/scripts/wikibase-suggest.js
+++ b/extensions/wikidata/module/scripts/wikibase-suggest.js
@@ -91,7 +91,6 @@
               self.input.data("request.count.suggest", calls);
             },
             success: function(data) {
-              $.suggest.cache[url] = data;
               // translate the results of the MediaWiki API to that of the reconciliation API
               var translated = {
                   prefix: val, // keep track of prefix to match up response with input value
@@ -100,6 +99,7 @@
                       name: result.label,
                       description: result.description};})
               };
+              $.suggest.cache[url] = translated;
               self.response(translated, cursor ? cursor : -1);
             },
             error: function(xhr) {


### PR DESCRIPTION
Closes #5190.

This bug was happening because we were storing the results of Wikibase requests incorrectly in the cache. They needed to be translated to a common format supported by the library.
