### PR TITLE
Fixed flaky test in facets.numeric.spec.js

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/column/facet/facets.numeric.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/facet/facets.numeric.spec.js
@@ -62,15 +62,16 @@ describe(__filename, function () {
     cy.get('#refine-tabs-facets .facets-container li:first-child a[bind="changeButton"]').click();
     cy.typeExpression('value.toNumber()');
     cy.get('.dialog-footer button').contains('OK').click();
-    cy.get('#refine-tabs-facets').should('exist');
+
+    cy.get('.browsing-panel-indicator').should("not.be.visible")
 
     cy.getNumericFacetContainer('Magnesium').find('#facet-0-numeric').click();
     cy.get('#summary-bar').contains('11 matching rows');
-
-    cy.waitForOrOperation();
+    cy.get('.browsing-panel-indicator').should("not.be.visible");
 
     cy.getNumericFacetContainer('Magnesium').find('#facet-0-error').click();
     cy.get('#summary-bar').contains('0 matching rows');
+    cy.get('.browsing-panel-indicator').should("not.be.visible");
 
     cy.getNumericFacetContainer('Magnesium').contains('reset').click();
     cy.get('#summary-bar').contains('199 rows');


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes the 'Test for checkboxes and reset button' Cypress test,  which was using cy.waitForOperation() which is a problem on faster machines.

When the test fails, the following error is visible:
```
Timed out retrying after 4000ms: Expected to find element: body[ajax_in_progress="true"], but never found it.
```

See the previous PR https://github.com/OpenRefine/OpenRefine/pull/5342 for further explanation.
