### PR TITLE
Allowed the cell edit popup and dialogs with textbox inputs to be resizable

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.html
@@ -5,16 +5,16 @@
       <tr>
         <td style="vertical-align: top"><div class="grid-layout layout-tighter layout-full" bind="controls"><table>
           <tr><td><label for="prefixTextareaId" bind="or_dialog_prefix"></label></td></tr>
-          <tr><td><div class="input-container"><textarea  spellcheck="false" bind="prefixTextarea" id="prefixTextareaId" class="code" wrap="off" style="height:5em;"></textarea></div></td></tr>
+          <tr><td><div class="input-container"><textarea  spellcheck="false" bind="prefixTextarea" id="prefixTextareaId" class="code" wrap="off" style="min-height: 5em; min-width: 430px;"></textarea></div></td></tr>
           <tr><td><label for="templateTextareaId" bind="or_dialog_rowTmpl"></label></td></tr>
-          <tr><td><div class="input-container"><textarea  spellcheck="false" bind="templateTextarea" id="templateTextareaId" class="code" wrap="off" style="height:20em;"></textarea></div></td></tr>
+          <tr><td><div class="input-container"><textarea  spellcheck="false" bind="templateTextarea" id="templateTextareaId" class="code" wrap="off" style="min-height: 20em; min-width: 430px;"></textarea></div></td></tr>
           <tr><td><label for="separatorTextareaId" bind="or_dialog_rowSep"></label></td></tr>
-          <tr><td><div class="input-container"><textarea  spellcheck="false" bind="separatorTextarea" id="separatorTextareaId" class="code" wrap="off" style="height:3em;"></textarea></div></td></tr>
+          <tr><td><div class="input-container"><textarea  spellcheck="false" bind="separatorTextarea" id="separatorTextareaId" class="code" wrap="off" style="min-height: 3em; min-width: 430px;"></textarea></div></td></tr>
           <tr><td><label for="suffixTextareaId" bind="or_dialog_suffix"></label></td></tr>
-          <tr><td><div class="input-container"><textarea  spellcheck="false" bind="suffixTextarea" id="suffixTextareaId" class="code" wrap="off" style="height:5em;"></textarea></div></td></tr>
+          <tr><td><div class="input-container"><textarea  spellcheck="false" bind="suffixTextarea" id="suffixTextareaId" class="code" wrap="off" style="min-height: 5em; min-width: 430px;"></textarea></div></td></tr>
         </table></div></td>
         <td width="50%" style="vertical-align: top">
-          <div class="input-container"><textarea aria-label="" spellcheck="false" bind="previewTextarea" class="code" wrap="off" style="height: 40em;"></textarea></div>
+          <div class="input-container"><textarea aria-label="" spellcheck="false" bind="previewTextarea" class="code" wrap="off" style="min-height: 40em; min-width: 430px;"></textarea></div>
         </td>
       </tr>
     </table></div>

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -1,9 +1,9 @@
-<div class="dialog-frame" style="width: 800px;">
+<div class="dialog-frame" style="min-width: 800px;">
   <div class="dialog-border">
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body" bind="dialogBody">
       <div class="dialog-instruction"><label for="textareaId" bind="or_proj_pasteJson"></label></div>
-      <div class="input-container"><textarea spellcheck="false" wrap="off" bind="textarea" id="textareaId" class="history-operation-json"></textarea></div>
+      <div class="input-container"><textarea spellcheck="false" wrap="off" bind="textarea" id="textareaId" class="history-operation-json" style="min-width: 764px"></textarea></div>
     </div>
     <div class="dialog-footer" bind="dialogFooter">
     <button class="button" bind="applyButton"></button>

--- a/main/webapp/modules/core/scripts/project/history-extract-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-extract-dialog.html
@@ -1,4 +1,4 @@
-<div class="dialog-frame" style="width: 800px;">
+<div class="dialog-frame" style="min-width: 800px;">
   <div class="dialog-border">
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body" bind="dialogBody">

--- a/main/webapp/modules/core/styles/project/sidebar.less
+++ b/main/webapp/modules/core/styles/project/sidebar.less
@@ -259,5 +259,6 @@ table.history-extract-dialog-entries {
 textarea.history-operation-json {
   white-space: pre;
   font-family: monospace;
-  height: 450px;
+  min-height: 450px;
+  min-width: 374px;
   }

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -363,10 +363,14 @@ a.data-table-flag-off {
   
 .data-table-cell-editor-editor {
   display: block;
-  width: 98%;
-  height: 3em;
+  min-width: 392px;
+  min-height: 3em;
   font-family: monospace;
-  margin: 3px 0;
+  margin: 3px 0px;
+  }
+
+  .data-table-cell-editor {
+  min-width: fit-content;
   }
 
 .data-table-cell-editor-action {


### PR DESCRIPTION
Changes proposed in this pull request:
- Allowed the cell edit popup and the templating, export and apply history dialogs to be resizable when changing the size of the textbox inputs.

Edit cell before:
![Edit cell resizable before](https://user-images.githubusercontent.com/42903164/195004689-bd420bb0-6da1-4235-94b8-50d560acc9b6.gif)

Edit cell after:
![Edit cell resizable](https://user-images.githubusercontent.com/42903164/195004084-fdcd3a19-126e-451e-8835-666a578c0fd3.gif)
