### PR TITLE
fix flaky test in main #5425

### DIFF
--- a/main/src/com/google/refine/clustering/binning/BinningClusterer.java
+++ b/main/src/com/google/refine/clustering/binning/BinningClusterer.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -134,7 +135,7 @@ public class BinningClusterer extends Clusterer {
         Object[] _params;
         BinningParameters _parameters;
 
-        Map<String, Map<String, Integer>> _map = new HashMap<String, Map<String, Integer>>();
+        Map<String, Map<String, Integer>> _map = new LinkedHashMap<String, Map<String, Integer>>();
 
         public BinningRowVisitor(Keyer k, BinningParameters parameters) {
             _keyer = k;


### PR DESCRIPTION
Fixes #5425

The order of the elements in json can changes and cause the junit test to fail. Using a `LinkedHashMap `maintains the order of the elements
