### PR TITLE
Update refine.bat

### DIFF
--- a/refine.bat
+++ b/refine.bat
@@ -75,20 +75,7 @@ goto end
 set OPTS=
 
 :endConfigReading
-
-rem --- Check JAVA_HOME ---------------------------------------------
-
-if not "%JAVA_HOME%" == "" goto gotJavaHome
-echo You must set JAVA_HOME to point at your Java Development Kit installation
-echo.
-echo If you don't know how to do this, follow the instructions at
-echo.
-echo   http://bit.ly/1c2gkR
-echo.
-
-goto fail
-:gotJavaHome
-
+														 
 rem --- Argument parsing --------------------------------------------
 
 :loop
@@ -158,6 +145,19 @@ for /f "tokens=1,* delims==" %%a in (%REFINE_INI_PATH%) do (
 )
 
 :endArgumentParsing
+
+rem --- Check JAVA_HOME ---------------------------------------------
+
+if not "%JAVA_HOME%" == "" goto gotJavaHome
+echo You must set JAVA_HOME to point at your Java Development Kit installation
+echo.
+echo If you don't know how to do this, follow the instructions at
+echo.
+echo   http://bit.ly/1c2gkR
+echo.
+
+goto fail
+:gotJavaHome			
 
 rem --- Fold in Environment Vars --------------------------------------------
 


### PR DESCRIPTION
The "Read ini file" part should be above the "Check JAVA_HOME" part. In the refine.ini file a custom JAVA_HOME can be defined and if JAVA_HOME is checked before reading the ini file, the custom JAVA_HOME setting is never used.

Fixes #5384

Changes proposed in this pull request:
- Read the contents of the refine.ini file before checking JAVA_HOME variable
