### PR TITLE
Cleaned up more Cypress tests that selected extra elements

### DIFF
--- a/main/tests/cypress/cypress/integration/create-project/preview_project.spec.js
+++ b/main/tests/cypress/cypress/integration/create-project/preview_project.spec.js
@@ -61,16 +61,17 @@ describe(__filename, function () {
     cy.get('.create-project-ui-panel').contains('Configure parsing options');
 
     cy.navigateTo('Language settings');
-    cy.get('tbody').should('to.contain', 'Select preferred language');
+    cy.get('#project-upload-form > table > tbody > tr:nth-child(1) > td > label').should(
+        'to.contain', 'Select preferred language');
 
     cy.navigateTo('Import project');
-    cy.get('tbody').should(
+    cy.get('#or-import-locate').should(
       'to.contain',
       'Locate an existing Refine project file (.tar or .tar.gz)'
     );
 
     cy.navigateTo('Create project');
-    cy.get('.create-project-ui-panel').should(
+    cy.get('#or-import-parsopt').should(
       'to.contain',
       'Configure parsing options'
     );

--- a/main/tests/cypress/cypress/integration/project/grid/column/edit-column/split_into_several_columns.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/edit-column/split_into_several_columns.spec.js
@@ -16,10 +16,10 @@ describe(__filename, function () {
       'Split 2 cell(s) in column Shrt_Desc into several columns by separator '
     );
 
-    cy.get('.data-table-header').find('th').should('have.length', 7);
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 1');
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 2');
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 3');
+    cy.get('.data-table-header').find('th').should('have.length', 7)
+    cy.get('th:nth-child(3) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 1');
+    cy.get('th:nth-child(4) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 2');
+    cy.get('th:nth-child(5) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 3');
 
     cy.assertCellEquals(0, 'Shrt_Desc 1', 'BUTTER');
     cy.assertCellEquals(0, 'Shrt_Desc 2', 'WITH SALT');
@@ -44,9 +44,9 @@ describe(__filename, function () {
     );
 
     cy.get('.data-table-header').find('th').should('have.length', 8);
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc');
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 2');
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 3');
+    cy.get('th:nth-child(3) > div.column-header-title > span').should('to.contain', 'Shrt_Desc');
+    cy.get('th:nth-child(5) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 2');
+    cy.get('th:nth-child(6) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 3');
 
     cy.assertCellEquals(0, 'Shrt_Desc', 'BUTTER,WITH SALT');
     cy.assertCellEquals(0, 'Shrt_Desc 1', 'BUTTER');
@@ -72,9 +72,9 @@ describe(__filename, function () {
     );
 
     cy.get('.data-table-header').find('th').should('have.length', 7);
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 1');
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 2');
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 3');
+    cy.get('th:nth-child(3) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 1');
+    cy.get('th:nth-child(4) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 2');
+    cy.get('th:nth-child(5) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 3');
 
     cy.assertCellEquals(0, 'Shrt_Desc 1', 'B');
     cy.assertCellEquals(0, 'Shrt_Desc 2', 'UT');
@@ -100,10 +100,10 @@ describe(__filename, function () {
     );
 
     cy.get('.data-table-header').find('th').should('have.length', 9);
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc');
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 2');
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 3');
-    cy.get('.data-table-header').find('th').should('to.contain', 'Shrt_Desc 4');
+    cy.get('th:nth-child(3) > div.column-header-title > span').should('to.contain', 'Shrt_Desc');
+    cy.get('th:nth-child(5) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 2');
+    cy.get('th:nth-child(6) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 3');
+    cy.get('th:nth-child(7) > div.column-header-title > span').should('to.contain', 'Shrt_Desc 4');
 
     cy.assertCellEquals(0, 'Shrt_Desc', 'BUTTER,WITH SALT');
     cy.assertCellEquals(0, 'Shrt_Desc 1', 'B');

--- a/main/tests/cypress/cypress/integration/project/grid/column/facet/facets.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/facet/facets.spec.js
@@ -66,7 +66,7 @@ describe(__filename, function () {
       .find('.facet-choice:first-child')
       .should('have.class', 'facet-choice-selected');
 
-    cy.get('#refine-tabs-facets a').contains('Reset all').click();
+    cy.get('a.button.button-pill-left').contains('Reset all').click();
 
     // all facets selections should be gone
     cy.getFacetContainer('Water')

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/clear_reconciliation_data.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/clear_reconciliation_data.spec.js
@@ -6,7 +6,7 @@ describe('Clear reconciliation data', () => {
     it('Test clearing reconciliation for a reconciled dataset', () => {
         cy.visitOpenRefine();
         cy.navigateTo('Import project');
-        cy.get('.grid-layout').should('to.contain', 'Locate an existing Refine project file');
+        cy.get('#or-import-locate').should('to.contain', 'Locate an existing Refine project file');
         cy.get('#project-tar-file-input').attachFile('reconciled-project-automatch.zip')
         cy.get('#import-project-button').click();
 

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/create_new_item_for_each.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/create_new_item_for_each.spec.js
@@ -6,7 +6,7 @@ describe('Create new item for each cell', () => {
     it('Test mark to create new items in many cells, previously reconciled', () => {
         cy.visitOpenRefine();
         cy.navigateTo('Import project');
-        cy.get('.grid-layout').should('to.contain', 'Locate an existing Refine project file');
+        cy.get('#or-import-locate').should('to.contain', 'Locate an existing Refine project file');
 
         cy.get('#project-tar-file-input').attachFile('reconciled-project-automatch.zip')
         cy.get('#import-project-button').click();

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/discard_reconciliation_judgments.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/discard_reconciliation_judgments.spec.js
@@ -6,7 +6,7 @@ describe('Discard reconciliation judgments', () => {
     it('Test discard existing reconciliation judgments', () => {
         cy.visitOpenRefine();
         cy.navigateTo('Import project');
-        cy.get('.grid-layout').should('to.contain', 'Locate an existing Refine project file');
+        cy.get('#or-import-locate').should('to.contain', 'Locate an existing Refine project file');
 
         //we're using here the "automatched" project, to have some rows that are matched
         cy.get('#project-tar-file-input').attachFile('reconciled-project-automatch.zip')

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/add_entity_identifiers.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/add_entity_identifiers.spec.js
@@ -6,7 +6,7 @@ describe('Add entity identifiers', () => {
   it('Add a new column that contains the reconciliation id', () => {
     cy.visitOpenRefine();
     cy.navigateTo('Import project');
-    cy.get('.grid-layout').should('to.contain', 'Locate an existing Refine project file');
+    cy.get('#or-import-locate').should('to.contain', 'Locate an existing Refine project file');
 
     //we're using here the "automatched" project, so we can test that the facet contains choice for matched and non-matched judgments
     cy.get('#project-tar-file-input').attachFile('reconciled-project-automatch.zip')

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/copy_reconciliation_data.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/copy_reconciliation_data.spec.js
@@ -6,7 +6,7 @@ describe('Copy reconciliation data', () => {
   it('Copy reconciliation data from species to species_copy', () => {
     cy.visitOpenRefine();
     cy.navigateTo('Import project');
-    cy.get('.grid-layout').should('to.contain', 'Locate an existing Refine project file');
+    cy.get('#or-import-locate').should('to.contain', 'Locate an existing Refine project file');
 
     //we're using here the "automatched" project, so we can test that the facet contains choice for matched and non-matched judgments
     cy.get('#project-tar-file-input').attachFile('reconciled-project-automatch.zip')

--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/facets/by_judgment.spec.js
@@ -6,7 +6,7 @@ describe('Facet by judgment', () => {
   it('Facets by judgment', () => {
     cy.visitOpenRefine();
     cy.navigateTo('Import project');
-    cy.get('.grid-layout').should('to.contain', 'Locate an existing Refine project file');
+    cy.get('#or-import-locate').should('to.contain', 'Locate an existing Refine project file');
 
     //we're using here the "automatched" project, so we can test that the facet contains choice for matched and non-matched judgments
     cy.get('#project-tar-file-input').attachFile('reconciled-project-automatch.zip')

--- a/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/rows_records.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/viewpanel-header/rows_records.spec.js
@@ -149,12 +149,17 @@ describe(__filename, function () {
     const projectName = Date.now();
     cy.loadAndVisitSampleJSONProject(projectName, jsonValue);
     cy.get('span[bind="modeSelectors"]').contains('records').click();
-    for (let i = 1; i <= 3; i++) {
-      cy.get('tr td:nth-child(3)').should('to.contain', i);
-    }
+    cy.get('tr td:nth-child(3)').then((recordNumber) => {
+      for (let i = 1; i <= 3; i++) {
+      expect(recordNumber.text()).to.contain(i);
+      }
+    });
+
     cy.get('span[bind="modeSelectors"]').contains('row').click();
-    for (let i = 1; i <= 10; i++) {
-      cy.get('tr td:nth-child(3)').should('to.contain', i);
-    }
+    cy.get('tr td:nth-child(3)').then((rowNumber) => {
+      for (let i = 1; i <= 10; i++) {
+        expect(rowNumber.text()).to.contain(i);
+      }
+    });
   });
 });

--- a/main/tests/cypress/cypress/integration/project_management/project_metadata.spec.js
+++ b/main/tests/cypress/cypress/integration/project_management/project_metadata.spec.js
@@ -17,8 +17,8 @@ describe(__filename, function () {
     cy.visitOpenRefine();
     cy.navigateTo('Open project');
     cy.contains('td', projectName).siblings().contains('a', 'About').click();
-    cy.get('#metadata-body tr').eq(3).contains('Project name');
-    cy.get('#metadata-body tr').eq(3).contains(projectName);
+    cy.get('#metadata-body > div > table > tr:nth-child(4) > td:nth-child(1)').contains('Project name');
+    cy.get('#metadata-body > div > table > tr:nth-child(4) > td:nth-child(2)').contains(projectName);
   });
   it('Ensures project-metadata can be edit project name', function () {
     const projectName = Date.now();
@@ -34,8 +34,8 @@ describe(__filename, function () {
       .siblings()
       .contains('button', 'Edit')
       .click();
-    cy.get('#metadata-body tr').eq(3).contains('Project name');
-    cy.get('#metadata-body tr').eq(3).contains('testProject');
+    cy.get('#metadata-body > div > table > tr:nth-child(4) > td:nth-child(1)').contains('Project name');
+    cy.get('#metadata-body > div > table > tr:nth-child(4) > td:nth-child(2)').contains('testProject');
   });
   it('Ensures project-metadata can be edit tags', function () {
     const projectName = Date.now();
@@ -48,8 +48,8 @@ describe(__filename, function () {
     cy.navigateTo('Open project');
     cy.contains('td', projectName).siblings().contains('a', 'About').click();
     cy.contains('td', 'Tags').siblings().contains('button', 'Edit').click();
-    cy.get('#metadata-body tr').eq(4).contains('Tags');
-    cy.get('#metadata-body tr').eq(4).contains('tagTest');
+    cy.get('#metadata-body > div > table > tr:nth-child(5) > td:nth-child(1)').contains('Tags');
+    cy.get('#metadata-body > div > table > tr:nth-child(5) > td:nth-child(2)').contains('tagTest');
   });
   it('Ensures project-metadata can be edit creator', function () {
     const projectName = Date.now();
@@ -62,8 +62,8 @@ describe(__filename, function () {
     cy.navigateTo('Open project');
     cy.contains('td', projectName).siblings().contains('a', 'About').click();
     cy.contains('td', 'Creator').siblings().contains('button', 'Edit').click();
-    cy.get('#metadata-body tr').eq(5).contains('Creator');
-    cy.get('#metadata-body tr').eq(5).contains('testCreator');
+    cy.get('#metadata-body > div > table > tr:nth-child(6) > td:nth-child(1)').contains('Creator');
+    cy.get('#metadata-body > div > table > tr:nth-child(6) > td:nth-child(2)').contains('testCreator');
   });
   it('Ensures project-metadata can be edit contributors', function () {
     const projectName = Date.now();
@@ -79,8 +79,8 @@ describe(__filename, function () {
       .siblings()
       .contains('button', 'Edit')
       .click();
-    cy.get('#metadata-body tr').eq(6).contains('Contributors');
-    cy.get('#metadata-body tr').eq(6).contains('testcontributor');
+    cy.get('#metadata-body > div > table > tr:nth-child(7) > td:nth-child(1)').contains('Contributors');
+    cy.get('#metadata-body > div > table > tr:nth-child(7) > td:nth-child(2)').contains('testcontributor');
   });
   it('Ensures project-metadata can be edit subject', function () {
     const projectName = Date.now();
@@ -93,8 +93,8 @@ describe(__filename, function () {
     cy.navigateTo('Open project');
     cy.contains('td', projectName).siblings().contains('a', 'About').click();
     cy.contains('td', 'Subject').siblings().contains('button', 'Edit').click();
-    cy.get('#metadata-body tr').eq(7).contains('Subject');
-    cy.get('#metadata-body tr').eq(7).contains('testSubject');
+    cy.get('#metadata-body > div > table > tr:nth-child(8) > td:nth-child(1)').contains('Subject');
+    cy.get('#metadata-body > div > table > tr:nth-child(8) > td:nth-child(2)').contains('testSubject');
   });
   it('Ensures project-metadata can be edit license', function () {
     const projectName = Date.now();
@@ -107,8 +107,8 @@ describe(__filename, function () {
     cy.navigateTo('Open project');
     cy.contains('td', projectName).siblings().contains('a', 'About').click();
     cy.contains('td', 'License').siblings().contains('button', 'Edit').click();
-    cy.get('#metadata-body tr').eq(12).contains('License');
-    cy.get('#metadata-body tr').eq(12).contains('GPL-3');
+    cy.get('#metadata-body > div > table > tr:nth-child(13) > td:nth-child(1)').contains('License');
+    cy.get('#metadata-body > div > table > tr:nth-child(13) > td:nth-child(2)').contains('GPL-3');
   });
   it('Ensures project-metadata can be edit homepage', function () {
     const projectName = Date.now();
@@ -124,7 +124,7 @@ describe(__filename, function () {
       .siblings()
       .contains('button', 'Edit')
       .click();
-    cy.get('#metadata-body tr').eq(13).contains('Homepage');
-    cy.get('#metadata-body tr').eq(13).contains('openrefine.org');
+    cy.get('#metadata-body > div > table > tr:nth-child(14) > td:nth-child(1)').contains('Homepage');
+    cy.get('#metadata-body > div > table > tr:nth-child(14) > td:nth-child(2)').contains('openrefine.org');
   });
 });


### PR DESCRIPTION
Fixes #{issue number here}

Changes proposed in this pull request:
- Cleaned up more Cypress tests that selected extra elements, including the following:
  - Ensures navigation works from project-preview page
  - Tests in project_metadata.spec.js
  - Tests in split_into_several_columns.spec.js
  - Test the Reset all button
  - Facets by judgment
  - Test clearing reconciliation for a reconciled dataset
  - Test mark to create new items in many cells, previously reconciled
  - Test discard existing reconciliation judgments
  - Add a new column that contains the reconciliation id
  - Copy reconciliation data from species to species_copy
  - ensures rows and records are different for 3-level json file
