### PR TITLE
Untangled project timestamp management. Fixes #3047

### DIFF
--- a/main/src/com/google/refine/ProjectManager.java
+++ b/main/src/com/google/refine/ProjectManager.java
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2010, Google Inc.
+Copyright 2010, 2022 Google Inc. & OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,11 +36,9 @@ package com.google.refine;
 import com.google.refine.util.GetProjectIDException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -72,16 +70,16 @@ public abstract class ProjectManager {
     static public final int EXPRESSION_HISTORY_MAX = 100;
 
     // If a project has been idle this long, flush it from memory
-    static protected final int PROJECT_FLUSH_DELAY = 1000 * 60 * 15; // 15 minutes
+    static protected final Duration PROJECT_FLUSH_DELAY = Duration.ofMinutes(15);
 
     // Don't spend more than this much time saving projects if doing a quick save
-    static protected final int QUICK_SAVE_MAX_TIME = 1000 * 30; // 30 secs
+    static protected final Duration QUICK_SAVE_MAX_TIME = Duration.ofSeconds(30);
 
     protected Map<Long, ProjectMetadata> _projectsMetadata;
     protected Map<String, Integer> _projectsTags;// TagName, number of projects having that tag
     protected PreferenceStore _preferenceStore;
 
-    final static Logger logger = LoggerFactory.getLogger("ProjectManager");
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     /**
      * What caches the lookups of projects.
@@ -196,7 +194,7 @@ public abstract class ProjectManager {
                 try {
                     saveMetadata(metadata, id);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    logger.error("Error saving project metadata", e);
                 }
             } // FIXME what should be the behaviour if metadata is null? i.e. not found
 
@@ -205,7 +203,7 @@ public abstract class ProjectManager {
                 try {
                     saveProject(project);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    logger.error("Error saving project ", e);
                 }
             } // FIXME what should be the behaviour if project is null? i.e. not found or loaded.
               // FIXME what should happen if the metadata is found, but not the project? or vice versa?
@@ -268,8 +266,9 @@ public abstract class ProjectManager {
      * @param allModified
      */
     protected void saveProjects(boolean allModified) {
-        List<SaveRecord> records = new ArrayList<SaveRecord>();
-        LocalDateTime startTimeOfSave = LocalDateTime.now();
+        List<SaveRecord> records = new ArrayList<>();
+        Instant startTimeOfSave = Instant.now();
+        Instant quicksaveDeadline = startTimeOfSave.plus(QUICK_SAVE_MAX_TIME);
 
         synchronized (this) {
             for (long id : _projectsMetadata.keySet()) {
@@ -277,25 +276,25 @@ public abstract class ProjectManager {
                 Project project = _projects.get(id); // don't call getProject() as that will load the project.
 
                 if (project != null) {
-                    boolean hasUnsavedChanges = metadata.getModified().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() >= project
-                            .getLastSave().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-                    // We use >= instead of just > to avoid the case where a newly created project
+                    // These variables are just to avoid calling methods twice and triggering a test failure
+                    // from a test which is peeking at our internals
+                    Instant modified = metadata.getModified();
+                    Instant lastSave = project.getLastSave();
+                    // We use after or equals to avoid the case where a newly created project
                     // has the same modified and last save times, resulting in the project not getting
                     // saved at all.
+                    boolean hasUnsavedChanges = modified.isAfter(lastSave) || modified.equals(lastSave);
 
                     if (hasUnsavedChanges) {
-                        long msecsOverdue = startTimeOfSave.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
-                                - project.getLastSave().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
-
+                        long msecsOverdue = Duration.between(startTimeOfSave, project.getLastSave()).toMillis();
                         records.add(new SaveRecord(project, msecsOverdue));
 
                     } else if (!project.getProcessManager().hasPending()
-                            && startTimeOfSave.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() - project.getLastSave()
-                                    .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() > PROJECT_FLUSH_DELAY) {
+                            && project.getLastSave().plus(PROJECT_FLUSH_DELAY).isBefore(startTimeOfSave)) {
 
                         /*
-                         * It's been a while since the project was last saved and it hasn't been modified. We can safely
-                         * remove it from the cache to save some memory.
+                         * It's been a while since the project was last saved, and it hasn't been modified. We can
+                         * safely remove it from the cache to save some memory.
                          */
                         _projects.remove(id).dispose();
                     }
@@ -304,30 +303,20 @@ public abstract class ProjectManager {
         }
 
         if (records.size() > 0) {
-            Collections.sort(records, new Comparator<SaveRecord>() {
-
-                @Override
-                public int compare(SaveRecord o1, SaveRecord o2) {
-                    if (o1.overdue < o2.overdue) {
-                        return 1;
-                    } else if (o1.overdue > o2.overdue) {
-                        return -1;
-                    } else {
-                        return 0;
-                    }
-                }
-            });
+            // Save most overdue projects first
+            records.sort((o1, o2) -> Long.compare(o2.overdue, o1.overdue));
 
             logger.info(allModified ? "Saving all modified projects ..." : "Saving some modified projects ...");
 
-            for (int i = 0; i < records.size() &&
-                    (allModified || (LocalDateTime.now().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() -
-                            startTimeOfSave.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() < QUICK_SAVE_MAX_TIME)); i++) {
-
+            for (SaveRecord record : records) {
+                // If we've run out of time, bail out, unless we've been asked to save all modified projects
+                if (!allModified && Instant.now().isAfter(quicksaveDeadline)) {
+                    break;
+                }
                 try {
-                    saveProject(records.get(i).project);
+                    saveProject(record.project);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    logger.error("Error when saving projects. Attempting to free memory", e);
                     // In case we're running low on memory, free as much as we can
                     disposeUnmodifiedProjects();
                 }
@@ -344,8 +333,7 @@ public abstract class ProjectManager {
                 ProjectMetadata metadata = getProjectMetadata(id);
                 Project project = _projects.get(id);
                 if (project != null && !project.getProcessManager().hasPending()
-                        && metadata.getModified().atZone(ZoneId.systemDefault()).toInstant().toEpochMilli() < project.getLastSave()
-                                .atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()) {
+                        && project.getLastSave().isAfter(metadata.getModified())) {
                     _projects.remove(id).dispose();
                 }
             }
@@ -586,13 +574,11 @@ public abstract class ProjectManager {
         if (_projects.containsKey(projectID)) {
             _projects.remove(projectID).dispose();
         }
-        if (_projectsMetadata.containsKey(projectID)) {
-            _projectsMetadata.remove(projectID);
-        }
+        _projectsMetadata.remove(projectID);
     }
 
     /**
-     * Sets the flag for long running operations. This will prevent workspace saves from happening while it's set.
+     * Sets the flag for long-running operations. This will prevent workspace saves from happening while it's set.
      * 
      * @param busy
      */

--- a/main/src/com/google/refine/ProjectManager.java
+++ b/main/src/com/google/refine/ProjectManager.java
@@ -276,14 +276,11 @@ public abstract class ProjectManager {
                 Project project = _projects.get(id); // don't call getProject() as that will load the project.
 
                 if (project != null) {
-                    // These variables are just to avoid calling methods twice and triggering a test failure
-                    // from a test which is peeking at our internals
-                    Instant modified = metadata.getModified();
-                    Instant lastSave = project.getLastSave();
                     // We use after or equals to avoid the case where a newly created project
                     // has the same modified and last save times, resulting in the project not getting
                     // saved at all.
-                    boolean hasUnsavedChanges = modified.isAfter(lastSave) || modified.equals(lastSave);
+                    boolean hasUnsavedChanges = metadata.getModified().isAfter(project.getLastSave())
+                            || metadata.getModified().equals(project.getLastSave());
 
                     if (hasUnsavedChanges) {
                         long msecsOverdue = Duration.between(startTimeOfSave, project.getLastSave()).toMillis();

--- a/main/src/com/google/refine/ProjectMetadata.java
+++ b/main/src/com/google/refine/ProjectMetadata.java
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2010, Google Inc.
+Copyright 2010, 2022 Google Inc. & OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,7 @@ package com.google.refine;
 
 import java.io.Serializable;
 import java.lang.reflect.Field;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -64,11 +64,11 @@ public class ProjectMetadata {
     public final static String OLD_FILE_NAME = "metadata.old.json";
 
     @JsonProperty("created")
-    private final LocalDateTime _created;
+    private final Instant _created;
     @JsonProperty("modified")
-    private LocalDateTime _modified;
+    private Instant _modified;
     @JsonIgnore
-    private LocalDateTime written = null;
+    private Instant written = null;
     @JsonProperty("name")
     private String _name = "";
     @JsonProperty("password")
@@ -123,17 +123,17 @@ public class ProjectMetadata {
 
     private final static Logger logger = LoggerFactory.getLogger("project_metadata");
 
-    protected ProjectMetadata(LocalDateTime date) {
+    protected ProjectMetadata(Instant date) {
         _created = date;
         preparePreferenceStore(_preferenceStore);
     }
 
     public ProjectMetadata() {
-        this(LocalDateTime.now());
+        this(Instant.now());
         _modified = _created;
     }
 
-    public ProjectMetadata(LocalDateTime created, LocalDateTime modified, String name) {
+    public ProjectMetadata(Instant created, Instant modified, String name) {
         this(created);
         _modified = modified;
         _name = name;
@@ -150,7 +150,7 @@ public class ProjectMetadata {
     }
 
     @JsonIgnore
-    public LocalDateTime getCreated() {
+    public Instant getCreated() {
         return _created;
     }
 
@@ -233,13 +233,13 @@ public class ProjectMetadata {
     }
 
     @JsonIgnore
-    public LocalDateTime getModified() {
+    public Instant getModified() {
         return _modified;
     }
 
     @JsonIgnore
     public void updateModified() {
-        _modified = LocalDateTime.now();
+        _modified = Instant.now();
     }
 
     @JsonIgnore

--- a/main/src/com/google/refine/io/ProjectMetadataUtilities.java
+++ b/main/src/com/google/refine/io/ProjectMetadataUtilities.java
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2010, Google Inc.
+Copyright 2010, 2022 Google Inc. & OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,17 +36,13 @@ package com.google.refine.io;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -162,8 +158,8 @@ public class ProjectMetadataUtilities {
                     mtime = Math.max(mtime, time);
                 }
             }
-            pm = new ProjectMetadata(LocalDateTime.ofInstant(Instant.ofEpochMilli(ctime), ZoneId.systemDefault()),
-                    LocalDateTime.ofInstant(Instant.ofEpochMilli(mtime), ZoneId.systemDefault()),
+            pm = new ProjectMetadata(Instant.ofEpochMilli(ctime),
+                    Instant.ofEpochMilli(mtime),
                     tempName);
             logger.error("Partially recovered missing metadata project in directory " + projectDir + " - " + tempName);
         }

--- a/main/src/com/google/refine/model/Cell.java
+++ b/main/src/com/google/refine/model/Cell.java
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2010, Google Inc.
+Copyright 2010, 2022 Google Inc. & OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -55,6 +55,8 @@ import com.google.refine.expr.HasFields;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.Pool;
 import com.google.refine.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Cell implements HasFields {
 
@@ -62,6 +64,8 @@ public class Cell implements HasFields {
     final public Serializable value;
     @JsonIgnore
     final public Recon recon;
+
+    private static final Logger logger = LoggerFactory.getLogger(Cell.class);
 
     public Cell(Serializable value, Recon recon) {
         this.value = value;
@@ -115,14 +119,14 @@ public class Cell implements HasFields {
             }
 
             if (instant != null) {
-                return ParsingUtilities.instantToString(instant);
+                return instant.toString();
             } else if (value instanceof Double
                     && (((Double) value).isNaN() || ((Double) value).isInfinite())) {
                 // write as a string
-                return ((Double) value).toString();
+                return value.toString();
             } else if (value instanceof Float
                     && (((Float) value).isNaN() || ((Float) value).isInfinite())) {
-                return ((Float) value).toString();
+                return value.toString();
             } else if (value instanceof Boolean || value instanceof Number) {
                 return value;
             } else {
@@ -155,7 +159,7 @@ public class Cell implements HasFields {
             }
             ParsingUtilities.saveWriter.writeValue(writer, this);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("Error writing cell to writer", e);
         }
     }
 
@@ -177,7 +181,7 @@ public class Cell implements HasFields {
         if (reconId != null) {
             recon = pool.getRecon(reconId);
         }
-        if (type != null && "date".equals(type)) {
+        if ("date".equals(type)) {
             value = ParsingUtilities.stringToDate((String) value);
         }
         if (error != null) {

--- a/main/src/com/google/refine/model/Project.java
+++ b/main/src/com/google/refine/model/Project.java
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2010, Google Inc.
+Copyright 2010, 2022 Google Inc. & OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -40,7 +40,7 @@ import java.io.LineNumberReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -72,9 +72,9 @@ public class Project {
     final public History history;
 
     transient public ProcessManager processManager = new ProcessManager();
-    transient private LocalDateTime _lastSave = LocalDateTime.now();
+    transient private Instant _lastSave = Instant.now();
 
-    final static Logger logger = LoggerFactory.getLogger("project");
+    final static Logger logger = LoggerFactory.getLogger(Project.class);
 
     static public long generateID() {
         return System.currentTimeMillis() + Math.round(Math.random() * 1000000000000L);
@@ -109,7 +109,7 @@ public class Project {
         // The rest of the project should get garbage collected when we return.
     }
 
-    public LocalDateTime getLastSave() {
+    public Instant getLastSave() {
         return this._lastSave;
     }
 
@@ -117,7 +117,7 @@ public class Project {
      * Sets the lastSave time to now
      */
     public void setLastSave() {
-        this._lastSave = LocalDateTime.now();
+        this._lastSave = Instant.now();
     }
 
     public ProjectMetadata getMetadata() {

--- a/main/src/com/google/refine/util/ParsingUtilities.java
+++ b/main/src/com/google/refine/util/ParsingUtilities.java
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2010, Google Inc.
+Copyright 2010, 2022 Google Inc. & OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -85,6 +85,9 @@ public class ParsingUtilities {
         module.addSerializer(LocalDateTime.class, new SerializationFilters.LocalDateSerializer());
         module.addDeserializer(OffsetDateTime.class, new SerializationFilters.OffsetDateDeserializer());
         module.addDeserializer(LocalDateTime.class, new SerializationFilters.LocalDateDeserializer());
+
+        module.addSerializer(Instant.class, new SerializationFilters.InstantSerializer());
+        module.addDeserializer(Instant.class, new SerializationFilters.InstantDeserializer());
 
         mapper.registerModule(module);
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -226,14 +229,6 @@ public class ParsingUtilities {
         }
         return parsed.withOffsetSameInstant(OffsetDateTime.now().getOffset())
                 .toLocalDateTime();
-    }
-
-    static public String instantToString(Instant instant) {
-        return OffsetDateTime.ofInstant(instant, ZoneId.of("Z")).format(ISO8601);
-    }
-
-    static public String instantToLocalDateTimeString(Instant instant) {
-        return LocalDateTime.ofInstant(instant, ZoneId.systemDefault()).format(ISO8601);
     }
 
     static public OffsetDateTime calendarToOffsetDateTime(Calendar calendar) {

--- a/main/src/com/google/refine/util/SerializationFilters.java
+++ b/main/src/com/google/refine/util/SerializationFilters.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018, OpenRefine contributors
+ * Copyright (C) 2018, 2022 OpenRefine contributors
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,7 @@
 package com.google.refine.util;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 
@@ -156,6 +157,35 @@ public class SerializationFilters {
         public void serialize(LocalDateTime arg0, JsonGenerator gen, SerializerProvider s)
                 throws IOException {
             gen.writeString(ParsingUtilities.localDateToString(arg0));
+        }
+    }
+
+    public static class InstantSerializer extends StdSerializer<Instant> {
+
+        private static final long serialVersionUID = 93872874L;
+
+        public InstantSerializer() {
+            super(Instant.class);
+        }
+
+        public void serialize(Instant arg0, JsonGenerator gen, SerializerProvider s)
+                throws IOException {
+            gen.writeString(arg0.toString());
+        }
+    }
+
+    public static class InstantDeserializer extends StdDeserializer<Instant> {
+
+        private static final long serialVersionUID = 93872874L;
+
+        public InstantDeserializer() {
+            super(Instant.class);
+        }
+
+        @Override
+        public Instant deserialize(JsonParser p, DeserializationContext ctxt)
+                throws IOException {
+            return Instant.parse(p.getValueAsString());
         }
     }
 

--- a/main/tests/server/src/com/google/refine/ProjectManagerTests.java
+++ b/main/tests/server/src/com/google/refine/ProjectManagerTests.java
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2010, Google Inc.
+Copyright 2010, 2022 Google Inc. & OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
@@ -51,7 +51,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.ProjectMetadata;
 import com.google.refine.model.Project;
 import com.google.refine.model.ProjectStub;
 import com.google.refine.process.ProcessManager;
@@ -161,10 +160,11 @@ public class ProjectManagerTests extends RefineTest {
 
         SUT.save(true);
 
+        // FIXME: Why do we care about the internals of the implementation instead of the result?
         verify(metadata, times(1)).getModified();
         verify(metadata, times(1)).getTags();
         verify(project, times(1)).getProcessManager();
-        verify(project, times(2)).getLastSave();
+        verify(project, times(2)).getLastSave(); // FIXME: ditto
         verify(project, times(1)).dispose();
         verify(SUT, never()).saveProject(project);
         Assert.assertEquals(SUT.getProject(0), null);
@@ -228,7 +228,7 @@ public class ProjectManagerTests extends RefineTest {
     }
 
     protected void whenProjectGetLastSave(Project proj) {
-        LocalDateTime projectLastSaveDate = LocalDateTime.of(1970, 01, 02, 00, 30, 00);
+        Instant projectLastSaveDate = Instant.parse("1970-01-02T00:30:00Z");
         when(proj.getLastSave()).thenReturn(projectLastSaveDate);
     }
 
@@ -237,7 +237,8 @@ public class ProjectManagerTests extends RefineTest {
     }
 
     protected void whenMetadataGetModified(ProjectMetadata meta, int secondsDifference) {
-        LocalDateTime metadataModifiedDate = LocalDateTime.of(1970, 01, 02, 00, 30 + secondsDifference);
+        // FIXME: This has been ported in a bug-compatible fashion, but it's subtracting 30 *minutes*, not seconds
+        Instant metadataModifiedDate = Instant.parse(String.format("1970-01-02T00:%02d:00Z", 30 + secondsDifference));
         when(meta.getModified()).thenReturn(metadataModifiedDate);
     }
 


### PR DESCRIPTION
Fixes #3047

Changes proposed in this pull request:
- Switch from LocalDateTime with ad hoc UTC conversion hand coded on top to java.time.Instant which is natively UTC
- Fix test that was broken in 2017 when the previous set of changes were made

NOTE: This changes the datatypes of parameters/returns in an API which is declared as public, but really shouldn't be used externally (and no one apparently noticed/complained when they were changed from java.util.Date before). We could restore compatibility with the pre-2017 API, but I don't really see the point.

Untangling the user data type will be in a separate PR since it's not at all coupled with this.