### PR TITLE
Improve error handling for upload of media files.

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
@@ -265,6 +265,20 @@ public class MediaFileUtils {
         private MediaInfoIdValue mid = null;
 
         /**
+         * Checks that the upload was successful, and if not raise an exception
+         * 
+         * @throws MediaWikiApiErrorException
+         */
+        public void checkForErrors() throws MediaWikiApiErrorException {
+            if (!"Success".equals(result)) {
+                throw new MediaWikiApiErrorException(result, "The file upload action returned the '" + result + "' error code");
+            }
+            if (filename == null) {
+                throw new MediaWikiApiErrorException(result, "The MediaWiki API did not return any filename for the uploaded file");
+            }
+        }
+
+        /**
          * Retrieves the Mid, either from the upload response or by issuing another call to obtain it from the filename
          * through the supplied connection.
          * 

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
@@ -246,6 +246,8 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
             response = mediaFileUtils.uploadRemoteFile(url, fileName, wikitext, summary, tags);
         }
 
+        response.checkForErrors();
+
         // Upload the structured data
         ReconEntityIdValue reconEntityIdValue = (ReconEntityIdValue) id;
         MediaInfoIdValue mid = response.getMid(mediaFileUtils.getApiConnection(), reconEntityIdValue.getRecon().identifierSpace);


### PR DESCRIPTION
Closes #5420.

The error handling for this API action was basically non-existent - guess who was to blame? Oops, sorry about that…
