### PR TITLE
Add logging dependencies for test scope. Fixes #5338

### DIFF
--- a/extensions/database/pom.xml
+++ b/extensions/database/pom.xml
@@ -143,7 +143,12 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/extensions/gdata/pom.xml
+++ b/extensions/gdata/pom.xml
@@ -113,6 +113,12 @@
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/extensions/jython/pom.xml
+++ b/extensions/jython/pom.xml
@@ -84,6 +84,12 @@
       <version>${testng.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/extensions/phonetic/pom.xml
+++ b/extensions/phonetic/pom.xml
@@ -71,7 +71,7 @@
       <scope>provided</scope>
     </dependency>
 
-   <!-- add here the dependencies of your extension -->
+   <!-- test dependencies -->
 
     <dependency>
       <groupId>org.testng</groupId>
@@ -79,6 +79,13 @@
       <version>${testng.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/extensions/wikidata/pom.xml
+++ b/extensions/wikidata/pom.xml
@@ -138,6 +138,18 @@
       <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -161,18 +161,18 @@
       <artifactId>butterfly</artifactId>
       <version>${butterfly.version}</version>
       <exclusions>
-	<exclusion>
+        <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-	  <artifactId>log4j-1.2-api</artifactId>
-	</exclusion>
-	<exclusion>
+          <artifactId>log4j-1.2-api</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-	  <artifactId>log4j-slf4j-impl</artifactId>
-	</exclusion>
-	<exclusion>
+          <artifactId>log4j-slf4j2-impl</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
-	  <artifactId>log4j-core</artifactId>
-	</exclusion>
+          <artifactId>log4j-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -246,10 +246,10 @@
       <artifactId>poi</artifactId>
       <version>${poi.version}</version>
       <exclusions>
-	<exclusion>
-      	  <groupId>org.apache.logging.log4j</groupId>
-	  <artifactId>log4j-api</artifactId>
-	</exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -257,10 +257,10 @@
       <artifactId>poi-ooxml</artifactId>
       <version>${poi.version}</version>
       <exclusions>
-	<exclusion>
-      	  <groupId>org.apache.logging.log4j</groupId>
-	  <artifactId>log4j-api</artifactId>
-	</exclusion>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -393,5 +393,12 @@
       <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>


### PR DESCRIPTION
Fixes #5338

Adds necessary logging dependencies to the test scope so that logging works for unit tests.
