### PR TITLE
Bump fs-extra from 10.1.0 to 11.1.0

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.5.1
         with:
-          node-version: '12'
+          node-version: '14'
       - id: set-matrix
         run: npm install --save glob && node main/tests/cypress/build-test-matrix.js
         env:
@@ -179,7 +179,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.5.1
         with:
-          node-version: '12'
+          node-version: '14'
 
       - name: Restore Tests dependency cache
         uses: actions/cache@v3

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.5.1
         with:
-          node-version: '12'
+          node-version: '14'
       - id: set-matrix
         run: npm install --save glob && node main/tests/cypress/build-test-matrix.js
         env:
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.5.1
         with:
-          node-version: '12'
+          node-version: '14'
 
       - name: Restore Tests dependency cache
         uses: actions/cache@v3

--- a/main/tests/cypress/package.json
+++ b/main/tests/cypress/package.json
@@ -15,7 +15,7 @@
         "cypress-file-upload": "^5.0.8",
         "cypress-wait-until": "^1.7.2",
         "dotenv": "^16.0.3",
-        "fs-extra": "^10.1.0",
+        "fs-extra": "^11.1.0",
         "uniqid": "^5.4.0"
     },
     "devDependencies": {

--- a/main/tests/cypress/yarn.lock
+++ b/main/tests/cypress/yarn.lock
@@ -842,10 +842,10 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-fs-extra@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
-  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
+fs-extra@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.0.tgz#5784b102104433bb0e090f48bfc4a30742c357ed"
+  integrity sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"


### PR DESCRIPTION
Changes proposed in this pull request:
- Upgrades fs-extra from 10.1.0 to 11.1.0.
- Upgrades Node from 12 to 14 in snapshot_release.yml and pull_request.yml to upgrade fs-extra.