### PR TITLE
Restore worksheet name in filename source column. Fixes #5034

### DIFF
--- a/main/src/com/google/refine/importers/ExcelImporter.java
+++ b/main/src/com/google/refine/importers/ExcelImporter.java
@@ -84,7 +84,8 @@ public class ExcelImporter extends TabularImportingParserBase {
             for (ObjectNode fileRecord : fileRecords) {
                 File file = ImportingUtilities.getFile(job, fileRecord);
 
-                try (Workbook wb = FileMagic.valueOf(file) == FileMagic.OOXML ? new XSSFWorkbook(file) : new HSSFWorkbook(new POIFSFileSystem(file))) {
+                try (Workbook wb = FileMagic.valueOf(file) == FileMagic.OOXML ? new XSSFWorkbook(file)
+                        : new HSSFWorkbook(new POIFSFileSystem(file))) {
 
                     int sheetCount = wb.getNumberOfSheets();
                     for (int i = 0; i < sheetCount; i++) {

--- a/main/src/com/google/refine/importers/FixedWidthImporter.java
+++ b/main/src/com/google/refine/importers/FixedWidthImporter.java
@@ -135,7 +135,7 @@ public class FixedWidthImporter extends TabularImportingParserBase {
             }
         };
 
-        TabularImportingParserBase.readTable(project, job, dataReader, limit, options, exceptions);
+        TabularImportingParserBase.readTable(project, metadata, job, dataReader, fileSource, limit, options, exceptions);
     }
 
     /**

--- a/main/src/com/google/refine/importers/ImporterUtilities.java
+++ b/main/src/com/google/refine/importers/ImporterUtilities.java
@@ -63,6 +63,7 @@ public class ImporterUtilities {
                 try {
                     return Long.parseLong(text2);
                 } catch (NumberFormatException e) {
+                    // Ignore possible exception for now so we can try floating point conversion
                 }
 
                 try {
@@ -71,6 +72,7 @@ public class ImporterUtilities {
                         return d;
                     }
                 } catch (NumberFormatException e) {
+                    // If we get a format exception here too, just return our original text
                 }
             }
         }
@@ -85,6 +87,7 @@ public class ImporterUtilities {
                 try {
                     value = Integer.parseInt(s);
                 } catch (NumberFormatException e) {
+                    // if we can't parse the value as an integer, fall through and return the default
                 }
             }
         }
@@ -130,7 +133,7 @@ public class ImporterUtilities {
             int index, boolean hasOurOwnColumnNames) {
         if (index < currentFileColumnNames.size()) {
             return project.columnModel.getColumnByName(currentFileColumnNames.get(index));
-        } else if (index >= currentFileColumnNames.size()) {
+        } else {
             String prefix = OpenRefineMessage.importer_utilities_column() + " ";
             int i = index + 1;
             while (true) {
@@ -158,13 +161,11 @@ public class ImporterUtilities {
                     return column;
                 }
             }
-        } else {
-            throw new RuntimeException("Unexpected code path");
         }
     }
 
     static public void setupColumns(Project project, List<String> columnNames) {
-        Map<String, Integer> nameToIndex = new HashMap<String, Integer>();
+        Map<String, Integer> nameToIndex = new HashMap<>();
         for (int c = 0; c < columnNames.size(); c++) {
             String cell = CharMatcher.whitespace().trimFrom(columnNames.get(c));
             if (cell.isEmpty()) {
@@ -195,13 +196,13 @@ public class ImporterUtilities {
         }
     }
 
-    static public interface MultiFileReadingProgress {
+    public interface MultiFileReadingProgress {
 
-        public void startFile(String fileSource);
+        void startFile(String fileSource);
 
-        public void readingFile(String fileSource, long bytesRead);
+        void readingFile(String fileSource, long bytesRead);
 
-        public void endFile(String fileSource, long bytesRead);
+        void endFile(String fileSource, long bytesRead);
     }
 
     static public MultiFileReadingProgress createMultiFileReadingProgress(

--- a/main/src/com/google/refine/importers/ImportingParserBase.java
+++ b/main/src/com/google/refine/importers/ImportingParserBase.java
@@ -156,7 +156,8 @@ abstract public class ImportingParserBase implements ImportingParser {
                     if (archiveColumnIndex >= 0) {
                         row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
                     }
-                    if (filenameColumnIndex >= 0) {
+                    // Only set the filename if it wasn't set by one of our subclasses (e.g. ExcelImporter which appends worksheet name)
+                    if (filenameColumnIndex >= 0 && row.getCell(filenameColumnIndex) == null) {
                         row.setCell(filenameColumnIndex, new Cell(fileSource, null));
                     }
                 }
@@ -177,15 +178,6 @@ abstract public class ImportingParserBase implements ImportingParser {
 
     /**
      * Parsing method to be implemented by Reader-based parsers. ie those initialized with useInputStream == false
-     * 
-     * @param project
-     * @param metadata
-     * @param job
-     * @param fileSource
-     * @param reader
-     * @param limit
-     * @param options
-     * @param exceptions
      */
     public void parseOneFile(
             Project project,
@@ -199,6 +191,9 @@ abstract public class ImportingParserBase implements ImportingParser {
         throw new NotImplementedException();
     }
 
+    /**
+     * Parsing method to be implemented by InputStream-based parsers. ie those initialized with useInputStream == false
+     */
     public void parseOneFile(
             Project project,
             ProjectMetadata metadata,
@@ -211,10 +206,7 @@ abstract public class ImportingParserBase implements ImportingParser {
         throw new NotImplementedException();
     }
 
-    /**
-     * @deprecated 2020-07-21 by tfmorris. This will become private in a future release.
-     */
-    @Deprecated
+
     protected static int addFilenameColumn(Project project, boolean archiveColumnAdded) {
         String fileNameColumnName = "File"; // TODO: Localize?
         int columnId = archiveColumnAdded ? 1 : 0;

--- a/main/src/com/google/refine/importers/ImportingParserBase.java
+++ b/main/src/com/google/refine/importers/ImportingParserBase.java
@@ -124,8 +124,7 @@ abstract public class ImportingParserBase implements ImportingParser {
 
         progress.startFile(fileSource);
         try {
-            InputStream inputStream = ImporterUtilities.openAndTrackFile(fileSource, file, progress);
-            try {
+            try (InputStream inputStream = ImporterUtilities.openAndTrackFile(fileSource, file, progress)) {
 
                 if (JSONUtilities.getBoolean(options, "includeArchiveFileName", false)
                         && archiveFileName != null) {
@@ -168,8 +167,6 @@ abstract public class ImportingParserBase implements ImportingParser {
                 // TODO: This will save a separate copy for each file in the import, but they're
                 // going to be mostly the same
                 metadata.appendImportOptionMetadata(fileOptions);
-            } finally {
-                inputStream.close();
             }
         } finally {
             progress.endFile(fileSource, file.length());

--- a/main/src/com/google/refine/importers/ImportingParserBase.java
+++ b/main/src/com/google/refine/importers/ImportingParserBase.java
@@ -155,7 +155,8 @@ abstract public class ImportingParserBase implements ImportingParser {
                     if (archiveColumnIndex >= 0) {
                         row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
                     }
-                    // Only set the filename if it wasn't set by one of our subclasses (e.g. ExcelImporter which appends worksheet name)
+                    // Only set the filename if it wasn't set by one of our subclasses (e.g. ExcelImporter which appends
+                    // worksheet name)
                     if (filenameColumnIndex >= 0 && row.getCell(filenameColumnIndex) == null) {
                         row.setCell(filenameColumnIndex, new Cell(fileSource, null));
                     }
@@ -202,7 +203,6 @@ abstract public class ImportingParserBase implements ImportingParser {
             List<Exception> exceptions) {
         throw new NotImplementedException();
     }
-
 
     protected static int addFilenameColumn(Project project, boolean archiveColumnAdded) {
         String fileNameColumnName = "File"; // TODO: Localize?

--- a/main/src/com/google/refine/importers/JsonImporter.java
+++ b/main/src/com/google/refine/importers/JsonImporter.java
@@ -107,8 +107,8 @@ public class JsonImporter extends TreeImportingParserBase {
         return options;
     }
 
-    final static private JsonNode parseForPreview(JsonParser parser, PreviewParsingState state, JsonToken token)
-            throws JsonParseException, IOException {
+    static private JsonNode parseForPreview(JsonParser parser, PreviewParsingState state, JsonToken token)
+            throws IOException {
         if (token != null) {
             switch (token) {
                 case START_ARRAY:
@@ -139,7 +139,7 @@ public class JsonImporter extends TreeImportingParserBase {
         return null;
     }
 
-    final static private JsonNode parseForPreview(JsonParser parser, PreviewParsingState state) {
+    static private JsonNode parseForPreview(JsonParser parser, PreviewParsingState state) {
         try {
             JsonToken token = parser.nextToken();
             state.tokenCount++;
@@ -149,7 +149,7 @@ public class JsonImporter extends TreeImportingParserBase {
         }
     }
 
-    final static private ObjectNode parseObjectForPreview(JsonParser parser, PreviewParsingState state) {
+    static private ObjectNode parseObjectForPreview(JsonParser parser, PreviewParsingState state) {
         ObjectNode result = ParsingUtilities.mapper.createObjectNode();
         loop: while (state.tokenCount < PREVIEW_PARSING_LIMIT) {
             try {
@@ -166,7 +166,6 @@ public class JsonImporter extends TreeImportingParserBase {
                         JSONUtilities.safePut(result, fieldName, fieldValue);
                         break;
                     case END_OBJECT:
-                        break loop;
                     default:
                         break loop;
                 }
@@ -177,7 +176,7 @@ public class JsonImporter extends TreeImportingParserBase {
         return result;
     }
 
-    final static private ArrayNode parseArrayForPreview(JsonParser parser, PreviewParsingState state) {
+    static private ArrayNode parseArrayForPreview(JsonParser parser, PreviewParsingState state) {
         ArrayNode result = ParsingUtilities.mapper.createArrayNode();
         loop: while (state.tokenCount < PREVIEW_PARSING_LIMIT) {
             try {
@@ -275,7 +274,7 @@ public class JsonImporter extends TreeImportingParserBase {
         }
 
         @Override
-        public String getFieldName() throws TreeReaderException {
+        public String getFieldName() {
             return fieldName;
         }
 
@@ -288,7 +287,7 @@ public class JsonImporter extends TreeImportingParserBase {
         }
 
         @Override
-        public String getFieldValue() throws TreeReaderException {
+        public String getFieldValue() {
             return fieldValue.toString();
         }
 
@@ -310,15 +309,15 @@ public class JsonImporter extends TreeImportingParserBase {
                         return parser.getText();
                     case VALUE_NUMBER_INT:
                         if (parser.getNumberType() == NumberType.INT || parser.getNumberType() == NumberType.LONG) {
-                            return Long.valueOf(parser.getLongValue());
+                            return parser.getLongValue();
                         } else {
                             return parser.getNumberValue();
                         }
                     case VALUE_NUMBER_FLOAT:
                         if (parser.getNumberType() == NumberType.FLOAT) {
-                            return Float.valueOf(parser.getFloatValue());
+                            return parser.getFloatValue();
                         } else if (parser.getNumberType() == NumberType.DOUBLE) {
-                            return Double.valueOf(parser.getDoubleValue());
+                            return parser.getDoubleValue();
                         } else {
                             return parser.getNumberValue();
                         }
@@ -371,33 +370,23 @@ public class JsonImporter extends TreeImportingParserBase {
         protected Token mapToToken(JsonToken token) {
             switch (token) {
                 case START_ARRAY:
-                    return Token.StartEntity;
-                case END_ARRAY:
-                    return Token.EndEntity;
                 case START_OBJECT:
                     return Token.StartEntity;
+                case END_ARRAY:
                 case END_OBJECT:
                     return Token.EndEntity;
                 case VALUE_STRING:
-                    return Token.Value;
-                case FIELD_NAME:
-                    return Token.Ignorable; // returned by the getLocalName function()
                 case VALUE_NUMBER_INT:
-                    return Token.Value;
-                // Json does not have START_DOCUMENT token type (so ignored as default)
-                // Json does not have END_DOCUMENT token type (so ignored as default)
+// Json does not have START_DOCUMENT token type (so ignored as default)
+                    // Json does not have END_DOCUMENT token type (so ignored as default)
                 case VALUE_TRUE:
-                    return Token.Value;
                 case VALUE_NUMBER_FLOAT:
-                    return Token.Value;
                 case VALUE_NULL:
-                    return Token.Value;
                 case VALUE_FALSE:
-                    return Token.Value;
+                    return Token.Value;// returned by the getLocalName function()
                 case VALUE_EMBEDDED_OBJECT:
-                    return Token.Ignorable;
                 case NOT_AVAILABLE:
-                    return Token.Ignorable;
+                case FIELD_NAME:
                 default:
                     return Token.Ignorable;
             }

--- a/main/src/com/google/refine/importers/JsonImporter.java
+++ b/main/src/com/google/refine/importers/JsonImporter.java
@@ -370,23 +370,33 @@ public class JsonImporter extends TreeImportingParserBase {
         protected Token mapToToken(JsonToken token) {
             switch (token) {
                 case START_ARRAY:
-                case START_OBJECT:
                     return Token.StartEntity;
                 case END_ARRAY:
+                    return Token.EndEntity;
+                case START_OBJECT:
+                    return Token.StartEntity;
                 case END_OBJECT:
                     return Token.EndEntity;
                 case VALUE_STRING:
-                case VALUE_NUMBER_INT:
-// Json does not have START_DOCUMENT token type (so ignored as default)
-                    // Json does not have END_DOCUMENT token type (so ignored as default)
-                case VALUE_TRUE:
-                case VALUE_NUMBER_FLOAT:
-                case VALUE_NULL:
-                case VALUE_FALSE:
-                    return Token.Value;// returned by the getLocalName function()
-                case VALUE_EMBEDDED_OBJECT:
-                case NOT_AVAILABLE:
+                    return Token.Value;
                 case FIELD_NAME:
+                    return Token.Ignorable; // returned by the getLocalName function()
+                case VALUE_NUMBER_INT:
+                    return Token.Value;
+                // Json does not have START_DOCUMENT token type (so ignored as default)
+                // Json does not have END_DOCUMENT token type (so ignored as default)
+                case VALUE_TRUE:
+                    return Token.Value;
+                case VALUE_NUMBER_FLOAT:
+                    return Token.Value;
+                case VALUE_NULL:
+                    return Token.Value;
+                case VALUE_FALSE:
+                    return Token.Value;
+                case VALUE_EMBEDDED_OBJECT:
+                    return Token.Ignorable;
+                case NOT_AVAILABLE:
+                    return Token.Ignorable;
                 default:
                     return Token.Ignorable;
             }

--- a/main/src/com/google/refine/importers/LineBasedImporter.java
+++ b/main/src/com/google/refine/importers/LineBasedImporter.java
@@ -135,6 +135,6 @@ public class LineBasedImporter extends TabularImportingParserBase {
             }
         };
 
-        TabularImportingParserBase.readTable(project, job, dataReader, limit, options, exceptions);
+        TabularImportingParserBase.readTable(project, metadata, job, dataReader, fileSource, limit, options, exceptions);
     }
 }

--- a/main/src/com/google/refine/importers/MarcImporter.java
+++ b/main/src/com/google/refine/importers/MarcImporter.java
@@ -97,8 +97,7 @@ public class MarcImporter extends XmlImporter {
                 logger.error("Failed to create temporary XML file from MARC file", e);
             }
         }
-        ObjectNode options = super.createParserUIInitializationData(job, fileRecords, format);
-        return options;
-    };
+        return super.createParserUIInitializationData(job, fileRecords, format);
+    }
 
 }

--- a/main/src/com/google/refine/importers/OdsImporter.java
+++ b/main/src/com/google/refine/importers/OdsImporter.java
@@ -143,10 +143,9 @@ public class OdsImporter extends TabularImportingParserBase {
 
         ArrayNode sheets = JSONUtilities.getArray(options, "sheets");
         for (int i = 0; i < sheets.size(); i++) {
-            String[] fileNameAndSheetIndex;
             ObjectNode sheetObj = JSONUtilities.getObjectElement(sheets, i);
             // value is fileName#sheetIndex
-            fileNameAndSheetIndex = sheetObj.get("fileNameAndSheetIndex").asText().split("#");
+            String[] fileNameAndSheetIndex = sheetObj.get("fileNameAndSheetIndex").asText().split("#");
 
             if (!fileNameAndSheetIndex[0].equals(fileSource))
                 continue;

--- a/main/src/com/google/refine/importers/RdfTripleImporter.java
+++ b/main/src/com/google/refine/importers/RdfTripleImporter.java
@@ -57,7 +57,7 @@ import com.google.refine.model.Row;
 
 public class RdfTripleImporter extends ImportingParserBase {
 
-    private Mode mode;
+    private final Mode mode;
 
     public enum Mode {
         RDFXML, NT, N3, TTL, JSONLD
@@ -109,7 +109,7 @@ public class RdfTripleImporter extends ImportingParserBase {
         StmtIterator triples = model.listStatements();
 
         try {
-            Map<String, List<Row>> subjectToRows = new LinkedHashMap<String, List<Row>>();
+            Map<String, List<Row>> subjectToRows = new LinkedHashMap<>();
             Column subjectColumn = new Column(project.columnModel.allocateNewCellIndex(), "subject");
             project.columnModel.addColumn(0, subjectColumn, false);
             project.columnModel.setKeyColumnIndex(0);
@@ -144,7 +144,7 @@ public class RdfTripleImporter extends ImportingParserBase {
                         row.setCell(cellIndex, new Cell(object, null));
                     }
                 } else {
-                    List<Row> rows = new ArrayList<Row>();
+                    List<Row> rows = new ArrayList<>();
                     subjectToRows.put(subject, rows);
 
                     Row row = new Row(project.columnModel.getMaxCellIndex() + 1);

--- a/main/src/com/google/refine/importers/SeparatorBasedImporter.java
+++ b/main/src/com/google/refine/importers/SeparatorBasedImporter.java
@@ -159,7 +159,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
             }
         };
 
-        TabularImportingParserBase.readTable(project, job, dataReader, limit, options, exceptions);
+        TabularImportingParserBase.readTable(project, metadata, job, dataReader, fileSource, limit, options, exceptions);
     }
 
     static protected ArrayList<Object> getCells(String line, CSVParser parser, LineNumberReader lnReader)

--- a/main/src/com/google/refine/importers/SeparatorBasedImporter.java
+++ b/main/src/com/google/refine/importers/SeparatorBasedImporter.java
@@ -40,10 +40,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -105,7 +103,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
         if (options.has("columnNames")) {
             String[] strings = JSONUtilities.getStringArray(options, "columnNames");
             if (strings.length > 0) {
-                retrievedColumnNames = new ArrayList<Object>();
+                retrievedColumnNames = new ArrayList<>();
                 for (String s : strings) {
                     s = CharMatcher.whitespace().trimFrom(s);
                     if (!s.isEmpty()) {
@@ -123,7 +121,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
 
         final List<Object> columnNames = retrievedColumnNames;
 
-        Character quote = CSVParser.DEFAULT_QUOTE_CHARACTER;
+        char quote = CSVParser.DEFAULT_QUOTE_CHARACTER;
         String quoteCharacter = JSONUtilities.getString(options, "quoteCharacter", null);
         if (quoteCharacter != null && CharMatcher.whitespace().trimFrom(quoteCharacter).length() == 1) {
             quote = CharMatcher.whitespace().trimFrom(quoteCharacter).charAt(0);
@@ -165,9 +163,8 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
     static protected ArrayList<Object> getCells(String line, CSVParser parser, LineNumberReader lnReader)
             throws IOException {
 
-        ArrayList<Object> cells = new ArrayList<Object>();
         String[] tokens = parser.parseLineMulti(line);
-        cells.addAll(Arrays.asList(tokens));
+        ArrayList<Object> cells = new ArrayList<>(Arrays.asList(tokens));
         while (parser.isPending()) {
             tokens = parser.parseLineMulti(lnReader.readLine());
             cells.addAll(Arrays.asList(tokens));
@@ -208,16 +205,14 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
         return guessSeparator(file, encoding, false); // quotes off for backward compatibility
     }
 
-    // TODO: Move this to the CSV project?
     static public Separator guessSeparator(File file, String encoding, boolean handleQuotes) {
         try {
             InputStream is = new FileInputStream(file);
             Reader reader = encoding != null ? new InputStreamReader(is, encoding) : new InputStreamReader(is);
-            LineNumberReader lineNumberReader = new LineNumberReader(reader);
 
-            try {
-                List<Separator> separators = new ArrayList<SeparatorBasedImporter.Separator>();
-                Map<Character, Separator> separatorMap = new HashMap<Character, SeparatorBasedImporter.Separator>();
+            try (is; reader; LineNumberReader lineNumberReader = new LineNumberReader(reader)) {
+                List<Separator> separators = new ArrayList<>();
+                Map<Character, Separator> separatorMap = new HashMap<>();
 
                 int totalChars = 0;
                 int lineCount = 0;
@@ -272,7 +267,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
                                         / ((double) lineCount * (lineCount - 1)));
                     }
 
-                    Collections.sort(separators, new Comparator<Separator>() {
+                    separators.sort(new Comparator<>() {
 
                         @Override
                         public int compare(Separator sep0, Separator sep1) {
@@ -287,13 +282,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
                     }
 
                 }
-            } finally {
-                lineNumberReader.close();
-                reader.close();
-                is.close();
             }
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/main/src/com/google/refine/importers/TabularImportingParserBase.java
+++ b/main/src/com/google/refine/importers/TabularImportingParserBase.java
@@ -113,7 +113,7 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
             List<String> columnNames = project.columnModel.getColumnNames();
             if (columnNames.size() > 1 && "Archive".equals(columnNames.get(0)) && "File".equals(columnNames.get(1))) {
                 filenameColumnIndex = 1;
-            } else  if (columnNames.size() > 0 && "File".equals(columnNames.get(0))) {
+            } else if (columnNames.size() > 0 && "File".equals(columnNames.get(0))) {
                 filenameColumnIndex = 0;
             }
         }

--- a/main/src/com/google/refine/importers/TabularImportingParserBase.java
+++ b/main/src/com/google/refine/importers/TabularImportingParserBase.java
@@ -51,9 +51,9 @@ import com.google.refine.util.JSONUtilities;
 
 abstract public class TabularImportingParserBase extends ImportingParserBase {
 
-    static public interface TableDataReader {
+    public interface TableDataReader {
 
-        public List<Object> getNextRowOfCells() throws IOException;
+        List<Object> getNextRowOfCells() throws IOException;
     }
 
     @Override
@@ -82,7 +82,7 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
 
     static public void readTable(
             Project project,
-            ProjectMetadata metadata,
+            ProjectMetadata ignoredMetadata,
             ImportingJob job,
             TableDataReader reader,
             String fileSource,
@@ -118,10 +118,10 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
             }
         }
 
-        List<String> columnNames = new ArrayList<String>();
+        List<String> columnNames = new ArrayList<>();
         boolean hasOurOwnColumnNames = headerLines > 0;
 
-        List<Object> cells = null;
+        List<Object> cells;
         int rowsWithData = 0;
 
         try {

--- a/main/src/com/google/refine/importers/TextFormatGuesser.java
+++ b/main/src/com/google/refine/importers/TextFormatGuesser.java
@@ -33,7 +33,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 
 import org.apache.commons.io.input.BoundedInputStream;
@@ -54,7 +53,6 @@ public class TextFormatGuesser implements FormatGuesser {
             if (isCompressed(file)) {
                 return "binary";
             }
-            ;
 
             InputStream bis = new BoundedInputStream(fis, 64 * 1024); // TODO: This seems like a lot
             try (BufferedReader reader = new BufferedReader(
@@ -124,8 +122,6 @@ public class TextFormatGuesser implements FormatGuesser {
                 }
                 return "text/line-based";
             }
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/main/src/com/google/refine/importers/WikitextImporter.java
+++ b/main/src/com/google/refine/importers/WikitextImporter.java
@@ -89,7 +89,6 @@ import com.google.refine.model.Recon;
 import com.google.refine.model.ReconStats;
 import com.google.refine.model.recon.ReconJob;
 import com.google.refine.model.recon.StandardReconConfig;
-import com.google.refine.model.recon.StandardReconConfig.ColumnDetail;
 import com.google.refine.util.JSONUtilities;
 
 import de.fau.cs.osr.ptk.common.AstVisitor;
@@ -190,10 +189,10 @@ public class WikitextImporter extends TabularImportingParserBase {
             this.blankSpanningCells = blankSpanningCells;
             this.includeRawTemplates = includeRawTemplates;
             caption = null;
-            rows = new ArrayList<List<String>>();
-            references = new ArrayList<List<String>>();
-            wikilinkedCells = new ArrayList<WikilinkedCell>();
-            spanningCells = new ArrayList<SpanningCell>();
+            rows = new ArrayList<>();
+            references = new ArrayList<>();
+            wikilinkedCells = new ArrayList<>();
+            spanningCells = new ArrayList<>();
             cellStringBuilder = null;
             xmlAttrStringBuilder = null;
             currentRowReferences = null;
@@ -206,8 +205,8 @@ public class WikitextImporter extends TabularImportingParserBase {
             rowspan = 0;
             rowId = 0;
             spanningCellIdx = 0;
-            internalLinksInCell = new ArrayList<String>();
-            namedReferences = new HashMap<String, String>();
+            internalLinksInCell = new ArrayList<>();
+            namedReferences = new HashMap<>();
         }
 
         @Override
@@ -242,8 +241,8 @@ public class WikitextImporter extends TabularImportingParserBase {
         }
 
         private void startRow() {
-            currentRow = new ArrayList<String>();
-            currentRowReferences = new ArrayList<String>();
+            currentRow = new ArrayList<>();
+            currentRowReferences = new ArrayList<>();
             spanningCellIdx = 0;
             addSpanningCells();
         }
@@ -568,8 +567,8 @@ public class WikitextImporter extends TabularImportingParserBase {
 
     public class WikiTableDataReader implements TableDataReader {
 
-        private int currentRow = 0;
-        private WikitextTableVisitor visitor = null;
+        private int currentRow;
+        private WikitextTableVisitor visitor;
         private List<List<Recon>> reconList = null;
         private List<Boolean> columnReconciled = null;
         private List<Boolean> columnReferenced = null;
@@ -581,7 +580,7 @@ public class WikitextImporter extends TabularImportingParserBase {
 
             if (references) {
                 // Check which column had references
-                columnReferenced = new ArrayList<Boolean>();
+                columnReferenced = new ArrayList<>();
                 for (List<String> row : this.visitor.references) {
                     for (int i = 0; i != row.size(); i++) {
                         while (i >= columnReferenced.size()) {
@@ -606,7 +605,7 @@ public class WikitextImporter extends TabularImportingParserBase {
             }
 
             if (origRow != null) {
-                row = new ArrayList<Object>();
+                row = new ArrayList<>();
                 for (int i = 0; i < origRow.size(); i++) {
                     Recon recon = null;
                     if (currentRow >= 0 && reconList != null) {
@@ -621,7 +620,7 @@ public class WikitextImporter extends TabularImportingParserBase {
 
                     // if we should add reference columns…
                     if (columnReferenced != null && i < columnReferenced.size() && columnReferenced.get(i)) {
-                        String refValue = null;
+                        String refValue;
                         // for headers
                         if (currentRow == -1) {
                             refValue = origRow.get(i) + "_ref";
@@ -646,11 +645,11 @@ public class WikitextImporter extends TabularImportingParserBase {
             }
 
             // Init the list of recons
-            reconList = new ArrayList<List<Recon>>();
-            columnReconciled = new ArrayList<Boolean>();
+            reconList = new ArrayList<>();
+            columnReconciled = new ArrayList<>();
             for (int i = 0; i < this.visitor.rows.size(); i++) {
                 int rowSize = this.visitor.rows.get(i).size();
-                List<Recon> recons = new ArrayList<Recon>(rowSize);
+                List<Recon> recons = new ArrayList<>(rowSize);
                 for (int j = 0; j < rowSize; j++) {
                     recons.add(null);
                     if (j >= columnReconciled.size())
@@ -664,7 +663,7 @@ public class WikitextImporter extends TabularImportingParserBase {
             int i = 0;
             int totalSize = this.visitor.wikilinkedCells.size();
             while (i < totalSize) {
-                List<ReconJob> jobs = new ArrayList<ReconJob>();
+                List<ReconJob> jobs = new ArrayList<>();
                 int batchStart = i;
                 while (i < batchStart + batchSize && i < totalSize) {
                     WikilinkedCell cell = this.visitor.wikilinkedCells.get(i);
@@ -775,7 +774,7 @@ public class WikitextImporter extends TabularImportingParserBase {
                 "",
                 "entity",
                 true,
-                new ArrayList<ColumnDetail>(),
+                new ArrayList<>(),
                 1);
         return cfg;
     }

--- a/main/src/com/google/refine/importers/WikitextImporter.java
+++ b/main/src/com/google/refine/importers/WikitextImporter.java
@@ -747,7 +747,7 @@ public class WikitextImporter extends TabularImportingParserBase {
                 // TODO this does not seem to do anything - maybe we need to pass it to OpenRefine in some other way?
             }
 
-            TabularImportingParserBase.readTable(project, job, dataReader, limit, options, exceptions);
+            TabularImportingParserBase.readTable(project, metadata, job, dataReader, fileSource, limit, options, exceptions);
 
             // Add reconciliation statistics
             if (dataReader.columnReconciled != null) {

--- a/main/src/com/google/refine/importers/XmlImporter.java
+++ b/main/src/com/google/refine/importers/XmlImporter.java
@@ -86,9 +86,8 @@ public class XmlImporter extends TreeImportingParserBase {
             if (fileRecords.size() > 0) {
                 ObjectNode firstFileRecord = fileRecords.get(0);
                 File file = ImportingUtilities.getFile(job, firstFileRecord);
-                InputStream is = new FileInputStream(file);
 
-                try {
+                try (InputStream is = new FileInputStream(file)) {
                     XMLStreamReader parser = createXMLStreamReader(is);
                     PreviewParsingState state = new PreviewParsingState();
 
@@ -101,14 +100,10 @@ public class XmlImporter extends TreeImportingParserBase {
                                 JSONUtilities.safePut(options, "dom", rootElement);
                                 break;
                             }
-                        } else {
-                            // ignore everything else
                         }
                     }
                 } catch (XMLStreamException e) {
                     logger.warn("Error generating parser UI initialization data for XML file", e);
-                } finally {
-                    is.close();
                 }
             }
         } catch (IOException e) {
@@ -118,7 +113,7 @@ public class XmlImporter extends TreeImportingParserBase {
         return options;
     }
 
-    final static private ObjectNode descendElement(XMLStreamReader parser, PreviewParsingState state) {
+    static private ObjectNode descendElement(XMLStreamReader parser, PreviewParsingState state) {
         ObjectNode result = ParsingUtilities.mapper.createObjectNode();
         {
             String name = parser.getLocalName();
@@ -180,8 +175,6 @@ public class XmlImporter extends TreeImportingParserBase {
                     ObjectNode childElement = ParsingUtilities.mapper.createObjectNode();
                     JSONUtilities.safePut(childElement, "t", parser.getText());
                     children.add(childElement);
-                } else {
-                    // ignore everything else
                 }
             }
         } catch (XMLStreamException e) {
@@ -203,9 +196,7 @@ public class XmlImporter extends TreeImportingParserBase {
         try {
             parseOneFile(project, metadata, job, fileSource,
                     new XmlParser(inputStream), rootColumnGroup, limit, options, exceptions);
-        } catch (XMLStreamException e) {
-            exceptions.add(e);
-        } catch (IOException e) {
+        } catch (XMLStreamException | IOException e) {
             exceptions.add(e);
         }
     }
@@ -229,7 +220,7 @@ public class XmlImporter extends TreeImportingParserBase {
                 throw new TreeReaderException(e);
             }
 
-            int currentToken = -1;
+            int currentToken;
             try {
                 currentToken = parser.next();
             } catch (XMLStreamException e) {
@@ -254,31 +245,19 @@ public class XmlImporter extends TreeImportingParserBase {
                 case XMLStreamConstants.END_ELEMENT:
                     return Token.EndEntity;
                 case XMLStreamConstants.CHARACTERS:
-                    return Token.Value;
-                case XMLStreamConstants.START_DOCUMENT:
-                    return Token.Ignorable;
-                case XMLStreamConstants.END_DOCUMENT:
-                    return Token.Ignorable;
                 case XMLStreamConstants.SPACE:
                     return Token.Value;
-                case XMLStreamConstants.PROCESSING_INSTRUCTION:
-                    return Token.Ignorable;
-                case XMLStreamConstants.NOTATION_DECLARATION:
-                    return Token.Ignorable;
-                case XMLStreamConstants.NAMESPACE:
-                    return Token.Ignorable;
-                case XMLStreamConstants.ENTITY_REFERENCE:
-                    return Token.Ignorable;
-                case XMLStreamConstants.DTD:
-                    return Token.Ignorable;
-                case XMLStreamConstants.COMMENT:
-                    return Token.Ignorable;
-                case XMLStreamConstants.CDATA:
-                    return Token.Ignorable;
-                case XMLStreamConstants.ATTRIBUTE:
-                    return Token.Ignorable;
                 case WHITESPACE_CHARACTERS_TOKEN:
-                    return Token.Ignorable;
+                case XMLStreamConstants.ATTRIBUTE:
+                case XMLStreamConstants.CDATA:
+                case XMLStreamConstants.COMMENT:
+                case XMLStreamConstants.DTD:
+                case XMLStreamConstants.ENTITY_REFERENCE:
+                case XMLStreamConstants.NAMESPACE:
+                case XMLStreamConstants.NOTATION_DECLARATION:
+                case XMLStreamConstants.PROCESSING_INSTRUCTION:
+                case XMLStreamConstants.END_DOCUMENT:
+                case XMLStreamConstants.START_DOCUMENT:
                 default:
                     return Token.Ignorable;
             }
@@ -299,7 +278,7 @@ public class XmlImporter extends TreeImportingParserBase {
         }
 
         @Override
-        public String getFieldName() throws TreeReaderException {
+        public String getFieldName() {
             try {
                 return parser.getLocalName();
             } catch (IllegalStateException e) {
@@ -344,7 +323,7 @@ public class XmlImporter extends TreeImportingParserBase {
         }
     }
 
-    final static private XMLStreamReader createXMLStreamReader(InputStream inputStream) throws XMLStreamException, IOException {
+    static private XMLStreamReader createXMLStreamReader(InputStream inputStream) throws XMLStreamException, IOException {
         XMLInputFactory factory = XMLInputFactory.newInstance();
         factory.setProperty(XMLInputFactory.IS_COALESCING, true);
         factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, true);
@@ -353,12 +332,13 @@ public class XmlImporter extends TreeImportingParserBase {
         return factory.createXMLStreamReader(wrapPrefixRemovingInputStream(inputStream));
     }
 
-    final static private InputStream wrapPrefixRemovingInputStream(InputStream inputStream)
+    static private InputStream wrapPrefixRemovingInputStream(InputStream inputStream)
             throws XMLStreamException, IOException {
         PushbackInputStream pis = new PushbackInputStream(inputStream);
         int b;
         int count = 0;
         while (count < 100 && (b = pis.read()) >= 0) {
+            // FIXME: This will never be triggered
             if (++count > 100) {
                 throw new XMLStreamException(
                         "File starts with too much non-XML content to skip over");

--- a/main/src/com/google/refine/importers/XmlImporter.java
+++ b/main/src/com/google/refine/importers/XmlImporter.java
@@ -66,6 +66,7 @@ import com.google.refine.util.ParsingUtilities;
 public class XmlImporter extends TreeImportingParserBase {
 
     static final Logger logger = LoggerFactory.getLogger(XmlImporter.class);
+    static final int PREFIX_SIZE_LIMIT = 100;
 
     public XmlImporter() {
         super(true);
@@ -337,9 +338,8 @@ public class XmlImporter extends TreeImportingParserBase {
         PushbackInputStream pis = new PushbackInputStream(inputStream);
         int b;
         int count = 0;
-        while (count < 100 && (b = pis.read()) >= 0) {
-            // FIXME: This will never be triggered
-            if (++count > 100) {
+        while (count < PREFIX_SIZE_LIMIT && (b = pis.read()) >= 0) {
+            if (++count == PREFIX_SIZE_LIMIT) {
                 throw new XMLStreamException(
                         "File starts with too much non-XML content to skip over");
             } else if (b == '<') {

--- a/main/src/com/google/refine/importers/XmlImporter.java
+++ b/main/src/com/google/refine/importers/XmlImporter.java
@@ -248,17 +248,17 @@ public class XmlImporter extends TreeImportingParserBase {
                 case XMLStreamConstants.CHARACTERS:
                 case XMLStreamConstants.SPACE:
                     return Token.Value;
-                case WHITESPACE_CHARACTERS_TOKEN:
-                case XMLStreamConstants.ATTRIBUTE:
-                case XMLStreamConstants.CDATA:
-                case XMLStreamConstants.COMMENT:
-                case XMLStreamConstants.DTD:
-                case XMLStreamConstants.ENTITY_REFERENCE:
-                case XMLStreamConstants.NAMESPACE:
-                case XMLStreamConstants.NOTATION_DECLARATION:
-                case XMLStreamConstants.PROCESSING_INSTRUCTION:
-                case XMLStreamConstants.END_DOCUMENT:
                 case XMLStreamConstants.START_DOCUMENT:
+                case XMLStreamConstants.END_DOCUMENT:
+                case XMLStreamConstants.PROCESSING_INSTRUCTION:
+                case XMLStreamConstants.NOTATION_DECLARATION:
+                case XMLStreamConstants.NAMESPACE:
+                case XMLStreamConstants.ENTITY_REFERENCE:
+                case XMLStreamConstants.DTD:
+                case XMLStreamConstants.COMMENT:
+                case XMLStreamConstants.CDATA:
+                case XMLStreamConstants.ATTRIBUTE:
+                case WHITESPACE_CHARACTERS_TOKEN:
                 default:
                     return Token.Ignorable;
             }

--- a/main/src/com/google/refine/importers/tree/TreeImportUtilities.java
+++ b/main/src/com/google/refine/importers/tree/TreeImportUtilities.java
@@ -35,7 +35,6 @@ package com.google.refine.importers.tree;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -52,13 +51,7 @@ public abstract class TreeImportUtilities {
     final static Logger logger = LoggerFactory.getLogger("TreeImportUtilities");
 
     static protected void sortRecordElementCandidates(List<RecordElementCandidate> list) {
-        Collections.sort(list, new Comparator<RecordElementCandidate>() {
-
-            @Override
-            public int compare(RecordElementCandidate o1, RecordElementCandidate o2) {
-                return o2.count - o1.count;
-            }
-        });
+        list.sort((o1, o2) -> o2.count - o1.count);
     }
 
     static public void createColumnsFromImport(
@@ -66,29 +59,22 @@ public abstract class TreeImportUtilities {
             ImportColumnGroup columnGroup) {
         int startColumnIndex = project.columnModel.columns.size();
 
-        List<ImportColumn> columns = new ArrayList<ImportColumn>(columnGroup.columns.values());
-        Collections.sort(columns, new Comparator<ImportColumn>() {
-
-            @Override
-            public int compare(ImportColumn o1, ImportColumn o2) {
-                if (o1.blankOnFirstRow != o2.blankOnFirstRow) {
-                    return o1.blankOnFirstRow ? 1 : -1;
-                }
-
-                return o2.nonBlankCount - o1.nonBlankCount;
+        List<ImportColumn> columns = new ArrayList<>(columnGroup.columns.values());
+        columns.sort((o1, o2) -> {
+            if (o1.blankOnFirstRow != o2.blankOnFirstRow) {
+                return o1.blankOnFirstRow ? 1 : -1;
             }
+            return o2.nonBlankCount - o1.nonBlankCount;
         });
 
-        for (int i = 0; i < columns.size(); i++) {
-            ImportColumn c = columns.get(i);
-
-            Column column = new com.google.refine.model.Column(c.cellIndex, c.name);
+        for (ImportColumn c : columns) {
+            Column column = new Column(c.cellIndex, c.name);
             project.columnModel.columns.add(column);
         }
 
         // The LinkedHashMap iterator will guaranteed that the list is arranged in order found
-        List<ImportColumnGroup> subgroups = new ArrayList<ImportColumnGroup>(columnGroup.subgroups.values());
-        Collections.sort(subgroups, new Comparator<ImportColumnGroup>() {
+        List<ImportColumnGroup> subgroups = new ArrayList<>(columnGroup.subgroups.values());
+        subgroups.sort(new Comparator<>() {
 
             @Override
             public int compare(ImportColumnGroup o1, ImportColumnGroup o2) {
@@ -153,7 +139,7 @@ public abstract class TreeImportUtilities {
 
         List<Cell> row = record.rows.get(rowIndex);
         if (row == null) {
-            row = new ArrayList<Cell>();
+            row = new ArrayList<>();
             record.rows.set(rowIndex, row);
         }
 
@@ -211,7 +197,7 @@ public abstract class TreeImportUtilities {
     }
 
     static protected ImportColumnGroup createColumnGroup(
-            Project project,
+            Project ignoredProject,
             ImportColumnGroup columnGroup,
             String localName) {
         ImportColumnGroup newGroup = new ImportColumnGroup();

--- a/main/src/com/google/refine/importers/tree/TreeImportingParserBase.java
+++ b/main/src/com/google/refine/importers/tree/TreeImportingParserBase.java
@@ -117,8 +117,7 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
 
         progress.startFile(fileSource);
         try {
-            InputStream inputStream = ImporterUtilities.openAndTrackFile(fileSource, file, progress);
-            try {
+            try (InputStream inputStream = ImporterUtilities.openAndTrackFile(fileSource, file, progress)) {
 
                 if (JSONUtilities.getBoolean(options, "includeArchiveFileName", false)
                         && archiveFileName != null) {
@@ -160,8 +159,6 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
                 // TODO: This will save a separate copy for each file in the import, but they're
                 // going to be mostly the same
                 metadata.appendImportOptionMetadata(fileOptions);
-            } finally {
-                inputStream.close();
             }
         } finally {
             progress.endFile(fileSource, file.length());

--- a/main/src/com/google/refine/importers/tree/TreeReader.java
+++ b/main/src/com/google/refine/importers/tree/TreeReader.java
@@ -42,31 +42,31 @@ import java.io.Serializable;
  */
 public interface TreeReader {
 
-    public enum Token {
+    enum Token {
         Ignorable, StartEntity, EndEntity, Value
         // append additional tokens only if necessary (most should be just mapped to Value or Ignorable)
     }
 
-    public Token current() throws TreeReaderException; // aka getCurrentToken
+    Token current() throws TreeReaderException; // aka getCurrentToken
 
-    public boolean hasNext() throws TreeReaderException;
+    boolean hasNext() throws TreeReaderException;
 
-    public Token next() throws TreeReaderException;
+    Token next() throws TreeReaderException;
 
-    public String getFieldName() throws TreeReaderException;
+    String getFieldName() throws TreeReaderException;
 
-    public String getPrefix();
+    String getPrefix();
 
     @Deprecated
-    public String getFieldValue() throws TreeReaderException;
+    String getFieldValue() throws TreeReaderException;
 
-    public Serializable getValue() throws TreeReaderException;
+    Serializable getValue() throws TreeReaderException;
 
-    public int getAttributeCount();
+    int getAttributeCount();
 
-    public String getAttributeValue(int index);
+    String getAttributeValue(int index);
 
-    public String getAttributePrefix(int index);
+    String getAttributePrefix(int index);
 
-    public String getAttributeLocalName(int index);
+    String getAttributeLocalName(int index);
 }

--- a/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
+++ b/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
@@ -158,7 +158,7 @@ public class XmlImportUtilities extends TreeImportUtilities {
                 }
             }
         } catch (TreeReaderException e) {
-            logger.error("Exception from XML parse", e);
+            logger.debug("Exception from XML parse", e);
             throw e;
         }
     }

--- a/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
+++ b/main/src/com/google/refine/importers/tree/XmlImportUtilities.java
@@ -78,7 +78,7 @@ public class XmlImportUtilities extends TreeImportUtilities {
      *            The element name (can be qualified) to search for
      * @return If the tag is found, an array of strings is returned. If the tag is at the top level, the tag will be the
      *         only item in the array. If the tag is nested beneath the top level, the array is filled with the
-     *         hierarchy with the tag name at the last index null if the the tag is not found.
+     *         hierarchy with the tag name at the last index null if the tag is not found.
      * @throws TreeReaderException
      */
     static protected List<String> detectRecordElement(TreeReader parser, String tag) throws TreeReaderException {

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -69,7 +69,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
-import org.apache.commons.compress.compressors.lzma.LZMACompressorInputStream;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.ProgressListener;

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -46,9 +46,6 @@ import java.time.OffsetDateTime;
 import java.util.Calendar;
 import java.util.Date;
 
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -63,6 +60,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.refine.util.ParsingUtilities;
 
 public class ExcelImporterTests extends ImporterTest {

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -265,7 +265,7 @@ public class ExcelImporterTests extends ImporterTest {
     }
 
     @Test
-    public void readMultiSheetXlsFilesource() throws  IOException {
+    public void readMultiSheetXlsFilesource() throws IOException {
         stageFile(xlsFileWithMultiSheets);
         initMetadata(xlsFileWithMultiSheets.getName(), 3);
 
@@ -309,7 +309,6 @@ public class ExcelImporterTests extends ImporterTest {
         verify(options, times(SHEETS)).get("limit");
         verify(options, times(SHEETS)).get("storeBlankCellsAsNulls");
     }
-
 
     @Test
     public void readMultiSheetXlsx() throws IOException {
@@ -455,7 +454,8 @@ public class ExcelImporterTests extends ImporterTest {
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         for (int i = 0; i < sheetCount; i++) {
             sheets.add(ParsingUtilities.mapper
-                    .readTree(String.format("{name: \"%1$s#Test Sheet %2$d\", fileNameAndSheetIndex: \"%1$s#%2$d\", rows: 31, selected: true}",
+                    .readTree(String.format(
+                            "{name: \"%1$s#Test Sheet %2$d\", fileNameAndSheetIndex: \"%1$s#%2$d\", rows: 31, selected: true}",
                             spreadsheet, i)));
         }
         whenGetArrayOption("sheets", options, sheets);

--- a/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
@@ -28,7 +28,6 @@
 package com.google.refine.importers;
 
 import java.io.IOException;
-import java.io.StringReader;
 
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;

--- a/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
@@ -27,6 +27,7 @@
 
 package com.google.refine.importers;
 
+import java.io.IOException;
 import java.io.StringReader;
 
 import org.slf4j.LoggerFactory;
@@ -70,8 +71,8 @@ public class FixedWidthImporterTests extends ImporterTest {
 
     // ---------------------read tests------------------------
     @Test
-    public void readFixedWidth() {
-        StringReader reader = new StringReader(SAMPLE_ROW + "\nTooShort");
+    public void readFixedWidth() throws IOException {
+        stageString(SAMPLE_ROW + "\nTooShort");
 
         ArrayNode columnWidths = ParsingUtilities.mapper.createArrayNode();
         JSONUtilities.append(columnWidths, 6);
@@ -92,7 +93,7 @@ public class FixedWidthImporterTests extends ImporterTest {
         whenGetBooleanOption("storeBlankCellsAsNulls", options, true);
 
         try {
-            parseOneFile(SUT, reader);
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }

--- a/main/tests/server/src/com/google/refine/importers/ImporterTest.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterTest.java
@@ -107,7 +107,6 @@ public abstract class ImporterTest extends RefineTest {
         project.update();
     }
 
-
     protected List<Exception> parseOneFileAndReturnExceptions(@NotNull ImportingParserBase parser)
             throws IOException {
         List<Exception> exceptions = new ArrayList<>();
@@ -155,7 +154,7 @@ public abstract class ImporterTest extends RefineTest {
                 project,
                 metadata,
                 job,
-                fileRecord, //"file-source",
+                fileRecord, // "file-source",
                 rootColumnGroup,
                 -1,
                 options,
@@ -189,12 +188,12 @@ public abstract class ImporterTest extends RefineTest {
     }
 
     protected void stageString(String contents) throws IOException {
-        FileUtils.writeStringToFile( new File(job.getRawDataDir(), "foo"), contents, StandardCharsets.UTF_8);
+        FileUtils.writeStringToFile(new File(job.getRawDataDir(), "foo"), contents, StandardCharsets.UTF_8);
         initMetadata("foo");
     }
 
     protected void stageString(String filename, String contents) throws IOException {
-        FileUtils.writeStringToFile( new File(job.getRawDataDir(), filename), contents, StandardCharsets.UTF_8);
+        FileUtils.writeStringToFile(new File(job.getRawDataDir(), filename), contents, StandardCharsets.UTF_8);
         initMetadata(filename);
     }
 
@@ -204,13 +203,17 @@ public abstract class ImporterTest extends RefineTest {
     }
 
     private static class NullProgress implements ImporterUtilities.MultiFileReadingProgress {
-        @Override
-        public void startFile(String fileSource) {}
 
         @Override
-        public void readingFile(String fileSource, long bytesRead) {}
+        public void startFile(String fileSource) {
+        }
 
         @Override
-        public void endFile(String fileSource, long bytesRead) {}
+        public void readingFile(String fileSource, long bytesRead) {
+        }
+
+        @Override
+        public void endFile(String fileSource, long bytesRead) {
+        }
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/ImporterTest.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterTest.java
@@ -35,7 +35,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.mockito.Mockito;
@@ -93,38 +92,6 @@ public abstract class ImporterTest extends RefineTest {
         options = null;
     }
 
-    @Deprecated
-    void parseOneFile(ImportingParserBase parser, Reader reader) throws IOException {
-        List<Exception> exceptions = new ArrayList<Exception>();
-        parser.parseOneFile(
-                project,
-                metadata,
-                job,
-                fileRecord, //"file-source",
-                -1,
-                options,
-                exceptions,
-                progress);
-        assertEquals(exceptions.size(), 0);
-        project.update();
-    }
-
-    @Deprecated
-    void parseOneFile(ImportingParserBase parser, InputStream inputStream) throws IOException {
-        List<Exception> exceptions = new ArrayList<Exception>();
-        parser.parseOneFile(
-                project,
-                metadata,
-                job,
-                fileRecord,
-                -1,
-                options,
-                exceptions,
-                progress);
-        assertEquals(exceptions.size(), 0);
-        project.update();
-    }
-
     protected void parseOneFile(@NotNull ImportingParserBase parser) throws IOException {
         List<Exception> exceptions = new ArrayList<>();
         parser.parseOneFile(
@@ -161,16 +128,16 @@ public abstract class ImporterTest extends RefineTest {
         parseOneInputStreamAsReader(parser, inputStream, options);
     }
 
-    protected void parseOneInputStream(
-            @NotNull TreeImportingParserBase parser, InputStream inputStream, ObjectNode options) throws IOException {
+    protected void parseOneTreeFile(
+            @NotNull TreeImportingParserBase parser, ObjectNode options) throws IOException {
         ImportColumnGroup rootColumnGroup = new ImportColumnGroup();
-        List<Exception> exceptions = new ArrayList<Exception>();
+        List<Exception> exceptions = new ArrayList<>();
 
         parser.parseOneFile(
                 project,
                 metadata,
                 job,
-                fileRecord, //"file-source",
+                fileRecord,
                 rootColumnGroup,
                 -1,
                 options,
@@ -182,9 +149,8 @@ public abstract class ImporterTest extends RefineTest {
     protected void parseOneInputStreamAsReader(
             @NotNull TreeImportingParserBase parser, InputStream inputStream, ObjectNode options) throws IOException {
         ImportColumnGroup rootColumnGroup = new ImportColumnGroup();
-        List<Exception> exceptions = new ArrayList<Exception>();
+        List<Exception> exceptions = new ArrayList<>();
 
-        Reader reader = new InputStreamReader(inputStream);
         parser.parseOneFile(
                 project,
                 metadata,
@@ -197,11 +163,6 @@ public abstract class ImporterTest extends RefineTest {
                 progress);
         postProcessProject(project, rootColumnGroup, exceptions);
 
-        try {
-            reader.close();
-        } catch (IOException e) {
-            // ignore errors on close
-        }
     }
 
     protected void postProcessProject(
@@ -216,13 +177,11 @@ public abstract class ImporterTest extends RefineTest {
         assertEquals(exceptions.size(), 0);
     }
 
-    @NotNull
     protected void stageFile(File spreadsheet) throws IOException {
         FileUtils.copyFile(spreadsheet, new File(job.getRawDataDir(), spreadsheet.getName()));
         initMetadata(spreadsheet.getName());
     }
 
-    @NotNull
     protected void stageResource(String name) throws IOException {
         FileUtils.copyURLToFile(ClassLoader.getSystemResource(name),
                 new File(job.getRawDataDir(), name));
@@ -239,12 +198,12 @@ public abstract class ImporterTest extends RefineTest {
         initMetadata(filename);
     }
 
-    private void initMetadata(String filename) throws JsonProcessingException {
+    private void initMetadata(String filename) {
         fileRecord = ParsingUtilities.evaluateJsonStringToObjectNode(
                 String.format("{\"location\": \"%1$s\",\"fileName\": \"%1$s\"}", filename));
     }
 
-    private class NullProgress implements ImporterUtilities.MultiFileReadingProgress {
+    private static class NullProgress implements ImporterUtilities.MultiFileReadingProgress {
         @Override
         public void startFile(String fileSource) {}
 

--- a/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
@@ -92,7 +92,7 @@ public class ImporterUtilitiesTests extends RefineTest {
 
     @Test
     public void appendColumnName() {
-        List<String> columnNames = new ArrayList<String>();
+        List<String> columnNames = new ArrayList<>();
 
         ImporterUtilities.appendColumnName(columnNames, 0, "foo");
         ImporterUtilities.appendColumnName(columnNames, 1, "bar");
@@ -103,7 +103,7 @@ public class ImporterUtilitiesTests extends RefineTest {
 
     @Test
     public void appendColumnNameFromMultipleRows() {
-        List<String> columnNames = new ArrayList<String>();
+        List<String> columnNames = new ArrayList<>();
 
         ImporterUtilities.appendColumnName(columnNames, 0, "foo");
         ImporterUtilities.appendColumnName(columnNames, 0, "bar");
@@ -116,7 +116,7 @@ public class ImporterUtilitiesTests extends RefineTest {
         String VALUE_1 = "value1";
         String VALUE_2 = "value2";
         Row row = new Row(2);
-        ArrayList<String> columnNames = new ArrayList<String>(2);
+        ArrayList<String> columnNames = new ArrayList<>(2);
         columnNames.add(VALUE_1);
         columnNames.add(VALUE_2);
 
@@ -134,7 +134,7 @@ public class ImporterUtilitiesTests extends RefineTest {
             row.cells.add(new Cell("value" + i, null));
         }
 
-        ArrayList<String> columnNames = new ArrayList<String>(2);
+        ArrayList<String> columnNames = new ArrayList<>(2);
 
         ImporterUtilities.ensureColumnsInRowExist(columnNames, row);
 
@@ -145,7 +145,7 @@ public class ImporterUtilitiesTests extends RefineTest {
     @Test
     public void setupColumns() {
         Project project = new Project();
-        List<String> columnNames = new ArrayList<String>();
+        List<String> columnNames = new ArrayList<>();
         columnNames.add("col1");
         columnNames.add("col2");
         columnNames.add("");
@@ -158,7 +158,7 @@ public class ImporterUtilitiesTests extends RefineTest {
     @Test
     public void testGetOrAllocateColumn() {
         Project project = new Project();
-        List<String> columnNames = new ArrayList<String>();
+        List<String> columnNames = new ArrayList<>();
         columnNames.add("Column 1");
         columnNames.add("Column 2");
         columnNames.add("Column 3");
@@ -170,7 +170,7 @@ public class ImporterUtilitiesTests extends RefineTest {
 
         // This will mock the situation of importing another sheet from the same file.
         // Expect newColumnNames can be updated using column names.
-        List<String> newColumnNames = new ArrayList<String>();
+        List<String> newColumnNames = new ArrayList<>();
         Column c0 = ImporterUtilities.getOrAllocateColumn(project, newColumnNames, 0, false);
         Column c1 = ImporterUtilities.getOrAllocateColumn(project, newColumnNames, 1, false);
         Assert.assertEquals(c0.getName(), "Column 1");

--- a/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
@@ -647,15 +647,10 @@ public class JsonImporterTests extends ImporterTest {
 
     private void RunTest(String testString, ObjectNode options) {
         try {
-            inputStream = new ByteArrayInputStream(testString.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e1) {
-            Assert.fail();
-        }
-
-        try {
-            parseOneInputStream(SUT, inputStream, options);
-        } catch (Exception e) {
-            Assert.fail();
+            stageString(testString);
+            parseOneFile(SUT);
+        } catch (IOException e) {
+            Assert.fail("JSON importer test failed", e);
         }
     }
 

--- a/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
@@ -621,8 +621,7 @@ public class JsonImporterTests extends ImporterTest {
     }
 
     private static String getSampleWithError() {
-        String sb =
-                "[" +
+        String sb = "[" +
                 "{\"id\":" + "\"\n\";" +
                 "]";
         return sb;

--- a/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
@@ -285,16 +285,16 @@ public class JsonImporterTests extends ImporterTest {
      * occurs after a Field_Name token
      */
     @Test
-    public void EnsureJSONParserHandlesgetLocalNameCorrectly() throws Exception {
+    public void EnsureJSONParserHandlesGetLocalNameCorrectly() {
         String sampleJson = "{\"field\":\"value\"}";
         String sampleJson2 = "{\"field\":{}}";
         String sampleJson3 = "{\"field\":[{},{}]}";
 
         JSONTreeReader parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson.getBytes(StandardCharsets.UTF_8)));
-        Token token = Token.Ignorable;
+        Token token;
         int i = 0;
         try {
-            while (token != null) {
+            while (true) {
                 token = parser.next();
                 if (token == null) {
                     break;
@@ -310,10 +310,9 @@ public class JsonImporterTests extends ImporterTest {
         }
 
         parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson2.getBytes(StandardCharsets.UTF_8)));
-        token = Token.Ignorable;
         i = 0;
         try {
-            while (token != null) {
+            while (true) {
                 token = parser.next();
                 if (token == null) {
                     break;
@@ -329,10 +328,9 @@ public class JsonImporterTests extends ImporterTest {
         }
 
         parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson3.getBytes(StandardCharsets.UTF_8)));
-        token = Token.Ignorable;
         i = 0;
         try {
-            while (token != null) {
+            while (true) {
                 token = parser.next();
                 if (token == null) {
                     break;
@@ -357,15 +355,15 @@ public class JsonImporterTests extends ImporterTest {
     }
 
     @Test
-    public void testCanParseTab() throws Exception {
+    public void testCanParseTab() {
         // Use un-escaped tabs here.
         String sampleJson = "{\"\tfield\":\t\"\tvalue\"}";
 
         JSONTreeReader parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson.getBytes(StandardCharsets.UTF_8)));
-        Token token = Token.Ignorable;
+        Token token;
         int i = 0;
         try {
-            while (token != null) {
+            while (true) {
                 token = parser.next();
                 if (token == null) {
                     break;
@@ -415,12 +413,12 @@ public class JsonImporterTests extends ImporterTest {
         row = project.rows.get(15);
         Assert.assertNotNull(row);
         Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Long.valueOf(0));
+        Assert.assertEquals(row.cells.get(1).value, 0L);
 
         row = project.rows.get(16);
         Assert.assertNotNull(row);
         Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Long.valueOf(1));
+        Assert.assertEquals(row.cells.get(1).value, 1L);
 
         row = project.rows.get(17);
         Assert.assertNotNull(row);
@@ -430,18 +428,18 @@ public class JsonImporterTests extends ImporterTest {
         row = project.rows.get(18);
         Assert.assertNotNull(row);
         Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Double.valueOf((double) 0.23));
+        Assert.assertEquals(row.cells.get(1).value, 0.23);
 
         row = project.rows.get(19);
         Assert.assertNotNull(row);
         Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Double.valueOf((double) -0.24));
+        Assert.assertEquals(row.cells.get(1).value, -0.24);
 
         row = project.rows.get(20);
         Assert.assertNotNull(row);
         Assert.assertEquals(row.cells.size(), 2);
         Assert.assertFalse(Double.isNaN((Double) row.cells.get(1).value));
-        Assert.assertEquals(row.cells.get(1).value, Double.valueOf((double) 3.14e100));
+        Assert.assertEquals(row.cells.get(1).value, 3.14e100);
 
         // null, true, false 0,1,-2.1,0.23,-0.24,3.14e100
 
@@ -451,7 +449,7 @@ public class JsonImporterTests extends ImporterTest {
     @Test
     public void testComplexJsonStructure() throws IOException {
         String fileName = "grid_small.json";
-        RunComplexJSONTest(getComplexJSON(fileName));
+        RunComplexJSONTest(getResourceAsString(fileName));
 
         logger.debug("************************ column number:" + project.columnModel.columns.size() +
                 ". \tcolumn groups number:" + project.columnModel.columnGroups.size() +
@@ -480,7 +478,7 @@ public class JsonImporterTests extends ImporterTest {
         JSONUtilities.safePut(options, "guessCellValueTypes", false);
         JSONUtilities.safePut(options, "includeFileSources", true);
 
-        List<Exception> exceptions = new ArrayList<Exception>();
+        List<Exception> exceptions = new ArrayList<>();
 
         SUT.parse(
                 project,
@@ -613,22 +611,21 @@ public class JsonImporterTests extends ImporterTest {
     }
 
     private static String getSampleWithDataTypes() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[");
         int i = 1;
-        sb.append("{\"id\":" + i++ + ",\"cell\":[\"39766\",\"T1009\",\"foo\",\"DEU\",\"19\",\"01:49\"]},\n");
-        sb.append("{\"id\":" + i++ + ",\"cell\":[\"39766\",\"T1009\",\"\",\"DEU\",\"19\",\"01:49\"]},\n");
-        sb.append("{\"id\":null,\"cell\":[null,true,false,0,1,-2.1,0.23,-0.24,3.14e100]}\n");
-        sb.append("]");
-        return sb.toString();
+        String sb = "[" +
+                "{\"id\":" + i++ + ",\"cell\":[\"39766\",\"T1009\",\"foo\",\"DEU\",\"19\",\"01:49\"]},\n" +
+                "{\"id\":" + i++ + ",\"cell\":[\"39766\",\"T1009\",\"\",\"DEU\",\"19\",\"01:49\"]},\n" +
+                "{\"id\":null,\"cell\":[null,true,false,0,1,-2.1,0.23,-0.24,3.14e100]}\n" +
+                "]";
+        return sb;
     }
 
     private static String getSampleWithError() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("[");
-        sb.append("{\"id\":" + "\"\n\";");
-        sb.append("]");
-        return sb.toString();
+        String sb =
+                "[" +
+                "{\"id\":" + "\"\n\";" +
+                "]";
+        return sb;
     }
 
     private void RunTest(String testString) {
@@ -646,18 +643,17 @@ public class JsonImporterTests extends ImporterTest {
     private void RunTest(String testString, ObjectNode options) {
         try {
             stageString(testString);
-//            parseOneFile(SUT);
-            parseOneInputStream(SUT, inputStream, options);
+            parseOneTreeFile(SUT, options);
         } catch (IOException e) {
             Assert.fail("JSON importer test failed", e);
         }
     }
 
-    private String getComplexJSON(String fileName) throws IOException {
-        InputStream in = this.getClass().getClassLoader()
-                .getResourceAsStream(fileName);
-        String content = org.apache.commons.io.IOUtils.toString(in, StandardCharsets.UTF_8);
-
-        return content;
+    private String getResourceAsString(String fileName) throws IOException {
+        InputStream in = this.getClass().getClassLoader().getResourceAsStream(fileName);
+        if (in == null) {
+            return null;
+        }
+        return org.apache.commons.io.IOUtils.toString(in, StandardCharsets.UTF_8);
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.importers;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
@@ -119,13 +120,10 @@ public class JsonImporterTests extends ImporterTest {
         JSONUtilities.safePut(options, "storeEmptyStrings", true);
         JSONUtilities.safePut(options, "guessCellValueTypes", false);
 
-        try {
-            inputStream = new ByteArrayInputStream(errJSON.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e1) {
-            Assert.fail();
-        }
+        inputStream = new ByteArrayInputStream(errJSON.getBytes(StandardCharsets.UTF_8));
+
         ImportColumnGroup rootColumnGroup = new ImportColumnGroup();
-        List<Exception> exceptions = new ArrayList<Exception>();
+        List<Exception> exceptions = new ArrayList<>();
 
         SUT.parseOneFile(
                 project,
@@ -292,7 +290,7 @@ public class JsonImporterTests extends ImporterTest {
         String sampleJson2 = "{\"field\":{}}";
         String sampleJson3 = "{\"field\":[{},{}]}";
 
-        JSONTreeReader parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson.getBytes("UTF-8")));
+        JSONTreeReader parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson.getBytes(StandardCharsets.UTF_8)));
         Token token = Token.Ignorable;
         int i = 0;
         try {
@@ -311,7 +309,7 @@ public class JsonImporterTests extends ImporterTest {
             // silent
         }
 
-        parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson2.getBytes("UTF-8")));
+        parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson2.getBytes(StandardCharsets.UTF_8)));
         token = Token.Ignorable;
         i = 0;
         try {
@@ -330,7 +328,7 @@ public class JsonImporterTests extends ImporterTest {
             // silent
         }
 
-        parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson3.getBytes("UTF-8")));
+        parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson3.getBytes(StandardCharsets.UTF_8)));
         token = Token.Ignorable;
         i = 0;
         try {
@@ -363,7 +361,7 @@ public class JsonImporterTests extends ImporterTest {
         // Use un-escaped tabs here.
         String sampleJson = "{\"\tfield\":\t\"\tvalue\"}";
 
-        JSONTreeReader parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson.getBytes("UTF-8")));
+        JSONTreeReader parser = new JSONTreeReader(new ByteArrayInputStream(sampleJson.getBytes(StandardCharsets.UTF_8)));
         Token token = Token.Ignorable;
         int i = 0;
         try {
@@ -455,7 +453,7 @@ public class JsonImporterTests extends ImporterTest {
         String fileName = "grid_small.json";
         RunComplexJSONTest(getComplexJSON(fileName));
 
-        logger.debug("************************ columnu number:" + project.columnModel.columns.size() +
+        logger.debug("************************ column number:" + project.columnModel.columns.size() +
                 ". \tcolumn groups number:" + project.columnModel.columnGroups.size() +
                 ".\trow number:" + project.rows.size() + ".\trecord number:" + project.recordModel.getRecordCount());
 
@@ -648,7 +646,8 @@ public class JsonImporterTests extends ImporterTest {
     private void RunTest(String testString, ObjectNode options) {
         try {
             stageString(testString);
-            parseOneFile(SUT);
+//            parseOneFile(SUT);
+            parseOneInputStream(SUT, inputStream, options);
         } catch (IOException e) {
             Assert.fail("JSON importer test failed", e);
         }
@@ -657,7 +656,7 @@ public class JsonImporterTests extends ImporterTest {
     private String getComplexJSON(String fileName) throws IOException {
         InputStream in = this.getClass().getClassLoader()
                 .getResourceAsStream(fileName);
-        String content = org.apache.commons.io.IOUtils.toString(in, "UTF-8");
+        String content = org.apache.commons.io.IOUtils.toString(in, StandardCharsets.UTF_8);
 
         return content;
     }

--- a/main/tests/server/src/com/google/refine/importers/LineBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/LineBasedImporterTests.java
@@ -64,8 +64,9 @@ public class LineBasedImporterTests extends ImporterTest {
         String input = "col1\ndata1";
 
         try {
+            stageString(input);
             prepareOptions("\\r?\\n", 1, 1, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             fail("Exception during file parse", e);
         }
@@ -82,8 +83,9 @@ public class LineBasedImporterTests extends ImporterTest {
         String input = "data1\r\ndata2\ndata3\rdata4";
 
         try {
+            stageString(input);
             prepareOptions("\\r?\\n", 1, 0, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             fail("Exception during file parse", e);
         }
@@ -100,8 +102,9 @@ public class LineBasedImporterTests extends ImporterTest {
         String input = "dataa,datab,datac,datad".replace(",", sep);
 
         try {
+            stageString(input);
             prepareOptions(pattern, 1, 0, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             fail("Exception during file parse", e);
         }

--- a/main/tests/server/src/com/google/refine/importers/LineBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/LineBasedImporterTests.java
@@ -30,8 +30,6 @@ package com.google.refine.importers;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.*;
 
-import java.io.StringReader;
-
 import static org.testng.Assert.*;
 
 public class LineBasedImporterTests extends ImporterTest {

--- a/main/tests/server/src/com/google/refine/importers/MarcImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/MarcImporterTests.java
@@ -40,9 +40,8 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -84,15 +83,11 @@ public class MarcImporterTests extends XmlImporterTests {
     @Test
     public void readMarcFileWithUnicode() throws FileNotFoundException, IOException {
         final String FILE = "scriblio.mrc";
-        String filename = ClassLoader.getSystemResource(FILE).getPath();
-        // File is assumed to be in job.getRawDataDir(), so copy it there
-        FileUtils.copyFile(new File(filename), new File(job.getRawDataDir(), FILE));
-        List<ObjectNode> fileRecords = new ArrayList<>();
-        fileRecords.add(ParsingUtilities.evaluateJsonStringToObjectNode(String.format("{\"location\": \"%s\"}", FILE)));
+        stageResource(FILE);
 
         // NOTE: This has the side effect of creating scriblio.mrc.xml
         ObjectNode options = SUT.createParserUIInitializationData(
-                job, fileRecords, "binary/marc");
+                job, Arrays.asList(fileRecord), "binary/marc");
 
         ArrayNode path = ParsingUtilities.mapper.createArrayNode();
         JSONUtilities.append(path, "marc:collection");
@@ -101,7 +96,7 @@ public class MarcImporterTests extends XmlImporterTests {
         JSONUtilities.safePut(options, "trimStrings", true);
         JSONUtilities.safePut(options, "storeEmptyStrings", false);
 
-        File xmlFile = ImportingUtilities.getFile(job, fileRecords.get(0));
+        File xmlFile = ImportingUtilities.getFile(job, fileRecord);
         InputStream inputStream = new FileInputStream(xmlFile);
         parseOneFile(SUT, inputStream, options);
         assertEquals(project.rows.size(), 30);

--- a/main/tests/server/src/com/google/refine/importers/MarcImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/MarcImporterTests.java
@@ -36,11 +36,9 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -81,13 +79,13 @@ public class MarcImporterTests extends XmlImporterTests {
     }
 
     @Test
-    public void readMarcFileWithUnicode() throws FileNotFoundException, IOException {
+    public void readMarcFileWithUnicode() throws IOException {
         final String FILE = "scriblio.mrc";
         stageResource(FILE);
 
         // NOTE: This has the side effect of creating scriblio.mrc.xml
         ObjectNode options = SUT.createParserUIInitializationData(
-                job, Arrays.asList(fileRecord), "binary/marc");
+                job, Collections.singletonList(fileRecord), "binary/marc");
 
         ArrayNode path = ParsingUtilities.mapper.createArrayNode();
         JSONUtilities.append(path, "marc:collection");

--- a/main/tests/server/src/com/google/refine/importers/OdsImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/OdsImporterTests.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -88,11 +89,8 @@ public class OdsImporterTests extends ImporterTest {
 
     @Test
     public void readOds() throws FileNotFoundException, IOException {
-
-        ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
-        sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
-        whenGetArrayOption("sheets", options, sheets);
+        stageResource("films.ods");
+        initMetadata("films.ods", 1);
 
         whenGetIntegerOption("ignoreLines", options, 0);
         whenGetIntegerOption("headerLines", options, 1);
@@ -100,10 +98,8 @@ public class OdsImporterTests extends ImporterTest {
         whenGetIntegerOption("limit", options, ROWS);
         whenGetBooleanOption("storeBlankCellsAsNulls", options, true);
 
-        InputStream stream = ClassLoader.getSystemResourceAsStream("films.ods");
-
         try {
-            parseOneFile(SUT, stream);
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
@@ -129,11 +125,8 @@ public class OdsImporterTests extends ImporterTest {
 
     @Test
     public void showErrorDialogWhenWrongFormat() throws FileNotFoundException, IOException {
-
-        ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
-        sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
-        whenGetArrayOption("sheets", options, sheets);
+        stageResource("NoData_NoSpreadsheet.ods");
+        initMetadata("NoData_NoSpreadsheet.ods", 1);
 
         whenGetIntegerOption("ignoreLines", options, 0);
         whenGetIntegerOption("headerLines", options, 1);
@@ -141,10 +134,9 @@ public class OdsImporterTests extends ImporterTest {
         whenGetIntegerOption("limit", options, ROWS);
         whenGetBooleanOption("storeBlankCellsAsNulls", options, true);
 
-        InputStream stream = ClassLoader.getSystemResourceAsStream("NoData_NoSpreadsheet.ods");
 
         try {
-            List<Exception> exceptions = parseOneFileAndReturnExceptions(SUT, stream);
+            List<Exception> exceptions = parseOneFileAndReturnExceptions(SUT);
             assertEquals(exceptions.size(), 1);
             Exception NPE = exceptions.get(0);
             assertEquals(NPE.getMessage(),
@@ -155,5 +147,15 @@ public class OdsImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail(e.getMessage());
         }
+    }
+
+    private void initMetadata(String spreadsheet, int sheetCount) throws JsonProcessingException {
+        ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
+        for (int i = 0; i < sheetCount; i++) {
+            sheets.add(ParsingUtilities.mapper
+                    .readTree(String.format("{name: \"%1$s#Test Sheet %2$d\", fileNameAndSheetIndex: \"%1$s#%2$d\", rows: 31, selected: true}",
+                            spreadsheet, i)));
+        }
+        whenGetArrayOption("sheets", options, sheets);
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/OdsImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/OdsImporterTests.java
@@ -40,11 +40,11 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.slf4j.LoggerFactory;
@@ -88,7 +88,7 @@ public class OdsImporterTests extends ImporterTest {
     }
 
     @Test
-    public void readOds() throws FileNotFoundException, IOException {
+    public void readOds() throws IOException {
         stageResource("films.ods");
         initMetadata("films.ods", 1);
 
@@ -114,7 +114,7 @@ public class OdsImporterTests extends ImporterTest {
         assertFalse((Boolean) row.getCellValue(7));
         assertTrue((Boolean) project.rows.get(1).getCellValue(7));
 
-        assertNull((String) project.rows.get(2).getCellValue(2));
+        assertNull(project.rows.get(2).getCellValue(2));
 
         verify(options, times(1)).get("ignoreLines");
         verify(options, times(1)).get("headerLines");
@@ -124,7 +124,7 @@ public class OdsImporterTests extends ImporterTest {
     }
 
     @Test
-    public void showErrorDialogWhenWrongFormat() throws FileNotFoundException, IOException {
+    public void showErrorDialogWhenWrongFormat() throws IOException {
         stageResource("NoData_NoSpreadsheet.ods");
         initMetadata("NoData_NoSpreadsheet.ods", 1);
 
@@ -136,6 +136,7 @@ public class OdsImporterTests extends ImporterTest {
 
 
         try {
+            Logger.getLogger("").setLevel(Level.OFF);  // disable annoying logging since we expect this to fail
             List<Exception> exceptions = parseOneFileAndReturnExceptions(SUT);
             assertEquals(exceptions.size(), 1);
             Exception NPE = exceptions.get(0);

--- a/main/tests/server/src/com/google/refine/importers/OdsImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/OdsImporterTests.java
@@ -134,9 +134,8 @@ public class OdsImporterTests extends ImporterTest {
         whenGetIntegerOption("limit", options, ROWS);
         whenGetBooleanOption("storeBlankCellsAsNulls", options, true);
 
-
         try {
-            Logger.getLogger("").setLevel(Level.OFF);  // disable annoying logging since we expect this to fail
+            Logger.getLogger("").setLevel(Level.OFF); // disable annoying logging since we expect this to fail
             List<Exception> exceptions = parseOneFileAndReturnExceptions(SUT);
             assertEquals(exceptions.size(), 1);
             Exception NPE = exceptions.get(0);
@@ -154,7 +153,8 @@ public class OdsImporterTests extends ImporterTest {
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         for (int i = 0; i < sheetCount; i++) {
             sheets.add(ParsingUtilities.mapper
-                    .readTree(String.format("{name: \"%1$s#Test Sheet %2$d\", fileNameAndSheetIndex: \"%1$s#%2$d\", rows: 31, selected: true}",
+                    .readTree(String.format(
+                            "{name: \"%1$s#Test Sheet %2$d\", fileNameAndSheetIndex: \"%1$s#%2$d\", rows: 31, selected: true}",
                             spreadsheet, i)));
         }
         whenGetArrayOption("sheets", options, sheets);

--- a/main/tests/server/src/com/google/refine/importers/RdfTripleImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/RdfTripleImporterTests.java
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2010,2012 Google Inc.
+Copyright 2010, 2022 Google Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -33,8 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.importers;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
+import java.io.IOException;
 
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;

--- a/main/tests/server/src/com/google/refine/importers/RdfTripleImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/RdfTripleImporterTests.java
@@ -33,10 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.importers;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.io.StringReader;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -68,10 +66,9 @@ public class RdfTripleImporterTests extends ImporterTest {
     @Test(enabled = false)
     public void canParseSingleLineTriple() {
         String sampleRdf = "<http://rdf.mybase.com/ns/en.bob_dylan> <http://rdf.mybase.com/ns/music.artist.album> <http://rdf.mybase.com/ns/en.blood_on_the_tracks>.";
-        StringReader reader = new StringReader(sampleRdf);
-
         try {
-            parseOneFile(SUT, reader);
+            stageString(sampleRdf);
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail();
         }
@@ -86,14 +83,14 @@ public class RdfTripleImporterTests extends ImporterTest {
     }
 
     @Test
-    public void canParseMultiLineTriple() throws UnsupportedEncodingException {
+    public void canParseMultiLineTriple() throws IOException {
         String sampleRdf = "<http://rdf.mybase.com/ns/en.bob_dylan> <http://rdf.mybase.com/ns/music.artist.album> <http://rdf.mybase.com/ns/en.blood_on_the_tracks>.\n"
                 +
                 "<http://rdf.mybase.com/ns/en.bob_dylan> <http://rdf.mybase.com/ns/music.artist.album> <http://rdf.mybase.com/ns/en.under_the_red_sky>.\n"
                 +
                 "<http://rdf.mybase.com/ns/en.bob_dylan> <http://rdf.mybase.com/ns/music.artist.album> <http://rdf.mybase.com/ns/en.bringing_it_all_back_home>.";
-        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
-        parseOneFile(SUT, input);
+        stageString(sampleRdf);
+        parseOneFile(SUT);
 
         // columns
         Assert.assertEquals(project.columnModel.columns.size(), 2);
@@ -124,14 +121,14 @@ public class RdfTripleImporterTests extends ImporterTest {
     }
 
     @Test
-    public void canParseMultiLineMultiPredicatesTriple() throws UnsupportedEncodingException {
+    public void canParseMultiLineMultiPredicatesTriple() throws IOException {
         String sampleRdf = "<http://rdf.mybase.com/ns/en.bob_dylan> <http://rdf.mybase.com/ns/music.artist.album> <http://rdf.mybase.com/ns/en.blood_on_the_tracks>.\n"
                 +
                 "<http://rdf.mybase.com/ns/en.bob_dylan> <http://rdf.mybase.com/ns/music.artist.genre> <http://rdf.mybase.com/ns/en.folk_rock>.\n"
                 +
                 "<http://rdf.mybase.com/ns/en.bob_dylan> <http://rdf.mybase.com/ns/music.artist.album> <http://rdf.mybase.com/ns/en.bringing_it_all_back_home>.";
-        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
-        parseOneFile(SUT, input);
+        stageString(sampleRdf);
+        parseOneFile(SUT);
 
         // columns
         Assert.assertEquals(project.columnModel.columns.size(), 3);
@@ -157,12 +154,11 @@ public class RdfTripleImporterTests extends ImporterTest {
     }
 
     @Test
-    public void canParseTripleWithValue() throws UnsupportedEncodingException {
+    public void canParseTripleWithValue() throws IOException {
         String sampleRdf = "<http://rdf.mybase.com/ns/en.bob_dylan> <http://rdf.mybase.com/ns/common.topic.alias>\"Robert Zimmerman\"@en.";
-        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
-
+        stageString(sampleRdf);
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.N3);
-        parseOneFile(SUT, input);
+        parseOneFile(SUT);
 
         Assert.assertEquals(project.columnModel.columns.size(), 2);
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "subject");
@@ -174,7 +170,7 @@ public class RdfTripleImporterTests extends ImporterTest {
     }
 
     @Test
-    public void canParseRdfXml() throws UnsupportedEncodingException {
+    public void canParseRdfXml() throws IOException {
         // From W3C spec http://www.w3.org/TR/REC-rdf-syntax/#example8
         String sampleRdf = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
                 + "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n"
@@ -192,9 +188,9 @@ public class RdfTripleImporterTests extends ImporterTest {
                 + "  </rdf:Description>\n"
                 + "</rdf:RDF>\n";
 
-        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
+        stageString(sampleRdf);
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.RDFXML);
-        parseOneFile(SUT, input);
+        parseOneFile(SUT);
 
         Assert.assertEquals(project.columnModel.columns.size(), 3);
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "subject");
@@ -211,7 +207,7 @@ public class RdfTripleImporterTests extends ImporterTest {
     }
 
     @Test
-    public void canParseN3() throws UnsupportedEncodingException {
+    public void canParseN3() throws IOException {
         String sampleRdf = "@prefix p:  <http://www.example.org/personal_details#> .\n" +
                 "@prefix m:  <http://www.example.org/meeting_organization#> .\n\n" +
                 "<http://www.example.org/people#fred>\n" +
@@ -219,10 +215,9 @@ public class RdfTripleImporterTests extends ImporterTest {
                 "p:hasEmail              <mailto:fred@example.com>;\n" +
                 "m:attending     <http://meetings.example.com/cal#m1> .\n";
 
-        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
-
+        stageString(sampleRdf);
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.N3);
-        parseOneFile(SUT, input);
+        parseOneFile(SUT);
 
         Assert.assertEquals(project.columnModel.columns.size(), 4);
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "subject");
@@ -238,7 +233,7 @@ public class RdfTripleImporterTests extends ImporterTest {
     }
 
     @Test
-    public void canParseTtl() throws UnsupportedEncodingException {
+    public void canParseTtl() throws IOException {
         String sampleRdf = "@prefix p:  <http://www.example.org/personal_details#> .\n" +
                 "@prefix m:  <http://www.example.org/meeting_organization#> .\n\n" +
                 "<http://www.example.org/people#fred>\n" +
@@ -246,10 +241,9 @@ public class RdfTripleImporterTests extends ImporterTest {
                 "p:hasEmail              <mailto:fred@example.com>;\n" +
                 "m:attending     <http://meetings.example.com/cal#m1> .\n";
 
-        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
-
+        stageString(sampleRdf);
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.TTL);
-        parseOneFile(SUT, input);
+        parseOneFile(SUT);
 
         Assert.assertEquals(project.columnModel.columns.size(), 4);
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "subject");
@@ -265,16 +259,15 @@ public class RdfTripleImporterTests extends ImporterTest {
     }
 
     @Test
-    public void canParseNTriples() throws UnsupportedEncodingException {
+    public void canParseNTriples() throws IOException {
         String sampleRdf = "<http://www.example.org/people#fred> <http://www.example.org/meeting_organization#attending> <http://meetings.example.com/cal#m1> . \n"
                 +
                 "<http://www.example.org/people#fred> <http://www.example.org/personal_details#hasEmail> <mailto:fred@example.com> . \n" +
                 "<http://www.example.org/people#fred> <http://www.example.org/personal_details#GivenName> \"Fred\" . ";
 
-        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
-
+        stageString(sampleRdf);
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.NT);
-        parseOneFile(SUT, input);
+        parseOneFile(SUT);
 
         Assert.assertEquals(project.columnModel.columns.size(), 4);
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "subject");
@@ -291,16 +284,15 @@ public class RdfTripleImporterTests extends ImporterTest {
     }
 
     @Test
-    public void canParseTurtleBlankNode() throws UnsupportedEncodingException {
+    public void canParseTurtleBlankNode() throws IOException {
         String sampleRdf = "@prefix ex: <http://example.org/data#> .\n" +
                 "<http://example.org/web-data> ex:title \"Web Data\" ;\n" +
                 "                               ex:professor [ ex:fullName \"Alice Carol\" ;\n" +
                 "                                              ex:homePage <http://example.net/alice-carol> ] .";
 
-        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
-
+        stageString(sampleRdf);
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.TTL);
-        parseOneFile(SUT, input);
+        parseOneFile(SUT);
 
         String[] columns = { "subject",
                 "http://example.org/data#professor",
@@ -323,7 +315,7 @@ public class RdfTripleImporterTests extends ImporterTest {
     }
 
     @Test
-    public void canParseJsonld() throws UnsupportedEncodingException {
+    public void canParseJsonld() throws IOException {
         String sampleJsonld = "{\n " +
                 "  \"@context\": {\n " +
                 "    \"m\": \"http://www.example.org/meeting_organization#\",\n " +
@@ -341,11 +333,10 @@ public class RdfTripleImporterTests extends ImporterTest {
                 "    \"@id\": \"mailto:fred@example.com\"\n " +
                 "  }\n " +
                 "}";
-
-        InputStream input = new ByteArrayInputStream(sampleJsonld.getBytes("UTF-8"));
+        stageString(sampleJsonld);
 
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.JSONLD);
-        parseOneFile(SUT, input);
+        parseOneFile(SUT);
 
         Assert.assertEquals(project.columnModel.columns.size(), 4);
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "subject");

--- a/main/tests/server/src/com/google/refine/importers/TextFormatGuesserTests.java
+++ b/main/tests/server/src/com/google/refine/importers/TextFormatGuesserTests.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.io.FileUtils;
@@ -113,7 +114,7 @@ public class TextFormatGuesserTests extends ImporterTest {
         String dir = ClassLoader.getSystemResource("food.csv").getPath();
         dir = dir.substring(0, dir.lastIndexOf('/'));
         File testDataDir = new File(dir);
-        for (String testFile : testDataDir.list(new PatternFilenameFilter(".+\\." + extension))) {
+        for (String testFile : Objects.requireNonNull(testDataDir.list(new PatternFilenameFilter(".+\\." + extension)))) {
             String format = guesser.guess(new File(dir, testFile), StandardCharsets.UTF_8.toString(), "text");
             assertEquals(format, expectedFormat, "Format guess failed for " + testFile);
         }
@@ -166,11 +167,11 @@ public class TextFormatGuesserTests extends ImporterTest {
         String input = "\n"
                 + "{|\n"
                 + "|-\n"
-                + "| [[Europäisches Zentrum für die Förderung der Berufsbildung|Cedefop]] || Cedefop || http://www.cedefop.europa.eu/\n"
+                + "| [[Europäisches Zentrum für die Förderung der Berufsbildung|Cedefop]] || Cedefop || https://www.cedefop.europa.eu/\n"
                 + "|-\n"
-                + "| [[Europäische Stiftung zur Verbesserung der Lebens- und Arbeitsbedingungen]] || EUROFOUND || [http://www.eurofound.europa.eu/]\n"
+                + "| [[Europäische Stiftung zur Verbesserung der Lebens- und Arbeitsbedingungen]] || EUROFOUND || [https://www.eurofound.europa.eu/]\n"
                 + "|-\n"
-                + "| [[Europäische Beobachtungsstelle für Drogen und Drogensucht]] || EMCDDA || [http://www.emcdda.europa.eu/ europa.eu]\n"
+                + "| [[Europäische Beobachtungsstelle für Drogen und Drogensucht]] || EMCDDA || [https://www.emcdda.europa.eu/ europa.eu]\n"
                 + "|-\n"
                 + "|}\n";
         testWikiTableString(input);
@@ -191,11 +192,11 @@ public class TextFormatGuesserTests extends ImporterTest {
                 + "! style=\"text-align:left; width: 6em\" | Gründung\n"
                 + "! style=\"text-align:left; width: 50em\" | Anmerkungen\n"
                 + "|-\n"
-                + "| [[Europäisches Zentrum für die Förderung der Berufsbildung]] || '''Cedefop''' || [http://www.cedefop.europa.eu/] || [[Thessaloniki]] || {{Griechenland}} || 1975 ||\n"
+                + "| [[Europäisches Zentrum für die Förderung der Berufsbildung]] || '''Cedefop''' || [https://www.cedefop.europa.eu/] || [[Thessaloniki]] || {{Griechenland}} || 1975 ||\n"
                 + "|-\n"
-                + "| [[Europäische Stiftung zur Verbesserung der Lebens- und Arbeitsbedingungen]] || ''EUROFOUND'' || [http://www.eurofound.europa.eu/] || [[Dublin]] || {{Irland}} || 1975 ||\n"
+                + "| [[Europäische Stiftung zur Verbesserung der Lebens- und Arbeitsbedingungen]] || ''EUROFOUND'' || [https://www.eurofound.europa.eu/] || [[Dublin]] || {{Irland}} || 1975 ||\n"
                 + "|-\n"
-                + "| [[Europäische Beobachtungsstelle für Drogen und Drogensucht]] || EMCDDA || [http://www.emcdda.europa.eu/] || [[Lissabon]] || {{Portugal}} || 1993 ||\n"
+                + "| [[Europäische Beobachtungsstelle für Drogen und Drogensucht]] || EMCDDA || [https://www.emcdda.europa.eu/] || [[Lissabon]] || {{Portugal}} || 1993 ||\n"
                 + "|-\n"
                 + "|}\n";
         testWikiTableString(input);
@@ -229,7 +230,7 @@ public class TextFormatGuesserTests extends ImporterTest {
                 + "! fruit\n"
                 + "! merchant\n"
                 + "|-\n"
-                + "| a || b <ref name=\"myref\"> See [http://gnu.org here]</ref>  || c <ref name=\"ms\"> or http://microsoft.com/ </ref>\n"
+                + "| a || b <ref name=\"myref\"> See [https://gnu.org here]</ref>  || c <ref name=\"ms\"> or https://microsoft.com/ </ref>\n"
                 + "|-\n"
                 + "| d || e <ref name=\"ms\"/>|| f <ref name=\"myref\" />\n"
                 + "|-\n"
@@ -245,7 +246,7 @@ public class TextFormatGuesserTests extends ImporterTest {
                 + "! fruit\n"
                 + "! merchant\n"
                 + "|-\n"
-                + "| a || b <ref name=\"myref\">{{cite web|url=http://gnu.org|accessdate=2017-08-30}}</ref>  || c <ref name=\"ms\"> or {{cite journal|url=http://microsoft.com/|title=BLah}} </ref>\n"
+                + "| a || b <ref name=\"myref\">{{cite web|url=https://gnu.org|accessdate=2017-08-30}}</ref>  || c <ref name=\"ms\"> or {{cite journal|url=https://microsoft.com/|title=BLah}} </ref>\n"
                 + "|-\n"
                 + "| d || e <ref name=\"ms\"/>|| f <ref name=\"myref\" />\n"
                 + "|-\n"

--- a/main/tests/server/src/com/google/refine/importers/TextFormatGuesserTests.java
+++ b/main/tests/server/src/com/google/refine/importers/TextFormatGuesserTests.java
@@ -37,12 +37,11 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 
 import org.apache.commons.io.FileUtils;
@@ -80,13 +79,13 @@ public class TextFormatGuesserTests extends ImporterTest {
     }
 
     @Test
-    public void xlsTextGuessTest() throws FileNotFoundException, IOException {
+    public void xlsTextGuessTest() throws IOException {
         // Test an XLSX file without the correct file extension
         String dir = ClassLoader.getSystemResource("Colorado-Municipalities-small-xlsx.gz").getPath();
-        InputStream is = new GZIPInputStream(new FileInputStream(new File(dir)));
+        InputStream is = new GZIPInputStream(new FileInputStream(dir));
         File tmp = File.createTempFile("openrefinetests-textguesser", "");
         FileUtils.copyInputStreamToFile(is, tmp);
-        String format = guesser.guess(tmp, "UTF-8", "text");
+        String format = guesser.guess(tmp, StandardCharsets.UTF_8.toString(), "text");
         assertEquals(format, "binary");
     }
 
@@ -115,7 +114,7 @@ public class TextFormatGuesserTests extends ImporterTest {
         dir = dir.substring(0, dir.lastIndexOf('/'));
         File testDataDir = new File(dir);
         for (String testFile : testDataDir.list(new PatternFilenameFilter(".+\\." + extension))) {
-            String format = guesser.guess(new File(dir, testFile), "UTF-8", "text");
+            String format = guesser.guess(new File(dir, testFile), StandardCharsets.UTF_8.toString(), "text");
             assertEquals(format, expectedFormat, "Format guess failed for " + testFile);
         }
     }
@@ -133,19 +132,19 @@ public class TextFormatGuesserTests extends ImporterTest {
         testWikiTableString(input);
     }
 
-    private void testWikiTableString(String input) throws IOException, FileNotFoundException {
+    private void testWikiTableString(String input) throws IOException {
         File tmp = File.createTempFile("openrefinetests-textguesser", "");
         OutputStreamWriter writer = new OutputStreamWriter(
                 new FileOutputStream(tmp),
-                Charset.forName("UTF-8").newEncoder());
+                StandardCharsets.UTF_8.newEncoder());
         writer.write(input);
         writer.close();
-        String format = guesser.guess(tmp, "UTF-8", "text");
+        String format = guesser.guess(tmp, StandardCharsets.UTF_8.toString(), "text");
         assertEquals(format, "text/wiki");
     }
 
     @Test
-    public void guessTableWithMisplacedHeaders() throws FileNotFoundException, IOException {
+    public void guessTableWithMisplacedHeaders() throws IOException {
         String input = "\n"
                 + "{|\n"
                 + "|-\n"
@@ -160,7 +159,7 @@ public class TextFormatGuesserTests extends ImporterTest {
     }
 
     @Test
-    public void guessTableWithLinks() throws FileNotFoundException, IOException {
+    public void guessTableWithLinks() throws IOException {
 
         // Data credits: Wikipedia contributors,
         // https://de.wikipedia.org/w/index.php?title=Agenturen_der_Europäischen_Union&action=edit
@@ -178,7 +177,7 @@ public class TextFormatGuesserTests extends ImporterTest {
     }
 
     @Test
-    public void readStyledTableWithHeader() throws FileNotFoundException, IOException {
+    public void readStyledTableWithHeader() throws IOException {
         // Data credits: Wikipedia contributors,
         // https://de.wikipedia.org/w/index.php?title=Agenturen_der_Europäischen_Union&action=edit
         String input = "\n"
@@ -203,7 +202,7 @@ public class TextFormatGuesserTests extends ImporterTest {
     }
 
     @Test
-    public void guessTableWithSpanningCells() throws FileNotFoundException, IOException {
+    public void guessTableWithSpanningCells() throws IOException {
         // inspired from https://www.mediawiki.org/wiki/Help:Tables
         String input = "{| class=\"wikitable\"\n"
                 + "!colspan=\"6\"|Shopping List\n"
@@ -223,7 +222,7 @@ public class TextFormatGuesserTests extends ImporterTest {
     }
 
     @Test
-    public void guessTableWithReferences() throws FileNotFoundException, IOException {
+    public void guessTableWithReferences() throws IOException {
         // inspired from https://www.mediawiki.org/wiki/Help:Tables
         String input = "{|\n"
                 + "! price\n"
@@ -239,7 +238,7 @@ public class TextFormatGuesserTests extends ImporterTest {
     }
 
     @Test
-    public void guessTableWithReferencesTemplates() throws FileNotFoundException, IOException {
+    public void guessTableWithReferencesTemplates() throws IOException {
         // inspired from https://www.mediawiki.org/wiki/Help:Tables
         String input = "{|\n"
                 + "! price\n"
@@ -255,7 +254,7 @@ public class TextFormatGuesserTests extends ImporterTest {
     }
 
     @Test
-    public void guessTableWithTemplates() throws FileNotFoundException, IOException {
+    public void guessTableWithTemplates() throws IOException {
         String input = "\n"
                 + "{|\n"
                 + "|-\n"

--- a/main/tests/server/src/com/google/refine/importers/TsvCsvImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/TsvCsvImporterTests.java
@@ -80,8 +80,9 @@ public class TsvCsvImporterTests extends ImporterTest {
         String input = "col1" + inputSeparator + "col2" + inputSeparator + "col3";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 1, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -99,8 +100,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "data1" + inputSeparator + "data2" + inputSeparator + "data3";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 1, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -124,8 +126,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "data1" + inputSeparator + "234" + inputSeparator + "data3";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 1, true, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -148,8 +151,9 @@ public class TsvCsvImporterTests extends ImporterTest {
         String input = "data1" + inputSeparator + "data2" + inputSeparator + "data3";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 0, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -171,8 +175,9 @@ public class TsvCsvImporterTests extends ImporterTest {
         String input = " data1 " + inputSeparator + " 3.4 " + inputSeparator + " data3 ";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 0, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -191,8 +196,9 @@ public class TsvCsvImporterTests extends ImporterTest {
         String input = " data1" + inputSeparator + " 12" + inputSeparator + " data3";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 0, true, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -211,8 +217,9 @@ public class TsvCsvImporterTests extends ImporterTest {
         String input = " data1 " + inputSeparator + " 3.4 " + inputSeparator + " data3 ";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 0, false, false, true);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -231,8 +238,9 @@ public class TsvCsvImporterTests extends ImporterTest {
         String input = " data1 " + inputSeparator + " 3.4 " + inputSeparator + " data3 ";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 0, false, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -251,8 +259,9 @@ public class TsvCsvImporterTests extends ImporterTest {
         String input = " data1 " + inputSeparator + " 3.4 " + inputSeparator + " data3 ";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 0, true, false, true);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -271,8 +280,9 @@ public class TsvCsvImporterTests extends ImporterTest {
         String input = " data1" + inputSeparator + inputSeparator + " data3";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 0, true, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -293,8 +303,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "data1" + inputSeparator + "data2" + inputSeparator + "data3";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 2, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -318,8 +329,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 + inputSeparator + "data6";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 1, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -348,8 +360,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "\"\"\"To Be\"\" is often followed by \"\"or not To Be\"\"\"" + inputSeparator + "data2";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 1, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -372,8 +385,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "data1" + inputSeparator + "data2" + inputSeparator + "data3";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 1, 1, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -397,8 +411,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "data1" + inputSeparator + "data2" + inputSeparator + "data3";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 1, 0, 1, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -426,8 +441,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "data1" + inputSeparator + "data2" + inputSeparator + "data3";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 1, 3, 2, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -460,8 +476,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "data-row3-cell1" + inputSeparator + "data-row3-cell2" + inputSeparator + "data-row1-cell3";
 
         try {
+            stageString(input);
             prepareOptions(sep, 2, 2, 3, 2, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -486,8 +503,9 @@ public class TsvCsvImporterTests extends ImporterTest {
         String inputSeparator = sep == null ? "\t" : sep;
         String input = "data1" + inputSeparator + "data2\"" + inputSeparator + "data3" + inputSeparator + "data4";
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 0, false, true);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -507,8 +525,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "\"\"\"To\n Be\"\" is often followed by \"\"or not To\n Be\"\"\"" + inputSeparator + "data2";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 1, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -530,8 +549,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "\"A line with many \n\n\n\n\n empty lines\"" + inputSeparator + "data2";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 1, false, false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -553,8 +573,9 @@ public class TsvCsvImporterTests extends ImporterTest {
                 "'data1'" + inputSeparator + "'data2'" + inputSeparator + "'data3'";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 1, false, false, "'");
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -577,8 +598,9 @@ public class TsvCsvImporterTests extends ImporterTest {
         String input = "data1" + inputSeparator + "data2" + inputSeparator + "data3\n";
 
         try {
+            stageString(input);
             prepareOptions(sep, -1, 0, 0, 1, false, false, "\"", "[\"col1\",\"col2\",\"col3\"]", false);
-            parseOneFile(SUT, new StringReader(input));
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -594,12 +616,11 @@ public class TsvCsvImporterTests extends ImporterTest {
     // ---------------------read tests------------------------
     @Test
     public void readCsvWithProperties() {
-        StringReader reader = new StringReader(SAMPLE_ROW);
-
-        prepareOptions(",", -1, 0, 0, 0, true, true);
+         prepareOptions(",", -1, 0, 0, 0, true, true);
 
         try {
-            parseOneFile(SUT, reader);
+            stageString(SAMPLE_ROW);
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
@@ -614,12 +635,12 @@ public class TsvCsvImporterTests extends ImporterTest {
     @Test
     public void readCsvWithPropertiesIgnoreQuotes() {
         String input = "data1,data2\",data3,data4";
-        StringReader reader = new StringReader(input);
 
         prepareOptions(",", -1, 0, 0, 0, true, true);
 
         try {
-            parseOneFile(SUT, reader);
+            stageString(input);
+            parseOneFile(SUT);
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }

--- a/main/tests/server/src/com/google/refine/importers/TsvCsvImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/TsvCsvImporterTests.java
@@ -614,7 +614,7 @@ public class TsvCsvImporterTests extends ImporterTest {
     // ---------------------read tests------------------------
     @Test
     public void readCsvWithProperties() {
-         prepareOptions(",", -1, 0, 0, 0, true, true);
+        prepareOptions(",", -1, 0, 0, 0, true, true);
 
         try {
             stageString(SAMPLE_ROW);

--- a/main/tests/server/src/com/google/refine/importers/TsvCsvImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/TsvCsvImporterTests.java
@@ -33,8 +33,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.importers;
 
-import java.io.StringReader;
-
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -168,7 +166,7 @@ public class TsvCsvImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
     }
 
-    @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
     public void readDoesNotTrimLeadingTrailingWhitespace(String sep) {
         // create input to test with
         String inputSeparator = sep == null ? "\t" : sep;
@@ -210,7 +208,7 @@ public class TsvCsvImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(0).cells.get(2).value, " data3");
     }
 
-    @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
     public void readTrimsLeadingTrailingWhitespaceOnTrimStrings(String sep) {
         // create input to test with
         String inputSeparator = sep == null ? "\t" : sep;
@@ -231,7 +229,7 @@ public class TsvCsvImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
     }
 
-    @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
     public void readDoesNotTrimLeadingTrailingWhitespaceOnNoTrimStrings(String sep) {
         // create input to test with
         String inputSeparator = sep == null ? "\t" : sep;
@@ -252,7 +250,7 @@ public class TsvCsvImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(0).cells.get(2).value, " data3 ");
     }
 
-    @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
     public void trimAndAutodetectDatatype(String sep) {
         // create input to test with
         String inputSeparator = sep == null ? "\t" : sep;
@@ -352,7 +350,7 @@ public class TsvCsvImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(0).cells.get(5).value, "data6");
     }
 
-    @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
     public void readQuotedData(String sep) {
         // create input
         String inputSeparator = sep == null ? "\t" : sep;
@@ -458,7 +456,7 @@ public class TsvCsvImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
     }
 
-    @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
     public void readIgnore3_Header2_Skip2_limit2(String sep) {
         // create input
         String inputSeparator = sep == null ? "\t" : sep;
@@ -517,7 +515,7 @@ public class TsvCsvImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
     }
 
-    @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
     public void readWithMultiLinedQuotedData(String sep) {
         // create input
         String inputSeparator = sep == null ? "\t" : sep;
@@ -541,7 +539,7 @@ public class TsvCsvImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
     }
 
-    @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
     public void readWithMultiLinedQuotedDataAndBlankLines(String sep) {
         // create input
         String inputSeparator = sep == null ? "\t" : sep;

--- a/main/tests/server/src/com/google/refine/importers/WikitextImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/WikitextImporterTests.java
@@ -345,5 +345,6 @@ public class WikitextImporterTests extends ImporterTest {
         whenGetBooleanOption("includeRawTemplates", options, true);
         whenGetStringOption("wikiUrl", options, wikiUrl);
         whenGetStringOption("reconService", options, reconEndpoint);
+        whenGetStringOption("encoding", options, "utf-8");
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/WikitextImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/WikitextImporterTests.java
@@ -33,16 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.importers;
 
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.Collections;
+import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -51,9 +45,6 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.refine.model.Recon;
-import com.google.refine.model.ReconCandidate;
-import com.google.refine.model.recon.ReconJob;
-import com.google.refine.model.recon.StandardReconConfig;
 
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -336,8 +327,9 @@ public class WikitextImporterTests extends ImporterTest {
 
     // --helpers--
 
-    private void parse(String wikitext) {
-        parseOneFile(importer, new StringReader(wikitext));
+    private void parse(String wikitext) throws IOException {
+        stageString(wikitext);
+        parseOneFile(importer);
     }
 
     private void prepareOptions(

--- a/main/tests/server/src/com/google/refine/importers/WikitextImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/WikitextImporterTests.java
@@ -128,6 +128,7 @@ public class WikitextImporterTests extends ImporterTest {
         Assert.assertEquals(project.rows.get(1).cells.get(2).value, "f");
     }
 
+    @Test(enabled = false)
     public void readTableWithLinks() throws Exception {
 
         // Data credits: Wikipedia contributors,

--- a/main/tests/server/src/com/google/refine/importers/WikitextImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/WikitextImporterTests.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.importers;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -134,11 +135,11 @@ public class WikitextImporterTests extends ImporterTest {
         String input = "\n"
                 + "{|\n"
                 + "|-\n"
-                + "| [[Europäisches Zentrum für die Förderung der Berufsbildung|Cedefop]] || Cedefop || http://www.cedefop.europa.eu/\n"
+                + "| [[Europäisches Zentrum für die Förderung der Berufsbildung|Cedefop]] || Cedefop || https://www.cedefop.europa.eu/\n"
                 + "|-\n"
-                + "| [[Europäische Stiftung zur Verbesserung der Lebens- und Arbeitsbedingungen]] || EUROFOUND || [http://www.eurofound.europa.eu/]\n"
+                + "| [[Europäische Stiftung zur Verbesserung der Lebens- und Arbeitsbedingungen]] || EUROFOUND || [https://www.eurofound.europa.eu/]\n"
                 + "|-\n"
-                + "| [[Europäische Beobachtungsstelle für Drogen und Drogensucht]] || EMCDDA || [http://www.emcdda.europa.eu/ europa.eu]\n"
+                + "| [[Europäische Beobachtungsstelle für Drogen und Drogensucht]] || EMCDDA || [https://www.emcdda.europa.eu/ europa.eu]\n"
                 + "|-\n"
                 + "|}\n";
 
@@ -161,14 +162,14 @@ public class WikitextImporterTests extends ImporterTest {
 
             // Reconciled cells
             Assert.assertEquals(project.rows.get(0).cells.get(1).value, "Cedefop");
-            Assert.assertEquals(project.rows.get(0).cells.get(1).recon, null);
+            Assert.assertNull(project.rows.get(0).cells.get(1).recon);
             Assert.assertEquals(project.rows.get(2).cells.get(0).value, "Europäische Beobachtungsstelle für Drogen und Drogensucht");
             Assert.assertEquals(project.rows.get(2).cells.get(0).recon.getBestCandidate().id, "Q1377256");
 
             // various ways to input external links
-            Assert.assertEquals(project.rows.get(1).cells.get(2).value, "http://www.eurofound.europa.eu/");
-            Assert.assertEquals(project.rows.get(2).cells.get(2).value, "http://www.emcdda.europa.eu/");
-            // Assert.assertEquals(project.rows.get(0).cells.get(2).value, "http://www.cedefop.europa.eu/");
+            Assert.assertEquals(project.rows.get(1).cells.get(2).value, "https://www.eurofound.europa.eu/");
+            Assert.assertEquals(project.rows.get(2).cells.get(2).value, "https://www.emcdda.europa.eu/");
+            // Assert.assertEquals(project.rows.get(0).cells.get(2).value, "https://www.cedefop.europa.eu/");
             // unfortunately the above does not seem to be supported by the parser (parsed as blank instead)
         }
     }
@@ -188,11 +189,11 @@ public class WikitextImporterTests extends ImporterTest {
                 + "! style=\"text-align:left; width: 6em\" | Gründung\n"
                 + "! style=\"text-align:left; width: 50em\" | Anmerkungen\n"
                 + "|-\n"
-                + "| [[Europäisches Zentrum für die Förderung der Berufsbildung]] || '''Cedefop''' || [http://www.cedefop.europa.eu/] || [[Thessaloniki]] || {{Griechenland}} || 1975 ||\n"
+                + "| [[Europäisches Zentrum für die Förderung der Berufsbildung]] || '''Cedefop''' || [https://www.cedefop.europa.eu/] || [[Thessaloniki]] || {{Griechenland}} || 1975 ||\n"
                 + "|-\n"
-                + "| [[Europäische Stiftung zur Verbesserung der Lebens- und Arbeitsbedingungen]] || ''EUROFOUND'' || [http://www.eurofound.europa.eu/] || [[Dublin]] || {{Irland}} || 1975 ||\n"
+                + "| [[Europäische Stiftung zur Verbesserung der Lebens- und Arbeitsbedingungen]] || ''EUROFOUND'' || [https://www.eurofound.europa.eu/] || [[Dublin]] || {{Irland}} || 1975 ||\n"
                 + "|-\n"
-                + "| [[Europäische Beobachtungsstelle für Drogen und Drogensucht]] || EMCDDA || [http://www.emcdda.europa.eu/] || [[Lissabon]] || {{Portugal}} || 1993 ||\n"
+                + "| [[Europäische Beobachtungsstelle für Drogen und Drogensucht]] || EMCDDA || [https://www.emcdda.europa.eu/] || [[Lissabon]] || {{Portugal}} || 1993 ||\n"
                 + "|-\n"
                 + "|}\n";
 
@@ -249,7 +250,7 @@ public class WikitextImporterTests extends ImporterTest {
                 + "! fruit\n"
                 + "! merchant\n"
                 + "|-\n"
-                + "| a || b <ref name=\"myref\"> See [http://gnu.org here]</ref>  || c <ref name=\"ms\"> or http://microsoft.com/ </ref>\n"
+                + "| a || b <ref name=\"myref\"> See [https://gnu.org here]</ref>  || c <ref name=\"ms\"> or https://microsoft.com/ </ref>\n"
                 + "|-\n"
                 + "| d || e <ref name=\"ms\"/>|| f <ref name=\"myref\" />\n"
                 + "|-\n"
@@ -263,10 +264,10 @@ public class WikitextImporterTests extends ImporterTest {
         }
         Assert.assertEquals(project.columnModel.columns.size(), 5);
         Assert.assertEquals(project.rows.get(0).cells.get(1).value, "b");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "http://gnu.org");
-        Assert.assertEquals(project.rows.get(0).cells.get(4).value, "http://microsoft.com/");
-        Assert.assertEquals(project.rows.get(1).cells.get(4).value, "http://gnu.org");
-        Assert.assertEquals(project.rows.get(1).cells.get(2).value, "http://microsoft.com/");
+        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "https://gnu.org");
+        Assert.assertEquals(project.rows.get(0).cells.get(4).value, "https://microsoft.com/");
+        Assert.assertEquals(project.rows.get(1).cells.get(4).value, "https://gnu.org");
+        Assert.assertEquals(project.rows.get(1).cells.get(2).value, "https://microsoft.com/");
     }
 
     @Test
@@ -277,7 +278,7 @@ public class WikitextImporterTests extends ImporterTest {
                 + "! fruit\n"
                 + "! merchant\n"
                 + "|-\n"
-                + "| a || b <ref name=\"myref\">{{cite web|url=http://gnu.org|accessdate=2017-08-30}}</ref>  || c <ref name=\"ms\"> or {{cite journal|url=http://microsoft.com/|title=BLah}} </ref>\n"
+                + "| a || b <ref name=\"myref\">{{cite web|url=https://gnu.org|accessdate=2017-08-30}}</ref>  || c <ref name=\"ms\"> or {{cite journal|url=https://microsoft.com/|title=BLah}} </ref>\n"
                 + "|-\n"
                 + "| d || e <ref name=\"ms\"/>|| f <ref name=\"myref\" />\n"
                 + "|-\n"
@@ -291,10 +292,10 @@ public class WikitextImporterTests extends ImporterTest {
         }
         Assert.assertEquals(project.columnModel.columns.size(), 5);
         Assert.assertEquals(project.rows.get(0).cells.get(1).value, "b");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "http://gnu.org");
-        Assert.assertEquals(project.rows.get(0).cells.get(4).value, "http://microsoft.com/");
-        Assert.assertEquals(project.rows.get(1).cells.get(4).value, "http://gnu.org");
-        Assert.assertEquals(project.rows.get(1).cells.get(2).value, "http://microsoft.com/");
+        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "https://gnu.org");
+        Assert.assertEquals(project.rows.get(0).cells.get(4).value, "https://microsoft.com/");
+        Assert.assertEquals(project.rows.get(1).cells.get(4).value, "https://gnu.org");
+        Assert.assertEquals(project.rows.get(1).cells.get(2).value, "https://microsoft.com/");
     }
 
     /**
@@ -345,6 +346,6 @@ public class WikitextImporterTests extends ImporterTest {
         whenGetBooleanOption("includeRawTemplates", options, true);
         whenGetStringOption("wikiUrl", options, wikiUrl);
         whenGetStringOption("reconService", options, reconEndpoint);
-        whenGetStringOption("encoding", options, "utf-8");
+        whenGetStringOption("encoding", options, StandardCharsets.UTF_8.toString());
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/XmlImportUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/XmlImportUtilitiesTests.java
@@ -50,7 +50,6 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
-import com.google.refine.importers.JsonImporter.JSONTreeReader;
 import com.google.refine.importers.XmlImporter.XmlParser;
 import com.google.refine.importers.tree.ImportColumn;
 import com.google.refine.importers.tree.ImportColumnGroup;
@@ -621,10 +620,6 @@ public class XmlImportUtilitiesTests extends RefineTest {
         loadData(XmlImporterTests.getSample());
     }
 
-    public void loadSampleJson() {
-        loadData(JsonImporterTests.getSample());
-    }
-
     public void loadData(String xml) {
         inputStream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
     }
@@ -646,11 +641,6 @@ public class XmlImportUtilitiesTests extends RefineTest {
         } catch (XMLStreamException | IOException e) {
             return null;
         }
-    }
-
-    public TreeReader createJsonParser() {
-        parser = new JSONTreeReader(inputStream);
-        return parser;
     }
 
     private String _getXmlDataFromFile(String fileName) throws IOException {

--- a/main/tests/server/src/com/google/refine/importers/XmlImportUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/XmlImportUtilitiesTests.java
@@ -36,7 +36,7 @@ package com.google.refine.importers;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -135,7 +135,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
 
         String tag = "library";
 
-        List<String> response = new ArrayList<String>();
+        List<String> response = new ArrayList<>();
         try {
             response = SUT.detectRecordElementWrapper(parser, tag);
         } catch (Exception e) {
@@ -153,7 +153,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
 
         String tag = "book";
 
-        List<String> response = new ArrayList<String>();
+        List<String> response = new ArrayList<>();
         try {
             response = SUT.detectRecordElementWrapper(parser, tag);
         } catch (Exception e) {
@@ -172,7 +172,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
 
         String tag = "";
 
-        List<String> response = new ArrayList<String>();
+        List<String> response = new ArrayList<>();
         try {
             response = SUT.detectRecordElementWrapper(parser, tag);
         } catch (Exception e) {
@@ -518,17 +518,11 @@ public class XmlImportUtilitiesTests extends RefineTest {
 
         Assert.assertNotNull(record);
         Assert.assertNotNull(record.rows);
-        // Assert.assertNotNull(record.columnEmptyRowIndices);
         Assert.assertEquals(record.rows.size(), 1);
-        // Assert.assertEquals(record.columnEmptyRowIndices.size(), 2);
         Assert.assertNotNull(record.rows.get(0));
-        // Assert.assertNotNull(record.columnEmptyRowIndices.get(0));
-        // Assert.assertNotNull(record.columnEmptyRowIndices.get(1));
         Assert.assertEquals(record.rows.get(0).size(), 1);
         Assert.assertNotNull(record.rows.get(0).get(0));
         Assert.assertEquals(record.rows.get(0).get(0).value, "Author1, The");
-        // Assert.assertEquals(record.columnEmptyRowIndices.get(0).intValue(),0);
-        // Assert.assertEquals(record.columnEmptyRowIndices.get(1).intValue(),1);
 
     }
 
@@ -632,11 +626,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
     }
 
     public void loadData(String xml) {
-        try {
-            inputStream = new ByteArrayInputStream(xml.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e1) {
-            Assert.fail();
-        }
+        inputStream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
     }
 
     public void ParserSkip() {
@@ -653,9 +643,7 @@ public class XmlImportUtilitiesTests extends RefineTest {
         try {
             parser = new XmlParser(inputStream);
             return parser;
-        } catch (XMLStreamException e) {
-            return null;
-        } catch (IOException e) {
+        } catch (XMLStreamException | IOException e) {
             return null;
         }
     }
@@ -666,9 +654,11 @@ public class XmlImportUtilitiesTests extends RefineTest {
     }
 
     private String _getXmlDataFromFile(String fileName) throws IOException {
-        InputStream in = this.getClass().getClassLoader()
-                .getResourceAsStream(fileName);
-        String content = org.apache.commons.io.IOUtils.toString(in, "UTF-8");
-        return content;
+        InputStream in = this.getClass().getClassLoader().getResourceAsStream(fileName);
+        if (in == null) {
+            logger.warn("Failed to find resource: " + fileName);
+            return null;
+        }
+        return org.apache.commons.io.IOUtils.toString(in, StandardCharsets.UTF_8);
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/XmlImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/XmlImporterTests.java
@@ -37,12 +37,12 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import com.google.refine.importers.tree.ImportColumnGroup;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -111,7 +111,7 @@ public class XmlImporterTests extends ImporterTest {
     @Test
     public void setsProjectMetadata() throws IOException {
         // Setup a file record to import
-        FileUtils.writeStringToFile(new File(job.getRawDataDir(), "test-file.xml"), getSample(), "UTF-8");
+        FileUtils.writeStringToFile(new File(job.getRawDataDir(), "test-file.xml"), getSample(), StandardCharsets.UTF_8);
         List<ObjectNode> fileRecords = new ArrayList<>();
         fileRecords.add(ParsingUtilities.evaluateJsonStringToObjectNode(
                 "{\"location\": \"test-file.xml\",\"fileName\": \"test-file.xml\"}"));
@@ -425,10 +425,11 @@ public class XmlImporterTests extends ImporterTest {
 
     private void RunTest(String testString, ObjectNode objectNode) {
         try {
-            inputStream = new ByteArrayInputStream(testString.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException e1) {
+            stageString(testString);
+        } catch (IOException e1) {
             Assert.fail();
         }
+
 
         try {
             parseOneFile(SUT, inputStream, objectNode);
@@ -439,7 +440,7 @@ public class XmlImporterTests extends ImporterTest {
     }
 
     @Override
-    protected void parseOneFile(TreeImportingParserBase parser, InputStream inputStream, ObjectNode options) {
+    protected void parseOneFile(TreeImportingParserBase parser, InputStream inputStream, ObjectNode options) throws IOException {
         parseOneInputStream(parser, inputStream, options);
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/XmlImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/XmlImporterTests.java
@@ -110,7 +110,7 @@ public class XmlImporterTests extends ImporterTest {
 
     @Test
     public void setsProjectMetadata() throws IOException {
-        // Setup a file record to import
+        // Set up a file record to import
         FileUtils.writeStringToFile(new File(job.getRawDataDir(), "test-file.xml"), getSample(), StandardCharsets.UTF_8);
         List<ObjectNode> fileRecords = new ArrayList<>();
         fileRecords.add(ParsingUtilities.evaluateJsonStringToObjectNode(
@@ -127,7 +127,7 @@ public class XmlImporterTests extends ImporterTest {
                 "text/json",
                 -1,
                 options,
-                new ArrayList<Exception>());
+                new ArrayList<>());
 
         assertNotNull(metadata.getModified());
         assertNotNull(metadata.getCreated());
@@ -249,7 +249,7 @@ public class XmlImporterTests extends ImporterTest {
         JSONUtilities.safePut(options, "guessCellValueTypes", false);
         JSONUtilities.safePut(options, "includeFileSources", true);
 
-        List<Exception> exceptions = new ArrayList<Exception>();
+        List<Exception> exceptions = new ArrayList<>();
 
         SUT.parse(
                 project,
@@ -423,24 +423,18 @@ public class XmlImporterTests extends ImporterTest {
         RunTest(testString, getOptions(job, SUT));
     }
 
-    private void RunTest(String testString, ObjectNode objectNode) {
+    private void RunTest(String testString, ObjectNode options) {
         try {
             stageString(testString);
         } catch (IOException e1) {
             Assert.fail();
         }
 
-
         try {
-            parseOneFile(SUT, inputStream, objectNode);
+            parseOneTreeFile(SUT, options);
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();
         }
-    }
-
-    @Override
-    protected void parseOneFile(TreeImportingParserBase parser, InputStream inputStream, ObjectNode options) throws IOException {
-        parseOneInputStream(parser, inputStream, options);
     }
 }


### PR DESCRIPTION
Fixes #5034

This fixes the regression that was introduced in the previous refactoring. As part of this, I discovered that all of the importer tests ran at a level below that were the filename source (and archive name) was implemented, so none of it was ever tested.

This PR refactors both the importer framework and the tests, allowing me to verify that the fixe actually works (and providing test coverage for the future). I did not extended this testing to any other importers or test the archive name functionality.

I also fixed a couple of latent bugs discovered as part of this and did a general cleanup of things that my IDE was warning about.

This is a draft for now so that I can take a look at the refactoring with clear eyes and make sure it makes things better, not worse. I'm not really thrilled with the complexity of the importer architecture and don't want to be making it any worse.