### PR TITLE
Preserve pagination after actions which trigger an update of the grid

### DIFF
--- a/extensions/database/module/scripts/index/database-import-controller.js
+++ b/extensions/database/module/scripts/index/database-import-controller.js
@@ -309,7 +309,7 @@ Refine.DatabaseImportController.prototype._getPreviewData = function(callback, n
             result.rowModel = data;
             callback(result);
           },
-          "jsonp"
+          "json"
         );
       },
       "json"

--- a/extensions/wikibase/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikibase/module/scripts/dialogs/perform-edits-dialog.js
@@ -60,7 +60,7 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
         tag: WikibaseManager.getSelectedWikibaseTagTemplate(),
         maxEditsPerMinute: WikibaseManager.getSelectedWikibaseMaxEditsPerMinute()
       },
-      { includeEngine: true, cellsChanged: true, columnStatsChanged: true },
+      { includeEngine: true, cellsChanged: true, columnStatsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true },
       { onDone: function() { dismiss(); } }
     );
   };

--- a/extensions/wikibase/src/org/openrefine/wikibase/schema/WikibaseSchema.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/schema/WikibaseSchema.java
@@ -201,7 +201,7 @@ public class WikibaseSchema implements OverlayModel {
             throw new IllegalStateException("The schema has not been validated before being evaluated");
         }
         List<EntityEdit> result = new ArrayList<>();
-        for (IndexedRow indexedRow : grid.iterateRows(engine.combinedRowFilters(), SortingConfig.NO_SORTING)) {
+        for (IndexedRow indexedRow : grid.iterateRows(engine.combinedRowFilters())) {
             ExpressionContext ctxt = new ExpressionContext(
                     siteIri,
                     entityTypeSiteIri,

--- a/main/src/main/java/org/openrefine/commands/expr/PreviewExpressionCommand.java
+++ b/main/src/main/java/org/openrefine/commands/expr/PreviewExpressionCommand.java
@@ -201,7 +201,12 @@ public class PreviewExpressionCommand extends Command {
                 Properties bindings = ExpressionUtils.createBindings();
 
                 if (Mode.RowBased.equals(engine.getMode())) {
-                    List<IndexedRow> rows = state.getRows(engine.combinedRowFilters(), sortingConfig, 0, limit);
+                    GridState sorted = state;
+                    if (!SortingConfig.NO_SORTING.equals(sortingConfig)) {
+                        // TODO cache appropriately
+                        sorted = state.reorderRows(sortingConfig, false);
+                    }
+                    List<IndexedRow> rows = sorted.getRowsAfter(engine.combinedRowFilters(), 0, limit);
                     for (IndexedRow indexedRow : rows) {
                         Cell cell = indexedRow.getRow().getCell(cellIndex);
                         Record record = null;
@@ -210,7 +215,12 @@ public class PreviewExpressionCommand extends Command {
                                         repeat, repeatCount));
                     }
                 } else {
-                    List<Record> records = state.getRecords(engine.combinedRecordFilters(), sortingConfig, 0, limit);
+                    GridState sorted = state;
+                    if (!SortingConfig.NO_SORTING.equals(sortingConfig)) {
+                        // TODO cache appropriately
+                        sorted = state.reorderRecords(sortingConfig, false);
+                    }
+                    List<Record> records = sorted.getRecordsAfter(engine.combinedRecordFilters(), 0, limit);
                     for (Record record : records) {
                         for (IndexedRow indexedRow : record.getIndexedRows()) {
                             Cell cell = indexedRow.getRow().getCell(cellIndex);

--- a/main/src/main/java/org/openrefine/commands/recon/GuessTypesOfColumnCommand.java
+++ b/main/src/main/java/org/openrefine/commands/recon/GuessTypesOfColumnCommand.java
@@ -149,7 +149,7 @@ public class GuessTypesOfColumnCommand extends Command {
         List<String> samples = new ArrayList<String>(sampleSize);
         Set<String> sampleSet = new HashSet<String>();
 
-        for (IndexedRow row : gridState.getRows(0, sampleSize)) {
+        for (IndexedRow row : gridState.getRowsAfter(0, sampleSize)) {
             Object value = row.getRow().getCellValue(cellIndex);
             if (ExpressionUtils.isNonBlankData(value)) {
                 String s = CharMatcher.whitespace().trimFrom(value.toString());

--- a/main/src/main/java/org/openrefine/commands/recon/PreviewExtendDataCommand.java
+++ b/main/src/main/java/org/openrefine/commands/recon/PreviewExtendDataCommand.java
@@ -135,7 +135,11 @@ public class PreviewExtendDataCommand extends Command {
 
             GridState state = project.getCurrentGridState();
             Engine engine = new Engine(state, engineConfig);
-            List<IndexedRow> previewRows = state.getRows(engine.combinedRowFilters(), sortingConfig, 0, limit);
+            GridState sorted = state;
+            if (!SortingConfig.NO_SORTING.equals(sortingConfig)) {
+                sorted = sorted.reorderRows(sortingConfig, false);
+            }
+            List<IndexedRow> previewRows = state.getRowsAfter(engine.combinedRowFilters(),0, limit);
             for (IndexedRow indexedRow : previewRows) {
                 try {
                     Row row = indexedRow.getRow();

--- a/main/src/main/java/org/openrefine/commands/recon/PreviewExtendDataCommand.java
+++ b/main/src/main/java/org/openrefine/commands/recon/PreviewExtendDataCommand.java
@@ -139,7 +139,7 @@ public class PreviewExtendDataCommand extends Command {
             if (!SortingConfig.NO_SORTING.equals(sortingConfig)) {
                 sorted = sorted.reorderRows(sortingConfig, false);
             }
-            List<IndexedRow> previewRows = state.getRowsAfter(engine.combinedRowFilters(),0, limit);
+            List<IndexedRow> previewRows = state.getRowsAfter(engine.combinedRowFilters(), 0, limit);
             for (IndexedRow indexedRow : previewRows) {
                 try {
                     Row row = indexedRow.getRow();

--- a/main/src/test/java/org/openrefine/commands/row/GetRowsCommandTest.java
+++ b/main/src/test/java/org/openrefine/commands/row/GetRowsCommandTest.java
@@ -82,6 +82,7 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         } ],\n" +
                 "         \"flagged\" : false,\n" +
                 "         \"i\" : 0,\n" +
+                "         \"k\" : 0,\n" +
                 "         \"starred\" : false\n" +
                 "       }, {\n" +
                 "         \"cells\" : [ null, {\n" +
@@ -89,6 +90,7 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         } ],\n" +
                 "         \"flagged\" : false,\n" +
                 "         \"i\" : 1,\n" +
+                "         \"k\" : 1,\n" +
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
@@ -99,7 +101,7 @@ public class GetRowsCommandTest extends CommandTestBase {
         when(request.getParameter("engine")).thenReturn("{\"mode\":\"row-based\",\"facets\":[]}");
         when(request.getParameter("limit")).thenReturn("2");
         command.doPost(request, response);
-        TestUtils.assertEqualAsJson(rowJson, writer.toString());
+        TestUtils.assertEqualsAsJson(writer.toString(), rowJson);
     }
 
     @Test
@@ -116,6 +118,7 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         } ],\n" +
                 "         \"flagged\" : false,\n" +
                 "         \"i\" : 0,\n" +
+                "         \"k\" : 0,\n" +
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
@@ -150,6 +153,7 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         } ],\n" +
                 "         \"flagged\" : false,\n" +
                 "         \"i\" : 0,\n" +
+                "         \"k\" : 0,\n" +
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
@@ -179,6 +183,7 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         \"flagged\" : false,\n" +
                 "         \"i\" : 0,\n" +
                 "         \"j\" : 0,\n" +
+                "         \"k\" : 0,\n" +
                 "         \"starred\" : false\n" +
                 "       }, {\n" +
                 "         \"cells\" : [ null, {\n" +
@@ -186,6 +191,7 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         } ],\n" +
                 "         \"flagged\" : false,\n" +
                 "         \"i\" : 1,\n" +
+                "         \"k\" : 1,\n" +
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
@@ -214,6 +220,7 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         \"flagged\" : false,\n" +
                 "         \"i\" : 0,\n" +
                 "         \"j\" : 0,\n" +
+                "         \"k\" : 0,\n" +
                 "         \"starred\" : false\n" +
                 "       }, {\n" +
                 "         \"cells\" : [ null, {\n" +
@@ -221,6 +228,7 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         } ],\n" +
                 "         \"flagged\" : false,\n" +
                 "         \"i\" : 1,\n" +
+                "         \"k\" : 1,\n" +
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
@@ -256,6 +264,7 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         \"flagged\" : false,\n" +
                 "         \"i\" : 0,\n" +
                 "         \"j\" : 0,\n" +
+                "         \"k\" : 0," +
                 "         \"starred\" : false\n" +
                 "       }, {\n" +
                 "         \"cells\" : [ null, {\n" +
@@ -263,6 +272,7 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         } ],\n" +
                 "         \"flagged\" : false,\n" +
                 "         \"i\" : 1,\n" +
+                "         \"k\" : 1,\n" +
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +

--- a/main/src/test/java/org/openrefine/commands/row/GetRowsCommandTest.java
+++ b/main/src/test/java/org/openrefine/commands/row/GetRowsCommandTest.java
@@ -69,7 +69,7 @@ public class GetRowsCommandTest extends CommandTestBase {
     }
 
     @Test
-    public void testJsonOutputRows() throws ServletException, IOException {
+    public void testJsonOutputRowsStart() throws ServletException, IOException {
         String rowJson = "{\n" +
                 "       \"filtered\" : 5,\n" +
                 "       \"limit\" : 2,\n" +
@@ -94,12 +94,123 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
+                "       \"nextPageId\": 2,\n" +
                 "       \"total\" : 5,\n" +
+                "       \"totalRows\" : 5,\n" +
                 "       \"processed\": 5\n" +
                 "     }";
 
         when(request.getParameter("engine")).thenReturn("{\"mode\":\"row-based\",\"facets\":[]}");
+        when(request.getParameter("start")).thenReturn("0");
         when(request.getParameter("limit")).thenReturn("2");
+        command.doPost(request, response);
+        TestUtils.assertEqualsAsJson(writer.toString(), rowJson);
+    }
+
+    @Test
+    public void testJsonOutputRowsStartWithNoNextPage() throws ServletException, IOException {
+        String rowJson = "{\n" +
+                "       \"filtered\" : 5,\n" +
+                "       \"limit\" : 2,\n" +
+                "       \"mode\" : \"row-based\",\n" +
+                "       \"rows\" : [ {\n" +
+                "         \"cells\" : [ {\n" +
+                "           \"v\" : \"a\"\n" +
+                "         }, {\n" +
+                "           \"v\" : \"b\"\n" +
+                "         } ],\n" +
+                "         \"flagged\" : false,\n" +
+                "         \"i\" : 0,\n" +
+                "         \"k\" : 0,\n" +
+                "         \"starred\" : false\n" +
+                "       }, {\n" +
+                "         \"cells\" : [ null, {\n" +
+                "           \"v\" : \"c\"\n" +
+                "         } ],\n" +
+                "         \"flagged\" : false,\n" +
+                "         \"i\" : 1,\n" +
+                "         \"k\" : 1,\n" +
+                "         \"starred\" : false\n" +
+                "       } ],\n" +
+                "       \"start\" : 0,\n" +
+                "       \"nextPageId\": 2,\n" +
+                "       \"total\" : 5,\n" +
+                "       \"totalRows\" : 5,\n" +
+                "       \"processed\": 5\n" +
+                "     }";
+
+        when(request.getParameter("engine")).thenReturn("{\"mode\":\"row-based\",\"facets\":[]}");
+        when(request.getParameter("start")).thenReturn("0");
+        when(request.getParameter("limit")).thenReturn("2");
+        command.doPost(request, response);
+        TestUtils.assertEqualsAsJson(writer.toString(), rowJson);
+    }
+
+    @Test
+    public void testJsonOutputRowsEnd() throws ServletException, IOException {
+        String rowJson = "{\n" +
+                "       \"filtered\" : 5,\n" +
+                "       \"limit\" : 1,\n" +
+                "       \"mode\" : \"row-based\",\n" +
+                "       \"rows\" : [ {\n" +
+                "         \"cells\" : [ null, {\n" +
+                "           \"v\" : \"c\"\n" +
+                "         } ],\n" +
+                "         \"flagged\" : false,\n" +
+                "         \"i\" : 1,\n" +
+                "         \"k\" : 1,\n" +
+                "         \"starred\" : false\n" +
+                "       } ],\n" +
+                "       \"end\" : 2,\n" +
+                "       \"previousPageId\": 1,\n" +
+                "       \"nextPageId\": 2,\n" +
+                "       \"total\" : 5,\n" +
+                "       \"totalRows\" : 5,\n" +
+                "       \"processed\": 5\n" +
+                "     }";
+
+        when(request.getParameter("engine")).thenReturn("{\"mode\":\"row-based\",\"facets\":[]}");
+        when(request.getParameter("end")).thenReturn("2");
+        when(request.getParameter("limit")).thenReturn("1");
+        command.doPost(request, response);
+        TestUtils.assertEqualsAsJson(writer.toString(), rowJson);
+    }
+
+    @Test
+    public void testJsonOutputRowsEndWithNoPreviousPage() throws ServletException, IOException {
+        String rowJson = "{\n" +
+                "       \"filtered\" : 5,\n" +
+                "       \"limit\" : 2,\n" +
+                "       \"mode\" : \"row-based\",\n" +
+                "       \"rows\" : [ {" +
+                "         \"cells\": [ {\n" +
+                "            \"v\" : \"a\"\n" +
+                "           }, {\n" +
+                "            \"v\" : \"b\"\n" +
+                "         } ],\n" +
+                "         \"flagged\" : false,\n" +
+                "         \"i\" : 0,\n" +
+                "         \"k\" : 0,\n" +
+                "         \"starred\" : false\n" +
+                "       }, {\n" +
+                "         \"cells\" : [ null, {\n" +
+                "           \"v\" : \"c\"\n" +
+                "         } ],\n" +
+                "         \"flagged\" : false,\n" +
+                "         \"i\" : 1,\n" +
+                "         \"k\" : 1,\n" +
+                "         \"starred\" : false\n" +
+                "       } ],\n" +
+                "       \"end\" : 2,\n" +
+                "       \"nextPageId\": 2,\n" +
+                "       \"total\" : 5,\n" +
+                "       \"totalRows\" : 5,\n" +
+                "       \"processed\": 5\n" +
+                "     }";
+
+        when(request.getParameter("engine")).thenReturn("{\"mode\":\"row-based\",\"facets\":[]}");
+        when(request.getParameter("end")).thenReturn("2");
+        when(request.getParameter("limit")).thenReturn("3");
         command.doPost(request, response);
         TestUtils.assertEqualsAsJson(writer.toString(), rowJson);
     }
@@ -122,11 +233,14 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
+                "       \"nextPageId\": 1,\n" +
                 "       \"total\" : 5,\n" +
+                "       \"totalRows\" : 5,\n" +
                 "       \"processed\": 5\n" +
                 "     }";
 
         when(request.getParameter("engine")).thenReturn("{\"mode\":\"row-based\",\"facets\":[],\"aggregationLimit\":2}");
+        when(request.getParameter("start")).thenReturn("0");
         when(request.getParameter("limit")).thenReturn("1");
         command.doPost(request, response);
         TestUtils.assertEqualsAsJson(writer.toString(), rowJson);
@@ -157,11 +271,14 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
+                "       \"nextPageId\": 1,\n" +
                 "       \"total\" : 5,\n" +
+                "       \"totalRows\" : 5,\n" +
                 "       \"processed\": 2\n" +
                 "     }";
 
         when(request.getParameter("engine")).thenReturn(engineConfig);
+        when(request.getParameter("start")).thenReturn("0");
         when(request.getParameter("limit")).thenReturn("1");
 
         command.doPost(request, response);
@@ -195,11 +312,14 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
+                "       \"nextPageId\": 2,\n" +
                 "       \"total\" : 3,\n" +
+                "       \"totalRows\" : 5,\n" +
                 "       \"processed\": 3\n" +
                 "     }";
 
         when(request.getParameter("engine")).thenReturn("{\"mode\":\"record-based\",\"facets\":[]}");
+        when(request.getParameter("start")).thenReturn("0");
         when(request.getParameter("limit")).thenReturn("1");
         command.doPost(request, response);
         TestUtils.assertEqualAsJson(recordJson, writer.toString());
@@ -232,11 +352,14 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
+                "       \"nextPageId\": 2,\n" +
                 "       \"total\" : 3,\n" +
+                "       \"totalRows\" : 5,\n" +
                 "       \"processed\": 3\n" +
                 "     }";
 
         when(request.getParameter("engine")).thenReturn("{\"mode\":\"record-based\",\"facets\":[],\"aggregationLimit\":2}");
+        when(request.getParameter("start")).thenReturn("0");
         when(request.getParameter("limit")).thenReturn("1");
         command.doPost(request, response);
         TestUtils.assertEqualsAsJson(writer.toString(), recordJson);
@@ -276,11 +399,14 @@ public class GetRowsCommandTest extends CommandTestBase {
                 "         \"starred\" : false\n" +
                 "       } ],\n" +
                 "       \"start\" : 0,\n" +
+                "       \"nextPageId\": 2,\n" +
                 "       \"total\" : 3,\n" +
+                "       \"totalRows\" : 5,\n" +
                 "       \"processed\": 2\n" +
                 "     }";
 
         when(request.getParameter("engine")).thenReturn(engineConfig);
+        when(request.getParameter("start")).thenReturn("0");
         when(request.getParameter("limit")).thenReturn("1");
         command.doPost(request, response);
         TestUtils.assertEqualsAsJson(writer.toString(), recordJson);

--- a/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/pagination.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/pagination.spec.js
@@ -27,7 +27,7 @@ describe(__filename, function () {
   it('Test the "next" button', function () {
     cy.loadAndVisitProject('food.small');
     cy.get('.viewpanel-paging').find('a').contains('next').click();
-    cy.get('#viewpanel-paging-current-input').should('have.value', 2);
+    cy.get('#viewpanel-paging-current-min-row').should('have.value', 11);
     cy.assertCellEquals(0, 'Shrt_Desc', 'CHEESE,COLBY');
     cy.assertCellEquals(9, 'Shrt_Desc', 'CHEESE,FONTINA');
   });
@@ -37,11 +37,11 @@ describe(__filename, function () {
 
     // First go next
     cy.get('.viewpanel-paging').find('a').contains('next').click();
-    cy.get('#viewpanel-paging-current-input').should('have.value', 2);
+    cy.get('#viewpanel-paging-current-min-row').should('have.value', 11);
 
     // Then test the previous button
     cy.get('.viewpanel-paging').find('a').contains('previous').click();
-    cy.get('#viewpanel-paging-current-input').should('have.value', 1);
+    cy.get('#viewpanel-paging-current-min-row').should('have.value', 1);
     cy.assertCellEquals(0, 'Shrt_Desc', 'BUTTER,WITH SALT');
     cy.assertCellEquals(9, 'Shrt_Desc', 'CHEESE,CHESHIRE');
   });
@@ -50,9 +50,9 @@ describe(__filename, function () {
     cy.loadAndVisitProject('food.small');
 
     cy.get('.viewpanel-paging').find('a').contains('last').click();
-    cy.get('#viewpanel-paging-current-input').should('have.value', 20);
-    cy.assertCellEquals(0, 'Shrt_Desc', 'SPICES,BASIL,DRIED');
-    cy.assertCellEquals(8, 'Shrt_Desc', 'CLOVES,GROUND');
+    cy.get('#viewpanel-paging-current-min-row').should('have.value', 190);
+    cy.assertCellEquals(0, 'Shrt_Desc', 'ANISE SEED');
+    cy.assertCellEquals(9, 'Shrt_Desc', 'CLOVES,GROUND');
   });
 
   it('Test the "first" button', function () {
@@ -60,11 +60,11 @@ describe(__filename, function () {
 
     // First go next
     cy.get('.viewpanel-paging').find('a').contains('next').click();
-    cy.get('#viewpanel-paging-current-input').should('have.value', 2);
+    cy.get('#viewpanel-paging-current-min-row').should('have.value', 11);
 
-    // Then test the previous button
+    // Then test the First button
     cy.get('.viewpanel-paging').find('a').contains('first').click();
-    cy.get('#viewpanel-paging-current-input').should('have.value', 1);
+    cy.get('#viewpanel-paging-current-min-row').should('have.value', 1);
     cy.assertCellEquals(0, 'Shrt_Desc', 'BUTTER,WITH SALT');
     cy.assertCellEquals(9, 'Shrt_Desc', 'CHEESE,CHESHIRE');
   });
@@ -72,8 +72,8 @@ describe(__filename, function () {
   it('Test entering an arbitrary page number', function () {
     cy.loadAndVisitProject('food.small');
 
-    cy.get('#viewpanel-paging-current-input').type('{backspace}2{enter}');
-    cy.get('#viewpanel-paging-current-input').should('have.value', 2);
+    cy.get('#viewpanel-paging-current-min-row').type('{backspace}11{enter}');
+    cy.get('#viewpanel-paging-current-min-row').should('have.value', 11);
     cy.assertCellEquals(0, 'Shrt_Desc', 'CHEESE,COLBY');
     cy.assertCellEquals(9, 'Shrt_Desc', 'CHEESE,FONTINA');
   });

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -633,7 +633,6 @@
     "core-views/move-to-left": "Move column left",
     "core-views/move-to-right": "Move column right",
     "core-views/show-as": "Show as",
-    "core-views/goto-page": "$1 of $2 {{plural:$2|page|pages}}",
     "core-views/first": "first",
     "core-views/previous": "previous",
     "core-views/next": "next",

--- a/main/webapp/modules/core/langs/translation-es.json
+++ b/main/webapp/modules/core/langs/translation-es.json
@@ -522,7 +522,6 @@
     "core-views/to-text/header": "A texto",
     "core-views/to-text/single": "A texto",
     "core-views/reg-exp": "expresión regular",
-    "core-views/goto-page": "$1 de $2 {{plural:$2|página|paginas}}",
     "core-views/word-facet": "Faceta por palabra",
     "core-views/collapse-left": "Contraer todas las columnas a la izquierda",
     "core-views/clear-recon": "Quitar la información de cotejo",

--- a/main/webapp/modules/core/langs/translation-fr.json
+++ b/main/webapp/modules/core/langs/translation-fr.json
@@ -536,7 +536,6 @@
     "core-views/to-text": "En texte…",
     "core-views/to-text/header": "En texte",
     "core-views/to-text/single": "En texte",
-    "core-views/goto-page": "$1 de $2 {{plural:$2|page|pages}}",
     "core-views/first": "première",
     "core-views/word-facet": "Facette par mot",
     "core-views/check-format": "Merci de vérifier le format du fichier.",

--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
@@ -424,7 +424,7 @@ ClusteringDialog.prototype._apply = function(onDone) {
                 expression: this._expression,
                 edits: JSON.stringify(edits)
             },
-            { cellsChanged: true },
+            { cellsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true },
             {
                 onError: function(o) {
                     alert("Error: " + o.message);

--- a/main/webapp/modules/core/scripts/dialogs/column-reordering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/column-reordering-dialog.js
@@ -92,7 +92,7 @@ ColumnReorderingDialog.prototype._commit = function() {
         "reorder-columns",
         null,
         { "columnNames" : JSON.stringify(columnNames) }, 
-        { modelsChanged: true },
+        { modelsChanged: true, rowIdsPreserved: true }, // TODO could add recordIdsPreserved: true if the record key column did not change
         { includeEngine: false }
     );
     

--- a/main/webapp/modules/core/scripts/dialogs/common-transform-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/common-transform-dialog.js
@@ -117,7 +117,7 @@ commonTransformDialog.prototype._commit = function(expression) {
           repeatCount: repeatCount
         },
         null,
-        { cellsChanged: true }
+        { cellsChanged: true, rowIdsPreserved: true }
       );
   };
 

--- a/main/webapp/modules/core/scripts/dialogs/expression-column-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-column-dialog.js
@@ -10,7 +10,7 @@ var doTextTransform = function(columnName, expression, onError, repeat, repeatCo
         repeatCount: repeatCount
       },
       null,
-      { cellsChanged: true }
+      { cellsChanged: true, rowIdsPreserved: true }
     );
 };
 

--- a/main/webapp/modules/core/scripts/index/default-importing-controller/controller.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-controller/controller.js
@@ -274,7 +274,7 @@ Refine.DefaultImportingController.prototype.getPreviewData = function(callback, 
 			  result.rowModel = data;
 			  callback(result);
 		  },
-        "jsonp"
+        "json"
 	   ).fail(() => { alert($.i18n('core-index/rows-loading-failed')); });
     },
     "json"

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -315,8 +315,9 @@ Refine.createUpdateFunction = function(options, onFinallyDone) {
     pushFunction(Refine.reinitializeProjectData);
   }
   if (options.everythingChanged || options.modelsChanged || options.rowsChanged || options.rowMetadataChanged || options.cellsChanged || options.engineChanged) {
+    var preservePage = options.rowIdsPreserved && (options.recordIdsPreserved || ui.browsingEngine.getMode() === "row-based");
     pushFunction(function(onDone) {
-      ui.dataTableView.update(onDone);
+      ui.dataTableView.update(onDone, preservePage);
     });
     pushFunction(function(onDone) {
       ui.browsingEngine.update(onDone);

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -502,7 +502,11 @@ Refine.columnNameToColumnIndex = function(columnName) {
   return -1;
 };
 
-Refine.fetchRows = function(start, limit, onDone, sorting) {
+/*
+  Fetch rows after or before a given row id. The engine configuration can also
+  be used to set filters (facets) or switch between rows/records mode.
+*/
+Refine.fetchRows = function(paginationOptions, limit, onDone, sorting) {
   var body = {
     engine: JSON.stringify(ui.browsingEngine.getJSON())
   };
@@ -511,7 +515,7 @@ Refine.fetchRows = function(start, limit, onDone, sorting) {
   }
 
   $.post(
-    "command/core/get-rows?" + $.param({ project: theProject.id, start: start, limit: limit }),
+    "command/core/get-rows?" + $.param({ ...paginationOptions, project: theProject.id, limit: limit }),
     body,
     function(data) {
       if(data.code === "error") {

--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -337,7 +337,7 @@ ReconStandardServicePanel.prototype.start = function() {
         limit: parseInt(this._elmts.maxCandidates[0].value) || 0
       })
     },
-    { cellsChanged: true, columnStatsChanged: true }
+    { cellsChanged: true, columnStatsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
   );
 };
 

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -493,7 +493,7 @@ DataTableCellUI.prototype._postProcessSeveralCells = function(command, params, b
     command, 
     params, 
     bodyParams,
-    { cellsChanged: true, columnStatsChanged: columnStatsChanged }
+    { cellsChanged: true, columnStatsChanged: columnStatsChanged, rowIdsPreserved: true, recordIdsPreserved: true }
   );
 };
 

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -44,10 +44,7 @@ function DataTableView(div) {
   this._columnHeaderUIs = [];
   this._shownulls = false;
 
-  this._currentPageNumber = 1;
   this._showRows(0);
-  
-  this._refocusPageInput = false;
 }
 
 DataTableView._extenders = [];
@@ -85,7 +82,6 @@ DataTableView.prototype.resize = function() {
 };
 
 DataTableView.prototype.update = function(onDone) {
-  this._currentPageNumber = 1;
   this._showRows(0, onDone);
 };
 
@@ -114,7 +110,6 @@ DataTableView.prototype.render = function() {
     '</div>'
   );
   var elmts = DOM.bind(html);
-  this._div.empty().append(html);
 
   ui.summaryBar.updateResultCount();
 
@@ -142,6 +137,7 @@ DataTableView.prototype.render = function() {
   }
 
   this._renderDataTables(elmts.table[0], elmts.tableHeader[0]);
+  this._div.empty().append(html);
 
   // show/hide null values in cells
   $(".data-table-null").toggle(self._shownulls);
@@ -167,8 +163,6 @@ DataTableView.prototype._renderSortingControls = function(sortingControls) {
 DataTableView.prototype._renderPagingControls = function(pageSizeControls, pagingControls) {
   var self = this;
 
-  self._lastPageNumber = Math.floor((theProject.rowModel.filtered - 1) / this._pageSize) + 1;
-
   var from = (theProject.rowModel.start + 1);
   var to = Math.min(theProject.rowModel.filtered, theProject.rowModel.start + theProject.rowModel.limit);
 
@@ -182,30 +176,8 @@ DataTableView.prototype._renderPagingControls = function(pageSizeControls, pagin
     previousPage.addClass("inaction");
   }
 
-  var pageControlsSpan = $('<span>').attr("id", "viewpanel-paging-current");
-  
-  var pageInputSize = 20 + (8 * ui.dataTableView._lastPageNumber.toString().length);
-  var currentPageInput = $('<input type="number">')
-    .on('change',function(evt) { self._onChangeGotoPage(this, evt); })
-    .on('keydown',function(evt) { self._onKeyDownGotoPage(this, evt); })
-    .attr("id", "viewpanel-paging-current-input")
-    .attr("min", 1)
-    .attr("max", self._lastPageNumber)
-    .attr("required", "required")
-    .val(self._currentPageNumber)
-    .css("width", pageInputSize +"px");
-    
-  pageControlsSpan.append($.i18n('core-views/goto-page', '<span id="currentPageInput" />', self._lastPageNumber));
-  pageControlsSpan.appendTo(pagingControls);
+  $('<span>').addClass("viewpanel-pagingcount").html(" " + from + " - " + to + " ").appendTo(pagingControls);
 
-  $('span#currentPageInput').replaceWith($(currentPageInput));
-  
-  if(self._refocusPageInput == true) { 
-    self._refocusPageInput = false;
-    var currentPageInputForFocus = $('input#viewpanel-paging-current-input');
-    currentPageInputForFocus.ready(function(evt) { setTimeout(() => { currentPageInputForFocus.focus(); }, 250); });
-  }
-  
   var nextPage = $('<a href="javascript:{}">'+$.i18n('core-views/next')+' &rsaquo;</a>').appendTo(pagingControls);
   var lastPage = $('<a href="javascript:{}">'+$.i18n('core-views/last')+' &raquo;</a>').appendTo(pagingControls);
   if (theProject.rowModel.start + theProject.rowModel.limit < theProject.rowModel.filtered) {
@@ -442,60 +414,20 @@ DataTableView.prototype._showRows = function(start, onDone) {
   }, this._sorting);
 };
 
-DataTableView.prototype._onChangeGotoPage = function(elmt, evt) {
-  var gotoPageNumber = parseInt($('input#viewpanel-paging-current-input').val());
-  
-  if(typeof gotoPageNumber != "number" || isNaN(gotoPageNumber) || gotoPageNumber == "") { 
-    $('input#viewpanel-paging-current-input').val(this._currentPageNumber); 
-    return;
-  }
-  
-  if(gotoPageNumber > this._lastPageNumber) gotoPageNumber = this._lastPageNumber;
-  if(gotoPageNumber < 1) gotoPageNumber = 1;
-  
-  this._currentPageNumber = gotoPageNumber;
-  this._showRows((gotoPageNumber - 1) * this._pageSize);
-};
-
-DataTableView.prototype._onKeyDownGotoPage = function(elmt, evt) {
-  var keyDownCode = event.which;
-  
-  if([38, 40].indexOf(keyDownCode) == -1) return;
-  if(self._refocusPageInput == true) return; 
-
-  evt.preventDefault();
-  this._refocusPageInput = true;
-  
-  var newPageValue = $('input#viewpanel-paging-current-input')[0].value;
-  if(keyDownCode == 38) {  // Up arrow
-    if(newPageValue <= 1) return;
-    this._onClickPreviousPage(elmt, evt);
-  }
-    
-  if(keyDownCode == 40) {  // Down arrow
-    if(newPageValue >= this._lastPageNumber) return;
-    this._onClickNextPage(elmt, evt);
-  }
-};
-
 DataTableView.prototype._onClickPreviousPage = function(elmt, evt) {
-  this._currentPageNumber--;
   this._showRows(theProject.rowModel.start - this._pageSize);
 };
 
 DataTableView.prototype._onClickNextPage = function(elmt, evt) {
-  this._currentPageNumber++;
   this._showRows(theProject.rowModel.start + this._pageSize);
 };
 
 DataTableView.prototype._onClickFirstPage = function(elmt, evt) {
-  this._currentPageNumber = 1;
   this._showRows(0);
 };
 
 DataTableView.prototype._onClickLastPage = function(elmt, evt) {
-  this._currentPageNumber = this._lastPageNumber;
-  this._showRows((this._lastPageNumber - 1) * this._pageSize);
+  this._showRows(Math.floor((theProject.rowModel.filtered - 1) / this._pageSize) * this._pageSize);
 };
 
 DataTableView.prototype._getSortingCriteriaCount = function() {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -190,7 +190,16 @@ DataTableView.prototype._renderPagingControls = function(pageSizeControls, pagin
     previousPage.addClass("inaction");
   }
 
-  $('<span>').addClass("viewpanel-pagingcount").html(" " + (minRowId + 1) + " - " + (maxRowId + 1) + " ").appendTo(pagingControls);
+  var minRowInputSize = 20 + (8* theProject.rowModel.total.toString().length);
+  var minRowInput = $('<input type="number">')
+    .attr("id", "viewpanel-paging-current-min-row")
+    .attr("min", 1)
+    .attr("max", theProject.rowModel.total)
+    .css("width", minRowInputSize)
+    .val(minRowId + 1)
+    .on('change', function(evt) { self._onChangeMinRow(this, evt); })
+    .appendTo(pagingControls);
+  $('<span>').addClass("viewpanel-pagingcount").html(" - " + (maxRowId + 1) + " ").appendTo(pagingControls);
 
   var nextPage = $('<a href="javascript:{}">'+$.i18n('core-views/next')+' &rsaquo;</a>').appendTo(pagingControls);
   var lastPage = $('<a href="javascript:{}">'+$.i18n('core-views/last')+' &raquo;</a>').appendTo(pagingControls);
@@ -442,6 +451,19 @@ DataTableView.prototype._onClickFirstPage = function(elmt, evt) {
 
 DataTableView.prototype._onClickLastPage = function(elmt, evt) {
   this._showRows({end: theProject.rowModel.totalRows});
+};
+
+DataTableView.prototype._onChangeMinRow = function(elmt, evt) {
+  var input = $('#viewpanel-paging-current-min-row');
+  var newMinRow = input.val();
+  if (newMinRow <= 0) {
+    newMinRow = 1;
+    input.val(newMinRow);
+  } else if (newMinRow > theProject.rowModel.total) {
+    newMinRow = theProject.rowModel.total;
+    input.val(theProject.rowModel.total);
+  }
+  this._showRows({start: newMinRow - 1});
 };
 
 DataTableView.prototype._getSortingCriteriaCount = function() {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -81,12 +81,14 @@ DataTableView.prototype.resize = function() {
   tableContainer.height((tableContainerIntendedHeight - tableContainerVPadding) + "px");
 };
 
-DataTableView.prototype.update = function(onDone) {
-  var paginationOptions = {};
-  if (theProject.rowModel.start !== undefined) {
-    paginationOptions.start = theProject.rowModel.start;
-  } else {
-    paginationOptions.end = theProject.rowModel.end;
+DataTableView.prototype.update = function(onDone, preservePage) {
+  var paginationOptions = { start: 0 };
+  if (preservePage) {
+    if (theProject.rowModel.start !== undefined) {
+      paginationOptions.start = theProject.rowModel.start;
+    } else {
+      paginationOptions.end = theProject.rowModel.end;
+    }
   }
   this._showRows(paginationOptions, onDone);
 };
@@ -212,7 +214,7 @@ DataTableView.prototype._renderPagingControls = function(pageSizeControls, pagin
     } else {
       a.text(pageSize).addClass("action").on('click',function(evt) {
         self._pageSize = pageSize;
-        self.update();
+        self.update(undefined, true);
       });
     }
   };
@@ -752,14 +754,14 @@ DataTableView.prototype._createMenuForAllColumns = function(elmt) {
           label: $.i18n('core-views/star-rows'),
           id: "core/star-rows",
           click: function() {
-            Refine.postCoreProcess("annotate-rows", { "starred" : "true" }, null, { rowMetadataChanged: true });
+            Refine.postCoreProcess("annotate-rows", { "starred" : "true" }, null, { rowMetadataChanged: true, rowIdsPreserved: true, recordIdsPreserved: true });
           }
         },
         {
           label: $.i18n('core-views/unstar-rows'),
           id: "core/unstar-rows",
           click: function() {
-            Refine.postCoreProcess("annotate-rows", { "starred" : "false" }, null, { rowMetadataChanged: true });
+            Refine.postCoreProcess("annotate-rows", { "starred" : "false" }, null, { rowMetadataChanged: true, rowIdsPreserved: true, recordIdsPreserved: true });
           }
         },
         {},
@@ -767,14 +769,14 @@ DataTableView.prototype._createMenuForAllColumns = function(elmt) {
           label: $.i18n('core-views/flag-rows'),
           id: "core/flag-rows",
           click: function() {
-            Refine.postCoreProcess("annotate-rows", { "flagged" : "true" }, null, { rowMetadataChanged: true });
+            Refine.postCoreProcess("annotate-rows", { "flagged" : "true" }, null, { rowMetadataChanged: true, rowIdsPreserved: true, recordIdsPreserved: true });
           }
         },
         {
           label: $.i18n('core-views/unflag-rows'),
           id: "core/unflag-rows",
           click: function() {
-            Refine.postCoreProcess("annotate-rows", { "flagged" : "false" }, null, { rowMetadataChanged: true });
+            Refine.postCoreProcess("annotate-rows", { "flagged" : "false" }, null, { rowMetadataChanged: true, rowIdsPreserved: true, recordIdsPreserved: true });
           }
         },
         {},

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
@@ -102,7 +102,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         columnName: column.name
       },
       null,
-      { modelsChanged: true }
+      { modelsChanged: true, rowIdsPreserved: true }
     );
   };
 
@@ -113,7 +113,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         columnName: column.name
       },
       null,
-      { modelsChanged: true }
+      { modelsChanged: true, rowIdsPreserved: true }
     );
   };
 

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
@@ -44,7 +44,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
 	        repeatCount: repeatCount
 	      },
 	      { expression: expression },
-	      { cellsChanged: true },
+	      { cellsChanged: true, rowIdsPreserved: true },
 	      callbacks
 	    );
 	  };
@@ -96,7 +96,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           onError: $('input[name="create-column-dialog-onerror-choice"]:checked')[0].value
         },
         { expression: previewWidget.getExpression(true) },
-        { modelsChanged: true },
+        { modelsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true },
         {
           onDone: function(o) {
             dismiss();
@@ -178,7 +178,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           httpHeaders: JSON.stringify(elmts.setHttpHeadersContainer.find("input").serializeArray())
         },
         null,
-        { modelsChanged: true }
+        { modelsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
       );
       dismiss();
     });
@@ -220,7 +220,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         columnName: column.name
       },
       null,
-      { modelsChanged: true }
+      { modelsChanged: true, rowIdsPreserved: true }
     );
   };
 
@@ -254,7 +254,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           newColumnName: newColumnName
         },
         null,
