### PR TITLE
Reenable ODF Toolkit deprecation warnings

### DIFF
--- a/main/src/com/google/refine/exporters/OdsExporter.java
+++ b/main/src/com/google/refine/exporters/OdsExporter.java
@@ -79,7 +79,7 @@ public class OdsExporter implements StreamExporter {
                 table = OdfTable.newTable(odfDoc);
                 String tableName = ProjectManager.singleton.getProjectMetadata(project.id).getName();
 
-                // the ODF document might already contain some other tables
+                // the ODF document might already contain some other tables
                 try {
                     table.setTableName(tableName);
                 } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Fixes #5485

Changes proposed in this pull request:
- Remove suppression of deprecation warnings now that historical ODS API has been undeprecated
- Protect against some (theoretical) NPEs. Although very unlikely this silences some warnings.
- A couple of minor simplifications (all straightforward to validate by inspection)
