### PR TITLE
Fix milli/microsecond cases. Improve tests to cover. Fixes #5488

### DIFF
--- a/main/src/com/google/refine/expr/functions/TimeSinceUnixEpochToDate.java
+++ b/main/src/com/google/refine/expr/functions/TimeSinceUnixEpochToDate.java
@@ -32,11 +32,11 @@ public class TimeSinceUnixEpochToDate implements Function {
                     date = OffsetDateTime.ofInstant(instant, zoneId);
                     return date;
                 } else if (unit.equals("millisecond")) {
-                    instant = Instant.ofEpochSecond(epoch / 1000);
+                    instant = Instant.ofEpochMilli(epoch);
                     date = OffsetDateTime.ofInstant(instant, zoneId);
                     return date;
                 } else if (unit.equals("microsecond")) {
-                    instant = Instant.ofEpochSecond(epoch / 1000000);
+                    instant = Instant.ofEpochSecond(epoch / 1000000, epoch % 1000000 * 1000);
                     date = OffsetDateTime.ofInstant(instant, zoneId);
                     return date;
                 }

--- a/main/tests/server/src/com/google/refine/expr/functions/TimeSinceUnixEpochToDateTest.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/TimeSinceUnixEpochToDateTest.java
@@ -11,7 +11,7 @@ import com.google.refine.expr.EvalError;
 
 public class TimeSinceUnixEpochToDateTest extends RefineTest {
 
-    long epoch = 1650547184707L; // 2022-04-21T13:19:44Z
+    long epoch = 1650547184707L; // 2022-04-21T13:19:44.707Z
     static Properties bindings = new Properties();
 
     @Test
@@ -25,11 +25,11 @@ public class TimeSinceUnixEpochToDateTest extends RefineTest {
     public void testTimeSinceUnixEpochToDateTwoParam() {
         long epochSecond = epoch / 1000;
         long epochMilliSecond = epoch;
-        long epochMicroSecond = epoch * 1000;
+        long epochMicroSecond = epoch * 1000 + 123;
         TimeSinceUnixEpochToDate etd = new TimeSinceUnixEpochToDate();
         assertEquals(etd.call(bindings, new Object[] { epochSecond, "second" }).toString(), "2022-04-21T13:19:44Z");
-        assertEquals(etd.call(bindings, new Object[] { epochMilliSecond, "millisecond" }).toString(), "2022-04-21T13:19:44Z");
-        assertEquals(etd.call(bindings, new Object[] { epochMicroSecond, "microsecond" }).toString(), "2022-04-21T13:19:44Z");
+        assertEquals(etd.call(bindings, new Object[] { epochMilliSecond, "millisecond" }).toString(), "2022-04-21T13:19:44.707Z");
+        assertEquals(etd.call(bindings, new Object[] { epochMicroSecond, "microsecond" }).toString(), "2022-04-21T13:19:44.707123Z");
     }
 
     @Test


### PR DESCRIPTION
Fixes #5488 

Changes proposed in this pull request:
- Preserve full precision for millisecond and microsecond. Enhance tests to cover these cases.