-            {modelsChanged: true},
+            {modelsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true},
             {
               onDone: function () {
                 dismiss();
@@ -275,7 +275,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         index: index
       },
       null,
-      { modelsChanged: true }
+      { modelsChanged: true, rowIdsPreserved: true }
     );
   };
 
@@ -289,7 +289,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
             index: newidx
           },
           null,
-          { modelsChanged: true }
+          { modelsChanged: true, rowIdsPreserved: true }
       );
     }
   };
@@ -426,7 +426,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
               "reorder-columns",
               null,
               { "columnNames" : JSON.stringify(columnsToKeep) }, 
-              { modelsChanged: true },
+              { modelsChanged: true, rowIdsPreserved: true },
               { includeEngine: false }
           );
         }
@@ -479,7 +479,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           onError: onError
           },
           { expression: expression },
-          { modelsChanged: true },
+          { modelsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true },
           { onFinallyDone: deleteColumns}
         );
       } 

--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -42,7 +42,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       "recon-discard-judgments",
       { columnName: column.name, clearData: false },
       null,
-      { cellsChanged: true, columnStatsChanged: true }
+      { cellsChanged: true, columnStatsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
     );
   };
 
@@ -51,7 +51,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       "recon-discard-judgments",
       { columnName: column.name, clearData: true },
       null,
-      { cellsChanged: true, columnStatsChanged: true }
+      { cellsChanged: true, columnStatsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
     );
   };
 
@@ -60,7 +60,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       "recon-match-best-candidates",
       { columnName: column.name },
       null,
-      { cellsChanged: true, columnStatsChanged: true }
+      { cellsChanged: true, columnStatsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
     );
   };
 
@@ -78,7 +78,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           schemaSpace: schemaSpace
         },
       null,
-      { cellsChanged: true, columnStatsChanged: true }
+      { cellsChanged: true, columnStatsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
     );
   };
 
@@ -143,7 +143,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
             schemaSpace: service.schemaSpace
         },
         null,
-        { cellsChanged: true, columnStatsChanged: true }
+        { cellsChanged: true, columnStatsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
         );
 
         DialogSystem.dismissUntil(level - 1);
@@ -231,7 +231,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
               schemaSpace: schemaSpace
             },
             null,
-            { cellsChanged: true, columnStatsChanged: true }
+            { cellsChanged: true, columnStatsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
          );
     };
 
@@ -270,7 +270,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           onError: "set-to-blank"
         },
         { expression: "cell.recon.match.id" },
-        { modelsChanged: true },
+        { modelsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true },
         {
           onDone: function(o) {
             dismiss();
@@ -336,7 +336,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           "recon-copy-across-columns", 
           null,
           config,
-          { rowsChanged: true }
+          { rowsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
         );
         dismiss();
       }

--- a/main/webapp/modules/core/styles/views/data-table-view.less
+++ b/main/webapp/modules/core/styles/views/data-table-view.less
@@ -55,45 +55,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   font-weight: bold;
   }
 
