### PR TITLE
Add explicit Wikibase QA warning when file names are normalized.

### DIFF
--- a/extensions/wikibase/module/langs/translation-en.json
+++ b/extensions/wikibase/module/langs/translation-en.json
@@ -289,6 +289,8 @@
     "warnings-messages/missing-file-name-extension/body": "The file names provided for files to be uploaded must end with a file extension, which is not the case for file names such as <span class=\"wb-issue-preformat\">{example_filename}.",
     "warnings-messages/inconsistent-file-name-and-path-extension/title": "Inconsistent extensions between file paths and file names",
     "warnings-messages/inconsistent-file-name-and-path-extension/body": "Some file paths and their corresponding target file name on the wiki have different extensions, such as <span class=\"wb-issue-preformat\">{example_filepath}</span> and <span class=\"wb-issue-preformat\">{example_filename}</span>.",
+    "warnings-messages/replaced-characters-in-filename/title": "Some special characters in file names will be replaced",
+    "warnings-messages/replaced-characters-in-filename/body": "The characaters <span class=\"wb-issue-preformat\">:/\\</span> will be replaced by <span class=\"wb-issue-preformat\">-</span>. For instance, filename <span class=\"wb-issue-preformat\">{original}</span> will become <span class=\"wb-issue-preformat\">{normalized}</span>.",
     "wikibase-statement-settings/dialog-header": "Statement settings",
     "wikibase-statement-settings/mode-label": "Editing mode",
     "wikibase-statement-settings/strategy-label": "Matching strategy",

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
@@ -20,6 +20,7 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.TokenErrorException;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.refine.util.ParsingUtilities;
 
@@ -271,7 +272,8 @@ public class MediaFileUtils {
          */
         public void checkForErrors() throws MediaWikiApiErrorException {
             if (!"Success".equals(result)) {
-                throw new MediaWikiApiErrorException(result, "The file upload action returned the '" + result + "' error code");
+                throw new MediaWikiApiErrorException(result,
+                        "The file upload action returned the '" + result + "' error code. Warnings are: " + Objects.toString(warnings));
             }
             if (filename == null) {
                 throw new MediaWikiApiErrorException(result, "The MediaWiki API did not return any filename for the uploaded file");

--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
@@ -21,7 +21,6 @@ public class FileNameScrutinizer extends EditScrutinizer {
     public static final int maxFileNameLength = 240;
     public static final Pattern forbiddenFileNameChars = Pattern.compile(
             ".*([^ %!\"$&'()*,\\-./0-9:;=?@A-Z\\\\^_`a-z~\\x80-\\xFF+]|%[0-9A-Fa-f]{2}|&[A-Za-z0-9\\x80-\\xff]+;|&#[0-9]+;|&#x[0-9A-Fa-f]+;).*");
-    public static final Pattern normalizedFileNameChars = Pattern.compile("[:/\\\\]");
 
     public static final String duplicateFileNamesInBatchType = "duplicate-file-names-in-batch";
     public static final String fileNamesAlreadyExistOnWikiType = "file-names-already-exist-on-wiki";
@@ -49,13 +48,12 @@ public class FileNameScrutinizer extends EditScrutinizer {
 
     /**
      * Attempt of a local implementation of the file name normalization that is done in MediaWiki. Assumes a non-empty
-     * file name as input.
+     * file name as input. This assumes that some special characters have been replaced already: `:`, `/` and `\`
      * 
      * @return
      */
     protected String normalizeFileName(String filename) {
-        String replaced = filename.replaceAll(normalizedFileNameChars.pattern(), "-")
-                .replaceAll("_", " ");
+        String replaced = filename.replaceAll("_", " ");
         return replaced.substring(0, 1).toUpperCase() + replaced.substring(1);
     }
 

--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
@@ -52,7 +52,7 @@ public class FileNameScrutinizer extends EditScrutinizer {
      * 
      * @return
      */
-    protected String normalizeFileName(String filename) {
+    protected String normalizeFileNameSpaces(String filename) {
         String replaced = filename.replaceAll("_", " ");
         return replaced.substring(0, 1).toUpperCase() + replaced.substring(1);
     }
@@ -67,7 +67,7 @@ public class FileNameScrutinizer extends EditScrutinizer {
 
         if (edit.isNew()) {
             // check whether multiple files in the batch to be uploaded have the same filename
-            String normalizedFileName = normalizeFileName(fileName);
+            String normalizedFileName = normalizeFileNameSpaces(fileName);
             if (seenFileNames.contains(normalizedFileName)) {
                 QAWarning issue = new QAWarning(duplicateFileNamesInBatchType, null, QAWarning.Severity.CRITICAL,
                         1);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbMediaInfoEditExprTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbMediaInfoEditExprTest.java
@@ -1,7 +1,10 @@
 
 package org.openrefine.wikibase.schema;
 
+import static org.testng.Assert.assertEquals;
+
 import java.util.Collections;
+import java.util.stream.Collectors;
 
 import org.openrefine.wikibase.qa.QAWarning;
 import org.openrefine.wikibase.qa.QAWarning.Severity;
@@ -195,6 +198,20 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFileName("Foo.png").build();
         evaluatesTo(result, filePathExpr);
+    }
+
+    @Test
+    public void testFileNameNormalization() {
+        WbMediaInfoEditExpr filePathExpr = new WbMediaInfoEditExpr(
+                new WbEntityVariable("column E"),
+                Collections.emptyList(), Collections.emptyList(), null, new WbStringConstant("Foo:bar.png"), null, false);
+
+        setRow("", "", "3.898,4.389", "my label", matchedCell);
+
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFileName("Foo-bar.png").build();
+        evaluatesTo(result, filePathExpr);
+        assertEquals(warningStore.getWarnings().stream().map(QAWarning::getType).collect(Collectors.toList()),
+                Collections.singletonList(WbMediaInfoEditExpr.REPLACED_CHARACTERS_IN_FILENAME));
     }
 
     @Test


### PR DESCRIPTION
This should let the user identify cases such as additional `File:` prefixes too, which was the problem encountered in #5430. Closes #5433.
