### PR TITLE
Disable cluster and edit dialog while it is clustering

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.html
@@ -1,4 +1,4 @@
-<div class="dialog-frame" style="width: 1000px;">
+<div id="cluster-and-edit-dialog" class="dialog-frame" style="width: 1000px;">
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body clustering-dialog-body" bind="dialogBody">
         <div>
@@ -9,17 +9,17 @@
         <div class="clustering-dialog-control-row">
             <div>
                 <label for="methodSelectorId" bind="or_dialog_method"></label>
-                <select bind="methodSelector" id="methodSelectorId" disabled>
+                <select bind="methodSelector" id="methodSelectorId">
                 <option selected="true" bind="or_dialog_keyCollision"></option>
                 <option bind="or_dialog_neighbor"></option>
             </select>
             </div>
             <div>
                 <div class="binning-controls"><label for="keyingFunctionSelectorId" bind="or_dialog_keying"></label>
-                    <select bind="keyingFunctionSelector" id="keyingFunctionSelectorId" disabled></select>
+                    <select bind="keyingFunctionSelector" id="keyingFunctionSelectorId"></select>
                 </div>
                 <div class="knn-controls hidden"><label for="distanceFunctionSelectorId" bind="or_dialog_distance"></label>
-                    <select bind="distanceFunctionSelector" id="distanceFunctionSelectorId" disabled></select>
+                    <select bind="distanceFunctionSelector" id="distanceFunctionSelectorId"></select>
                 </div>
             </div>
             <div>
@@ -49,16 +49,16 @@
             <div bind="facetContainer"></div>
         </div>
     </div>
-    <div class="dialog-footer clustering-dialog-footer" bind="dialogFooter" style="justify-content: space-between">
+    <div class="dialog-footer" bind="dialogFooter" style="justify-content: space-between">
         <div class="dialog-footer-bg">
-            <button class="button" bind="selectAllButton" disabled></button>
-            <button class="button" bind="deselectAllButton" disabled></button>
+            <button class="button" bind="selectAllButton"></button>
+            <button class="button" bind="deselectAllButton"></button>
         </div>
         <div class="dialog-footer-bg">
-            <button class="button" bind="exportClusterButton" disabled></button>
-            <button class="button button-primary" bind="applyReClusterButton" disabled></button>
-            <button class="button" bind="applyCloseButton" disabled></button>
-            <button class="button" bind="closeButton" disabled></button>
+            <button class="button" bind="exportClusterButton"></button>
+            <button class="button button-primary" bind="applyReClusterButton"></button>
+            <button class="button" bind="applyCloseButton"></button>
+            <button class="button" bind="closeButton"></button>
         </div>
     </div>
 </div>

--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.html
@@ -9,17 +9,17 @@
         <div class="clustering-dialog-control-row">
             <div>
                 <label for="methodSelectorId" bind="or_dialog_method"></label>
-                <select bind="methodSelector" id="methodSelectorId">
+                <select bind="methodSelector" id="methodSelectorId" disabled>
                 <option selected="true" bind="or_dialog_keyCollision"></option>
                 <option bind="or_dialog_neighbor"></option>
             </select>
             </div>
             <div>
                 <div class="binning-controls"><label for="keyingFunctionSelectorId" bind="or_dialog_keying"></label>
-                    <select bind="keyingFunctionSelector" id="keyingFunctionSelectorId"></select>
+                    <select bind="keyingFunctionSelector" id="keyingFunctionSelectorId" disabled></select>
                 </div>
                 <div class="knn-controls hidden"><label for="distanceFunctionSelectorId" bind="or_dialog_distance"></label>
-                    <select bind="distanceFunctionSelector" id="distanceFunctionSelectorId"></select>
+                    <select bind="distanceFunctionSelector" id="distanceFunctionSelectorId" disabled></select>
                 </div>
             </div>
             <div>
@@ -49,16 +49,16 @@
             <div bind="facetContainer"></div>
         </div>
     </div>
-    <div class="dialog-footer" bind="dialogFooter" style="justify-content: space-between">
+    <div class="dialog-footer clustering-dialog-footer" bind="dialogFooter" style="justify-content: space-between">
         <div class="dialog-footer-bg">
-            <button class="button" bind="selectAllButton"></button>
-            <button class="button" bind="deselectAllButton"></button>
+            <button class="button" bind="selectAllButton" disabled></button>
+            <button class="button" bind="deselectAllButton" disabled></button>
         </div>
         <div class="dialog-footer-bg">
