### PR TITLE
Add option to import Excel as text only. Closes #4838

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -155,6 +155,7 @@
     "core-index-parser/invalid-wikitext": "No table could be parsed. Are you sure this is a valid wiki table?",
     "core-index-parser/store-source": "Store file source",
     "core-index-parser/store-archive": "Store archive file",
+    "core-index-parser/force-text": "Import all cells as text",
     "core-index-parser/preserve-empty": "Preserve empty strings",
     "core-index-parser/trim": "Trim leading &amp; trailing whitespace from strings",
     "core-index-parser/json-parser": "Click on the first JSON { } node corresponding to the first record to load.",

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.html
@@ -49,6 +49,8 @@
         <td><label for="$include-file-sources" id="or-import-source"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="includeArchiveFileCheckbox" id="$include-archive-file" /></td>
         <td><label for="$include-archive-file" id="or-import-archive"></label></td></tr>
+      <tr><td width="1%"><input type="checkbox" bind="forceTextCheckbox" id="$force-text" /></td>
+        <td><label for="$force-text" id="or-force-text"></label></td></tr>
     </table></div></td>
   </tr>
 </table></div>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.js
@@ -109,6 +109,7 @@ Refine.ExcelParserUI.prototype.getOptions = function() {
   options.storeBlankCellsAsNulls = this._optionContainerElmts.storeBlankCellsAsNullsCheckbox[0].checked;
   options.includeFileSources = this._optionContainerElmts.includeFileSourcesCheckbox[0].checked;
   options.includeArchiveFileName = this._optionContainerElmts.includeArchiveFileCheckbox[0].checked;
+  options.forceText = this._optionContainerElmts.forceTextCheckbox[0].checked;
 
   options.disableAutoPreview = this._optionContainerElmts.disableAutoPreviewCheckbox[0].checked;
 
@@ -141,6 +142,7 @@ Refine.ExcelParserUI.prototype._initialize = function() {
   $('#or-import-null').text($.i18n('core-index-parser/store-nulls'));
   $('#or-import-source').html($.i18n('core-index-parser/store-source'));
   $('#or-import-archive').html($.i18n('core-index-parser/store-archive'));
+  $('#or-force-text').html($.i18n('core-index-parser/force-text'));
 
   var sheetTable = this._optionContainerElmts.sheetRecordContainer[0];
   $.each(this._config.sheetRecords, function(i, v) {
@@ -193,6 +195,9 @@ Refine.ExcelParserUI.prototype._initialize = function() {
   }
   if (this._config.includeArchiveFileName) {
     this._optionContainerElmts.includeArchiveFileCheckbox.prop("checked", true);
+  }
+  if (this._config.forceText) {
+    this._optionContainerElmts.forceTextCheckbox.prop("checked", true);
   }
 
   if (this._config.disableAutoPreview) {


### PR DESCRIPTION
Fixes #4838

Adds an option (default=False) to import all cell values using a textual rendering, rather than the value that is stored in Excel. 

This can be useful for datatypes which aren't supported by OpenRefine such as times, dates, intervals or where the datatype information is only available in the format string (e.g. integers).