### PR TITLE
Added a fix to remove the cy.wait(500) on the cy.typeExpression() command

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/misc/expressions.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/misc/expressions.spec.js
@@ -249,7 +249,7 @@ describe(__filename, function () {
     // Star the expression
     loadExpressionPanel();
     cy.get('#expression-preview-tabs li').contains('History').click();
-    cy.get('.expression-preview-table-wrapper tr td')
+    cy.get('tbody > tr:nth-child(2) > td:nth-child(5)')
       .contains(uniqueExpression)
       .parent()
       .find('a.data-table-star-off')

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -293,8 +293,7 @@ Cypress.Commands.add('waitForImportUpdate', () => {
  * Need to wait for OpenRefine to preview the result, hence the cy.wait
  */
 Cypress.Commands.add('typeExpression', (expression) => {
-  let expressionLength = expression.length;
-  if(expressionLength <= 30) {
+  if (expression.length <= 30) {
     cy.get('textarea.expression-preview-code').type(expression);
     cy.get('tbody > tr:nth-child(1) > td:nth-child(3)').should('contain',expression);
   } else {

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -293,8 +293,15 @@ Cypress.Commands.add('waitForImportUpdate', () => {
  * Need to wait for OpenRefine to preview the result, hence the cy.wait
  */
 Cypress.Commands.add('typeExpression', (expression) => {
-  cy.get('textarea.expression-preview-code').type(expression);
-  cy.wait(500); // eslint-disable-line
+  let expressionLength = expression.length;
+  if(expressionLength <= 30) {
+    cy.get('textarea.expression-preview-code').type(expression);
+    cy.get('tbody > tr:nth-child(1) > td:nth-child(3)').should('contain',expression);
+  } else {
+    cy.get('textarea.expression-preview-code').type(expression);
+    cy.get('tbody > tr:nth-child(1) > td:nth-child(3)').should('contain',expression.substring(0,30) + ' ...');
+  }
+
 });
 
 /**


### PR DESCRIPTION
Changes proposed in this pull request:
- Updated the `typeExpression` Cypress command to be able to work without `cy.wait(500)`.
