### PR TITLE
Upload packaged artifacts to GitHub for new releases

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -252,18 +252,18 @@ jobs:
       uses: shogo82148/actions-upload-release-asset@v1.6.3
       with:
         upload_url: ${{ steps.get_release_upload_url.outputs.upload_url }}
-        asset_path: ./packaging/target/openrefine-win-${{ env.OR_VERSION }}.zip
-        asset_name: openrefine-win-${{ env.OR_VERSION }}.zip
+        asset_path: ./packaging/target/openrefine-win-${{ steps.get_release_upload_url.outputs.tag_name }}.zip
+        asset_name: openrefine-win-${{ steps.get_release_upload_url.outputs.tag_name }}.zip
         asset_content_type: application/zip
 
     - name: Upload release asset for Windows (with Java)
-      id: upload-release-asset-win
+      id: upload-release-asset-win-with-java
       if: github.event_name == 'release'
       uses: shogo82148/actions-upload-release-asset@v1.6.3
       with:
         upload_url: ${{ steps.get_release_upload_url.outputs.upload_url }}
-        asset_path: ./packaging/target/openrefine-win-${{ env.OR_VERSION }}.zip
-        asset_name: openrefine-win-with-java-${{ env.OR_VERSION }}.zip
+        asset_path: ./packaging/target/openrefine-win-${{ steps.get_release_upload_url.outputs.tag_name }}.zip
+        asset_name: openrefine-win-with-java-${{ steps.get_release_upload_url.outputs.tag_name }}.zip
         asset_content_type: application/zip
 
     - name: Upload Release Asset Linux
@@ -272,8 +272,8 @@ jobs:
       uses: shogo82148/actions-upload-release-asset@v1.6.3
       with:
         upload_url: ${{ steps.get_release_upload_url.outputs.upload_url }}
-        asset_path: ./packaging/target/openrefine-linux-${{ env.OR_VERSION }}.tar.gz
-        asset_name: openrefine-linux-${{ env.OR_VERSION }}.tar.gz
+        asset_path: ./packaging/target/openrefine-linux-${{ steps.get_release_upload_url.outputs.tag_name }}.tar.gz
+        asset_name: openrefine-linux-${{ steps.get_release_upload_url.outputs.tag_name }}.tar.gz
         asset_content_type: application/tar+gzip
 
     - name: Upload Release Asset Mac
@@ -282,7 +282,7 @@ jobs:
       uses: shogo82148/actions-upload-release-asset@v1.6.3
       with:
         upload_url: ${{ steps.get_release_upload_url.outputs.upload_url }}
-        asset_path: ./packaging/target/openrefine-mac-${{ env.OR_VERSION }}.dmg
-        asset_name: openrefine-mac-${{ env.OR_VERSION }}.dmg
+        asset_path: ./packaging/target/openrefine-mac-${{ steps.get_release_upload_url.outputs.tag_name }}.dmg
+        asset_name: openrefine-mac-${{ steps.get_release_upload_url.outputs.tag_name }}.dmg
         asset_content_type: application/x-apple-diskimage
 

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -239,3 +239,50 @@ jobs:
         OSSRH_PASS: ${{ secrets.OSSRH_PASS }}
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
+    - name: Get release upload URL
+      id: get_release_upload_url
+      if: github.event_name == 'release'
+      uses: bruceadams/get-release@v1.3.2
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Upload release asset for Windows (without Java)
+      id: upload-release-asset-win
+      if: github.event_name == 'release'
+      uses: shogo82148/actions-upload-release-asset@v1.6.3
+      with:
+        upload_url: ${{ steps.get_release_upload_url.outputs.upload_url }}
+        asset_path: ./packaging/target/openrefine-win-${{ env.OR_VERSION }}.zip
+        asset_name: openrefine-win-${{ env.OR_VERSION }}.zip
+        asset_content_type: application/zip
+
+    - name: Upload release asset for Windows (with Java)
+      id: upload-release-asset-win
+      if: github.event_name == 'release'
+      uses: shogo82148/actions-upload-release-asset@v1.6.3
+      with:
+        upload_url: ${{ steps.get_release_upload_url.outputs.upload_url }}
+        asset_path: ./packaging/target/openrefine-win-${{ env.OR_VERSION }}.zip
+        asset_name: openrefine-win-with-java-${{ env.OR_VERSION }}.zip
+        asset_content_type: application/zip
+
+    - name: Upload Release Asset Linux
+      id: upload-release-asset-linux
+      if: github.event_name == 'release'
+      uses: shogo82148/actions-upload-release-asset@v1.6.3
+      with:
+        upload_url: ${{ steps.get_release_upload_url.outputs.upload_url }}
+        asset_path: ./packaging/target/openrefine-linux-${{ env.OR_VERSION }}.tar.gz
+        asset_name: openrefine-linux-${{ env.OR_VERSION }}.tar.gz
+        asset_content_type: application/tar+gzip
+
+    - name: Upload Release Asset Mac
+      id: upload-release-asset-mac
+      if: github.event_name == 'release'
+      uses: shogo82148/actions-upload-release-asset@v1.6.3
+      with:
+        upload_url: ${{ steps.get_release_upload_url.outputs.upload_url }}
+        asset_path: ./packaging/target/openrefine-mac-${{ env.OR_VERSION }}.dmg
+        asset_name: openrefine-mac-${{ env.OR_VERSION }}.dmg
+        asset_content_type: application/x-apple-diskimage
+


### PR DESCRIPTION
Fixes #5492.

This is not tested in real conditions. I expect it is likely it does not work out of the box: if the workflow fails, it should be after upload to Maven Central, and so it should be possible to upload the artifacts manually to the GitHub release and attempt a fix of the workflow to be tested at the next release.