### PR TITLE
Optimized Cypress tests that have selectors matching a large amount of elements

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/column/facet/facets.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/facet/facets.spec.js
@@ -31,7 +31,7 @@ describe(__filename, function () {
       2
     );
 
-    cy.get('#refine-tabs-facets a').contains('Remove all').click();
+    cy.get('a.button.button-pill-right').contains('Remove all').click();
     cy.get('#refine-tabs-facets .facets-container .facet-container').should(
       'have.length',
       0
@@ -252,13 +252,10 @@ describe(__filename, function () {
 
     // do a basic facetting, expect 1 row
     cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice-toggle')
-      .invoke('attr', 'style', 'visibility:visible');
-    cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice')
       .contains('ALLSPICE,GROUND')
       .parent()
-      .find('.facet-choice-toggle')
+      .trigger('mouseover')
+      .contains('include')
       .click();
     cy.getCell(0, 'Shrt_Desc').should('to.contain', 'ALLSPICE,GROUND');
     cy.get('#tool-panel').contains('1 matching rows');
@@ -284,13 +281,10 @@ describe(__filename, function () {
 
     // do a basic facetting, expect 1 row
     cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice-toggle')
-      .invoke('attr', 'style', 'visibility:visible');
-    cy.getFacetContainer('Shrt_Desc')
-      .find('.facet-choice')
       .contains('ALLSPICE,GROUND')
       .parent()
-      .find('.facet-choice-toggle')
+      .trigger('mouseover')
+      .contains('include')
       .click();
     cy.get('#tool-panel').contains('1 matching rows');
 
@@ -345,7 +339,7 @@ describe(__filename, function () {
     cy.columnActionClick('Water', ['Facet', 'Text facet']);
 
     cy.getFacetContainer('Water').within(() => {
-      cy.get('.facet-choice')
+      cy.get('div.facet-body-inner > div:nth-child(8)')
         .contains('15.87')
         .parent()
         .trigger('mouseover')

--- a/main/tests/cypress/cypress/integration/project/grid/misc/expressions.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/misc/expressions.spec.js
@@ -199,7 +199,7 @@ describe(__filename, function () {
     // Use it
     loadExpressionPanel();
     cy.get('#expression-preview-tabs li').contains('History').click();
-    cy.get('#expression-preview-tabs-history tr td')
+    cy.get('tbody > tr:nth-child(2) > td:nth-child(5)')
       .contains(uniqueExpression)
       .parent()
       .find('a')


### PR DESCRIPTION
Changes proposed in this pull request:
- Optimized the Cypress tests with the selectors that matched the highest amount of unnecessary elements to match fewer elements or just the needed one, so that viewing snapshots for those areas of the following tests requires less time and memory:

  - facets.spec:
    - Test the mass edit from a Facet (~190 elements)

    - Test the Remove all button (~1.2k elements)

    - Test include/exclude, invert (~199 x 3 elements)

    - Test facet reset (~199 x 3 elements)
    
  - expressions.spec:
    - Test the reuse of expressions from the history (~500 elements)

