### PR TITLE
Fixed flaky Cypress tests and cleaned up the logic on the include/exclude filters tests in facets.spec

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/column/facet/facets.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/facet/facets.spec.js
@@ -204,65 +204,44 @@ describe(__filename, function () {
     cy.loadAndVisitProject('food.small');
     cy.columnActionClick('Shrt_Desc', ['Facet', 'Text facet']);
 
-    // force visibility
-    cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice-toggle')
-      .invoke('attr', 'style', 'visibility:visible');
-
     // include ALLSPICE,GROUND, and check rows
     cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice')
       .contains('ALLSPICE,GROUND')
       .parent()
-      .find('.facet-choice-toggle')
+      .trigger('mouseover')
+      .contains('include')
       .click();
     cy.getCell(0, 'Shrt_Desc').should('to.contain', 'ALLSPICE,GROUND');
     cy.get('#tool-panel').contains('1 matching rows');
 
-    // OR is refreshing facets, need to show the toggle again
-    cy.waitForOrOperation();
-    cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice-toggle')
-      .invoke('attr', 'style', 'visibility:visible');
-
+    cy.wait(0);
     // include CELERY SEED, and check rows
     cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice')
       .contains('ANISE SEED')
       .parent()
-      .find('.facet-choice-toggle')
+      .trigger('mouseover')
+      .contains('include')
       .click();
     cy.getCell(1, 'Shrt_Desc').should('to.contain', 'ANISE SEED');
     cy.get('#tool-panel').contains('2 matching rows');
 
-    // OR ir refreshing facets, need to show the toggle again
-    cy.waitForOrOperation();
-    cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice-toggle')
-      .invoke('attr', 'style', 'visibility:visible');
-
+    cy.wait(0);
     // include a third one, CELERY SEED, and check rows
     cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice')
       .contains('BUTTER OIL,ANHYDROUS')
       .parent()
-      .find('.facet-choice-toggle')
+      .trigger('mouseover')
+      .contains('include')
       .click();
     cy.getCell(0, 'Shrt_Desc').should('to.contain', 'BUTTER OIL,ANHYDROUS'); // this row is added first
     cy.get('#tool-panel').contains('3 matching rows');
-
-    // OR ir refreshing facets, need to show the toggle again
-    cy.waitForOrOperation();
-    cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice-toggle')
-      .invoke('attr', 'style', 'visibility:visible');
-
+    
+    cy.wait(0);
     // EXCLUDE ALLSPICE,GROUND
     cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice')
       .contains('ALLSPICE,GROUND')
       .parent()
-      .find('.facet-choice-toggle')
+      .contains('exclude')
       .click();
     cy.get('#tool-panel').contains('2 matching rows');
   });
@@ -296,7 +275,6 @@ describe(__filename, function () {
 
     // remove invert
     cy.getFacetContainer('Shrt_Desc').find('a[bind="invertButton"]').click();
-    cy.waitForOrOperation();
     cy.get('#tool-panel').contains('1 matching rows');
   });
 

--- a/main/tests/cypress/cypress/integration/project/undo_redo/undo_redo.spec.js
+++ b/main/tests/cypress/cypress/integration/project/undo_redo/undo_redo.spec.js
@@ -71,7 +71,6 @@ describe(__filename, function () {
     cy.get(
       '.history-panel-body .history-past a.history-entry:last-of-type'
     ).click();
-    cy.waitForOrOperation();
     cy.get('.history-panel-body .history-past').should(
       'to.contain',
       'Remove column NDB_No'
@@ -88,7 +87,6 @@ describe(__filename, function () {
     cy.get(
       '.history-panel-body .history-past a.history-entry:last-of-type'
     ).click();
-    cy.waitForOrOperation();
     cy.get('.history-panel-body .history-now').should(
       'to.contain',
       'Remove column NDB_No'

--- a/main/tests/cypress/cypress/integration/tutorial/layout-of-openrefine.spec.js
+++ b/main/tests/cypress/cypress/integration/tutorial/layout-of-openrefine.spec.js
@@ -1,4 +1,4 @@
-// librarycarpentry.org/lc-open-refine/03-working-with-data/index.html
+ // librarycarpentry.org/lc-open-refine/03-working-with-data/index.html
 
 describe(__filename, function () {
   it('Working with rows and records in openrefine', function () {
@@ -30,9 +30,6 @@ describe(__filename, function () {
     // Click the Records option to change to Records mode,
     // Note how the numbering has changed - indicating that several rows are related to the same record
     cy.get('span[bind="modeSelectors"]').contains('records').click();
-
-    cy.get('body[ajax_in_progress="true"]');
-    cy.get('body[ajax_in_progress="false"]');
 
     cy.get('#summary-bar').should('to.contain', '1001 records');
 

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -266,6 +266,13 @@ Cypress.Commands.add('navigateTo', (target) => {
 
 /**
  * Wait for OpenRefine to finish an Ajax load
+ *
+ * @deprecated
+ *
+ * NOTE: This command is unreliable because if you call it after starting an operation e.g. with a click(), the loading
+ * indicator may have come and gone already by the time waitForOrOperation() is called, causing the cypress test to
+ * wait forever on ajax_in_progress=true until it fails due to timeout.
+ *
  */
 Cypress.Commands.add('waitForOrOperation', () => {
   cy.get('body[ajax_in_progress="true"]');


### PR DESCRIPTION
This PR fixes two flaky tests which were due to this error:

`Timed out retrying after 4000ms: Expected to find element: body[ajax_in_progress="true"], but never found it.`

Following tests show this same error:
* Test include/exclude filters (facets.spec.js)
* Delete 3 columns, then successively undo and redo the modifications using the Undo/Redo panel (undo_redo.spec.js)

The tests are flaky because they are waiting for the loading indicator to appear, and then disappear. However, if the background task finishes quickly enough, the indicator appears and disappears, or just never appears, and the test is stuck waiting for the loading indicator to appear, resulting in a timeout and test failure.

```
  cy.get('body[ajax_in_progress="true"]');  // <= may get stuck here
  cy.get('body[ajax_in_progress="false"]'); //
```

Some tests are calling `cy.waitForOrOperation()` which does the same thing:

```
/**
 * Wait for OpenRefine to finish an Ajax load
 */
Cypress.Commands.add('waitForOrOperation', () => {
  cy.get('body[ajax_in_progress="true"]');
  cy.get('body[ajax_in_progress="false"]');
});

```

Solution:
Instead of checking for the loading indicator appearing/disappearing, just wait for the expected result after the operation completes.

There are still several tests calling `cy.waitForOperation()`, including the #3 flaky and #4 flaky on the dashboard. Those may be fixed in future PRs.

I have also put a @deprecated tag and comment on the `cy.waitForOperation()` function.  

![image](https://user-images.githubusercontent.com/42903164/195969195-27e8f2a5-602b-4746-8cf6-4c1b0d32f6fa.png)
