### PR TITLE
Exclude generated code tables from JaCoCo - fixes #5353

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -146,6 +146,17 @@
             </includeOnlyProperties>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>org/marc4j/converter/impl/*CodeTableGenerated*</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 


### PR DESCRIPTION
Fixes #5353

Exclude a large generated module from instrumentation so that we don't get an error on it.