-            <button class="button" bind="exportClusterButton"></button>
-            <button class="button button-primary" bind="applyReClusterButton"></button>
-            <button class="button" bind="applyCloseButton"></button>
-            <button class="button" bind="closeButton"></button>
+            <button class="button" bind="exportClusterButton" disabled></button>
+            <button class="button button-primary" bind="applyReClusterButton" disabled></button>
+            <button class="button" bind="applyCloseButton" disabled></button>
+            <button class="button" bind="closeButton" disabled></button>
         </div>
     </div>
 </div>

--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
@@ -121,6 +121,8 @@ ClusteringDialog.prototype._createDialog = function() {
     this._elmts.applyCloseButton.on('click',function() { self._onApplyClose(); });
     this._elmts.closeButton.on('click',function() { self._dismiss(); });
 
+    self._level = DialogSystem.showDialog(dialog);
+
     // Fill in all the keyers and distances
     $.get("command/core/get-clustering-functions-and-distances")
     .done(function(data) {
@@ -153,7 +155,6 @@ ClusteringDialog.prototype._createDialog = function() {
              option.prop('selected', 'true');
           }
        }
-       self._level = DialogSystem.showDialog(dialog);
     })
     .fail(function(error) {
             alert($.i18n('core-dialogs/no-clustering-functions-and-distances'));
@@ -306,7 +307,7 @@ ClusteringDialog.prototype._renderTable = function(clusters) {
 };
 
 ClusteringDialog.prototype._cluster = function() {
-    $('body > div.dialog-container.ui-draggable :input').prop('disabled', true);
+    $('#cluster-and-edit-dialog :input').prop('disabled', true);
     $(".clustering-dialog-facet").css("display","none");
     var self = this;
 
@@ -330,6 +331,7 @@ ClusteringDialog.prototype._cluster = function() {
         function(data) {
             self._updateData(data);
             $(".clustering-dialog-facet").css("display","block");
+            $('#cluster-and-edit-dialog :input').prop('disabled', false);
         },
         "json"
     );
@@ -366,7 +368,6 @@ ClusteringDialog.prototype._updateData = function(data) {
 
     this._resetFacets();
     this._updateAll();
-    $('body > div.dialog-container.ui-draggable :input').prop('disabled', false);
 };
 
 ClusteringDialog.prototype._selectAll = function() {

--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
@@ -306,6 +306,7 @@ ClusteringDialog.prototype._renderTable = function(clusters) {
 };
 
 ClusteringDialog.prototype._cluster = function() {
+    $('body > div.dialog-container.ui-draggable :input').prop('disabled', true);
     $(".clustering-dialog-facet").css("display","none");
     var self = this;
 
@@ -365,6 +366,7 @@ ClusteringDialog.prototype._updateData = function(data) {
 
     this._resetFacets();
     this._updateAll();
+    $('body > div.dialog-container.ui-draggable :input').prop('disabled', false);
 };
 
 ClusteringDialog.prototype._selectAll = function() {

--- a/main/webapp/modules/core/styles/dialogs/clustering-dialog.less
+++ b/main/webapp/modules/core/styles/dialogs/clustering-dialog.less
@@ -127,12 +127,6 @@ table.clustering-dialog-entry-table a:hover {
   text-align: center;
   color: #888;
   }
-.clustering-dialog-footer :disabled {
-  opacity: 0.5;
-}
-.clustering-dialog-footer button:hover:disabled  {
-  border: 1px solid #bbb !important;
-}
 .clustering-dialog-value-focus {
   text-align: right;
   font-size: 80%;

--- a/main/webapp/modules/core/styles/dialogs/clustering-dialog.less
+++ b/main/webapp/modules/core/styles/dialogs/clustering-dialog.less
@@ -127,7 +127,12 @@ table.clustering-dialog-entry-table a:hover {
   text-align: center;
   color: #888;
   }
-
+.clustering-dialog-footer :disabled {
+  opacity: 0.5;
+}
+.clustering-dialog-footer button:hover:disabled  {
+  border: 1px solid #bbb !important;
+}
 .clustering-dialog-value-focus {
   text-align: right;
   font-size: 80%;

--- a/main/webapp/modules/core/styles/util/dialog.less
+++ b/main/webapp/modules/core/styles/util/dialog.less
@@ -93,6 +93,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   column-gap: 5px;
 }
 
+.dialog-footer :disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.dialog-footer button:hover:disabled  {
+  border: 1px solid #bbb !important;
+}
+
 .dialog-busy {
   width: 400px;
   border: none;


### PR DESCRIPTION
Fixes #5283

Changes proposed in this pull request:
- Disable the cluster and edit dialog while it is clustering.
- Add CSS for disabled dialog footer buttons.

After:
![Cluster and edit disable while processing](https://user-images.githubusercontent.com/42903164/197322095-0f5ce627-a41b-4e28-8701-974c7c93508e.gif)

