### PR TITLE
Migrate std lib trim to guava trim

### DIFF
--- a/main/src/com/google/refine/ProjectMetadata.java
+++ b/main/src/com/google/refine/ProjectMetadata.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.CharMatcher;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -199,7 +200,7 @@ public class ProjectMetadata {
             List<String> tmpTags = new ArrayList<String>(tags.length);
             for (String tag : tags) {
                 if (tag != null) {
-                    String trimmedTag = tag.trim();
+                    String trimmedTag = CharMatcher.whitespace().trimFrom(tag);
 
                     if (!trimmedTag.isEmpty()) {
                         tmpTags.add(trimmedTag);

--- a/main/src/com/google/refine/clustering/binning/FingerprintKeyer.java
+++ b/main/src/com/google/refine/clustering/binning/FingerprintKeyer.java
@@ -37,6 +37,7 @@ import java.text.Normalizer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -101,7 +102,7 @@ public class FingerprintKeyer extends Keyer {
 
     protected String normalize(String s, boolean strong) {
         if (strong) {
-            s = s.trim(); // first off, remove whitespace around the string
+            s = CharMatcher.whitespace().trimFrom(s); // first off, remove whitespace around the string
             s = s.toLowerCase(); // TODO: This is using the default locale. Is that what we want?
         }
         s = stripDiacritics(s);

--- a/main/src/com/google/refine/commands/project/SetProjectTagsCommand.java
+++ b/main/src/com/google/refine/commands/project/SetProjectTagsCommand.java
@@ -34,6 +34,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.common.base.CharMatcher;
 import com.google.refine.ProjectManager;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.commands.Command;
@@ -84,7 +85,7 @@ public class SetProjectTagsCommand extends Command {
         String[] newTags = newT.split(" |\\,");
         List<String> polishedTags = new ArrayList<String>(newTags.length);
         for (String tag : newTags) {
-            tag = tag.trim();
+            tag = CharMatcher.whitespace().trimFrom(tag);
 
             if (!tag.isEmpty()) {
                 if (allProjectTags != null) {

--- a/main/src/com/google/refine/commands/recon/GuessTypesOfColumnCommand.java
+++ b/main/src/com/google/refine/commands/recon/GuessTypesOfColumnCommand.java
@@ -55,6 +55,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.CharMatcher;
 import com.google.refine.commands.Command;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Column;
@@ -151,7 +152,7 @@ public class GuessTypesOfColumnCommand extends Command {
         for (Row row : project.rows) {
             Object value = row.getCellValue(cellIndex);
             if (ExpressionUtils.isNonBlankData(value)) {
-                String s = value.toString().trim();
+                String s = CharMatcher.whitespace().trimFrom(value.toString());
                 if (!sampleSet.contains(s)) {
                     samples.add(s);
                     sampleSet.add(s);

--- a/main/src/com/google/refine/expr/functions/ToDate.java
+++ b/main/src/com/google/refine/expr/functions/ToDate.java
@@ -47,6 +47,7 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
 
+import com.google.common.base.CharMatcher;
 import com.google.refine.grel.EvalErrorMessage;
 import com.google.refine.grel.FunctionDescription;
 import org.apache.commons.lang3.StringUtils;
@@ -77,7 +78,7 @@ public class ToDate implements Function {
                 return arg0;
             } else if (arg0 instanceof Long) {
                 o1 = ((Long) arg0).toString(); // treat integers as years
-            } else if (arg0 instanceof String && arg0.toString().trim().length() > 0) {
+            } else if (arg0 instanceof String && CharMatcher.whitespace().trimFrom(arg0.toString()).length() > 0) {
                 o1 = (String) arg0;
             } else {
                 // ignore cell values that aren't Date, Calendar, Long or String

--- a/main/src/com/google/refine/expr/functions/strings/Range.java
+++ b/main/src/com/google/refine/expr/functions/strings/Range.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.base.CharMatcher;
 import com.google.refine.expr.EvalError;
 import com.google.refine.grel.ControlFunctionRegistry;
 import com.google.refine.grel.EvalErrorMessage;
@@ -105,7 +106,7 @@ public class Range implements Function {
 
         // Check for valid string argument(s)
         if (range != null && range instanceof String) {
-            String rangeString = ((String) range).trim();
+            String rangeString = CharMatcher.whitespace().trimFrom((String) range);
             String[] rangeValues = rangeString.split(SEPARATOR);
 
             if (hasCommaAsLastCharacter(rangeString)) {
@@ -114,16 +115,16 @@ public class Range implements Function {
 
             try {
                 if (rangeValues.length == 1) {
-                    rangeEnd = Integer.parseInt(rangeValues[0].trim());
+                    rangeEnd = Integer.parseInt(CharMatcher.whitespace().trimFrom(rangeValues[0]));
                     return createRange(rangeStart, rangeEnd, rangeStep);
                 } else if (rangeValues.length == 2) {
-                    rangeStart = Integer.parseInt(rangeValues[0].trim());
-                    rangeEnd = Integer.parseInt(rangeValues[1].trim());
+                    rangeStart = Integer.parseInt(CharMatcher.whitespace().trimFrom(rangeValues[0]));
+                    rangeEnd = Integer.parseInt(CharMatcher.whitespace().trimFrom(rangeValues[1]));
                     return createRange(rangeStart, rangeEnd, rangeStep);
                 } else if (rangeValues.length == 3) {
-                    rangeStart = Integer.parseInt(rangeValues[0].trim());
-                    rangeEnd = Integer.parseInt(rangeValues[1].trim());
-                    rangeStep = Integer.parseInt(rangeValues[2].trim());
+                    rangeStart = Integer.parseInt(CharMatcher.whitespace().trimFrom(rangeValues[0]));
+                    rangeEnd = Integer.parseInt(CharMatcher.whitespace().trimFrom(rangeValues[1]));
+                    rangeStep = Integer.parseInt(CharMatcher.whitespace().trimFrom(rangeValues[2]));
                     return createRange(rangeStart, rangeEnd, rangeStep);
                 }
             } catch (NumberFormatException nfe) {
@@ -204,8 +205,8 @@ public class Range implements Function {
             secondArg = ((Double) secondArg).intValue();
         }
 
-        String firstArgStringified = String.valueOf(firstArg).trim();
-        String secondArgStringified = String.valueOf(secondArg).trim();
+        String firstArgStringified = CharMatcher.whitespace().trimFrom(String.valueOf(firstArg));
+        String secondArgStringified = CharMatcher.whitespace().trimFrom(String.valueOf(secondArg));
         String thirdArgStringified = "";
 
         if (hasCommaAsLastCharacter(firstArgStringified) || hasCommaAsLastCharacter(secondArgStringified)) {
@@ -224,12 +225,12 @@ public class Range implements Function {
                 hasThreeArguments = true;
 
                 if (firstArgArray.length == 1) {
-                    secondArgStringified = secondArgArray[0].trim();
-                    thirdArgStringified = secondArgArray[1].trim();
+                    secondArgStringified = CharMatcher.whitespace().trimFrom(secondArgArray[0]);
+                    thirdArgStringified = CharMatcher.whitespace().trimFrom(secondArgArray[1]);
                 } else {
-                    firstArgStringified = firstArgArray[0].trim();
-                    secondArgStringified = firstArgArray[1].trim();
-                    thirdArgStringified = secondArgArray[0].trim();
+                    firstArgStringified = CharMatcher.whitespace().trimFrom(firstArgArray[0]);
+                    secondArgStringified = CharMatcher.whitespace().trimFrom(firstArgArray[1]);
+                    thirdArgStringified = CharMatcher.whitespace().trimFrom(secondArgArray[0]);
                 }
 
             } else if (combinedArrayLength == 2) {
@@ -285,9 +286,9 @@ public class Range implements Function {
         }
 
         try {
-            int rangeStart = Integer.parseInt(String.valueOf(firstArg).trim());
-            int rangeEnd = Integer.parseInt(String.valueOf(secondArg).trim());
-            int rangeStep = Integer.parseInt(String.valueOf(thirdArg).trim());
+            int rangeStart = Integer.parseInt(CharMatcher.whitespace().trimFrom(String.valueOf(firstArg)));
+            int rangeEnd = Integer.parseInt(CharMatcher.whitespace().trimFrom(String.valueOf(secondArg)));
+            int rangeStep = Integer.parseInt(CharMatcher.whitespace().trimFrom(String.valueOf(thirdArg)));
             return createRange(rangeStart, rangeEnd, rangeStep);
         } catch (NumberFormatException nfe) {
             // + " expects a string of the form 'a, b, c' or integers a, b, c where a and b "

--- a/main/src/com/google/refine/importers/FixedWidthImporter.java
+++ b/main/src/com/google/refine/importers/FixedWidthImporter.java
@@ -40,6 +40,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.CharMatcher;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingUtilities;
@@ -97,7 +98,7 @@ public class FixedWidthImporter extends TabularImportingParserBase {
             if (strings.length > 0) {
                 retrievedColumnNames = new ArrayList<Object>();
                 for (String s : strings) {
-                    s = s.trim();
+                    s = CharMatcher.whitespace().trimFrom(s);
                     if (!s.isEmpty()) {
                         retrievedColumnNames.add(s);
                     }

--- a/main/src/com/google/refine/importers/ImporterUtilities.java
+++ b/main/src/com/google/refine/importers/ImporterUtilities.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.CharMatcher;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingUtilities;
 import com.google.refine.messages.OpenRefineMessage;
@@ -57,7 +58,7 @@ public class ImporterUtilities {
 
     static public Serializable parseCellValue(String text) {
         if (text.length() > 0) {
-            String text2 = text.trim();
+            String text2 = CharMatcher.whitespace().trimFrom(text);
             if (text2.length() > 0) {
                 try {
                     return Long.parseLong(text2);
@@ -102,7 +103,7 @@ public class ImporterUtilities {
     }
 
     static public void appendColumnName(List<String> columnNames, int index, String name) {
-        name = name.trim();
+        name = CharMatcher.whitespace().trimFrom(name);
 
         while (columnNames.size() <= index) {
             columnNames.add("");
@@ -165,7 +166,7 @@ public class ImporterUtilities {
     static public void setupColumns(Project project, List<String> columnNames) {
         Map<String, Integer> nameToIndex = new HashMap<String, Integer>();
         for (int c = 0; c < columnNames.size(); c++) {
-            String cell = columnNames.get(c).trim();
+            String cell = CharMatcher.whitespace().trimFrom(columnNames.get(c));
             if (cell.isEmpty()) {
                 cell = "Column";
             } else if (cell.startsWith("\"") && cell.endsWith("\"")) {

--- a/main/src/com/google/refine/importers/SeparatorBasedImporter.java
+++ b/main/src/com/google/refine/importers/SeparatorBasedImporter.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.base.CharMatcher;
 import org.apache.commons.text.StringEscapeUtils;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -106,7 +107,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
             if (strings.length > 0) {
                 retrievedColumnNames = new ArrayList<Object>();
                 for (String s : strings) {
-                    s = s.trim();
+                    s = CharMatcher.whitespace().trimFrom(s);
                     if (!s.isEmpty()) {
                         retrievedColumnNames.add(s);
                     }
@@ -124,8 +125,8 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
 
         Character quote = CSVParser.DEFAULT_QUOTE_CHARACTER;
         String quoteCharacter = JSONUtilities.getString(options, "quoteCharacter", null);
-        if (quoteCharacter != null && quoteCharacter.trim().length() == 1) {
-            quote = quoteCharacter.trim().charAt(0);
+        if (quoteCharacter != null && CharMatcher.whitespace().trimFrom(quoteCharacter).length() == 1) {
+            quote = CharMatcher.whitespace().trimFrom(quoteCharacter).charAt(0);
         }
 
         final CSVParser parser = new CSVParser(

--- a/main/src/com/google/refine/importers/TabularImportingParserBase.java
+++ b/main/src/com/google/refine/importers/TabularImportingParserBase.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.CharMatcher;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.importing.ImportingJob;
@@ -151,9 +152,9 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
                             // add column even if cell is blank
                             columnName = "";
                         } else if (cell instanceof Cell) {
-                            columnName = ((Cell) cell).value.toString().trim();
+                            columnName = CharMatcher.whitespace().trimFrom(((Cell) cell).value.toString());
                         } else {
-                            columnName = cell.toString().trim();
+                            columnName = CharMatcher.whitespace().trimFrom(cell.toString());
                         }
 
                         ImporterUtilities.appendColumnName(columnNames, c, columnName);
@@ -184,7 +185,7 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
                                 Serializable storedValue;
                                 if (value instanceof String) {
                                     if (trimStrings) {
-                                        value = ((String) value).trim();
+                                        value = CharMatcher.whitespace().trimFrom(((String) value));
                                     }
                                     storedValue = guessCellValueTypes ? ImporterUtilities.parseCellValue((String) value) : (String) value;
 

--- a/main/src/com/google/refine/importers/TextFormatGuesser.java
+++ b/main/src/com/google/refine/importers/TextFormatGuesser.java
@@ -75,7 +75,7 @@ public class TextFormatGuesser implements FormatGuesser {
 
                 String line;
                 while ((line = reader.readLine()) != null && controls < CONTROLS_THRESHOLD) {
-                    line = line.trim();
+                    line = CharMatcher.whitespace().trimFrom(line);
                     controls += CharMatcher.javaIsoControl().and(CharMatcher.whitespace().negate()).countIn(line);
                     openBraces += line.chars().filter(ch -> ch == '{').count();
                     closeBraces += StringUtils.countMatches(line, "}");

--- a/main/src/com/google/refine/importers/WikitextImporter.java
+++ b/main/src/com/google/refine/importers/WikitextImporter.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.base.CharMatcher;
 import org.sweble.wikitext.parser.ParserConfig;
 import org.sweble.wikitext.parser.WikitextEncodingValidator;
 import org.sweble.wikitext.parser.WikitextParser;
@@ -308,7 +309,7 @@ public class WikitextImporter extends TabularImportingParserBase {
             if (value == null) {
                 value = "";
             }
-            value = value.trim();
+            value = CharMatcher.whitespace().trimFrom(value);
             cellStringBuilder = null;
             return value;
         }

--- a/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
+++ b/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.google.common.base.CharMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -346,7 +347,7 @@ public class XmlImportUtilities extends TreeImportUtilities {
         if (value instanceof String) {
             String text = (String) value;
             if (trimStrings) {
-                text = text.trim();
+                text = CharMatcher.whitespace().trimFrom(text);
             }
             if (text.length() > 0 | !storeEmptyStrings) {
                 record = new ImportRecord();
@@ -442,7 +443,7 @@ public class XmlImportUtilities extends TreeImportUtilities {
         for (int i = 0; i < attributeCount; i++) {
             String text = parser.getAttributeValue(i);
             if (trimStrings) {
-                text = text.trim();
+                text = CharMatcher.whitespace().trimFrom(text);
             }
             if (text.length() > 0 | !storeEmptyStrings) {
                 addCell(
@@ -475,7 +476,7 @@ public class XmlImportUtilities extends TreeImportUtilities {
                 if (value instanceof String) {
                     String text = (String) value;
                     if (trimStrings) {
-                        text = text.trim();
+                        text = CharMatcher.whitespace().trimFrom(text);
                     }
                     addCell(project, thisColumnGroup, record, colName, text,
                             storeEmptyStrings, guessDataType);

--- a/main/src/com/google/refine/model/Row.java
+++ b/main/src/com/google/refine/model/Row.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.InjectableValues;
+import com.google.common.base.CharMatcher;
 import com.google.refine.expr.CellTuple;
 import com.google.refine.expr.HasFields;
 import com.google.refine.util.ParsingUtilities;
@@ -144,7 +145,7 @@ public class Row implements HasFields {
     }
 
     protected boolean isValueBlank(Object value) {
-        return value == null || (value instanceof String && ((String) value).trim().length() == 0);
+        return value == null || (value instanceof String && CharMatcher.whitespace().trimFrom((String) value).length() == 0);
     }
 
     public void setCell(int cellIndex, Cell cell) {


### PR DESCRIPTION
Fixes #5105 

Changes proposed in this pull request:
- All uses of the std lib String trim have been migrated to Guava's implementation of trim

I have also tested the csv file from #5246 to verify that the NBSP's are catered for.