### PR TITLE
Fixed flaky export project tests to properly verify downloads

### DIFF
--- a/main/tests/cypress/cypress/integration/project/project-header/export_project.spec.js
+++ b/main/tests/cypress/cypress/integration/project/project-header/export_project.spec.js
@@ -18,6 +18,25 @@ describe(__filename, function () {
       })
     })
   }
+
+  // Ref: https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__download/cypress/e2e/utils.js
+  const path = require('path')
+  function validateFile(filename,length=10) {
+    const downloadsFolder = Cypress.config('downloadsFolder')
+    const downloadedFilename = path.join(downloadsFolder, filename)
+
+    // ensure the file has been saved before trying to parse it
+    cy.readFile(downloadedFilename, 'binary', {timeout: 15000})
+        .should((buffer) => {
+          // by having length assertion we ensure the file has text
+          // since we don't know when the browser finishes writing it to disk
+
+          // Tip: use expect() form to avoid dumping binary contents
+          // of the buffer into the Command Log
+          expect(buffer.length).to.be.gte(length);
+        });
+  }
+
   it('Export a project through "OpenRefine project archive to file"', function () {
 
     cy.loadAndVisitProject(fixture, Date.now());
@@ -29,7 +48,7 @@ describe(__filename, function () {
       .click();
 
     cy.get('.app-path-section').invoke('text').then((name)=>{
-      cy.readFile(`cypress/downloads/${name}.openrefine.tar.gz`).should('not.be.empty');
+      validateFile(`${name}.openrefine.tar.gz`);
     });
 
   });
@@ -43,7 +62,7 @@ describe(__filename, function () {
       .contains('Tab-separated value')
       .click();
     cy.get('.app-path-section').invoke('text').then((name)=>{
-      cy.readFile(`cypress/downloads/${name}.tsv`).should('not.be.empty');
+      validateFile(`${name}.tsv`);
     });
   });
   it('Export a project through "Comma-separated value"', function () {
@@ -56,7 +75,7 @@ describe(__filename, function () {
       .contains('Comma-separated value')
       .click();
     cy.get('.app-path-section').invoke('text').then((name)=> {
-      cy.readFile(`cypress/downloads/${name}.csv`).should('not.be.empty');
+      validateFile(`${name}.csv`);
     });
   });
   it('Export a project through "HTML table"', function () {
@@ -70,7 +89,7 @@ describe(__filename, function () {
       .click();
 
     cy.get('.app-path-section').invoke('text').then((name)=>{
-      cy.readFile(`cypress/downloads/${name}.html`).should('not.be.empty');
+      validateFile(`${name}.html`);
     });
 
   });
@@ -85,7 +104,7 @@ describe(__filename, function () {
       .click();
 
     cy.get('.app-path-section').invoke('text').then((name)=>{
-      cy.readFile(`cypress/downloads/${name}.xls`).should('not.be.empty');
+      validateFile(`${name}.xls`);
     });
 
   });
@@ -100,7 +119,7 @@ describe(__filename, function () {
       .click();
 
     cy.get('.app-path-section').invoke('text').then((name)=>{
-      cy.readFile(`cypress/downloads/${name}.xlsx`).should('not.be.empty');
+      validateFile(`${name}.xlsx`);
     });
 
   });
@@ -115,7 +134,7 @@ describe(__filename, function () {
       .click();
 
     cy.get('.app-path-section').invoke('text').then((name)=>{
-      cy.readFile(`cypress/downloads/${name}.ods`).should('not.be.empty');
+      validateFile(`${name}.ods`);
     });
 
   });
@@ -132,7 +151,7 @@ describe(__filename, function () {
     cy.get('button[bind="downloadButton"]').click();
 
     cy.get('.app-path-section').invoke('text').then((name)=>{
-      cy.readFile(`cypress/downloads/${name}.tsv`).should('not.be.empty');
+      validateFile(`${name}.tsv`);
     });
 
   });
@@ -149,7 +168,7 @@ describe(__filename, function () {
     cy.get('button[bind="downloadButton"]').click();
 
     cy.get('.app-path-section').invoke('text').then((name)=>{
-      cy.readFile(`cypress/downloads/${name}.sql`).should('not.be.empty');
+      validateFile(`${name}.sql`);
     });
 
   });
@@ -161,11 +180,12 @@ describe(__filename, function () {
     cy.get('.menu-container a')
       .contains('Templating')
       .click();
+
     triggerLoadEvent();
     cy.get('button[bind="exportButton"]').click();
 
     cy.get('.app-path-section').invoke('text').then((name)=>{
-      cy.readFile(`cypress/downloads/${name}.txt`).should('not.be.empty');
+      validateFile(`${name}.txt`);
     });
 
   });


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed flaky export project tests failing with error:
`Timed out retrying after 4000ms: cy.readFile("cypress/downloads/1659083769462.xlsx") failed because the file does not exist at the following path:
`

The old code would return as soon as file was created, but possibly before file contents were flushed to disk, so sometimes the file would be empty (filesize: 0).

Solution:
Use Cypress's file download recipe to check that the downloaded files have contents. (Ref: https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__download/cypress/e2e/utils.js)
