### PR TITLE
Made the textarea for the edit cell/text facet editors larger

### DIFF
--- a/main/webapp/modules/core/scripts/facets/list-facet.js
+++ b/main/webapp/modules/core/scripts/facets/list-facet.js
@@ -610,6 +610,8 @@ class ListFacet extends Facet {
     .trigger('select')
     .trigger('focus');
 
+    setInitialHeightTextArea(elmts.textarea[0]);
+
     elmts.cancelButton.on('click',function() {
       MenuSystem.dismissAll();
     });

--- a/main/webapp/modules/core/scripts/util/misc.js
+++ b/main/webapp/modules/core/scripts/util/misc.js
@@ -87,3 +87,12 @@ function formatRelativeDate(d) {
 function daysIntoYear(date){
   return (Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) - Date.UTC(date.getFullYear(), 0, 0)) / 24 / 60 / 60 / 1000;
 }
+
+function setInitialHeightTextArea(textarea) {
+  const textareaStyle = getComputedStyle(textarea);
+  const fontSizePx = textareaStyle.fontSize;
+  const fontSize = Number(fontSizePx.replace(/px$/, ''));
+  let initialHeight = Math.max(textarea.scrollHeight,Math.round(3*1.1*fontSize));
+  initialHeight = Math.min(initialHeight,Math.round(15*1.1*fontSize));
+  textarea.style.height = initialHeight+'px';
+}

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -715,6 +715,8 @@ DataTableCellUI.prototype._startEdit = function(elmt) {
   .trigger('select')
   .trigger('focus');
 
+  setInitialHeightTextArea(elmts.textarea[0]);
+
   elmts.cancelButton.on('click',function() {
     MenuSystem.dismissAll();
   });

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -365,6 +365,7 @@ a.data-table-flag-off {
   display: block;
   min-width: 392px;
   min-height: 3em;
+  line-height: 1.1;
   font-family: monospace;
   margin: 3px 0px;
   }


### PR DESCRIPTION
Fixes #5349

Increased the initial height for the cell and text facet editor when the content has more rows. Minimum initial height is 3 rows; maximum initial height is 15 rows (5x more than before). Scrollbars are displayed if the content has more than 15 rows.

The user can still manually make the textarea even taller if they want.  See recording for examples.

![edit-cell-larger-size](https://user-images.githubusercontent.com/42903164/196600031-37fc8435-f823-4f98-a378-33bf2afab0d5.gif)
