### PR TITLE
Cleaned up flaky test that used ajax_in_progress="true" in join_columns.cy

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/join_columns.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/join_columns.cy.js
@@ -115,7 +115,6 @@ describe(__filename, function () {
     cy.get('input[bind="new_column_nameInput"]').type('Test_Merged_Grid');
 
     cy.confirmDialogPanel();
-    cy.get('body[ajax_in_progress="true"]');
     cy.get('body[ajax_in_progress="false"]');
     cy.assertGridEquals([
       ['Test_Merged_Grid'],


### PR DESCRIPTION
Changes proposed in this pull request:
-  Fixes a flaky Cypress test in join_columns.spec that used `ajax_in_progress="true"`