-.viewpanel-rowrecord a {
-  background-color: @fill_primary;
-  margin: 0px 1px 0px 1px;
-  padding: 2px 5px 2px 5px;
-  .rounded_corners(4px);
-  }
-
-.viewpanel-pagesize a {
-  background-color: @fill_primary;
-  margin: 0px 2px 0px 2px;
-  padding: 2px 3px 2px 3px;
-  .rounded_corners(4px);
-  }
-
-div.viewpanel-pagesize span:first-of-type {
-  margin: 0px 0px 0px 20px;
-}
-
-.viewpanel-paging a {
-  background-color: @fill_primary;
-  margin: 0px 4px 0px 4px;
-  padding: 2px 10px 2px 10px;
-  .rounded_corners(4px);
-  }
-
-.viewpanel-paging span#viewpanel-paging-current {
-  margin: 0 10px 0 10px;
-  padding: 0px;
-  }
-
-.viewpanel-paging input#viewpanel-paging-current-input {
-  width: 60px;
-  margin: 0px;
-  padding: 0px;
-  height: 16px;
-  position: relative;
-  top: -2px;
-  }
-
 .data-table-header {
   width: 1px;
   position: relative;

--- a/refine-local-runner/src/main/java/org/openrefine/model/LocalGridState.java
+++ b/refine-local-runner/src/main/java/org/openrefine/model/LocalGridState.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.apache.commons.collections.IteratorUtils;
 import org.openrefine.browsing.facets.RecordAggregator;
 import org.openrefine.browsing.facets.RowAggregator;
 import org.openrefine.model.changes.ChangeData;
@@ -49,7 +50,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 public class LocalGridState implements GridState {
 
     protected final LocalDatamodelRunner runner;
-    protected final PairPLL<Long, Row> grid;
+    protected final PairPLL<Long, IndexedRow> grid;
     protected final ColumnModel columnModel;
     protected final Map<String, OverlayModel> overlayModels;
 
@@ -59,6 +60,26 @@ public class LocalGridState implements GridState {
     /**
      * Constructs a grid state, supplying all required fields.
      * 
+     * @param runner
+     * @param columnModel
+     * @param grid
+     * @param overlayModels
+     */
+    public LocalGridState(
+            LocalDatamodelRunner runner,
+            ColumnModel columnModel,
+            PairPLL<Long, IndexedRow> grid,
+            Map<String, OverlayModel> overlayModels) {
+        this.runner = runner;
+        this.grid = grid;
+        this.columnModel = columnModel;
+        this.overlayModels = overlayModels;
+        this.records = null;
+    }
+
+    /**
+     * Convenience constructor to construct a grid from a PLL of a slightly different type.
+     *
      * @param runner
      * @param grid
      * @param columnModel
@@ -70,7 +91,7 @@ public class LocalGridState implements GridState {
             ColumnModel columnModel,
             Map<String, OverlayModel> overlayModels) {
         this.runner = runner;
-        this.grid = grid;
+        this.grid = grid.mapToPair(tuple -> new Tuple2<>(tuple.getKey(), new IndexedRow(tuple.getKey(), tuple.getValue())));
         this.columnModel = columnModel;
         this.overlayModels = overlayModels;
         this.records = null;
@@ -84,7 +105,7 @@ public class LocalGridState implements GridState {
     }
 
     protected PLL<IndexedRow> indexedRows() {
-        return grid.map(tuple -> new IndexedRow(tuple.getKey(), tuple.getValue()));
+        return grid.values();
     }
 
     @Override
@@ -99,7 +120,7 @@ public class LocalGridState implements GridState {
 
     @Override
     public GridState withColumnModel(ColumnModel newColumnModel) {
-        return new LocalGridState(runner, grid, newColumnModel, overlayModels);
+        return new LocalGridState(runner, newColumnModel, grid, overlayModels);
     }
 
     @Override
@@ -108,76 +129,75 @@ public class LocalGridState implements GridState {
         // it must actually scan at least one entire partition,
         // which is unnecessary since we know it is sorted and there
         // is at most one result. So we use `getRange` instead.
-        List<Tuple2<Long, Row>> rows = grid.getRange(id, 1, Comparator.naturalOrder());
+        List<Tuple2<Long, IndexedRow>> rows = grid.getRangeAfter(id, 1, Comparator.naturalOrder());
         if (rows.size() == 0) {
             throw new IndexOutOfBoundsException(String.format("Row id %d not found", id));
         } else if (rows.size() > 1) {
             throw new IllegalStateException(String.format("Found %d rows at index %d", rows.size(), id));
         } else {
-            return rows.get(0).getValue();
+            return rows.get(0).getValue().getRow();
         }
     }
 
     @Override
-    public List<IndexedRow> getRows(long start, int limit) {
-        return grid.getRange(start, limit, Comparator.naturalOrder())
+    public List<IndexedRow> getRowsAfter(long start, int limit) {
+        return grid.getRangeAfter(start, limit, Comparator.naturalOrder())
                 .stream()
-                .map(tuple -> new IndexedRow(tuple.getKey(), tuple.getValue()))
+                .map(Tuple2::getValue)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<IndexedRow> getRows(RowFilter filter, SortingConfig sortingConfig, long start, int limit) {
-        PairPLL<Long, Row> filteredRows = grid.filter(tuple -> filter.filterRow(tuple.getKey(), tuple.getValue()));
-        if (SortingConfig.NO_SORTING.equals(sortingConfig)) {
-            return filteredRows
-                    .getRange(start, limit, Comparator.naturalOrder())
-                    .stream()
-                    .map(tuple -> new IndexedRow(tuple.getKey(), tuple.getValue()))
-                    .collect(Collectors.toList());
-        } else {
-            RowSorter rowSorter = new RowSorter(this, sortingConfig);
-            return filteredRows
-                    .map(tuple -> new IndexedRow(tuple.getKey(), tuple.getValue()))
-                    .sort(rowSorter)
-                    .zipWithIndex() // this is cheap because sort loads everything in memory anyway
-                    .getRange(start, limit, Comparator.naturalOrder())
-                    .stream()
-                    .map(tuple -> tuple.getValue())
-                    .collect(Collectors.toList());
-        }
+    public List<IndexedRow> getRowsAfter(RowFilter filter, long start, int limit) {
+        PairPLL<Long, IndexedRow> filteredRows = grid
+                .filter(tuple -> filter.filterRow(tuple.getValue().getLogicalIndex(), tuple.getValue().getRow()));
+        return filteredRows
+                .getRangeAfter(start, limit, Comparator.naturalOrder())
+                .stream()
+                .map(Tuple2::getValue)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<IndexedRow> getRowsBefore(long end, int limit) {
+        return grid.getRangeBefore(end, limit, Comparator.naturalOrder())
+                .stream()
+                .map(Tuple2::getValue)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<IndexedRow> getRowsBefore(RowFilter filter, long end, int limit) {
+        return grid
+                .filter(tuple -> filter.filterRow(tuple.getValue().getLogicalIndex(), tuple.getValue().getRow()))
+                .getRangeBefore(end, limit, Comparator.naturalOrder())
+                .stream()
+                .map(Tuple2::getValue)
+                .collect(Collectors.toList());
     }
 
     @Override
     public List<IndexedRow> getRows(List<Long> rowIndices) {
         Map<Long, IndexedRow> results = grid.getByKeys(rowIndices.stream().collect(Collectors.toSet()))
                 .stream()
-                .collect(Collectors.toMap(t -> t.getKey(), t -> new IndexedRow(t.getKey(), t.getValue())));
+                .collect(Collectors.toMap(t -> t.getKey(), t -> t.getValue()));
         return rowIndices.stream()
                 .map(i -> results.get(i))
                 .collect(Collectors.toList());
     }
 
     @Override
-    public Iterable<IndexedRow> iterateRows(RowFilter filter, SortingConfig sortingConfig) {
+    public Iterable<IndexedRow> iterateRows(RowFilter filter) {
         return new Iterable<IndexedRow>() {
 
             @Override
             public Iterator<IndexedRow> iterator() {
                 PLL<IndexedRow> filteredRows = grid
-                        .filter(tuple -> filter.filterRow(tuple.getKey(), tuple.getValue()))
-                        .map(tuple -> new IndexedRow(tuple.getKey(), tuple.getValue()));
-                if (SortingConfig.NO_SORTING.equals(sortingConfig)) {
-                    return filteredRows
-                            .stream()
-                            .iterator();
-                } else {
-                    RowSorter rowSorter = new RowSorter(LocalGridState.this, sortingConfig);
-                    return filteredRows
-                            .sort(rowSorter)
-                            .stream()
-                            .iterator();
-                }
+                        .filter(tuple -> filter.filterRow(tuple.getValue().getLogicalIndex(), tuple.getValue().getRow()))
+                        .values();
+                return filteredRows
+                        .stream()
+                        .iterator();
             }
 
         };
@@ -185,7 +205,7 @@ public class LocalGridState implements GridState {
 
     @Override
     public long countMatchingRows(RowFilter filter) {
-        return grid.filter(tuple -> filter.filterRow(tuple.getKey(), tuple.getValue())).count();
+        return grid.filter(tuple -> filter.filterRow(tuple.getValue().getLogicalIndex(), tuple.getValue().getRow())).count();
     }
 
     @Override
@@ -197,7 +217,7 @@ public class LocalGridState implements GridState {
                 .aggregate(initialState,
                         (ac, tuple) -> new ApproxCount(
                                 ac.getProcessed() + 1,
-                                ac.getMatched() + (filter.filterRow(tuple.getKey(), tuple.getValue()) ? 1 : 0),
+                                ac.getMatched() + (filter.filterRow(tuple.getValue().getLogicalIndex(), tuple.getValue().getRow()) ? 1 : 0),
                                 ac.limitReached() || ac.getProcessed() + 1 == partitionLimit),
                         (ac1, ac2) -> new ApproxCount(
                                 ac1.getProcessed() + ac2.getProcessed(),
@@ -207,7 +227,7 @@ public class LocalGridState implements GridState {
 
     @Override
     public List<IndexedRow> collectRows() {
-        return grid.map(tuple -> new IndexedRow(tuple.getKey(), tuple.getValue())).collect();
+        return grid.values().collect();
     }
 
     @Override
@@ -223,45 +243,51 @@ public class LocalGridState implements GridState {
     }
 
     @Override
-    public List<Record> getRecords(long start, int limit) {
+    public List<Record> getRecordsAfter(long start, int limit) {
         return records()
-                .getRange(start, limit, Comparator.naturalOrder())
+                .getRangeAfter(start, limit, Comparator.naturalOrder())
                 .stream()
                 .map(tuple -> tuple.getValue())
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<Record> getRecords(RecordFilter filter, SortingConfig sortingConfig, long start, int limit) {
+    public List<Record> getRecordsAfter(RecordFilter filter, long start, int limit) {
         PairPLL<Long, Record> records = records();
-        if (!SortingConfig.NO_SORTING.equals(sortingConfig)) {
-            RecordSorter recordSorter = new RecordSorter(this, sortingConfig);
-            records = records()
-                    .values()
-                    .sort(recordSorter)
-                    .zipWithIndex();
-            // this zipWithIndex is efficient because sorting fetches everything in
-            // memory, and it is trivial to zipWithIndex an InMemoryPLL.
-        }
         return records
                 .filter(tuple -> filter.filterRecord(tuple.getValue()))
-                .getRange(start, limit, Comparator.naturalOrder())
+                .getRangeAfter(start, limit, Comparator.naturalOrder())
                 .stream()
                 .map(tuple -> tuple.getValue())
                 .collect(Collectors.toList());
     }
 
     @Override
-    public Iterable<Record> iterateRecords(RecordFilter filter, SortingConfig sortingConfig) {
+    public List<Record> getRecordsBefore(long end, int limit) {
+        return records()
+                .getRangeBefore(end, limit, Comparator.naturalOrder())
+                .stream()
+                .map(Tuple2::getValue)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Record> getRecordsBefore(RecordFilter filter, long end, int limit) {
+        return records()
+                .filter(tuple -> filter.filterRecord(tuple.getValue()))
+                .getRangeBefore(end, limit, Comparator.naturalOrder())
+                .stream()
+                .map(Tuple2::getValue)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Iterable<Record> iterateRecords(RecordFilter filter) {
         return new Iterable<Record>() {
 
             @Override
             public Iterator<Record> iterator() {
                 PLL<Record> records = records().values();
-                if (!SortingConfig.NO_SORTING.equals(sortingConfig)) {
-                    RecordSorter recordSorter = new RecordSorter(LocalGridState.this, sortingConfig);
-                    records = records.sort(recordSorter);
-                }
                 return records
                         .filter(tuple -> filter.filterRecord(tuple))
                         .stream()
@@ -333,6 +359,7 @@ public class LocalGridState implements GridState {
         File gridFile = new File(file, GRID_PATH);
 
         grid
+                .values()
                 .map(LocalGridState::serializeIndexedRow)
                 .saveAsTextFile(gridFile.getAbsolutePath(), progressReporter);
 
@@ -348,9 +375,9 @@ public class LocalGridState implements GridState {
         return metadata;
     }
 
-    protected static String serializeIndexedRow(Tuple2<Long, Row> tuple) {
+    protected static String serializeIndexedRow(IndexedRow indexedRow) {
         try {
-            return ParsingUtilities.saveWriter.writeValueAsString(new IndexedRow(tuple.getKey(), tuple.getValue()));
+            return ParsingUtilities.saveWriter.writeValueAsString(indexedRow);
         } catch (JsonProcessingException e) {
             throw new UncheckedIOException(e);
         }
@@ -358,9 +385,11 @@ public class LocalGridState implements GridState {
 
     @Override
     public <T extends Serializable> T aggregateRows(RowAggregator<T> aggregator, T initialState) {
-        return grid.aggregate(initialState,
-                (s, t) -> aggregator.withRow(s, t.getKey(), t.getValue()),
-                (s1, s2) -> aggregator.sum(s1, s2));
+        return grid
+                .values()
+                .aggregate(initialState,
+                        (s, t) -> aggregator.withRow(s, t.getLogicalIndex(), t.getRow()),
+                        (s1, s2) -> aggregator.sum(s1, s2));
     }
 
     @Override
@@ -376,9 +405,10 @@ public class LocalGridState implements GridState {
         PartialAggregation<T> initialPartialState = new PartialAggregation<T>(initialState, 0, partitionLimit == 0);
         return grid
                 .limitPartitions(partitionLimit)
+                .values()
                 .aggregate(initialPartialState,
                         (s, t) -> new PartialAggregation<T>(
-                                aggregator.withRow(s.getState(), t.getKey(), t.getValue()),
+                                aggregator.withRow(s.getState(), t.getLogicalIndex(), t.getRow()),
                                 s.getProcessed() + 1,
                                 s.limitReached() || s.getProcessed() + 1 == partitionLimit),
                         (s1, s2) -> new PartialAggregation<T>(
@@ -407,18 +437,20 @@ public class LocalGridState implements GridState {
 
     @Override
     public GridState withOverlayModels(Map<String, OverlayModel> newOverlayModels) {
-        return new LocalGridState(runner, grid, columnModel, newOverlayModels);
+        return new LocalGridState(runner, columnModel, grid, newOverlayModels);
     }
 
     @Override
     public GridState mapRows(RowMapper mapper, ColumnModel newColumnModel) {
-        PairPLL<Long, Row> newGrid = grid.mapValues((i, r) -> mapper.call(i, r));
+        PairPLL<Long, Row> newGrid = grid.mapValues((i, r) -> mapper.call(r.getLogicalIndex(), r.getRow()));
         return new LocalGridState(runner, newGrid, newColumnModel, overlayModels);
     }
 
     @Override
     public GridState flatMapRows(RowFlatMapper mapper, ColumnModel newColumnModel) {
-        PairPLL<Long, Row> newGrid = grid.flatMap(tuple -> mapper.call(tuple.getKey(), tuple.getValue()).stream()).zipWithIndex();
+        PairPLL<Long, Row> newGrid = grid.values()
+                .flatMap(tuple -> mapper.call(tuple.getLogicalIndex(), tuple.getRow()).stream())
+                .zipWithIndex();
         return new LocalGridState(runner, newGrid, newColumnModel, overlayModels);
     }
 
@@ -426,9 +458,9 @@ public class LocalGridState implements GridState {
     public <S extends Serializable> GridState mapRows(RowScanMapper<S> mapper, ColumnModel newColumnModel) {
         PLL<Tuple2<Long, Row>> newGrid = grid.scanMap(
                 mapper.unit(),
-                tuple -> mapper.feed(tuple.getKey(), tuple.getValue()),
+                tuple -> mapper.feed(tuple.getValue().getLogicalIndex(), tuple.getValue().getRow()),
                 (s1, s2) -> mapper.combine(s1, s2),
-                (s, tuple) -> Tuple2.of(tuple.getKey(), mapper.map(s, tuple.getKey(), tuple.getValue())));
+                (s, tuple) -> Tuple2.of(tuple.getKey(), mapper.map(s, tuple.getValue().getLogicalIndex(), tuple.getValue().getRow())));
         PairPLL<Long, Row> paired = new PairPLL<>(newGrid, grid.getPartitioner());
 
         return new LocalGridState(runner, paired, newColumnModel, overlayModels);
@@ -444,34 +476,51 @@ public class LocalGridState implements GridState {
     }
 
     @Override
-    public GridState reorderRows(SortingConfig sortingConfig) {
+    public GridState reorderRows(SortingConfig sortingConfig, boolean permanent) {
         RowSorter rowSorter = new RowSorter(this, sortingConfig);
-        PairPLL<Long, Row> newRows = indexedRows()
-                .sort(rowSorter)
-                .map(IndexedRow::getRow)
-                .zipWithIndex();
-
-        return new LocalGridState(runner, newRows, columnModel, overlayModels);
+        if (permanent) {
+            PairPLL<Long, Row> newRows = indexedRows()
+                    .sort(rowSorter)
+                    .map(IndexedRow::getRow)
+                    .zipWithIndex();
+            return new LocalGridState(runner, newRows, columnModel, overlayModels);
+        } else {
+            PairPLL<Long, IndexedRow> newRows = indexedRows()
+                    .sort(rowSorter)
+                    .zipWithIndex()
+                    .mapValues((newIndex, indexedRow) -> new IndexedRow(newIndex, indexedRow.getLogicalIndex(), indexedRow.getRow()));
+            return new LocalGridState(runner, columnModel, newRows, overlayModels);
+        }
     }
 
     @Override
-    public GridState reorderRecords(SortingConfig sortingConfig) {
+    public GridState reorderRecords(SortingConfig sortingConfig, boolean permanent) {
         RecordSorter recordSorter = new RecordSorter(this, sortingConfig);
-        PairPLL<Long, Row> newRows = records()
+        PLL<Record> sorted = records()
                 .values()
-                .sort(recordSorter)
-                .flatMap(record -> record.getRows().stream())
-                .zipWithIndex();
-
-        return new LocalGridState(runner, newRows, columnModel, overlayModels);
+                .sort(recordSorter);
+        if (permanent) {
+            PairPLL<Long, Row> newRows = sorted
+                    .flatMap(record -> record.getRows().stream())
+                    .zipWithIndex();
+            return new LocalGridState(runner, newRows, columnModel, overlayModels);
+        } else {
+            PLL<IndexedRow> pll = sorted
+                    .flatMap(record -> IteratorUtils.toList(record.getIndexedRows().iterator()).stream());
+            PairPLL<Long, IndexedRow> newRows = pll
+                    .zipWithIndex()
+                    .mapValues((newIndex, indexedRow) -> new IndexedRow(newIndex, indexedRow.getLogicalIndex(), indexedRow.getRow()));
+            return new LocalGridState(runner, columnModel, newRows, overlayModels);
+        }
     }
 
     @Override
     public GridState removeRows(RowFilter filter) {
         PairPLL<Long, Row> newGrid = grid
-                .filter(tuple -> !filter.filterRow(tuple.getKey(), tuple.getValue()))
                 .values()
-                .zipWithIndex();
+                .filter(tuple -> !filter.filterRow(tuple.getLogicalIndex(), tuple.getRow()))
+                .zipWithIndex()
+                .mapValues((index, indexedRow) -> indexedRow.getRow());
         return new LocalGridState(runner, newGrid, columnModel, overlayModels);
     }
 
@@ -487,13 +536,15 @@ public class LocalGridState implements GridState {
 
     @Override
     public <T> ChangeData<T> mapRows(RowFilter filter, RowChangeDataProducer<T> rowMapper) {
-        PairPLL<Long, Row> filteredGrid = grid.filter(tuple -> filter.filterRow(tuple.getKey(), tuple.getValue()));
+        PairPLL<Long, IndexedRow> filteredGrid = grid
+                .filter(tuple -> filter.filterRow(tuple.getValue().getLogicalIndex(), tuple.getValue().getRow()));
         PairPLL<Long, T> data;
         if (rowMapper.getBatchSize() == 1) {
             data = filteredGrid.mapValues(
-                    (id, row) -> rowMapper.call(id, row));
+                    (id, row) -> rowMapper.call(row.getLogicalIndex(), row.getRow()));
         } else {
             data = filteredGrid
+                    .values()
                     .batchPartitions(rowMapper.getBatchSize())
                     .flatMap(rowBatch -> applyRowChangeDataMapper(rowMapper, rowBatch))
                     .mapToPair(indexedData -> indexedData)
@@ -506,17 +557,14 @@ public class LocalGridState implements GridState {
     }
 
     protected static <T> Stream<Tuple2<Long, T>> applyRowChangeDataMapper(RowChangeDataProducer<T> rowMapper,
-            List<Tuple2<Long, Row>> rowBatch) {
-        List<T> changeData = rowMapper.callRowBatch(
-                rowBatch.stream()
-                        .map(tuple -> new IndexedRow(tuple.getKey(), tuple.getValue()))
-                        .collect(Collectors.toList()));
+            List<IndexedRow> rowBatch) {
+        List<T> changeData = rowMapper.callRowBatch(rowBatch);
         if (changeData.size() != rowBatch.size()) {
             throw new IllegalStateException(
                     String.format("Change data producer returned %d results on a batch of %d rows", changeData.size(), rowBatch.size()));
         }
         return IntStream.range(0, rowBatch.size())
-                .mapToObj(i -> new Tuple2<Long, T>(rowBatch.get(i).getKey(), changeData.get(i)));
+                .mapToObj(i -> new Tuple2<Long, T>(rowBatch.get(i).getIndex(), changeData.get(i)));
     }
 
     @Override
@@ -565,14 +613,16 @@ public class LocalGridState implements GridState {
         // because they would be computed anyway to re-index
         // the rows after the drop.
         grid.getPartitionSizes();
-        PairPLL<Long, Row> dropped = grid.dropFirstElements(rowsToDrop);
+        PairPLL<Long, IndexedRow> dropped = grid.dropFirstElements(rowsToDrop);
         Optional<Partitioner<Long>> partitioner = dropped.getPartitioner();
         if (partitioner.isPresent() && partitioner.get() instanceof LongRangePartitioner) {
             partitioner = partitioner.map(p -> ((LongRangePartitioner) p).shiftKeys(-rowsToDrop));
         }
-        PairPLL<Long, Row> shifted = dropped.mapToPair(tuple -> Tuple2.of(tuple.getKey() - rowsToDrop, tuple.getValue()))
+        PairPLL<Long, IndexedRow> shifted = dropped
+                .mapToPair(tuple -> Tuple2.of(tuple.getKey() - rowsToDrop,
+                        new IndexedRow(tuple.getKey() - rowsToDrop, tuple.getValue().getRow())))
                 .withPartitioner(partitioner);
-        return new LocalGridState(runner, shifted, columnModel, overlayModels);
+        return new LocalGridState(runner, columnModel, shifted, overlayModels);
     }
 
     protected static <T> Stream<Tuple2<Long, T>> applyRecordChangeDataMapper(
@@ -598,7 +648,7 @@ public class LocalGridState implements GridState {
         }
         PairPLL<Long, Row> joined = grid
                 .outerJoinOrdered(((LocalChangeData<T>) changeData).getPLL(), Comparator.naturalOrder())
-                .mapValues((id, tuple) -> rowJoiner.call(id, tuple.getKey(), tuple.getValue()));
+                .mapValues((id, tuple) -> rowJoiner.call(id, tuple.getKey().getRow(), tuple.getValue()));
         return new LocalGridState(runner, joined, newColumnModel, overlayModels);
     }
 
@@ -610,7 +660,7 @@ public class LocalGridState implements GridState {
         }
         PairPLL<Long, Row> joined = grid
                 .outerJoinOrdered(((LocalChangeData<T>) changeData).getPLL(), Comparator.naturalOrder())
-                .flatMap(tuple -> rowJoiner.call(tuple.getKey(), tuple.getValue().getKey(), tuple.getValue().getValue()).stream())
+                .flatMap(tuple -> rowJoiner.call(tuple.getKey(), tuple.getValue().getKey().getRow(), tuple.getValue().getValue()).stream())
                 .zipWithIndex();
         return new LocalGridState(runner, joined, newColumnModel, overlayModels);
     }
@@ -639,7 +689,9 @@ public class LocalGridState implements GridState {
         mergedOverlayModels.putAll(overlayModels);
         return new LocalGridState(
                 runner,
-                grid.values().concatenate(otherLocal.grid.values()).zipWithIndex(),
+                grid.values()
+                        .map(IndexedRow::getRow)
+                        .concatenate(otherLocal.grid.values().map(IndexedRow::getRow)).zipWithIndex(),
                 merged,
                 mergedOverlayModels);
     }

--- a/refine-local-runner/src/main/java/org/openrefine/model/local/OrderedJoinPLL.java
+++ b/refine-local-runner/src/main/java/org/openrefine/model/local/OrderedJoinPLL.java
@@ -100,6 +100,13 @@ public class OrderedJoinPLL<K, V, W> extends PLL<Tuple2<K, Tuple2<V, W>>> {
         Optional<K> upperBound = Optional.empty();
         if (partition.getIndex() > 0) {
             lowerBound = firstKeys.get(partition.getIndex() - 1);
+            if (lowerBound.isEmpty()) {
+                // This partition is empty on the left side.
+                // We skip it: for an inner join, the result is clearly empty,
+                // and for an outer join the corresponding elements on the right-hand side
+                // are added to the joins of the neighbouring partitions.
+                return Stream.empty();
+            }
         }
         if (partition.getIndex() < numPartitions() - 1) {
             upperBound = upperBounds.get(numPartitions() - 2 - partition.getIndex());

--- a/refine-local-runner/src/main/java/org/openrefine/model/local/PairPLL.java
+++ b/refine-local-runner/src/main/java/org/openrefine/model/local/PairPLL.java
@@ -1,16 +1,9 @@
 
 package org.openrefine.model.local;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -128,7 +121,7 @@ public class PairPLL<K, V> extends PLL<Tuple2<K, V>> {
 
     /**
      * Returns the list of elements starting at the given key and for up to the given number of elements. This assumes
-     * that the PLL is sorted by keys.
+     * that the PLL is sorted by keys.
      * 
      * @param from
      *            the first key to return
@@ -138,10 +131,65 @@ public class PairPLL<K, V> extends PLL<Tuple2<K, V>> {
      *            the ordering on K that is assumed on the PLL
      * @return
      */
-    public List<Tuple2<K, V>> getRange(K from, int limit, Comparator<K> comparator) {
+    public List<Tuple2<K, V>> getRangeAfter(K from, int limit, Comparator<K> comparator) {
         Stream<Tuple2<K, V>> stream = streamFromKey(from, comparator);
         return stream
                 .limit(limit).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns the list of elements ending at the given key (excluded) and for up to the given number of elements. This
+     * assumes that the PLL is sorted by keys.
+     *
+     * @param upperBound
+     *            the least key not to return
+     * @param limit
+     *            the maximum number of elements to return
+     * @param comparator
+     *            the ordering on K that is assumed on the PLL
+     * @return
+     *
+     *         TODO this could be optimized further, when the partitions are cached in memory, we can iterate from them
+     *         in reverse
+     */
+    public List<Tuple2<K, V>> getRangeBefore(K upperBound, int limit, Comparator<K> comparator) {
+        Stream<Tuple2<K, V>> stream;
+        if (partitioner.isEmpty() || !(partitioner.get() instanceof LongRangePartitioner)) {
+            // we resort to simple scanning of all partitions
+            return gatherElementsBefore(upperBound, limit, stream(), comparator);
+        } else {
+            // we can use the partitioner to locate the partition to end at
+            int endPartition = partitioner.get().getPartition(upperBound);
+            List<Tuple2<K, V>> result = new ArrayList<>(limit);
+            for (int currentPartition = endPartition; currentPartition >= 0 && result.size() != limit; currentPartition--) {
+                List<Tuple2<K, V>> lastElements = gatherElementsBefore(upperBound, limit, iterate(getPartitions().get(currentPartition)),
+                        comparator);
+                for (int i = lastElements.size() - 1; i >= 0 && result.size() < limit; i--) {
+                    result.add(lastElements.get(i));
+                }
+            }
+            Collections.reverse(result);
+            return result;
+        }
+    }
+
+    /**
+     * Returns the last n elements whose key is strictly less than the supplied upper bound.
+     *
+     * @param stream
+     *            the stream to take the elements from, which is assumed to be in increasing order
+     */
+    protected static <K, V> List<Tuple2<K, V>> gatherElementsBefore(K upperBound, int limit, Stream<Tuple2<K, V>> stream,
+            Comparator<K> comparator) {
+        Deque<Tuple2<K, V>> lastElements = new ArrayDeque<>(limit);
+        stream.takeWhile(tuple -> comparator.compare(upperBound, tuple.getKey()) > 0)
+                .forEach(tuple -> {
+                    if (lastElements.size() == limit) {
+                        lastElements.removeFirst();
+                    }
+                    lastElements.addLast(tuple);
+                });
+        return new ArrayList<>(lastElements);
     }
 
     /**
@@ -155,7 +203,7 @@ public class PairPLL<K, V> extends PLL<Tuple2<K, V>> {
         if (partitioner.isEmpty() || !(partitioner.get() instanceof LongRangePartitioner)) {
             return this.filter(t -> keys.contains(t.getKey())).collect();
         } else {
-            // if the PLL is sorted by keys then we can only scan the partitions
+            // if the PLL is sorted by keys then we can only scan the partitions
             // where the keys would go, and stop scanning those partitions as soon
             // as a greater element is found
             LongRangePartitioner sortedPartitioner = (LongRangePartitioner) partitioner.get();
@@ -198,7 +246,7 @@ public class PairPLL<K, V> extends PLL<Tuple2<K, V>> {
      *            the first key to start iterating from
      * @param comparator
      *            the order used to compare the keys
-     * @return
+     * @return a streams which starts on the first element whose key is greater or equal to the provided one
      */
     public Stream<Tuple2<K, V>> streamFromKey(K from, Comparator<K> comparator) {
         Stream<Tuple2<K, V>> stream;
@@ -437,47 +485,5 @@ public class PairPLL<K, V> extends PLL<Tuple2<K, V>> {
         OrderedJoinPLL<K, V, W> joined = new OrderedJoinPLL<K, V, W>(this, other, comparator, false);
         return new PairPLL<K, Tuple2<V, W>>(joined, joined.getPartitioner());
     }
-
-    /*
-     * public void saveAsHadoopFile(String path, Class<K> keyClass, Class<V> valueClass, OutputFormat<K, V>
-     * outputFormat, Class<? extends CompressionCodec> codec) throws IOException { Job job =
-     * Job.getInstance(context.getFileSystem().getConf()); job.setOutputKeyClass(keyClass);
-     * job.setOutputValueClass(valueClass); job.setOutputFormatClass(outputFormat.getClass()); Configuration jobConf =
-     * job.getConfiguration(); jobConf.set("mapreduce.output.fileoutputformat.outputdir", path); if (codec != null) {
-     * jobConf.set("mapreduce.output.fileoutputformat.compress", "true");
-     * jobConf.set("mapreduce.output.fileoutputformat.compress.codec", codec.getCanonicalName());
-     * jobConf.set("mapreduce.output.fileoutputformat.compress.type", CompressionType.BLOCK.toString()); }
-     * 
-     * // Create the committer OutputCommitter committer = outputFormat.getOutputCommitter(attemptContext); JobContext
-     * jobContext; Configuration jobContextConfig = jobContext.getConfiguration();
-     * jobContextConfig.set("mapreduce.job.id", jobId.toString()); jobContextConfig.set("mapreduce.task.id",
-     * attemptId.getTaskID().toString()); jobContextConfig.set("mapreduce.task.attempt.id", attemptId.toString());
-     * jobContextConfig.setBoolean("mapreduce.task.ismap", true); committer.setupJob(jobContext);
-     * 
-     * runOnPartitions(writePartition(jobConf, outputFormat.getClass())); }
-     * 
-     * protected Function<Partition, Long> writePartition(Configuration jobConf, Class<? extends OutputFormat> class1) {
-     * return (partition -> { // Derive the filename used to serialize this partition NumberFormat formatter =
-     * NumberFormat.getInstance(Locale.US); formatter.setMinimumIntegerDigits(5); formatter.setGroupingUsed(false);
-     * String outputName = "part-" + formatter.format(partition.getIndex());
-     * 
-     * // Create the task attempt context int jobId = 0; TaskAttemptID attemptId = new TaskAttemptID("", jobId,
-     * TaskType.REDUCE, partition.getIndex(), 0); Configuration attemptConf = new Configuration(jobConf);
-     * attemptConf.setInt("mapreduce.task.partition", partition.getIndex()); TaskAttemptContext attemptContext = new
-     * TaskAttemptContextImpl(attemptConf, attemptId);
-     * 
-     * try { // Instantiate the output format OutputFormat<K, V> outputFormat = class1.newInstance(); if (outputFormat
-     * instanceof Configurable) { ((Configurable) outputFormat).setConf(attemptConf); }
-     * 
-     * 
-     * 
-     * 
-     * // Initialize the writer RecordWriter<K,V> writer = outputFormat.getRecordWriter(attemptContext);
-     * iterate(partition).forEach(tuple -> { try { writer.write(tuple.getKey(), tuple.getValue()); } catch (IOException
-     * | InterruptedException e) { throw new UncheckedExecutionException(e); } finally { try {
-     * writer.close(attemptContext); } catch (IOException | InterruptedException e) { throw new
-     * UncheckedExecutionException(e); } } }); } catch (IOException | InterruptedException | InstantiationException |
-     * IllegalAccessException e) { throw new UncheckedExecutionException(e); } return 0L; }); }
-     */
 
 }

--- a/refine-local-runner/src/main/java/org/openrefine/model/local/RecordPLL.java
+++ b/refine-local-runner/src/main/java/org/openrefine/model/local/RecordPLL.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Streams;
  */
 public class RecordPLL extends PLL<Tuple2<Long, Record>> {
 
-    private final PairPLL<Long, Row> parent;
+    private final PairPLL<Long, IndexedRow> parent;
     private List<RecordPartition> partitions;
     protected final int keyColumnIndex;
 
@@ -35,7 +35,7 @@ public class RecordPLL extends PLL<Tuple2<Long, Record>> {
      * @param keyColumnIndex
      *            the index of the column used as record key
      */
-    public static PairPLL<Long, Record> groupIntoRecords(PairPLL<Long, Row> grid, int keyColumnIndex) {
+    public static PairPLL<Long, Record> groupIntoRecords(PairPLL<Long, IndexedRow> grid, int keyColumnIndex) {
         return new PairPLL<Long, Record>(new RecordPLL(grid, keyColumnIndex), grid.getPartitioner());
     }
 
@@ -48,13 +48,15 @@ public class RecordPLL extends PLL<Tuple2<Long, Record>> {
      * @param keyColumnIndex
      *            the index of the column used as record key
      */
-    public RecordPLL(PairPLL<Long, Row> grid, int keyColumnIndex) {
+    public RecordPLL(PairPLL<Long, IndexedRow> grid, int keyColumnIndex) {
         super(grid.getContext());
         this.keyColumnIndex = keyColumnIndex;
         List<? extends Partition> parentPartitions = grid.getPartitions();
         Stream<? extends Partition> lastPartitions = parentPartitions.stream().skip(1L);
-        List<RecordEnd> recordEnds = grid
-                .runOnPartitionsWithoutInterruption(partition -> extractRecordEnd(grid.iterate(partition), keyColumnIndex), lastPartitions);
+        PLL<IndexedRow> indexedRows = grid.values();
+        List<RecordEnd> recordEnds = indexedRows
+                .runOnPartitionsWithoutInterruption(partition -> extractRecordEnd(indexedRows.iterate(partition), keyColumnIndex),
+                        lastPartitions);
         parent = grid;
         partitions = new ArrayList<>(parentPartitions.size());
         for (int i = 0; i != parentPartitions.size(); i++) {
@@ -76,28 +78,27 @@ public class RecordPLL extends PLL<Tuple2<Long, Record>> {
         }
     }
 
-    protected static RecordEnd extractRecordEnd(Stream<Tuple2<Long, Row>> rows, int keyColumnIndex) {
+    protected static RecordEnd extractRecordEnd(Stream<IndexedRow> rows, int keyColumnIndex) {
         // We cannot use Stream.takeWhile here because we need to know if we have reached the end of the stream
         List<Row> end = new ArrayList<>();
-        Iterator<Tuple2<Long, Row>> iterator = rows.iterator();
-        Tuple2<Long, Row> lastTuple = null;
+        Iterator<IndexedRow> iterator = rows.iterator();
+        IndexedRow lastTuple = null;
         while (iterator.hasNext()) {
             lastTuple = iterator.next();
-            if (!lastTuple.getValue().isCellBlank(keyColumnIndex)) {
+            if (!lastTuple.getRow().isCellBlank(keyColumnIndex)) {
                 break;
             }
-            end.add(lastTuple.getValue());
+            end.add(lastTuple.getRow());
         }
-        return new RecordEnd(end, lastTuple == null || lastTuple.getValue().isCellBlank(keyColumnIndex));
+        return new RecordEnd(end, lastTuple == null || lastTuple.getRow().isCellBlank(keyColumnIndex));
     }
 
     protected static Stream<Tuple2<Long, Record>> groupIntoRecords(
-            Stream<Tuple2<Long, Row>> stream,
+            Stream<IndexedRow> stream,
             int keyCellIndex,
             boolean ignoreFirstRows,
             List<Row> additionalRows) {
-        Iterator<Tuple2<Long, Row>> iterator = stream.iterator();
-        Iterator<IndexedRow> indexedRows = Iterators.transform(iterator, tuple -> new IndexedRow(tuple.getKey(), tuple.getValue()));
+        Iterator<IndexedRow> indexedRows = stream.iterator();
         Iterator<Record> recordIterator = Record.groupIntoRecords(indexedRows, keyCellIndex, ignoreFirstRows, additionalRows);
         Iterator<Tuple2<Long, Record>> indexedRecords = Iterators.transform(recordIterator,
                 record -> Tuple2.of(record.getStartRowId(), record));
@@ -107,7 +108,8 @@ public class RecordPLL extends PLL<Tuple2<Long, Record>> {
     @Override
     protected Stream<Tuple2<Long, Record>> compute(Partition partition) {
         RecordPartition recordPartition = (RecordPartition) partition;
-        Stream<Tuple2<Long, Row>> rows = parent.iterate(recordPartition.getParent());
+        Stream<IndexedRow> rows = parent.iterate(recordPartition.getParent())
+                .map(Tuple2::getValue);
         Stream<Tuple2<Long, Record>> records = groupIntoRecords(rows, keyColumnIndex, partition.getIndex() != 0,
                 recordPartition.additionalRows);
         return records;

--- a/refine-local-runner/src/test/java/org/openrefine/model/local/OrderedJoinPLLTests.java
+++ b/refine-local-runner/src/test/java/org/openrefine/model/local/OrderedJoinPLLTests.java
@@ -11,7 +11,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-public class SortedJoinPLLTests extends PLLTestsBase {
+public class OrderedJoinPLLTests extends PLLTestsBase {
 
     private List<Tuple2<Long, String>> first;
     private List<Tuple2<Long, String>> second;
@@ -90,6 +90,26 @@ public class SortedJoinPLLTests extends PLLTestsBase {
         PairPLL<Long, String> firstPLL = parallelize(2, first)
                 .mapToPair(t -> t);
         PairPLL<Long, String> secondPLL = parallelize(2, second)
+                .mapToPair(t -> t);
+
+        PairPLL<Long, Tuple2<String, String>> joined = firstPLL.outerJoinOrdered(secondPLL, Comparator.naturalOrder());
+
+        Assert.assertEquals(joined.collect(),
+                Arrays.asList(
+                        Tuple2.of(1L, Tuple2.of(null, "one")),
+                        Tuple2.of(2L, Tuple2.of("foo", null)),
+                        Tuple2.of(4L, Tuple2.of("bar", "four")),
+                        Tuple2.of(5L, Tuple2.of("boom", null)),
+                        Tuple2.of(6L, Tuple2.of("hey", "six")),
+                        Tuple2.of(7L, Tuple2.of(null, "seven")),
+                        Tuple2.of(8L, Tuple2.of("you", null))));
+    }
+
+    @Test
+    public void testOuterJoinWithEmptyPartitions() {
+        PairPLL<Long, String> firstPLL = parallelize(10, first)
+                .mapToPair(t -> t);
+        PairPLL<Long, String> secondPLL = parallelize(10, second)
                 .mapToPair(t -> t);
 
         PairPLL<Long, Tuple2<String, String>> joined = firstPLL.outerJoinOrdered(secondPLL, Comparator.naturalOrder());

--- a/refine-local-runner/src/test/java/org/openrefine/model/local/PairPLLTests.java
+++ b/refine-local-runner/src/test/java/org/openrefine/model/local/PairPLLTests.java
@@ -76,42 +76,82 @@ public class PairPLLTests extends PLLTestsBase {
     }
 
     @Test
-    public void testGetRangeWithPartitioner() {
+    public void testGetRangeAfterWithPartitioner() {
         PairPLL<Long, Integer> zipped = parallelize(4, Arrays.asList(10, 11, 12, 13, 14, 15, 16, 17)).zipWithIndex();
 
-        Assert.assertEquals(zipped.getRange(-1L, 2, Comparator.naturalOrder()),
+        Assert.assertEquals(zipped.getRangeAfter(-1L, 2, Comparator.naturalOrder()),
                 Arrays.asList(
                         Tuple2.of(0L, 10),
                         Tuple2.of(1L, 11)));
 
-        Assert.assertEquals(zipped.getRange(7L, 2, Comparator.naturalOrder()),
+        Assert.assertEquals(zipped.getRangeAfter(7L, 2, Comparator.naturalOrder()),
                 Arrays.asList(
                         Tuple2.of(7L, 17)));
 
-        Assert.assertEquals(zipped.getRange(3L, 2, Comparator.naturalOrder()),
+        Assert.assertEquals(zipped.getRangeAfter(3L, 2, Comparator.naturalOrder()),
                 Arrays.asList(
                         Tuple2.of(3L, 13),
                         Tuple2.of(4L, 14)));
     }
 
     @Test
-    public void testGetRangeWithoutPartitioner() {
+    public void testGetRangeAfterWithoutPartitioner() {
         PairPLL<Long, Integer> zipped = new PairPLL<Long, Integer>(
                 parallelize(4, Arrays.asList(10, 11, 12, 13, 14, 15, 16, 17)).zipWithIndex().toPLL(), Optional.empty());
 
-        Assert.assertEquals(zipped.getRange(-1L, 2, Comparator.naturalOrder()),
+        Assert.assertEquals(zipped.getRangeAfter(-1L, 2, Comparator.naturalOrder()),
                 Arrays.asList(
                         Tuple2.of(0L, 10),
                         Tuple2.of(1L, 11)));
 
-        Assert.assertEquals(zipped.getRange(7L, 2, Comparator.naturalOrder()),
+        Assert.assertEquals(zipped.getRangeAfter(7L, 2, Comparator.naturalOrder()),
                 Arrays.asList(
                         Tuple2.of(7L, 17)));
 
-        Assert.assertEquals(zipped.getRange(3L, 2, Comparator.naturalOrder()),
+        Assert.assertEquals(zipped.getRangeAfter(3L, 2, Comparator.naturalOrder()),
                 Arrays.asList(
                         Tuple2.of(3L, 13),
                         Tuple2.of(4L, 14)));
+    }
+
+    @Test
+    public void testGetRangeBeforeWithPartitioner() {
+        PairPLL<Long, Integer> zipped = parallelize(4, Arrays.asList(10, 11, 12, 13, 14, 15, 16, 17)).zipWithIndex();
+
+        Assert.assertEquals(zipped.getRangeBefore(3L, 2, Comparator.naturalOrder()),
+                Arrays.asList(
+                        Tuple2.of(1L, 11),
+                        Tuple2.of(2L, 12)));
+
+        Assert.assertEquals(zipped.getRangeBefore(1L, 2, Comparator.naturalOrder()),
+                Arrays.asList(
+                        Tuple2.of(0L, 10)));
+
+        Assert.assertEquals(zipped.getRangeBefore(9L, 2, Comparator.naturalOrder()),
+                Arrays.asList(
+                        Tuple2.of(6L, 16),
+                        Tuple2.of(7L, 17)));
+    }
+
+    @Test
+    public void testGetRangeBeforeWithoutPartitioner() {
+        PairPLL<Long, Integer> zipped = new PairPLL<>(
+                parallelize(4, Arrays.asList(10, 11, 12, 13, 14, 15, 16, 17)).zipWithIndex().toPLL(),
+                Optional.empty());
+
+        Assert.assertEquals(zipped.getRangeBefore(3L, 2, Comparator.naturalOrder()),
+                Arrays.asList(
+                        Tuple2.of(1L, 11),
+                        Tuple2.of(2L, 12)));
+
+        Assert.assertEquals(zipped.getRangeBefore(1L, 2, Comparator.naturalOrder()),
+                Arrays.asList(
+                        Tuple2.of(0L, 10)));
+
+        Assert.assertEquals(zipped.getRangeBefore(9L, 2, Comparator.naturalOrder()),
+                Arrays.asList(
+                        Tuple2.of(6L, 16),
+                        Tuple2.of(7L, 17)));
     }
 
     @Test
@@ -277,5 +317,24 @@ public class PairPLLTests extends PLLTestsBase {
         Assert.assertEquals(dropped.collect(), Arrays.asList(Tuple2.of(0L, 3), Tuple2.of(1L, 8), Tuple2.of(2L, 1), Tuple2.of(3L, -3)));
         Assert.assertTrue(dropped.partitioner.isPresent());
         PartitionerTestUtils.checkPartitionerAdequacy(dropped.partitioner.get(), dropped);
+    }
+
+    @Test
+    public void testGatherElementsBefore() {
+        List<Tuple2<Long, Integer>> list = Arrays.asList(
+                Tuple2.of(0L, 10),
+                Tuple2.of(2L, 12),
+                Tuple2.of(4L, 14),
+                Tuple2.of(6L, 16),
+                Tuple2.of(8L, 18));
+
+        Assert.assertEquals(PairPLL.gatherElementsBefore(5L, 2, list.stream(), Comparator.naturalOrder()),
+                list.subList(1, 3));
+        Assert.assertEquals(PairPLL.gatherElementsBefore(13L, 2, list.stream(), Comparator.naturalOrder()),
+                list.subList(3, 5));
+        Assert.assertEquals(PairPLL.gatherElementsBefore(1L, 2, list.stream(), Comparator.naturalOrder()),
+                list.subList(0, 1));
+        Assert.assertEquals(PairPLL.gatherElementsBefore(10L, 20, list.stream(), Comparator.naturalOrder()),
+                list);
     }
 }

--- a/refine-model/src/main/java/org/openrefine/LookupCacheManager.java
+++ b/refine-model/src/main/java/org/openrefine/LookupCacheManager.java
@@ -97,7 +97,7 @@ public class LookupCacheManager {
             }
 
             // We can't use for-each here, because we'll need the row index when creating WrappedRow
-            for (IndexedRow indexedRow : grid.iterateRows(RowFilter.ANY_ROW, SortingConfig.NO_SORTING)) {
+            for (IndexedRow indexedRow : grid.iterateRows(RowFilter.ANY_ROW)) {
                 Row targetRow = indexedRow.getRow();
                 Object value = targetRow.getCellValue(targetColumnIndex);
                 if (ExpressionUtils.isNonBlankData(value)) {

--- a/refine-model/src/main/java/org/openrefine/model/GridState.java
+++ b/refine-model/src/main/java/org/openrefine/model/GridState.java
@@ -7,7 +7,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import org.openrefine.browsing.facets.RecordAggregator;
 import org.openrefine.browsing.facets.RowAggregator;
@@ -57,7 +56,8 @@ public interface GridState {
      * fetching them by batch, depending on the implementation.
      * 
      * @param id
-     *            the row index
+     *            the row index. This refers to the current position of the row in the grid, which corresponds to
+     *            {@link IndexedRow#getIndex()}.
      * @return the row at the given index
      * @throws IndexOutOfBoundsException
      *             if row id could not be found
@@ -73,13 +73,56 @@ public interface GridState {
      *            the maximum number of rows to fetch
      * @return the list of rows with their ids (if any)
      */
-    public List<IndexedRow> getRows(long start, int limit);
+    public List<IndexedRow> getRowsAfter(long start, int limit);
+
+    /**
+     * Among the subset of filtered rows, return a list of rows, starting from a given index and defined by a maximum
+     * size.
+     * 
+     * @param filter
+     *            the subset of rows to paginate through. This object and its dependencies are required to be
+     *            serializable.
+     * @param start
+     *            the first row id to fetch (inclusive)
+     * @param limit
+     *            the maximum number of rows to fetch
+     * @return the list of rows with their ids (if any)
+     * @see #getRowsBefore(long, int)
+     */
+    public List<IndexedRow> getRowsAfter(RowFilter filter, long start, int limit);
+
+    /**
+     * Returns a list of consecutive rows, just before the given row index (not included) and up to a maximum size.
+     *
+     * @param end
+     *            the last row id to fetch (exclusive)
+     * @param limit
+     *            the maximum number of rows to fetch
+     * @return the list of rows with their ids (if any)
+     * @see #getRowsAfter(long, int)
+     */
+    public List<IndexedRow> getRowsBefore(long end, int limit);
+
+    /**
+     * Among the subset of filtered rows, return a list of rows, just before the row with a given index (excluded) and
+     * defined by a maximum size.
+     *
+     * @param filter
+     *            the subset of rows to paginate through. This object and its dependencies are required to be
+     *            serializable.
+     * @param end
+     *            the last row id to fetch (exclusive)
+     * @param limit
+     *            the maximum number of rows to fetch
+     * @return the list of rows with their ids (if any)
+     */
+    public List<IndexedRow> getRowsBefore(RowFilter filter, long end, int limit);
 
     /**
      * Returns a list of rows corresponding to the row indices supplied. By default, this calls
      * {@link GridState#getRow(long)} on all values, but implementations can override this to more efficient strategies
      * if available.
-     * 
+     *
      * @param rowIndices
      *            the indices of the rows to lookup
      * @return the list contains null values for the row indices which could not be found.
@@ -97,23 +140,6 @@ public interface GridState {
     }
 
     /**
-     * Among the subset of filtered rows, return a list of rows, starting from a given index and defined by a maximum
-     * size.
-     * 
-     * @param filter
-     *            the subset of rows to paginate through. This object and its dependencies are required to be
-     *            serializable.
-     * @param sortingConfig
-     *            the order in which to return the rows
-     * @param start
-     *            the first row id to fetch (inclusive)
-     * @param limit
-     *            the maximum number of rows to fetch
-     * @return the list of rows with their ids (if any)
-     */
-    public List<IndexedRow> getRows(RowFilter filter, SortingConfig sortingConfig, long start, int limit);
-
-    /**
      * Iterate over rows matched by a filter, in the order determined by a sorting configuration. This might not require
      * loading all rows in memory at once, but might be less efficient than {@link #collectRows()} if all rows are to be
      * stored in memory downstream.
@@ -122,7 +148,7 @@ public interface GridState {
      * leaks with some implementations. This should be clarified by the interface. Consider exposing a closeable
      * iterable instead.
      */
-    public Iterable<IndexedRow> iterateRows(RowFilter filter, SortingConfig sortingConfig);
+    public Iterable<IndexedRow> iterateRows(RowFilter filter);
 
     /**
      * Count the number of rows which match a given filter.
@@ -155,7 +181,8 @@ public interface GridState {
      * inefficient depending on the implementation.
      * 
      * @param id
-     *            the row id of the first row in the record
+     *            the row id of the first row in the record. This refers to the current position of the record in the
+     *            grid, which corresponds to {@link Record#getStartRowId()}.
      * @return the corresponding record
      * @throws IllegalArgumentException
      *             if record id could not be found
@@ -170,8 +197,9 @@ public interface GridState {
      * @param limit
      *            the maximum number of records to fetch
      * @return the list of records (if any)
+     * @see #getRecordsBefore(long, int)
      */
-    public List<Record> getRecords(long start, int limit);
+    public List<Record> getRecordsAfter(long start, int limit);
 
     /**
      * Among the filtered subset of records, returns a list of records, starting from a given index and defined by a
@@ -180,22 +208,46 @@ public interface GridState {
      * @param filter
      *            the filter which defines the subset of records to paginate through This object and its dependencies
      *            are required to be serializable.
-     * @param sortingConfig
-     *            the order in which the rows should be returned
      * @param start
      *            the first record id to fetch (inclusive)
      * @param limit
      *            the maximum number of records to fetch
      * @return the list of records (if any)
      */
-    public List<Record> getRecords(RecordFilter filter, SortingConfig sortingConfig, long start, int limit);
+    public List<Record> getRecordsAfter(RecordFilter filter, long start, int limit);
 
     /**
-     * Iterate over records matched by a filter, ordered according to the sorting configuration. This might not require
-     * loading all records in memory at once, but might be less efficient than {@link #collectRecords()} if all records
-     * are to be stored in memory downstream.
+     * Returns a list of consecutive records, ending at a given index (exclusive) and defined by a maximum size.
+     *
+     * @param end
+     *            the last record id to fetch (exclusive)
+     * @param limit
+     *            the maximum number of records to fetch
+     * @return the list of records (if any)
+     * @see #getRecordsAfter(long, int)
      */
-    public Iterable<Record> iterateRecords(RecordFilter filter, SortingConfig sortingConfig);
+    public List<Record> getRecordsBefore(long end, int limit);
+
+    /**
+     * Among the filtered subset of records, returns a list of records, ending at a given index (exclusive) and defined
+     * by a maximum size.
+     *
+     * @param filter
+     *            the filter which defines the subset of records to paginate through This object and its dependencies
+     *            are required to be serializable.
+     * @param end
+     *            the last record id to fetch (exclusive)
+     * @param limit
+     *            the maximum number of records to fetch
+     * @return the list of records (if any)
+     */
+    public List<Record> getRecordsBefore(RecordFilter filter, long end, int limit);
+
+    /**
+     * Iterate over records matched by a filter. This might not require loading all records in memory at once, but might
+     * be less efficient than {@link #collectRecords()} if all records are to be stored in memory downstream.
+     */
+    public Iterable<Record> iterateRecords(RecordFilter filter);
 
     /**
      * Return the number of records which are filtered by this filter.
@@ -348,18 +400,24 @@ public interface GridState {
      * 
      * @param sortingConfig
      *            the criteria to sort rows
+     * @param permanent
+     *            if true, forget the original row ids. If false, store them in the corresponding
+     *            {@link IndexedRow#getOriginalIndex()}.
      * @return the resulting grid state
      */
-    public GridState reorderRows(SortingConfig sortingConfig);
+    public GridState reorderRows(SortingConfig sortingConfig, boolean permanent);
 
     /**
      * Returns a new grid state where records have been reordered according to the configuration supplied.
      * 
      * @param sortingConfig
      *            the criteria to sort records
+     * @param permanent
+     *            if true, forget the original record ids. If false, store them in the corresponding
+     *            {@link Record#getOriginalStartRowId()}.
      * @return the resulting grid state
      */
-    public GridState reorderRecords(SortingConfig sortingConfig);
+    public GridState reorderRecords(SortingConfig sortingConfig, boolean permanent);
 
     /**
      * Removes all rows selected by a filter

--- a/refine-model/src/main/java/org/openrefine/model/IndexedRow.java
+++ b/refine-model/src/main/java/org/openrefine/model/IndexedRow.java
@@ -4,11 +4,17 @@ package org.openrefine.model;
 import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * A row with its row index. Equivalent to {@code Tuple2<long, Row>} but serializable and deserializable with Jackson
  * easily. Serialization keys are kept short to reduce the memory overhead.
+ * <p>
+ * This class can also hold a so-called original row id, which is used when sorting grids. The original row id is the
+ * original position of the row before sorting the grid. This is used when the user adds sorting settings in the UI
+ * without permanently re-ordering the rows yet.
  * 
  * @author Antonin Delpeuch
  */
@@ -17,24 +23,59 @@ public class IndexedRow implements Serializable {
     private static final long serialVersionUID = -8959175171376953548L;
 
     private final long _id;
+    private final long _originalId;
     private final Row _row;
+
+    public IndexedRow(
+            long id,
+            Row row) {
+        _id = id;
+        _row = row;
+        _originalId = -1;
+    }
 
     @JsonCreator
     public IndexedRow(
             @JsonProperty("i") long id,
+            @JsonProperty("o") Long originalId,
             @JsonProperty("r") Row row) {
         _id = id;
         _row = row;
+        _originalId = originalId == null ? -1 : originalId;
     }
 
+    /**
+     * The position (0-based) of the row in the grid.
+     */
     @JsonProperty("i")
     public long getIndex() {
         return _id;
     }
 
+    /**
+     * The row
+     */
     @JsonProperty("r")
     public Row getRow() {
         return _row;
+    }
+
+    /**
+     * If this grid was obtained by applying a temporary sorting, this returns the original id of the row in the
+     * unsorted grid. Otherwise, this returns null.
+     */
+    @JsonProperty("o")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public Long getOriginalIndex() {
+        return _originalId == -1 ? null : _originalId;
+    }
+
+    /**
+     * The original index of this row, or if it is not set, the actual one.
+     */
+    @JsonIgnore
+    public long getLogicalIndex() {
+        return _originalId == -1 ? _id : _originalId;
     }
 
     @Override
@@ -43,7 +84,7 @@ public class IndexedRow implements Serializable {
             return false;
         }
         IndexedRow otherRow = (IndexedRow) other;
-        return _id == otherRow._id && _row.equals(otherRow._row);
+        return _id == otherRow._id && _row.equals(otherRow._row) && _originalId == otherRow._originalId;
     }
 
     @Override
@@ -53,6 +94,10 @@ public class IndexedRow implements Serializable {
 
     @Override
     public String toString() {
-        return String.format("IndexedRow %d: %s", _id, _row);
+        if (_originalId == -1) {
+            return String.format("IndexedRow %d: %s", _id, _row);
+        } else {
+            return String.format("IndexRow (%d -> %d): %s", _originalId, _id, _row);
+        }
     }
 }

--- a/refine-model/src/test/java/org/openrefine/browsing/EngineTests.java
+++ b/refine-model/src/test/java/org/openrefine/browsing/EngineTests.java
@@ -171,7 +171,7 @@ public class EngineTests {
     public void testGetMatchingRows() {
         @SuppressWarnings("unchecked")
         Iterable<IndexedRow> mockIterable = mock(Iterable.class);
-        when(initialState.iterateRows(Mockito.any(), Mockito.eq(SortingConfig.NO_SORTING))).thenReturn(mockIterable);
+        when(initialState.iterateRows(Mockito.any())).thenReturn(mockIterable);
 
         Assert.assertEquals(engine.getMatchingRows(SortingConfig.NO_SORTING), mockIterable);
     }

--- a/refine-model/src/test/java/org/openrefine/model/IndexedRowTests.java
+++ b/refine-model/src/test/java/org/openrefine/model/IndexedRowTests.java
@@ -31,4 +31,23 @@ public class IndexedRowTests {
                 IndexedRow.class);
         Assert.assertEquals(tuple.getIndex(), 1234L);
     }
+
+    @Test
+    public void saveIndexedRowWithOriginalId() {
+        Row row = new Row(Arrays.asList(new Cell("I'm not empty", null)));
+        IndexedRow tuple = new IndexedRow(1234L, 5678L, row);
+        TestUtils.isSerializedTo(
+                tuple,
+                "{\"i\":1234,\"o\":5678,\"r\":{\"flagged\":false,\"starred\":false,\"cells\":[{\"v\":\"I'm not empty\"}]}}",
+                ParsingUtilities.defaultWriter);
+    }
+
+    @Test
+    public void readIndexedRowWithOriginalId() throws JsonParseException, JsonMappingException, IOException {
+        IndexedRow tuple = ParsingUtilities.mapper.readValue(
+                "{\"i\":1234,\"o\":5678,\"r\":{\"flagged\":false,\"starred\":false,\"cells\":[{\"v\":\"I'm not empty\"}]}}",
+                IndexedRow.class);
+        Assert.assertEquals(tuple.getIndex(), 1234L);
+        Assert.assertEquals(tuple.getOriginalIndex(), 5678L);
+    }
 }

--- a/refine-model/src/test/java/org/openrefine/model/RecordTests.java
+++ b/refine-model/src/test/java/org/openrefine/model/RecordTests.java
@@ -18,6 +18,7 @@ public class RecordTests {
 
     List<Row> rows;
     Record SUT;
+    Record sortedRecord;
 
     @BeforeMethod
     public void setUp() {
@@ -26,6 +27,7 @@ public class RecordTests {
                 row(null, "c"),
                 row("", "d"));
         SUT = new Record(34L, rows);
+        sortedRecord = new Record(34L, 56L, rows);
     }
 
     @Test
@@ -34,6 +36,11 @@ public class RecordTests {
         Assert.assertEquals(SUT.getStartRowId(), 34L);
         Assert.assertEquals(SUT.getEndRowId(), 37L);
         Assert.assertEquals(SUT.size(), 3);
+        Assert.assertEquals(SUT.getOriginalStartRowId(), null);
+        Assert.assertEquals(SUT.getLogicalStartRowId(), 34L);
+
+        Assert.assertEquals(sortedRecord.getOriginalStartRowId(), 56L);
+        Assert.assertEquals(sortedRecord.getLogicalStartRowId(), 56L);
     }
 
     @Test
@@ -86,6 +93,7 @@ public class RecordTests {
         Assert.assertNotEquals(SUT, 23);
         Assert.assertNotEquals(SUT, new Record(34L, Collections.emptyList()));
         Assert.assertEquals(SUT, new Record(34L, rows));
+        Assert.assertNotEquals(SUT, sortedRecord);
     }
 
     @Test
@@ -96,6 +104,7 @@ public class RecordTests {
     @Test
     public void testToString() {
         Assert.assertTrue(SUT.toString().contains("Record"));
+        Assert.assertTrue(sortedRecord.toString().contains("56"));
     }
 
 }

--- a/refine-spark-runner/src/main/java/org/openrefine/model/SparkGridState.java
+++ b/refine-spark-runner/src/main/java/org/openrefine/model/SparkGridState.java
@@ -69,7 +69,7 @@ public class SparkGridState implements GridState {
 
     protected final Map<String, OverlayModel> overlayModels;
     protected final ColumnModel columnModel;
-    protected final JavaPairRDD<Long, Row> grid;
+    protected final JavaPairRDD<Long, IndexedRow> grid;
     // not final because it is initialized on demand, as creating
     // it involves running a (small) Spark job
     protected JavaPairRDD<Long, Record> records = null;
@@ -97,6 +97,22 @@ public class SparkGridState implements GridState {
 
     /**
      * Creates a grid state from a grid and a column model
+     *
+     * @param grid
+     *            the state of the table
+     * @param columnModel
+     *            the header of the table
+     */
+    public SparkGridState(
+            JavaPairRDD<Long, IndexedRow> grid,
+            ColumnModel columnModel,
+            Map<String, OverlayModel> overlayModels,
+            SparkDatamodelRunner runner) {
+        this(grid, columnModel, overlayModels, runner, -1, -1);
+    }
+
+    /**
+     * Creates a grid state from a grid and a column model
      * 
      * @param columnModel
      *            the header of the table
@@ -113,6 +129,37 @@ public class SparkGridState implements GridState {
             long cachedRowCount,
             long cachedRecordCount) {
         this.columnModel = columnModel;
+
+        // Ensure that the grid has a partitioner
+        JavaPairRDD<Long, IndexedRow> rdd = grid
+                .mapToPair(tuple -> new Tuple2<Long, IndexedRow>(tuple._1, new IndexedRow(tuple._1, tuple._2)));
+        this.grid = SortedRDD.assumeSorted(rdd);
+
+        this.cachedRowCount = cachedRowCount;
+        this.cachedRecordCount = cachedRecordCount;
+
+        this.overlayModels = immutableMap(overlayModels);
+        this.runner = runner;
+    }
+
+    /**
+     * Creates a grid state from a grid and a column model
+     *
+     * @param grid
+     *            the state of the table
+     * @param columnModel
+     *            the header of the table
+     * @param cachedRowCount
+     *            the number of rows in the table, cached
+     */
+    protected SparkGridState(
+            JavaPairRDD<Long, IndexedRow> grid,
+            ColumnModel columnModel,
+            Map<String, OverlayModel> overlayModels,
+            SparkDatamodelRunner runner,
+            long cachedRowCount,
+            long cachedRecordCount) {
+        this.columnModel = columnModel;
         // Ensure that the grid has a partitioner
         this.grid = SortedRDD.assumeSorted(grid);
 
@@ -121,7 +168,6 @@ public class SparkGridState implements GridState {
 
         this.overlayModels = immutableMap(overlayModels);
         this.runner = runner;
-
     }
 
     private ImmutableMap<String, OverlayModel> immutableMap(Map<String, OverlayModel> map) {
@@ -150,7 +196,7 @@ public class SparkGridState implements GridState {
      * @return the grid data at this stage of the workflow
      */
     @JsonIgnore
-    public JavaPairRDD<Long, Row> getGrid() {
+    public JavaPairRDD<Long, IndexedRow> getGrid() {
         return grid;
     }
 
@@ -176,26 +222,26 @@ public class SparkGridState implements GridState {
      */
     @JsonIgnore
     public JavaRDD<IndexedRow> getIndexedRows() {
-        return grid.map(t -> new IndexedRow(t._1, t._2));
+        return grid.values();
     }
 
     @Override
     public Row getRow(long id) {
-        List<Row> rows = grid.lookup(id);
+        List<IndexedRow> rows = grid.lookup(id);
         if (rows.size() == 0) {
             throw new IndexOutOfBoundsException(String.format("Row id %d not found", id));
         } else if (rows.size() > 1) {
             throw new IllegalStateException(String.format("Found %d rows at index %d", rows.size(), id));
         } else {
-            return rows.get(0);
+            return rows.get(0).getRow();
         }
     }
 
     @Override
-    public List<IndexedRow> getRows(long start, int limit) {
-        return RDDUtils.paginate(grid, start, limit)
+    public List<IndexedRow> getRowsAfter(long start, int limit) {
+        return RDDUtils.paginateAfter(grid, start, limit)
                 .stream()
-                .map(tuple -> new IndexedRow(tuple._1, tuple._2))
+                .map(Tuple2::_2)
                 .collect(Collectors.toList());
     }
 
@@ -212,61 +258,54 @@ public class SparkGridState implements GridState {
     }
 
     @Override
-    public List<IndexedRow> getRows(RowFilter filter, SortingConfig sortingConfig, long start, int limit) {
-        JavaPairRDD<Long, Row> filteredGrid = grid;
+    public List<IndexedRow> getRowsAfter(RowFilter filter, long start, int limit) {
+        JavaPairRDD<Long, IndexedRow> filteredGrid = grid;
         if (!filter.equals(RowFilter.ANY_ROW)) {
             filteredGrid = grid.filter(wrapRowFilter(filter));
         }
-        if (sortingConfig.equals(SortingConfig.NO_SORTING)) {
-            // Without sorting, we can rely on row ids to paginate
-            return RDDUtils.paginate(filteredGrid, start, limit)
-                    .stream()
-                    .map(tuple -> new IndexedRow(tuple._1, tuple._2))
-                    .collect(Collectors.toList());
-        } else {
-            RowSorter sorter = new RowSorter(this, sortingConfig);
-            // If we have a sorter, pagination is less efficient since we cannot rely
-            // on the partitioner to locate the rows in the appropriate partition
-            List<IndexedRow> rows = filteredGrid
-                    .map(t -> new IndexedRow(t._1, t._2))
-                    .keyBy(ir -> ir)
-                    .sortByKey(sorter)
-                    .values()
-                    .take((int) start + limit);
-            return rows
-                    .subList(Math.min((int) start, rows.size()), Math.min((int) start + limit, rows.size()));
-        }
+        // Without sorting, we can rely on row ids to paginate
+        return RDDUtils.paginateAfter(filteredGrid, start, limit)
+                .stream()
+                .map(Tuple2::_2)
+                .collect(Collectors.toList());
     }
 
-    private static Function<Tuple2<Long, Row>, Boolean> wrapRowFilter(RowFilter filter) {
-        return new Function<Tuple2<Long, Row>, Boolean>() {
+    @Override
+    public List<IndexedRow> getRowsBefore(long end, int limit) {
+        return getRowsBefore(RowFilter.ANY_ROW, end, limit);
+    }
+
+    @Override
+    public List<IndexedRow> getRowsBefore(RowFilter filter, long end, int limit) {
+        JavaPairRDD<Long, IndexedRow> filteredGrid = grid;
+        if (!filter.equals(RowFilter.ANY_ROW)) {
+            filteredGrid = grid.filter(wrapRowFilter(filter));
+        }
+        // Without sorting, we can rely on row ids to paginate
+        return RDDUtils.paginateBefore(filteredGrid, end, limit)
+                .stream()
+                .map(Tuple2::_2)
+                .collect(Collectors.toList());
+    }
+
+    private static Function<Tuple2<Long, IndexedRow>, Boolean> wrapRowFilter(RowFilter filter) {
+        return new Function<Tuple2<Long, IndexedRow>, Boolean>() {
 
             private static final long serialVersionUID = 2093008247452689031L;
 
             @Override
-            public Boolean call(Tuple2<Long, Row> tuple) throws Exception {
-                return filter.filterRow(tuple._1, tuple._2);
+            public Boolean call(Tuple2<Long, IndexedRow> tuple) throws Exception {
+                return filter.filterRow(tuple._2.getLogicalIndex(), tuple._2.getRow());
             }
 
         };
     }
 
     @Override
-    public Iterable<IndexedRow> iterateRows(RowFilter filter, SortingConfig sortingConfig) {
-        JavaRDD<IndexedRow> filtered;
-        if (SortingConfig.NO_SORTING.equals(sortingConfig)) {
-            filtered = grid
-                    .filter(wrapRowFilter(filter))
-                    .map(t -> new IndexedRow(t._1, t._2));
-        } else {
-            RowSorter sorter = new RowSorter(this, sortingConfig);
-            filtered = grid
-                    .filter(wrapRowFilter(filter))
-                    .map(t -> new IndexedRow(t._1, t._2))
-                    .keyBy(ir -> ir)
-                    .sortByKey(sorter)
-                    .values();
-        }
+    public Iterable<IndexedRow> iterateRows(RowFilter filter) {
+        JavaRDD<IndexedRow> filtered = grid
+                .filter(wrapRowFilter(filter))
+                .values();
 
         return new Iterable<IndexedRow>() {
 
@@ -280,7 +319,7 @@ public class SparkGridState implements GridState {
 
     @Override
     public List<IndexedRow> collectRows() {
-        return grid.map(tuple -> new IndexedRow(tuple._1, tuple._2)).collect();
+        return grid.values().collect();
     }
 
     /**
@@ -323,14 +362,15 @@ public class SparkGridState implements GridState {
         };
     }
 
-    private static Function2<ApproxCount, Tuple2<Long, Row>, ApproxCount> approxRowFilterAggregator(RowFilter filter, long rowLimit) {
-        return new Function2<ApproxCount, Tuple2<Long, Row>, ApproxCount>() {
+    private static Function2<ApproxCount, Tuple2<Long, IndexedRow>, ApproxCount> approxRowFilterAggregator(RowFilter filter,
+            long rowLimit) {
+        return new Function2<ApproxCount, Tuple2<Long, IndexedRow>, ApproxCount>() {
 
             private static final long serialVersionUID = -54284705503006433L;
 
             @Override
-            public ApproxCount call(ApproxCount count, Tuple2<Long, Row> tuple) throws Exception {
-                long matched = count.getMatched() + (filter.filterRow(tuple._1, tuple._2) ? 1 : 0);
+            public ApproxCount call(ApproxCount count, Tuple2<Long, IndexedRow> tuple) throws Exception {
+                long matched = count.getMatched() + (filter.filterRow(tuple._2.getLogicalIndex(), tuple._2.getRow()) ? 1 : 0);
                 return new ApproxCount(count.getProcessed() + 1, matched, count.limitReached() || count.getProcessed() + 1 == rowLimit);
             }
 
@@ -361,32 +401,36 @@ public class SparkGridState implements GridState {
     }
 
     @Override
-    public List<Record> getRecords(long start, int limit) {
-        return RDDUtils.paginate(getRecords(), start, limit)
+    public List<Record> getRecordsAfter(long start, int limit) {
+        return RDDUtils.paginateAfter(getRecords(), start, limit)
                 .stream()
                 .map(tuple -> tuple._2)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<Record> getRecords(RecordFilter filter, SortingConfig sortingConfig, long start, int limit) {
+    public List<Record> getRecordsAfter(RecordFilter filter, long start, int limit) {
         JavaPairRDD<Long, Record> filteredRecords = getRecords();
         if (!filter.equals(RecordFilter.ANY_RECORD)) {
             filteredRecords = filteredRecords.filter(wrapRecordFilter(filter));
         }
-        if (SortingConfig.NO_SORTING.equals(sortingConfig)) {
-            return RDDUtils.paginate(filteredRecords, start, limit)
-                    .stream().map(tuple -> tuple._2).collect(Collectors.toList());
-        } else {
-            RecordSorter sorter = new RecordSorter(this, sortingConfig);
-            return filteredRecords
-                    .values()
-                    .keyBy(record -> record)
-                    .sortByKey(sorter)
-                    .values()
-                    .take((int) start + limit)
-                    .subList((int) start, (int) start + limit);
+        return RDDUtils.paginateAfter(filteredRecords, start, limit)
+                .stream().map(tuple -> tuple._2).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Record> getRecordsBefore(long end, int limit) {
+        return getRecordsBefore(RecordFilter.ANY_RECORD, end, limit);
+    }
+
+    @Override
+    public List<Record> getRecordsBefore(RecordFilter filter, long end, int limit) {
+        JavaPairRDD<Long, Record> filteredRecords = getRecords();
+        if (!filter.equals(RecordFilter.ANY_RECORD)) {
+            filteredRecords = filteredRecords.filter(wrapRecordFilter(filter));
         }
+        return RDDUtils.paginateBefore(filteredRecords, end, limit)
+                .stream().map(tuple -> tuple._2).collect(Collectors.toList());
     }
 
     private static Function<Tuple2<Long, Record>, Boolean> wrapRecordFilter(RecordFilter filter) {
@@ -403,21 +447,10 @@ public class SparkGridState implements GridState {
     }
 
     @Override
-    public Iterable<Record> iterateRecords(RecordFilter filter, SortingConfig sortingConfig) {
-        JavaRDD<Record> filtered;
-        if (SortingConfig.NO_SORTING.equals(sortingConfig)) {
-            filtered = getRecords()
-                    .filter(wrapRecordFilter(filter))
-                    .values();
-        } else {
-            RecordSorter sorter = new RecordSorter(this, sortingConfig);
-            filtered = getRecords()
-                    .filter(wrapRecordFilter(filter))
-                    .values()
-                    .keyBy(record -> record)
-                    .sortByKey(sorter)
-                    .values();
-        }
+    public Iterable<Record> iterateRecords(RecordFilter filter) {
+        JavaRDD<Record> filtered = getRecords()
+                .filter(wrapRecordFilter(filter))
+                .values();
         return new Iterable<Record>() {
 
             @Override
@@ -516,8 +549,8 @@ public class SparkGridState implements GridState {
         progressReporter.reportProgress(100);
     }
 
-    protected static String serializeIndexedRow(Tuple2<Long, Row> indexedRow) throws JsonProcessingException {
-        return ParsingUtilities.saveWriter.writeValueAsString(new IndexedRow(indexedRow._1, indexedRow._2));
+    protected static String serializeIndexedRow(Tuple2<Long, IndexedRow> indexedRow) throws JsonProcessingException {
+        return ParsingUtilities.saveWriter.writeValueAsString(indexedRow._2);
     }
 
     public static SparkGridState loadFromFile(JavaSparkContext context, File file) throws IOException {
@@ -582,27 +615,27 @@ public class SparkGridState implements GridState {
                 .aggregate(initialPartialState, recordSeqOpPartial(aggregator, partitionLimit), facetCombineOpPartial(aggregator));
     }
 
-    private static <T> Function2<T, Tuple2<Long, Row>, T> rowSeqOp(RowAggregator<T> aggregator) {
-        return new Function2<T, Tuple2<Long, Row>, T>() {
+    private static <T> Function2<T, Tuple2<Long, IndexedRow>, T> rowSeqOp(RowAggregator<T> aggregator) {
+        return new Function2<T, Tuple2<Long, IndexedRow>, T>() {
 
             private static final long serialVersionUID = 2188564367142265354L;
 
             @Override
-            public T call(T states, Tuple2<Long, Row> rowTuple) throws Exception {
-                return aggregator.withRow(states, rowTuple._1, rowTuple._2);
+            public T call(T states, Tuple2<Long, IndexedRow> rowTuple) throws Exception {
+                return aggregator.withRow(states, rowTuple._2.getLogicalIndex(), rowTuple._2.getRow());
             }
         };
     }
 
-    private static <T extends Serializable> Function2<PartialAggregation<T>, Tuple2<Long, Row>, PartialAggregation<T>> rowSeqOpPartial(
+    private static <T extends Serializable> Function2<PartialAggregation<T>, Tuple2<Long, IndexedRow>, PartialAggregation<T>> rowSeqOpPartial(
             RowAggregator<T> aggregator, long limit) {
-        return new Function2<PartialAggregation<T>, Tuple2<Long, Row>, PartialAggregation<T>>() {
+        return new Function2<PartialAggregation<T>, Tuple2<Long, IndexedRow>, PartialAggregation<T>>() {
 
             private static final long serialVersionUID = 2188564367142265354L;
 
             @Override
-            public PartialAggregation<T> call(PartialAggregation<T> states, Tuple2<Long, Row> rowTuple) throws Exception {
-                T newState = aggregator.withRow(states.getState(), rowTuple._1, rowTuple._2);
+            public PartialAggregation<T> call(PartialAggregation<T> states, Tuple2<Long, IndexedRow> rowTuple) throws Exception {
+                T newState = aggregator.withRow(states.getState(), rowTuple._2.getLogicalIndex(), rowTuple._2.getRow());
                 return new PartialAggregation<T>(newState, states.getProcessed() + 1,
                         states.limitReached() || (states.getProcessed() + 1 == limit));
             }
@@ -670,18 +703,18 @@ public class SparkGridState implements GridState {
 
     @Override
     public SparkGridState mapRows(RowMapper mapper, ColumnModel newColumnModel) {
-        JavaPairRDD<Long, Row> rows = RDDUtils.mapKeyValuesToValues(grid, rowMap(mapper));
-        return new SparkGridState(newColumnModel, rows, overlayModels, runner, cachedRowCount, -1);
+        JavaPairRDD<Long, IndexedRow> rows = RDDUtils.mapKeyValuesToValues(grid, rowMap(mapper));
+        return new SparkGridState(rows, newColumnModel, overlayModels, runner, cachedRowCount, -1);
     }
 
-    private static Function2<Long, Row, Row> rowMap(RowMapper mapper) {
-        return new Function2<Long, Row, Row>() {
+    private static Function2<Long, IndexedRow, IndexedRow> rowMap(RowMapper mapper) {
+        return new Function2<Long, IndexedRow, IndexedRow>() {
 
             private static final long serialVersionUID = 429225090136968798L;
 
             @Override
-            public Row call(Long id, Row row) throws Exception {
-                return mapper.call(id, row);
+            public IndexedRow call(Long id, IndexedRow row) throws Exception {
+                return new IndexedRow(row.getIndex(), row.getOriginalIndex(), mapper.call(row.getLogicalIndex(), row.getRow()));
             }
         };
     }
@@ -692,14 +725,14 @@ public class SparkGridState implements GridState {
         return new SparkGridState(newColumnModel, rows, overlayModels, runner);
     }
 
-    private static FlatMapFunction<Tuple2<Long, Row>, Row> rowFlatMap(RowFlatMapper mapper) {
-        return new FlatMapFunction<Tuple2<Long, Row>, Row>() {
+    private static FlatMapFunction<Tuple2<Long, IndexedRow>, Row> rowFlatMap(RowFlatMapper mapper) {
+        return new FlatMapFunction<Tuple2<Long, IndexedRow>, Row>() {
 
             private static final long serialVersionUID = -2920197696120331752L;
 
             @Override
-            public Iterator<Row> call(Tuple2<Long, Row> t) throws Exception {
-                return mapper.call(t._1, t._2).iterator();
+            public Iterator<Row> call(Tuple2<Long, IndexedRow> t) throws Exception {
+                return mapper.call(t._2.getLogicalIndex(), t._2.getRow()).iterator();
             }
 
         };
@@ -707,31 +740,31 @@ public class SparkGridState implements GridState {
 
     @Override
     public <S extends Serializable> GridState mapRows(RowScanMapper<S> mapper, ColumnModel newColumnModel) {
-        RDD<Tuple2<Long, Row>> rows = new ScanMapRDD<Serializable, Tuple2<Long, Row>, Tuple2<Long, Row>>(
+        RDD<Tuple2<Long, IndexedRow>> rows = new ScanMapRDD<Serializable, Tuple2<Long, IndexedRow>, Tuple2<Long, IndexedRow>>(
                 grid.rdd(),
                 rowScanMapperToFeed(mapper),
                 rowScanMapperToCombine(mapper),
                 rowScanMapperToMap(mapper),
                 mapper.unit(),
-                RDDUtils.ROW_TUPLE2_TAG,
-                RDDUtils.ROW_TUPLE2_TAG,
+                RDDUtils.INDEXEDROW_TUPLE2_TAG,
+                RDDUtils.INDEXEDROW_TUPLE2_TAG,
                 ClassManifestFactory.fromClass(Serializable.class));
 
         return new SparkGridState(
+                new JavaPairRDD<Long, IndexedRow>(rows, RDDUtils.LONG_TAG, RDDUtils.INDEXEDROW_TAG),
                 newColumnModel,
-                new JavaPairRDD<Long, Row>(rows, RDDUtils.LONG_TAG, RDDUtils.ROW_TAG),
                 overlayModels,
                 runner);
     }
 
-    private static <S extends Serializable> Function<Tuple2<Long, Row>, Serializable> rowScanMapperToFeed(RowScanMapper<S> mapper) {
-        return new Function<Tuple2<Long, Row>, Serializable>() {
+    private static <S extends Serializable> Function<Tuple2<Long, IndexedRow>, Serializable> rowScanMapperToFeed(RowScanMapper<S> mapper) {
+        return new Function<Tuple2<Long, IndexedRow>, Serializable>() {
 
             private static final long serialVersionUID = -5264889389519072017L;
 
             @Override
-            public Serializable call(Tuple2<Long, Row> tuple) throws Exception {
-                return mapper.feed(tuple._1, tuple._2);
+            public Serializable call(Tuple2<Long, IndexedRow> tuple) throws Exception {
+                return mapper.feed(tuple._2.getLogicalIndex(), tuple._2.getRow());
             }
 
         };
@@ -752,16 +785,17 @@ public class SparkGridState implements GridState {
         };
     }
 
-    private static <S extends Serializable> Function2<Serializable, Tuple2<Long, Row>, Tuple2<Long, Row>> rowScanMapperToMap(
+    private static <S extends Serializable> Function2<Serializable, Tuple2<Long, IndexedRow>, Tuple2<Long, IndexedRow>> rowScanMapperToMap(
             RowScanMapper<S> mapper) {
-        return new Function2<Serializable, Tuple2<Long, Row>, Tuple2<Long, Row>>() {
+        return new Function2<Serializable, Tuple2<Long, IndexedRow>, Tuple2<Long, IndexedRow>>() {
 
             private static final long serialVersionUID = -321428794497355320L;
 
             @SuppressWarnings("unchecked")
             @Override
-            public Tuple2<Long, Row> call(Serializable v1, Tuple2<Long, Row> v2) throws Exception {
-                return new Tuple2<Long, Row>(v2._1, mapper.map((S) v1, v2._1, v2._2));
+            public Tuple2<Long, IndexedRow> call(Serializable v1, Tuple2<Long, IndexedRow> v2) throws Exception {
+                return new Tuple2<Long, IndexedRow>(v2._1,
+                        new IndexedRow(v2._1, v2._2.getOriginalIndex(), mapper.map((S) v1, v2._2.getLogicalIndex(), v2._2.getRow())));
             }
 
         };
@@ -775,7 +809,7 @@ public class SparkGridState implements GridState {
             JavaPairRDD<Long, Tuple2<Long, Row>> newRows = getRecords().flatMapValues(rowPreservingRecordMap(mapper));
             rows = new PartitionedRDD<Long, Row>(JavaPairRDD.fromJavaRDD(newRows.values()),
                     newRows.partitioner().get())
-                            .asPairRDD(newRows.kClassTag(), grid.vClassTag());
+                            .asPairRDD(newRows.kClassTag(), RDDUtils.ROW_TAG);
         } else {
             // We need to recompute row ids and get a new partitioner
             JavaRDD<Row> newRows = getRecords().values().flatMap(recordMap(mapper));
@@ -819,11 +853,22 @@ public class SparkGridState implements GridState {
         };
     }
 
+    private static FlatMapFunction<Record, IndexedRow> recordToIndexedRows = new FlatMapFunction<Record, IndexedRow>() {
+
+        private static final long serialVersionUID = 6663749328661449792L;
+
+        @Override
+        public Iterator<IndexedRow> call(Record record) throws Exception {
+            return record.getIndexedRows().iterator();
+        }
+
+    };
+
     @Override
     public SparkGridState withOverlayModels(Map<String, OverlayModel> newOverlayModels) {
         return new SparkGridState(
-                columnModel,
                 grid,
+                columnModel,
                 newOverlayModels,
                 runner,
                 cachedRowCount,
@@ -833,8 +878,8 @@ public class SparkGridState implements GridState {
     @Override
     public GridState withColumnModel(ColumnModel newColumnModel) {
         return new SparkGridState(
-                newColumnModel,
                 grid,
+                newColumnModel,
                 overlayModels,
                 runner,
                 cachedRowCount,
@@ -842,51 +887,79 @@ public class SparkGridState implements GridState {
     }
 
     @Override
-    public GridState reorderRows(SortingConfig sortingConfig) {
+    public GridState reorderRows(SortingConfig sortingConfig, boolean permanent) {
         RowSorter sorter = new RowSorter(this, sortingConfig);
         // TODO: we should map by the keys generated by the sortingConfig,
         // and provide a comparator for those: that could be more efficient
-        JavaPairRDD<Long, Row> sortedGrid = RDDUtils.zipWithIndex(
-                getIndexedRows()
-                        .keyBy(ir -> ir)
-                        .sortByKey(sorter)
-                        .values()
-                        .map(ir -> ir.getRow()));
-        return new SparkGridState(
-                columnModel,
-                sortedGrid,
-                overlayModels,
-                runner,
-                cachedRowCount,
-                -1); // reordering rows can change the number of records
+        JavaRDD<IndexedRow> sortedIndexedRows = getIndexedRows()
+                .keyBy(ir -> ir)
+                .sortByKey(sorter)
+                .values();
+        if (permanent) {
+            JavaPairRDD<Long, Row> sortedGrid = RDDUtils.zipWithIndex(
+                    sortedIndexedRows
+                            .map(ir -> ir.getRow()));
+            return new SparkGridState(
+                    columnModel,
+                    sortedGrid,
+                    overlayModels,
+                    runner,
+                    cachedRowCount,
+                    -1); // reordering rows can change the number of records
+        } else {
+            JavaPairRDD<Long, IndexedRow> zipped = RDDUtils.mapKeyValuesToValues(RDDUtils.zipWithIndex(sortedIndexedRows),
+                    (id, indexedRow) -> new IndexedRow(id, indexedRow.getLogicalIndex(), indexedRow.getRow()));
+            return new SparkGridState(
+                    zipped,
+                    columnModel,
+                    overlayModels,
+                    runner,
+                    cachedRowCount,
+                    -1); // reordering rows can change the number of records
+
+        }
     }
 
     @Override
-    public GridState reorderRecords(SortingConfig sortingConfig) {
+    public GridState reorderRecords(SortingConfig sortingConfig, boolean permanent) {
         RecordSorter sorter = new RecordSorter(this, sortingConfig);
         // TODO: we should map by the keys generated by the sortingConfig,
         // and provide a comparator for those: that could be more efficient
-        JavaPairRDD<Long, Row> sortedGrid = RDDUtils.zipWithIndex(
-                getRecords()
-                        .values()
-                        .keyBy(record -> record)
-                        .sortByKey(sorter)
-                        .values()
-                        .flatMap(recordMap(RecordMapper.IDENTITY)));
-        return new SparkGridState(
-                columnModel,
-                sortedGrid,
-                overlayModels,
-                runner,
-                cachedRowCount,
-                cachedRecordCount); // reordering records does not change their count
+        JavaRDD<Record> records = getRecords()
+                .values()
+                .keyBy(record -> record)
+                .sortByKey(sorter)
+                .values();
+        if (permanent) {
+            JavaPairRDD<Long, Row> sortedGrid = RDDUtils.zipWithIndex(
+                    records.flatMap(recordMap(RecordMapper.IDENTITY)));
+            return new SparkGridState(
+                    columnModel,
+                    sortedGrid,
+                    overlayModels,
+                    runner,
+                    cachedRowCount,
+                    cachedRecordCount); // reordering records does not change their count
+        } else {
+            JavaPairRDD<Long, IndexedRow> sortedGrid = RDDUtils.mapKeyValuesToValues(RDDUtils.zipWithIndex(
+                    records.flatMap(recordToIndexedRows)),
+                    (key, indexedRow) -> new IndexedRow(key, indexedRow.getLogicalIndex(), indexedRow.getRow()));
+            return new SparkGridState(
+                    sortedGrid,
+                    columnModel,
+                    overlayModels,
+                    runner,
+                    cachedRowCount,
+                    cachedRecordCount); // reordering records does not change their count
+        }
     }
 
     @Override
     public GridState removeRows(RowFilter filter) {
         JavaPairRDD<Long, Row> newRows = RDDUtils.zipWithIndex(grid
                 .filter(wrapRowFilter(RowFilter.negate(filter)))
-                .values());
+                .values()
+                .map(IndexedRow::getRow));
 
         return new SparkGridState(
                 columnModel,
@@ -913,11 +986,11 @@ public class SparkGridState implements GridState {
 
     @Override
     public GridState limitRows(long rowLimit) {
-        JavaPairRDD<Long, Row> limited = RDDUtils.limit(grid, rowLimit);
+        JavaPairRDD<Long, IndexedRow> limited = RDDUtils.limit(grid, rowLimit);
         long newCachedRowCount = cachedRowCount == -1 ? -1 : Math.max(cachedRowCount, rowLimit);
         return new SparkGridState(
-                columnModel,
                 limited,
+                columnModel,
                 overlayModels,
                 runner,
                 newCachedRowCount,
@@ -928,6 +1001,7 @@ public class SparkGridState implements GridState {
     public GridState dropRows(long rowLimit) {
         JavaPairRDD<Long, Row> newRows = grid
                 .filter(wrapRowFilter(RowFilter.limitFilter(rowLimit)))
+                .mapValues(IndexedRow::getRow)
                 .mapToPair(offsetRowIds(-rowLimit));
 
         // Adapt the partitioner to the new row ids
@@ -945,7 +1019,7 @@ public class SparkGridState implements GridState {
                 }
             }
             Partitioner newPartitioner = new SortedRDD.SortedPartitioner<>(oldPartitioner.numPartitions(), newIndices);
-            newRows = new PartitionedRDD<Long, Row>(newRows, newPartitioner).asPairRDD(grid.kClassTag(), grid.vClassTag());
+            newRows = new PartitionedRDD<Long, Row>(newRows, newPartitioner).asPairRDD(grid.kClassTag(), RDDUtils.ROW_TAG);
         }
 
         // Compute the new row count
@@ -973,14 +1047,14 @@ public class SparkGridState implements GridState {
         };
     }
 
-    private static <T> Function2<Long, Row, T> rowMap(RowChangeDataProducer<T> mapper) {
-        return new Function2<Long, Row, T>() {
+    private static <T> Function2<Long, IndexedRow, T> rowMap(RowChangeDataProducer<T> mapper) {
+        return new Function2<Long, IndexedRow, T>() {
 
             private static final long serialVersionUID = 429225090136968798L;
 
             @Override
-            public T call(Long id, Row row) throws Exception {
-                return mapper.call(id, row);
+            public T call(Long id, IndexedRow row) throws Exception {
+                return mapper.call(row.getLogicalIndex(), row.getRow());
             }
         };
     }
@@ -988,11 +1062,11 @@ public class SparkGridState implements GridState {
     @Override
     public <T> ChangeData<T> mapRows(RowFilter filter, RowChangeDataProducer<T> rowMapper) {
         JavaPairRDD<Long, T> data;
-        JavaPairRDD<Long, Row> filteredGrid = grid.filter(wrapRowFilter(filter));
+        JavaPairRDD<Long, IndexedRow> filteredGrid = grid.filter(wrapRowFilter(filter));
         if (rowMapper.getBatchSize() == 1) {
             data = RDDUtils.mapKeyValuesToValues(filteredGrid, rowMap(rowMapper));
         } else {
-            JavaRDD<List<IndexedRow>> batched = RDDUtils.partitionWiseBatching(filteredGrid.map(t -> new IndexedRow(t._1, t._2)),
+            JavaRDD<List<IndexedRow>> batched = RDDUtils.partitionWiseBatching(filteredGrid.values(),
                     rowMapper.getBatchSize());
             data = JavaPairRDD.fromJavaRDD(batched.flatMap(batchedRowMap(rowMapper)));
         }
@@ -1077,21 +1151,22 @@ public class SparkGridState implements GridState {
         // TODO this left outer join does not rely on the fact that the RDDs are sorted by key
         // and there could be spurious shuffles if the partitioners differ slightly.
         // the last sort could be avoided as well (but by default leftOuterJoin will not preserve order…)
-        JavaPairRDD<Long, Tuple2<Row, Optional<T>>> join = grid.leftOuterJoin(sparkChangeData.getData()).sortByKey();
-        JavaPairRDD<Long, Row> newGrid = RDDUtils.mapKeyValuesToValues(join, wrapJoiner(rowJoiner));
+        JavaPairRDD<Long, Tuple2<IndexedRow, Optional<T>>> join = grid.leftOuterJoin(sparkChangeData.getData()).sortByKey();
+        JavaPairRDD<Long, IndexedRow> newGrid = RDDUtils.mapKeyValuesToValues(join, wrapJoiner(rowJoiner));
 
-        return new SparkGridState(newColumnModel, newGrid, overlayModels, runner);
+        return new SparkGridState(newGrid, newColumnModel, overlayModels, runner);
     }
 
-    private static <T> Function2<Long, Tuple2<Row, Optional<T>>, Row> wrapJoiner(RowChangeDataJoiner<T> joiner) {
+    private static <T> Function2<Long, Tuple2<IndexedRow, Optional<T>>, IndexedRow> wrapJoiner(RowChangeDataJoiner<T> joiner) {
 
-        return new Function2<Long, Tuple2<Row, Optional<T>>, Row>() {
+        return new Function2<Long, Tuple2<IndexedRow, Optional<T>>, IndexedRow>() {
 
             private static final long serialVersionUID = 3976239801526423806L;
 
             @Override
-            public Row call(Long id, Tuple2<Row, Optional<T>> tuple) throws Exception {
-                return joiner.call(id, tuple._1, tuple._2.or(null));
+            public IndexedRow call(Long id, Tuple2<IndexedRow, Optional<T>> tuple) throws Exception {
+                return new IndexedRow(id, tuple._1.getOriginalIndex(),
+                        joiner.call(tuple._1.getLogicalIndex(), tuple._1.getRow(), tuple._2.or(null)));
             }
         };
     }
@@ -1106,21 +1181,21 @@ public class SparkGridState implements GridState {
         // TODO this left outer join does not rely on the fact that the RDDs are sorted by key
         // and there could be spurious shuffles if the partitioners differ slightly.
         // the last sort could be avoided as well (but by default leftOuterJoin will not preserve order…)
-        JavaPairRDD<Long, Tuple2<Row, Optional<T>>> join = grid.leftOuterJoin(sparkChangeData.getData()).sortByKey();
+        JavaPairRDD<Long, Tuple2<IndexedRow, Optional<T>>> join = grid.leftOuterJoin(sparkChangeData.getData()).sortByKey();
         JavaPairRDD<Long, List<Row>> newGrid = RDDUtils.mapKeyValuesToValues(join, wrapFlatJoiner(rowJoiner));
         JavaPairRDD<Long, Row> flattened = RDDUtils.zipWithIndex(newGrid.values().flatMap(l -> l.iterator()));
         return new SparkGridState(newColumnModel, flattened, overlayModels, runner);
     }
 
-    private static <T> Function2<Long, Tuple2<Row, Optional<T>>, List<Row>> wrapFlatJoiner(RowChangeDataFlatJoiner<T> joiner) {
+    private static <T> Function2<Long, Tuple2<IndexedRow, Optional<T>>, List<Row>> wrapFlatJoiner(RowChangeDataFlatJoiner<T> joiner) {
 
-        return new Function2<Long, Tuple2<Row, Optional<T>>, List<Row>>() {
+        return new Function2<Long, Tuple2<IndexedRow, Optional<T>>, List<Row>>() {
 
             private static final long serialVersionUID = 3976239801526423806L;
 
             @Override
-            public List<Row> call(Long id, Tuple2<Row, Optional<T>> tuple) throws Exception {
-                return joiner.call(id, tuple._1, tuple._2.or(null));
+            public List<Row> call(Long id, Tuple2<IndexedRow, Optional<T>> tuple) throws Exception {
+                return joiner.call(tuple._1.getLogicalIndex(), tuple._1.getRow(), tuple._2.or(null));
             }
         };
     }
@@ -1164,7 +1239,7 @@ public class SparkGridState implements GridState {
         ColumnModel merged = columnModel.merge(other.getColumnModel());
         SparkGridState sparkGrid = (SparkGridState) other;
 
-        JavaRDD<Row> rows = grid.values().union(sparkGrid.getGrid().values());
+        JavaRDD<Row> rows = grid.values().union(sparkGrid.getGrid().values()).map(IndexedRow::getRow);
         JavaPairRDD<Long, Row> indexedRows = RDDUtils.zipWithIndex(rows);
         Map<String, OverlayModel> mergedOverlayModels = new HashMap<>(other.getOverlayModels());
         mergedOverlayModels.putAll(overlayModels);

--- a/refine-spark-runner/src/main/java/org/openrefine/model/rdd/RecordRDD.java
+++ b/refine-spark-runner/src/main/java/org/openrefine/model/rdd/RecordRDD.java
@@ -89,7 +89,7 @@ public class RecordRDD extends RDD<Tuple2<Long, Record>> implements Serializable
         }
     }
 
-    private final ClassTag<Tuple2<Long, Row>> classTag;
+    private final ClassTag<Tuple2<Long, IndexedRow>> classTag;
     private final int keyCellIndex;
     private final UnfinishedRecord[] firstRows;
     private final Partitioner sortedPartitioner;
@@ -102,7 +102,7 @@ public class RecordRDD extends RDD<Tuple2<Long, Record>> implements Serializable
      * @param keyCellIndex
      *            the column index used to determine record boundaries
      */
-    public RecordRDD(JavaPairRDD<Long, Row> prev, int keyCellIndex) {
+    public RecordRDD(JavaPairRDD<Long, IndexedRow> prev, int keyCellIndex) {
         super(prev.rdd(), TUPLE2_TAG);
         classTag = prev.classTag();
         this.keyCellIndex = keyCellIndex;
@@ -132,10 +132,10 @@ public class RecordRDD extends RDD<Tuple2<Long, Record>> implements Serializable
     @Override
     public Iterator<Tuple2<Long, Record>> compute(Partition partition, TaskContext context) {
         RecordRDDPartition recordPartition = (RecordRDDPartition) partition;
-        Iterator<Tuple2<Long, Row>> parentIter = this.firstParent(classTag).iterator(recordPartition.prev, context);
+        Iterator<Tuple2<Long, IndexedRow>> parentIter = this.firstParent(classTag).iterator(recordPartition.prev, context);
         java.util.Iterator<IndexedRow> indexedRows = Iterators.transform(
                 JavaConverters.asJavaIterator(parentIter),
-                tuple -> new IndexedRow(tuple._1, tuple._2));
+                Tuple2::_2);
         java.util.Iterator<Record> records = Record.groupIntoRecords(
                 indexedRows,
                 keyCellIndex,
@@ -183,7 +183,7 @@ public class RecordRDD extends RDD<Tuple2<Long, Record>> implements Serializable
      *
      */
     protected static class ExtractFirstRecord
-            implements Function2<TaskContext, Iterator<Tuple2<Long, Row>>, UnfinishedRecord>, Serializable {
+            implements Function2<TaskContext, Iterator<Tuple2<Long, IndexedRow>>, UnfinishedRecord>, Serializable {
 
         private static final long serialVersionUID = 8473670054764783718L;
         private final int keyCellIndex;
@@ -193,15 +193,15 @@ public class RecordRDD extends RDD<Tuple2<Long, Record>> implements Serializable
         }
 
         @Override
-        public UnfinishedRecord apply(TaskContext v1, Iterator<Tuple2<Long, Row>> iterator) {
+        public UnfinishedRecord apply(TaskContext v1, Iterator<Tuple2<Long, IndexedRow>> iterator) {
             List<Row> currentRows = new ArrayList<>();
             Long firstRecordStart = null;
             while (firstRecordStart == null && iterator.hasNext()) {
-                Tuple2<Long, Row> tuple = iterator.next();
-                if (Record.isRecordStart(tuple._2, keyCellIndex)) {
+                Tuple2<Long, IndexedRow> tuple = iterator.next();
+                if (Record.isRecordStart(tuple._2.getRow(), keyCellIndex)) {
                     firstRecordStart = tuple._1;
                 } else {
-                    currentRows.add(tuple._2);
+                    currentRows.add(tuple._2.getRow());
                 }
             }
             return new UnfinishedRecord(currentRows, firstRecordStart);

--- a/refine-spark-runner/src/main/java/org/openrefine/util/RDDUtils.java
+++ b/refine-spark-runner/src/main/java/org/openrefine/util/RDDUtils.java
@@ -1,9 +1,7 @@
 
 package org.openrefine.util;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import org.apache.spark.Partitioner;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -12,7 +10,7 @@ import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
-import org.apache.spark.rdd.OrderedRDDFunctions;
+import org.openrefine.model.IndexedRow;
 import org.openrefine.model.Row;
 import org.openrefine.model.rdd.PartitionedRDD;
 import org.openrefine.model.rdd.SortedRDD.SortedPartitioner;
@@ -21,7 +19,6 @@ import org.openrefine.model.rdd.ZippedWithIndexRDD;
 import com.google.common.collect.Iterators;
 
 import scala.Tuple2;
-import scala.math.Ordering;
 import scala.reflect.ClassManifestFactory;
 import scala.reflect.ClassTag;
 
@@ -36,8 +33,11 @@ public class RDDUtils {
     @SuppressWarnings("unchecked")
     public static final ClassTag<Tuple2<Long, Row>> ROW_TUPLE2_TAG = ClassManifestFactory
             .fromClass((Class<Tuple2<Long, Row>>) (Class<?>) Tuple2.class);
+    public static final ClassTag<Tuple2<Long, IndexedRow>> INDEXEDROW_TUPLE2_TAG = ClassManifestFactory
+            .fromClass((Class<Tuple2<Long, IndexedRow>>) (Class<?>) Tuple2.class);
     public static final ClassTag<Long> LONG_TAG = ClassManifestFactory.fromClass(Long.class);
     public static final ClassTag<Row> ROW_TAG = ClassManifestFactory.fromClass(Row.class);
+    public static final ClassTag<IndexedRow> INDEXEDROW_TAG = ClassManifestFactory.fromClass(IndexedRow.class);
 
     /**
      * Returns the first few records after a given index from an indexed RDD. If the RDD has a RangePartitioner (any
@@ -51,12 +51,37 @@ public class RDDUtils {
      *            the maximum number of records to return
      * @return the list of records corresponding to the requested page
      */
-    public static <T> List<Tuple2<Long, T>> paginate(JavaPairRDD<Long, T> rdd, long start, int limit) {
+    public static <T> List<Tuple2<Long, T>> paginateAfter(JavaPairRDD<Long, T> rdd, long start, int limit) {
         if (start == 0) {
             return rdd.take(limit);
         } else {
-            return filterByRange(rdd, start, Long.MAX_VALUE).take(limit);
+            return rdd.filterByRange(start, Long.MAX_VALUE).take(limit);
         }
+    }
+
+    /**
+     * Returns the last few records up to a given upper bound from an indexed RDD. If the RDD has a RangePartitioner
+     * (any sorted RDD), this will be achieved by only scanning the relevant partitions.
+     *
+     * @param rdd
+     *            the RDD to extract the records from.
+     * @param end
+     *            the minimum index (inclusive) to return
+     * @param limit
+     *            the maximum number of records to return
+     * @return the list of records corresponding to the requested page
+     */
+    public static <T> List<Tuple2<Long, T>> paginateBefore(JavaPairRDD<Long, T> rdd, long end, int limit) {
+        // TODO this could be optimized (see the PLL implementation which is more efficient)
+        Iterator<Tuple2<Long, T>> iterator = rdd.filterByRange(Long.MIN_VALUE, end - 1).toLocalIterator();
+        Deque<Tuple2<Long, T>> buffer = new ArrayDeque<>(limit);
+        while (iterator.hasNext()) {
+            if (buffer.size() == limit) {
+                buffer.removeFirst();
+            }
+            buffer.addLast(iterator.next());
+        }
+        return new ArrayList<>(buffer);
     }
 
     /**
@@ -68,41 +93,6 @@ public class RDDUtils {
      */
     public static <T> JavaPairRDD<Long, T> zipWithIndex(JavaRDD<T> rdd) {
         return new ZippedWithIndexRDD<T>(rdd).asPairRDD();
-    }
-
-    /**
-     * Efficiently filters a RDD which has a RangePartitioner (any sorted RDD) by pruning partitions which cannot
-     * contain keys outside the range, or falls back on regular filter if no RangePartitioner is available.
-     * <p>
-     * Workaround for <a href="https://issues.apache.org/jira/browse/SPARK-31518">SPARK-31518</a>, which will be fixed
-     * in 3.1.0
-     * <p>
-     * TODO remove this once 3.1.0 is released
-     *
-     * @param <V>
-     *            type of values
-     * @param rdd
-     *            the RDD to filter
-     * @param lower
-     *            the lower bound (inclusive)
-     * @param upper
-     *            the upper bound (exclusive)
-     * @return a RDD containing only keys within the range
-     */
-    public static <V> JavaPairRDD<Long, V> filterByRange(JavaPairRDD<Long, V> rdd, long lower, long upper) {
-        Ordering<Long> ordering = new Ordering<Long>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public int compare(Long x, Long y) {
-                return Long.compare(x, y);
-            }
-        };
-        return JavaPairRDD.fromRDD(new OrderedRDDFunctions<Long, V, Tuple2<Long, V>>(
-                rdd.rdd(), ordering, ClassManifestFactory.fromClass(Long.class), rdd.vClassTag(), rdd.classTag())
-                        .filterByRange(lower, upper),
-                rdd.kClassTag(), rdd.vClassTag());
     }
 
     /**

--- a/refine-spark-runner/src/test/java/org/openrefine/SparkBasedTest.java
+++ b/refine-spark-runner/src/test/java/org/openrefine/SparkBasedTest.java
@@ -12,7 +12,9 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.openrefine.io.OrderedLocalFileSystem;
 import org.openrefine.model.Cell;
+import org.openrefine.model.IndexedRow;
 import org.openrefine.model.Row;
+import org.openrefine.util.RDDUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterSuite;
@@ -76,6 +78,11 @@ public class SparkBasedTest {
             }
         }
         return rowRDD(cells, numPartitions);
+    }
+
+    protected JavaPairRDD<Long, IndexedRow> indexedRowRDD(Serializable[][] cellValues, int numPartitions) {
+        return RDDUtils.mapKeyValuesToValues(rowRDD(cellValues, numPartitions),
+                (key, value) -> new IndexedRow(key, value));
     }
 
     protected JavaPairRDD<Long, Row> rowRDD(Serializable[][] cells) {

--- a/refine-spark-runner/src/test/java/org/openrefine/model/SparkGridStateTests.java
+++ b/refine-spark-runner/src/test/java/org/openrefine/model/SparkGridStateTests.java
@@ -76,12 +76,12 @@ public class SparkGridStateTests extends SparkBasedTest {
 
     @Test
     public void testGetGrid() {
-        JavaPairRDD<Long, Row> grid = state.getGrid();
-        Row row1 = grid.lookup(0L).get(0);
+        JavaPairRDD<Long, IndexedRow> grid = state.getGrid();
+        Row row1 = grid.lookup(0L).get(0).getRow();
         Assert.assertEquals(row1.getCellValue(0), 1);
         Assert.assertEquals(row1.getCellValue(1), 2);
         Assert.assertEquals(row1.getCellValue(2), "3");
-        Row row2 = grid.lookup(1L).get(0);
+        Row row2 = grid.lookup(1L).get(0).getRow();
         Assert.assertEquals(row2.getCellValue(0), 4);
         Assert.assertEquals(row2.getCellValue(1), "5");
         Assert.assertEquals(row2.getCellValue(2), true);
@@ -95,7 +95,7 @@ public class SparkGridStateTests extends SparkBasedTest {
         SparkGridState loaded = SparkGridState.loadFromFile(context(), tempFile);
 
         Assert.assertEquals(loaded.getOverlayModels(), state.getOverlayModels());
-        List<Tuple2<Long, Row>> loadedGrid = loaded.getGrid().collect();
+        List<Tuple2<Long, IndexedRow>> loadedGrid = loaded.getGrid().collect();
         Assert.assertEquals(loadedGrid, state.getGrid().collect());
     }
 
@@ -110,7 +110,7 @@ public class SparkGridStateTests extends SparkBasedTest {
 
     @Test
     public void testGetRecords() {
-        Assert.assertEquals(state.getRecords(1L, 10),
+        Assert.assertEquals(state.getRecordsAfter(1L, 10),
                 Collections.singletonList(new Record(1L, Collections.singletonList(rows.get(1)._2))));
     }
 

--- a/refine-spark-runner/src/test/java/org/openrefine/model/rdd/RecordRDDTests.java
+++ b/refine-spark-runner/src/test/java/org/openrefine/model/rdd/RecordRDDTests.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.apache.spark.Partitioner;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.openrefine.SparkBasedTest;
+import org.openrefine.model.IndexedRow;
 import org.openrefine.model.Record;
 import org.openrefine.model.Row;
 import org.testng.Assert;
@@ -22,7 +23,7 @@ public class RecordRDDTests extends SparkBasedTest {
 
     @Test(dataProvider = "partitionNumbers")
     public void testSplitRecordsOverPartitions(int numPartitions) {
-        JavaPairRDD<Long, Row> rdd = rowRDD(new Serializable[][] {
+        JavaPairRDD<Long, IndexedRow> rdd = indexedRowRDD(new Serializable[][] {
                 { "a", "b" },
                 { "", "c" },
                 { null, "d" },
@@ -50,7 +51,7 @@ public class RecordRDDTests extends SparkBasedTest {
 
     @Test(dataProvider = "partitionNumbers")
     public void testNoRecordKey(int numPartitions) {
-        JavaPairRDD<Long, Row> rdd = rowRDD(new Serializable[][] {
+        JavaPairRDD<Long, IndexedRow> rdd = indexedRowRDD(new Serializable[][] {
                 { "", "b" },
                 { "", "c" },
                 { null, "d" },
@@ -72,7 +73,7 @@ public class RecordRDDTests extends SparkBasedTest {
 
     @Test(dataProvider = "partitionNumbers")
     public void testAllBlank(int numPartitions) {
-        JavaPairRDD<Long, Row> rdd = rowRDD(new Serializable[][] {
+        JavaPairRDD<Long, IndexedRow> rdd = indexedRowRDD(new Serializable[][] {
                 { "", null },
                 { "", "" },
                 { null, null },
@@ -93,7 +94,7 @@ public class RecordRDDTests extends SparkBasedTest {
 
     @Test(dataProvider = "partitionNumbers")
     public void testCustomRecordKey(int numPartitions) {
-        JavaPairRDD<Long, Row> rdd = rowRDD(new Serializable[][] {
+        JavaPairRDD<Long, IndexedRow> rdd = indexedRowRDD(new Serializable[][] {
                 { "a", "b" },
                 { "", "c" },
                 { null, "d" },
@@ -121,7 +122,7 @@ public class RecordRDDTests extends SparkBasedTest {
 
     @Test
     public void testPartitioner() {
-        JavaPairRDD<Long, Row> rdd = rowRDD(new Serializable[][] {
+        JavaPairRDD<Long, IndexedRow> rdd = indexedRowRDD(new Serializable[][] {
                 { "a", "b" },
                 { "", "c" },
                 { null, "d" },
@@ -131,7 +132,7 @@ public class RecordRDDTests extends SparkBasedTest {
                 { null, "i" },
                 { "j", "k" },
         }, 4);
-        JavaPairRDD<Long, Row> sortedRDD = SortedRDD.assumeSorted(rdd);
+        JavaPairRDD<Long, IndexedRow> sortedRDD = SortedRDD.assumeSorted(rdd);
         Partitioner partitioner = sortedRDD.partitioner().get();
 
         // preliminary check that the data is partitioned as we expect for this test

--- a/refine-spark-runner/src/test/java/org/openrefine/util/RDDUtilsTests.java
+++ b/refine-spark-runner/src/test/java/org/openrefine/util/RDDUtilsTests.java
@@ -1,7 +1,6 @@
 
 package org.openrefine.util;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -19,21 +18,6 @@ import org.testng.annotations.Test;
 import scala.Tuple2;
 
 public class RDDUtilsTests extends SparkBasedTest {
-
-    @Test
-    public void testFilterByRange() {
-        JavaPairRDD<Long, Row> rdd = rowRDD(new Serializable[][] {
-                { 1, 2 },
-                { 3, 4 },
-                { 5, 6 },
-                { 7, 8 }
-        });
-        JavaPairRDD<Long, Row> filtered = RDDUtils.filterByRange(rdd, 2L, 5L);
-        List<Tuple2<Long, Row>> rows = filtered.collect();
-        Assert.assertEquals(rows.size(), 2);
-        Assert.assertEquals(rows.get(0)._2.getCellValue(0), 5);
-        Assert.assertEquals(rows.get(1)._2.getCellValue(1), 8);
-    }
 
     @Test
     public void testLimitPartitionsPair() {
@@ -131,5 +115,17 @@ public class RDDUtilsTests extends SparkBasedTest {
         JavaPairRDD<Long, Long> limited = RDDUtils.limit(pairs, 6);
 
         Assert.assertEquals(limited.keys().collect(), LongStream.range(0L, 6L).boxed().collect(Collectors.toList()));
+    }
+
+    @Test
+    public void testPaginateBefore() {
+        List<Long> list = LongStream.range(0L, 16L).boxed().collect(Collectors.toList());
+        JavaRDD<Long> rdd = context().parallelize(list, 4);
+        JavaPairRDD<Long, Long> pairs = RDDUtils.zipWithIndex(rdd);
+        List<Tuple2<Long, Long>> pairsList = pairs.collect();
+
+        Assert.assertEquals(RDDUtils.paginateBefore(pairs, 7L, 3), pairsList.subList(4, 7));
+        Assert.assertEquals(RDDUtils.paginateBefore(pairs, 3L, 8), pairsList.subList(0, 3));
+        Assert.assertEquals(RDDUtils.paginateBefore(pairs, 20L, 4), pairsList.subList(12, 16));
     }
 }

--- a/refine-testing/src/main/java/org/openrefine/model/TestingGridState.java
+++ b/refine-testing/src/main/java/org/openrefine/model/TestingGridState.java
@@ -17,6 +17,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
+import org.apache.commons.collections.IteratorUtils;
 import org.openrefine.browsing.facets.RecordAggregator;
 import org.openrefine.browsing.facets.RowAggregator;
 import org.openrefine.model.changes.ChangeData;
@@ -47,6 +48,7 @@ public class TestingGridState implements GridState {
     private ColumnModel columnModel;
     private Map<String, OverlayModel> overlayModels;
     private List<Row> rows;
+    private List<IndexedRow> indexedRows;
     private List<Record> records;
 
     // the following is just to emulate the behaviour of a real implementation,
@@ -55,10 +57,15 @@ public class TestingGridState implements GridState {
     private boolean isCached = false;
 
     public TestingGridState(ColumnModel columnModel, List<Row> rows, Map<String, OverlayModel> overlayModels) {
+        this(indexRows(rows), columnModel, overlayModels);
+    }
+
+    protected TestingGridState(List<IndexedRow> indexedRows, ColumnModel columnModel, Map<String, OverlayModel> overlayModels) {
         this.columnModel = columnModel;
-        this.rows = rows;
+        this.indexedRows = indexedRows;
+        this.rows = indexedRows.stream().map(IndexedRow::getRow).collect(Collectors.toList());
         this.overlayModels = overlayModels;
-        records = groupRowsIntoRecords(rows, columnModel.getKeyColumnIndex());
+        records = groupRowsIntoRecords(indexedRows, columnModel.getKeyColumnIndex());
 
         // Check that all rows have the same number of cells as the project has columns
         int expectedSize = columnModel.getColumns().size();
@@ -67,22 +74,8 @@ public class TestingGridState implements GridState {
         }
     }
 
-    public static List<Record> groupRowsIntoRecords(List<Row> rows, int keyCellIndex) {
-        List<Record> records = new ArrayList<>();
-        List<Row> currentRecord = new ArrayList<>();
-        int recordStart = 0;
-        for (int i = 0; i < rows.size(); i++) {
-            if (Record.isRecordStart(rows.get(i), keyCellIndex) && !currentRecord.isEmpty()) {
-                records.add(new Record(recordStart, currentRecord));
-                recordStart = i;
-                currentRecord = new ArrayList<>();
-            }
-            currentRecord.add(rows.get(i));
-        }
-        if (!currentRecord.isEmpty()) {
-            records.add(new Record(recordStart, currentRecord));
-        }
-        return records;
+    public static List<Record> groupRowsIntoRecords(List<IndexedRow> rows, int keyCellIndex) {
+        return IteratorUtils.toList(Record.groupIntoRecords(rows.iterator(), keyCellIndex, false, Collections.emptyList()));
     }
 
     @Override
@@ -95,39 +88,58 @@ public class TestingGridState implements GridState {
         return rows.get((int) id);
     }
 
-    private List<IndexedRow> indexedRows() {
+    private static List<IndexedRow> indexRows(List<Row> rows) {
         return IntStream.range(0, rows.size()).mapToObj(i -> new IndexedRow((long) i, rows.get(i))).collect(Collectors.toList());
     }
 
     @Override
-    public List<IndexedRow> getRows(long start, int limit) {
-        return indexedRows().subList(
+    public List<IndexedRow> getRowsAfter(long start, int limit) {
+        return indexedRows.subList(
                 Math.min((int) start, rows.size()),
                 Math.min((int) start + limit, rows.size()));
     }
 
     @Override
-    public List<IndexedRow> getRows(RowFilter filter, SortingConfig sortingConfig, long start, int limit) {
+    public List<IndexedRow> getRowsAfter(RowFilter filter, long start, int limit) {
         // Check that the filter is serializable as it is required by the interface,
         // even if this implementation does not rely on it.
         RowFilter deserializedFilter = TestingDatamodelRunner.serializeAndDeserialize(filter);
 
-        List<IndexedRow> sortedRows = sortedRows(sortingConfig);
-        return sortedRows.stream()
-                .filter(tuple -> deserializedFilter.filterRow(tuple.getIndex(), tuple.getRow()))
-                .skip(start)
+        return indexedRows.stream()
+                .filter(tuple -> deserializedFilter.filterRow(tuple.getLogicalIndex(), tuple.getRow()) && tuple.getIndex() >= start)
                 .limit(limit)
                 .collect(Collectors.toList());
     }
 
     @Override
+    public List<IndexedRow> getRowsBefore(long end, int limit) {
+        int actualEnd = Math.min((int) end, rows.size());
+        return indexedRows.subList(
+                Math.max(actualEnd - limit, 0),
+                actualEnd);
+    }
+
+    @Override
+    public List<IndexedRow> getRowsBefore(RowFilter filter, long end, int limit) {
+        // Check that the filter is serializable as it is required by the interface,
+        // even if this implementation does not rely on it.
+        RowFilter deserializedFilter = TestingDatamodelRunner.serializeAndDeserialize(filter);
+
+        // this is really not efficient but that is not the point of this implementation: it should just be correct
+        List<IndexedRow> matchingRows = indexedRows.stream()
+                .filter(tuple -> deserializedFilter.filterRow(tuple.getLogicalIndex(), tuple.getRow()) && tuple.getIndex() < end)
+                .collect(Collectors.toList());
+        return matchingRows.subList(Math.max(0, matchingRows.size() - limit), matchingRows.size());
+    }
+
+    @Override
     public List<IndexedRow> collectRows() {
-        return indexedRows();
+        return indexedRows;
     }
 
     @Override
     public Record getRecord(long id) {
-        List<Record> matching = getRecords(id, 1);
+        List<Record> matching = getRecordsAfter(id, 1);
         if (matching.isEmpty() || matching.get(0).getStartRowId() != id) {
             throw new IllegalArgumentException(String.format("No record with id %d", id));
         }
@@ -135,7 +147,7 @@ public class TestingGridState implements GridState {
     }
 
     @Override
-    public List<Record> getRecords(long start, int limit) {
+    public List<Record> getRecordsAfter(long start, int limit) {
         return records
                 .stream()
                 .filter(record -> record.getStartRowId() >= start)
@@ -144,16 +156,32 @@ public class TestingGridState implements GridState {
     }
 
     @Override
-    public List<Record> getRecords(RecordFilter filter, SortingConfig sortingConfig, long start, int limit) {
+    public List<Record> getRecordsAfter(RecordFilter filter, long start, int limit) {
         // Check that the filter is serializable as it is required by the interface,
         // even if this implementation does not rely on it.
         RecordFilter deserializedFilter = TestingDatamodelRunner.serializeAndDeserialize(filter);
-        List<Record> sorted = sortedRecords(sortingConfig);
-        return sorted
+        return records
                 .stream()
                 .filter(record -> record.getStartRowId() >= start && deserializedFilter.filterRecord(record))
                 .limit(limit)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Record> getRecordsBefore(long end, int limit) {
+        return getRecordsBefore(RecordFilter.ANY_RECORD, end, limit);
+    }
+
+    @Override
+    public List<Record> getRecordsBefore(RecordFilter filter, long end, int limit) {
+        // Check that the filter is serializable as it is required by the interface,
+        // even if this implementation does not rely on it.
+        RecordFilter deserializedFilter = TestingDatamodelRunner.serializeAndDeserialize(filter);
+        List<Record> matching = records
+                .stream()
+                .filter(record -> record.getStartRowId() < end && deserializedFilter.filterRecord(record))
+                .collect(Collectors.toList());
+        return matching.subList(Math.max(0, matching.size() - limit), matching.size());
     }
 
     @Override
@@ -173,7 +201,7 @@ public class TestingGridState implements GridState {
 
     @Override
     public long countMatchingRows(RowFilter filter) {
-        return indexedRows()
+        return indexedRows
                 .stream()
                 .filter(tuple -> filter.filterRow(tuple.getIndex(), tuple.getRow()))
                 .count();
@@ -181,7 +209,7 @@ public class TestingGridState implements GridState {
 
     @Override
     public ApproxCount countMatchingRowsApprox(RowFilter filter, long limit) {
-        long matching = indexedRows()
+        long matching = indexedRows
                 .stream()
                 .limit(limit)
                 .filter(tuple -> filter.filterRow(tuple.getIndex(), tuple.getRow()))
@@ -233,7 +261,7 @@ public class TestingGridState implements GridState {
         try {
             fos = new FileOutputStream(partFile);
             gos = new GZIPOutputStream(fos);
-            for (IndexedRow row : indexedRows()) {
+            for (IndexedRow row : indexedRows) {
                 ParsingUtilities.saveWriter.writeValue(gos, row);
                 gos.write('\n');
             }
@@ -276,7 +304,7 @@ public class TestingGridState implements GridState {
         T statesA = initialState;
         T statesB = initialState;
         long count = 0;
-        for (IndexedRow row : indexedRows()) {
+        for (IndexedRow row : indexedRows) {
             if (count == maxRows) {
                 break;
             }
@@ -324,7 +352,7 @@ public class TestingGridState implements GridState {
         mapper = TestingDatamodelRunner.serializeAndDeserialize(mapper);
 
         List<Row> rows = new ArrayList<>(this.rows.size());
-        for (IndexedRow indexedRow : indexedRows()) {
+        for (IndexedRow indexedRow : indexedRows) {
             Row row = mapper.call(indexedRow.getIndex(), indexedRow.getRow());
             if (row.getCells().size() != newColumnModel.getColumns().size()) {
                 Assert.fail(String.format("Row size (%d) inconsistent with supplied column model (%s)",
@@ -342,7 +370,7 @@ public class TestingGridState implements GridState {
         mapper = TestingDatamodelRunner.serializeAndDeserialize(mapper);
 
         List<Row> rows = new ArrayList<>(this.rows.size());
-        for (IndexedRow indexedRow : indexedRows()) {
+        for (IndexedRow indexedRow : indexedRows) {
             List<Row> rowBatch = mapper.call(indexedRow.getIndex(), indexedRow.getRow());
             for (Row row : rowBatch) {
                 if (row.getCells().size() != newColumnModel.getColumns().size()) {
@@ -363,7 +391,7 @@ public class TestingGridState implements GridState {
 
         S currentState = mapper.unit();
         List<Row> rows = new ArrayList<>(this.rows.size());
-        for (IndexedRow indexedRow : indexedRows()) {
+        for (IndexedRow indexedRow : indexedRows) {
             Row row = mapper.map(currentState, indexedRow.getIndex(), indexedRow.getRow());
             currentState = mapper.combine(currentState, mapper.feed(indexedRow.getIndex(), indexedRow.getRow()));
             if (row.getCells().size() != newColumnModel.getColumns().size()) {
@@ -395,15 +423,14 @@ public class TestingGridState implements GridState {
     }
 
     @Override
-    public Iterable<IndexedRow> iterateRows(RowFilter filter, SortingConfig sortingConfig) {
-        List<IndexedRow> sortedRows = sortedRows(sortingConfig);
+    public Iterable<IndexedRow> iterateRows(RowFilter filter) {
         return new Iterable<IndexedRow>() {
 
             @Override
             public Iterator<IndexedRow> iterator() {
-                return sortedRows
+                return indexedRows
                         .stream()
-                        .filter(ir -> filter.filterRow(ir.getIndex(), ir.getRow()))
+                        .filter(ir -> filter.filterRow(ir.getLogicalIndex(), ir.getRow()))
                         .iterator();
             }
 
@@ -411,13 +438,12 @@ public class TestingGridState implements GridState {
     }
 
     @Override
-    public Iterable<Record> iterateRecords(RecordFilter filter, SortingConfig sortingConfig) {
-        List<Record> sorted = sortedRecords(sortingConfig);
+    public Iterable<Record> iterateRecords(RecordFilter filter) {
         return new Iterable<Record>() {
 
             @Override
             public Iterator<Record> iterator() {
-                return sorted
+                return records
                         .stream()
                         .filter(r -> filter.filterRecord(r))
                         .iterator();
@@ -437,31 +463,39 @@ public class TestingGridState implements GridState {
     }
 
     @Override
-    public GridState reorderRows(SortingConfig sortingConfig) {
-        return new TestingGridState(columnModel,
-                sortedRows(sortingConfig).stream().map(r -> r.getRow()).collect(Collectors.toList()),
-                overlayModels);
+    public GridState reorderRows(SortingConfig sortingConfig, boolean permanent) {
+        List<IndexedRow> newRows = sortedRows(sortingConfig);
+        if (permanent) {
+            return new TestingGridState(columnModel, newRows.stream().map(IndexedRow::getRow).collect(Collectors.toList()), overlayModels);
+        } else {
+            List<IndexedRow> indexed = IntStream.range(0, newRows.size())
+                    .mapToObj(i -> new IndexedRow((long) i, newRows.get(i).getLogicalIndex(), newRows.get(i).getRow()))
+                    .collect(Collectors.toList());
+            return new TestingGridState(indexed, columnModel, overlayModels);
+        }
     }
 
     @Override
-    public GridState reorderRecords(SortingConfig sortingConfig) {
-        List<Row> newRows = new ArrayList<>(rows.size());
+    public GridState reorderRecords(SortingConfig sortingConfig, boolean permanent) {
+        List<IndexedRow> newRows = new ArrayList<>(rows.size());
         if (sortingConfig.getCriteria().isEmpty()) {
-            newRows = rows;
+            newRows = indexedRows;
         } else {
             for (Record record : sortedRecords(sortingConfig)) {
-                newRows.addAll(record.getRows());
+                for (IndexedRow row : record.getIndexedRows()) {
+                    newRows.add(new IndexedRow(newRows.size(), permanent ? null : row.getLogicalIndex(), row.getRow()));
+                }
             }
         }
-        return new TestingGridState(columnModel, newRows, overlayModels);
+        return new TestingGridState(newRows, columnModel, overlayModels);
     }
 
     private List<IndexedRow> sortedRows(SortingConfig sortingConfig) {
         if (sortingConfig.equals(SortingConfig.NO_SORTING)) {
-            return indexedRows();
+            return indexedRows;
         }
         RowSorter rowSorter = new RowSorter(this, sortingConfig);
-        List<IndexedRow> sortedIndexedRows = new ArrayList<>(indexedRows());
+        List<IndexedRow> sortedIndexedRows = new ArrayList<>(indexedRows);
         Collections.sort(sortedIndexedRows, rowSorter);
         return sortedIndexedRows;
     }
@@ -484,9 +518,9 @@ public class TestingGridState implements GridState {
 
     @Override
     public GridState removeRows(RowFilter filter) {
-        List<Row> newRows = indexedRows()
+        List<Row> newRows = indexedRows
                 .stream()
-                .filter(ir -> !filter.filterRow(ir.getIndex(), ir.getRow()))
+                .filter(ir -> !filter.filterRow(ir.getLogicalIndex(), ir.getRow()))
                 .map(ir -> ir.getRow())
                 .collect(Collectors.toList());
         return new TestingGridState(columnModel, newRows, overlayModels);
@@ -510,7 +544,7 @@ public class TestingGridState implements GridState {
         RowFilter deserializedFilter = TestingDatamodelRunner.serializeAndDeserialize(filter);
 
         Map<Long, T> changeData = new HashMap<>();
-        Stream<IndexedRow> filteredRows = indexedRows().stream()
+        Stream<IndexedRow> filteredRows = indexedRows.stream()
                 .filter(ir -> deserializedFilter.filterRow(ir.getIndex(), ir.getRow()));
         if (deserializedMapper.getBatchSize() == 1) {
             filteredRows.forEach(ir -> changeData.put(ir.getIndex(), deserializedMapper.call(ir.getIndex(), ir.getRow())));
@@ -567,7 +601,7 @@ public class TestingGridState implements GridState {
         // even if this implementation does not rely on it.
         RowChangeDataJoiner<T> deserializedJoiner = TestingDatamodelRunner.serializeAndDeserialize(rowJoiner);
 
-        List<Row> newRows = indexedRows()
+        List<Row> newRows = indexedRows
                 .stream()
                 .map(ir -> deserializedJoiner.call(ir.getIndex(), ir.getRow(), changeData.get(ir.getIndex())))
                 .collect(Collectors.toList());
@@ -581,7 +615,7 @@ public class TestingGridState implements GridState {
         // even if this implementation does not rely on it.
         RowChangeDataFlatJoiner<T> deserializedJoiner = TestingDatamodelRunner.serializeAndDeserialize(rowJoiner);
 
-        List<Row> newRows = indexedRows()
+        List<Row> newRows = indexedRows
                 .stream()
                 .flatMap(ir -> deserializedJoiner.call(ir.getIndex(), ir.getRow(), changeData.get(ir.getIndex())).stream())
                 .collect(Collectors.toList());

--- a/refine-workflow/src/main/java/org/openrefine/exporters/CustomizableTabularExporterUtilities.java
+++ b/refine-workflow/src/main/java/org/openrefine/exporters/CustomizableTabularExporterUtilities.java
@@ -140,7 +140,7 @@ abstract public class CustomizableTabularExporterUtilities {
             serializer.addRow(cells, true);
         }
 
-        for (IndexedRow indexedRow : grid.iterateRows(engine.combinedRowFilters(), sortingConfig)) {
+        for (IndexedRow indexedRow : grid.reorderRows(sortingConfig, false).iterateRows(engine.combinedRowFilters())) {
             List<CellData> cells = new ArrayList<TabularSerializer.CellData>(columnNames.size());
             int nonNullCount = 0;
 

--- a/refine-workflow/src/main/java/org/openrefine/importers/LineBasedImporter.java
+++ b/refine-workflow/src/main/java/org/openrefine/importers/LineBasedImporter.java
@@ -54,7 +54,7 @@ public class LineBasedImporter extends LineBasedImporterBase {
             // so we resort to loading everything in memory
             List<Row> newRows = new ArrayList<>();
             List<Cell> currentCells = new ArrayList<>();
-            for (IndexedRow row : parsed.iterateRows(RowFilter.ANY_ROW, SortingConfig.NO_SORTING)) {
+            for (IndexedRow row : parsed.iterateRows(RowFilter.ANY_ROW)) {
                 currentCells.add(row.getRow().getCell(0));
                 if (currentCells.size() >= linesPerRow) {
                     newRows.add(new Row(currentCells));

--- a/refine-workflow/src/main/java/org/openrefine/importers/LineBasedImporterBase.java
+++ b/refine-workflow/src/main/java/org/openrefine/importers/LineBasedImporterBase.java
@@ -166,7 +166,7 @@ public abstract class LineBasedImporterBase extends URIImporter {
             }
             headerLines = 0;
         } else if (headerLines > 0) {
-            List<IndexedRow> firstLines = rawCells.getRows(ignoreLines, headerLines);
+            List<IndexedRow> firstLines = rawCells.getRowsAfter(ignoreLines, headerLines);
             for (int i = 0; i < firstLines.size(); i++) {
                 IndexedRow headerLine = firstLines.get(i);
                 Row mappedRow = rowMapper.call(headerLine.getIndex(), headerLine.getRow());

--- a/refine-workflow/src/main/java/org/openrefine/importers/SeparatorBasedImporter.java
+++ b/refine-workflow/src/main/java/org/openrefine/importers/SeparatorBasedImporter.java
@@ -187,7 +187,7 @@ public class SeparatorBasedImporter extends LineBasedImporterBase {
 
         final CSVParser parser = getCSVParser(options);
 
-        Iterator<IndexedRow> lines = grid.iterateRows(RowFilter.ANY_ROW, SortingConfig.NO_SORTING).iterator();
+        Iterator<IndexedRow> lines = grid.iterateRows(RowFilter.ANY_ROW).iterator();
 
         TableDataReader dataReader = new TableDataReader() {
 

--- a/refine-workflow/src/main/java/org/openrefine/operations/cell/KeyValueColumnizeOperation.java
+++ b/refine-workflow/src/main/java/org/openrefine/operations/cell/KeyValueColumnizeOperation.java
@@ -147,7 +147,7 @@ public class KeyValueColumnizeOperation implements Operation {
                 currentNotes.add(notes);
             }
 
-            for (IndexedRow indexedRow : projectState.iterateRows(RowFilter.ANY_ROW, SortingConfig.NO_SORTING)) {
+            for (IndexedRow indexedRow : projectState.iterateRows(RowFilter.ANY_ROW)) {
                 Row oldRow = indexedRow.getRow();
 
                 Object key = oldRow.getCellValue(keyColumnIndex);

--- a/refine-workflow/src/main/java/org/openrefine/operations/cell/TransposeColumnsIntoRowsOperation.java
+++ b/refine-workflow/src/main/java/org/openrefine/operations/cell/TransposeColumnsIntoRowsOperation.java
@@ -273,7 +273,7 @@ public class TransposeColumnsIntoRowsOperation implements Operation {
             }
 
             List<RowBuilder> newRows = new ArrayList<>();
-            for (IndexedRow indexedRow : projectState.iterateRows(RowFilter.ANY_ROW, SortingConfig.NO_SORTING)) {
+            for (IndexedRow indexedRow : projectState.iterateRows(RowFilter.ANY_ROW)) {
                 Row oldRow = indexedRow.getRow();
                 RowBuilder firstNewRow = RowBuilder.create(newColumns.size());
                 int firstNewRowIndex = newRows.size();

--- a/refine-workflow/src/main/java/org/openrefine/operations/cell/TransposeRowsIntoColumnsOperation.java
+++ b/refine-workflow/src/main/java/org/openrefine/operations/cell/TransposeRowsIntoColumnsOperation.java
@@ -120,7 +120,7 @@ public class TransposeRowsIntoColumnsOperation implements Operation {
             int nbNewColumns = newColumns.getColumns().size();
             RowBuilder firstNewRow = null;
             List<RowBuilder> newRows = new ArrayList<>();
-            for (IndexedRow indexedRow : projectState.iterateRows(RowFilter.ANY_ROW, SortingConfig.NO_SORTING)) {
+            for (IndexedRow indexedRow : projectState.iterateRows(RowFilter.ANY_ROW)) {
                 long r = indexedRow.getIndex();
                 int r2 = (int) (r % (long) _rowCount);
 

--- a/refine-workflow/src/main/java/org/openrefine/operations/row/RowReorderOperation.java
+++ b/refine-workflow/src/main/java/org/openrefine/operations/row/RowReorderOperation.java
@@ -99,9 +99,9 @@ public class RowReorderOperation implements Operation {
         @Override
         public GridState apply(GridState projectState, ChangeContext context) throws DoesNotApplyException {
             if (Mode.RowBased.equals(_mode)) {
-                return projectState.reorderRows(_sorting);
+                return projectState.reorderRows(_sorting, true);
             } else {
-                return projectState.reorderRecords(_sorting);
+                return projectState.reorderRecords(_sorting, true);
             }
         }
 


### PR DESCRIPTION
Fixes #33, fixes #570, fixes #572.

In short: this preserves the current paging settings when applying an operation which triggers a refresh of the grid.
This change is based on the new architecture (4.0 branch), because this architecture makes this change more natural (although it would not be impossible to implement this in the 3.x series).

## Known issues

* This is quite radical: it does not just affect reconciliation actions, but basically all other operations. The frontend will attempt to preserve the position in the grid for all of them. I am thinking for some of them it does not actually make sense to do that: for instance, when doing data extension, we create additional rows needed by the record structure, and so it is pointless to preserve paging based on row ids after that. Same for the transpose operations. So I will need to refine this to preserve the old behaviour for those operations (basically all operations which are not row/record wise).
* This removes the input field introduced by @antoine2711 in #2639 to let the user pick a particular page number. With this change there is no easily computable notion of page number anymore, and so I have reverted that change to show the range of rows being displayed, as it was before. We could consider making those editable, but I am not sure about the desired UX for that. If we make both of them editable then we let the user input something that is inconsistent with the page size selected on the left-hand side. We could make only the start editable, perhaps? But then I am not sure the UI will be clear enough to show that the user understands the meaning of those two numbers? Also, when a temporary sort is applied, those numbers bear no relationship to the row numbers displayed in the grid.

## Overview of the changes

This required a bit more changes in the backend than I expected:
* introducing the ability to request a page ending at a given row/record id (not just starting at a given row/record id)
* changing the `GridState` interface to support this, which means adapting the three existing implementations of that interface (testing, local and spark)
* changing the sorting API so that both the original row ids and the new row ids (after sorting) are available. This is because we cannot rely on the original row ids for pagination, since they are out of order. This was a significant change but it ended up simplifying the `GridState` interface quite a bit and it opens up the possibility of new optimizations (such as avoiding to re-sort the grid every time a request is made). I have not made those optimizations yet because I wanted to first check if the UX makes sense.

Trying it out interactively, I find it to work as expected.
Perhaps one thing that is a bit counter-intuitive is that when you click on "Previous" to get a previous page, and then apply an action, the grid will be refreshed in a way that preserves the last row being displayed in the page, not the first one. It is something that we can change easily though.

Marking as draft per the additional changes mentioned above.