### PR TITLE
Changed keystrokeDelay to 0ms to make Cypress tests with cy.type run faster

### DIFF
--- a/main/tests/cypress/cypress.json
+++ b/main/tests/cypress/cypress.json
@@ -3,7 +3,6 @@
   "keystrokeDelay": 0,
   "viewportWidth": 1280,
   "viewportHeight": 768,
-  "keystrokeDelay": 0,
   "retries": {
     "runMode": 3,
     "openMode": 0

--- a/main/tests/cypress/cypress.json
+++ b/main/tests/cypress/cypress.json
@@ -2,6 +2,7 @@
   "integrationFolder": "./cypress/integration",
   "viewportWidth": 1280,
   "viewportHeight": 768,
+  "keystrokeDelay": 0,
   "retries": {
     "runMode": 3,
     "openMode": 0

--- a/main/tests/cypress/cypress.json
+++ b/main/tests/cypress/cypress.json
@@ -1,5 +1,6 @@
 {
   "integrationFolder": "./cypress/integration",
+  "keystrokeDelay": 0,
   "viewportWidth": 1280,
   "viewportHeight": 768,
   "keystrokeDelay": 0,


### PR DESCRIPTION
Running the entire test suite locally takes 451 seconds with the default 10ms keystroke delay, and 426 seconds with 0ms delay.

Changes proposed in this pull request:
- Changed `keystrokeDelay` to 0ms to make Cypress tests with `.type` run faster.

Before (10 ms):
![keystroke-10delay](https://user-images.githubusercontent.com/42903164/200259451-d0488d0f-7bed-4e20-9f93-595af7b1eb68.gif)

After (0ms):
![keystroke-0delay](https://user-images.githubusercontent.com/42903164/200259534-00442cff-7a83-4d85-97e1-f56cd66b09a4.gif)
