### PR TITLE
Changed "parse-next" to "parse-first"

### DIFF
--- a/extensions/database/module/langs/translation-ca.json
+++ b/extensions/database/module/langs/translation-ca.json
@@ -46,7 +46,7 @@
     "database-parsing/disable-auto-preview": "Desactivar previsualització automàtica",
     "database-parsing/ignore-first": "Ignorar primera",
     "database-parsing/ignore": "línia/es al començament de l'arxiu",
-    "database-parsing/parse-next": "Analitza la següent",
+    "database-parsing/parse-first": "Analitza la següent",
     "database-parsing/parse": "línia/es com a capçaleres de columna",
     "database-parsing/limit-next": "Carrega com a màxim",
     "database-parsing/limit": "fila/es de dades",

--- a/extensions/database/module/langs/translation-cs.json
+++ b/extensions/database/module/langs/translation-cs.json
@@ -13,7 +13,7 @@
     "database-parsing/discard": "řádek/řádky/řádků dat",
     "database-parsing/discard-next": "Vynechat počáteční(ch)",
     "database-parsing/parse": "řádek/řádky jako hlavičky sloupců",
-    "database-parsing/parse-next": "Analyzuj další(ch)",
+    "database-parsing/parse-first": "Analyzuj další(ch)",
     "database-parsing/preview-button": "Aktualizuj&nbsp;náhled",
     "database-parsing/option": "Možnosti",
     "database-parsing/worksheet": "Pracovní listy",

--- a/extensions/database/module/langs/translation-en.json
+++ b/extensions/database/module/langs/translation-en.json
@@ -50,7 +50,7 @@
     "database-parsing/disable-auto-preview": "Disable auto preview",
     "database-parsing/ignore-first": "Ignore first",
     "database-parsing/ignore": "line(s) at beginning of file",
-    "database-parsing/parse-next": "Parse next",
+    "database-parsing/parse-first": "Parse first",
     "database-parsing/parse": "line(s) as column headers",
     "database-parsing/discard-next": "Discard initial",
     "database-parsing/discard": "row(s) of data",

--- a/extensions/database/module/langs/translation-en_GB.json
+++ b/extensions/database/module/langs/translation-en_GB.json
@@ -10,7 +10,7 @@
     "database-parsing/discard": "row(s) of data",
     "database-parsing/discard-next": "Discard initial",
     "database-parsing/parse": "line(s) as column headers",
-    "database-parsing/parse-next": "Parse next",
+    "database-parsing/parse-first": "Parse first",
     "database-parsing/ignore": "line(s) at beginning of file",
     "database-parsing/ignore-first": "Ignore first",
     "database-parsing/preview-button": "Update&nbsp;preview",

--- a/extensions/database/module/langs/translation-fr.json
+++ b/extensions/database/module/langs/translation-fr.json
@@ -49,7 +49,7 @@
     "database-parsing/preview-button": "Mise&nbsp;à&nbsp;jour&nbsp;de&nbsp;l'aperçu",
     "database-parsing/ignore-first": "Ignorer la/les",
     "database-parsing/ignore": "première(s) ligne(s) au début du fichier",
-    "database-parsing/parse-next": "Analyser (parse) la/les",
+    "database-parsing/parse-first": "Analyser (parse) la/les",
     "database-parsing/parse": "ligne(s) suivante(s) comme des entêtes de colonnes",
     "database-parsing/discard-next": "Omettre la/les",
     "database-parsing/discard": "première(s) ligne(s) de données",

--- a/extensions/database/module/langs/translation-he.json
+++ b/extensions/database/module/langs/translation-he.json
@@ -4,7 +4,7 @@
     "database-parsing/discard": "שורות הנתונים הראשונות",
     "database-parsing/discard-next": "התעלמות מ־",
     "database-parsing/parse": "השורות הבאות ככותרות העמודות",
-    "database-parsing/parse-next": "לעבד את",
+    "database-parsing/parse-first": "לעבד את",
     "database-parsing/ignore": "השורות הראשונות בתחילת הקובץ",
     "database-parsing/ignore-first": "התעלמות מ־",
     "database-source/alert-db-port-invalid-character": "שגיאת פתחת מסד נתונים: תו שגוי בקלט. מותר רק ספרות.",

--- a/extensions/database/module/langs/translation-id.json
+++ b/extensions/database/module/langs/translation-id.json
@@ -10,7 +10,7 @@
     "database-parsing/discard": "baris data",
     "database-parsing/discard-next": "Buang awalan",
     "database-parsing/parse": "baris sebagai header kolom",
-    "database-parsing/parse-next": "Uraikan berikutnya",
+    "database-parsing/parse-first": "Uraikan berikutnya",
     "database-parsing/ignore": "baris di awal berkas",
     "database-parsing/ignore-first": "Abaikan dahulu",
     "database-parsing/preview-button": "Pratinjau Pembaruan",

--- a/extensions/database/module/langs/translation-it.json
+++ b/extensions/database/module/langs/translation-it.json
@@ -37,7 +37,7 @@
     "database-parsing/preview-button": "Aggiorna&nbsp;anteprima",
     "database-parsing/ignore-first": "Ignora le prime",
     "database-parsing/ignore": "righe dall'inizio del file",
-    "database-parsing/parse-next": "Usa le successive",
+    "database-parsing/parse-first": "Usa le successive",
     "database-parsing/parse": "linee come nomi delle colonne",
     "database-parsing/discard-next": "Scarta le prime",
     "database-parsing/discard": "righe di dati",

--- a/extensions/database/module/langs/translation-ja.json
+++ b/extensions/database/module/langs/translation-ja.json
@@ -38,7 +38,7 @@
     "database-parsing/preview-button": "プレビューを更新",
     "database-parsing/ignore-first": "最初の",
     "database-parsing/ignore": "行を無視",
-    "database-parsing/parse-next": "その次の",
+    "database-parsing/parse-first": "その次の",
     "database-parsing/parse": "行をカラム名として解釈",
     "database-parsing/discard-next": "最初の",
     "database-parsing/discard": "行分を破棄",

--- a/extensions/database/module/langs/translation-ko.json
+++ b/extensions/database/module/langs/translation-ko.json
@@ -38,7 +38,7 @@
     "database-parsing/preview-button": "미리보기&nbsp;업데이트",
     "database-parsing/ignore-first": "처음을 무시",
     "database-parsing/ignore": "파일 시작시 라인(들)",
-    "database-parsing/parse-next": "다음을 파싱",
+    "database-parsing/parse-first": "다음을 파싱",
     "database-parsing/parse": "컬럼 헤더 라인(들)",
     "database-parsing/discard-next": "초기값을 버리세요",
     "database-parsing/discard": "데이터 줄수",

--- a/extensions/database/module/langs/translation-nb_NO.json
+++ b/extensions/database/module/langs/translation-nb_NO.json
@@ -35,7 +35,7 @@
     "database-parsing/preview-button": "Oppdater&nbsp;forhåndsvisning",
     "database-parsing/ignore-first": "Ignorer første",
     "database-parsing/ignore": "linje(r) i begynnelsen av fila",
-    "database-parsing/parse-next": "Tolk neste",
+    "database-parsing/parse-first": "Tolk neste",
     "database-parsing/parse": "linje(r) som kolonneoverskrifter",
     "database-parsing/discard-next": "Forkast de første",
     "database-parsing/discard": "raden(e) med data",

--- a/extensions/database/module/langs/translation-nl.json
+++ b/extensions/database/module/langs/translation-nl.json
@@ -38,7 +38,7 @@
     "database-parsing/preview-button": "Preview&nbsp;bijwerken",
     "database-parsing/ignore-first": "Negeer eerste",
     "database-parsing/ignore": "regel(s) aan het begin van het bestand",
-    "database-parsing/parse-next": "Parse de volgende",
+    "database-parsing/parse-first": "Parse de volgende",
     "database-parsing/parse": "rij(en) als kolomkoppen",
     "database-parsing/discard-next": "Verwijder de initiële",
     "database-parsing/limit-next": "Laad maximaal",

--- a/extensions/database/module/langs/translation-pl.json
+++ b/extensions/database/module/langs/translation-pl.json
@@ -15,7 +15,7 @@
     "database-parsing/store-row": "Przechowuj puste wiersze",
     "database-parsing/limit": "wiersz(e) danych",
     "database-parsing/discard": "wiersz(e) danych",
-    "database-parsing/parse-next": "Analizuj następne",
+    "database-parsing/parse-first": "Analizuj następne",
     "database-parsing/ignore": "linia(e) na początku pliku",
     "database-parsing/preview-button": "Aktualizuj&nbsp;podgląd",
     "database-parsing/create-proj": "Utwórz projekt &raquo;",

--- a/extensions/database/module/langs/translation-pt.json
+++ b/extensions/database/module/langs/translation-pt.json
@@ -49,7 +49,7 @@
     "database-parsing/create-proj": "Criar Projeto &raquo;",
     "database-source/alert-password": "Deve definir uma palavra-passe de banco de dados",
     "database-parsing/ignore-first": "Ignorar primeira(s)",
-    "database-parsing/parse-next": "Analisar próximo",
+    "database-parsing/parse-first": "Analisar próximo",
     "database-source/connectionNameLabel": "Nome",
     "database-parsing/option": "Opções",
     "database-parsing/worksheet": "Planilhas",

--- a/extensions/database/module/langs/translation-pt_BR.json
+++ b/extensions/database/module/langs/translation-pt_BR.json
@@ -11,7 +11,7 @@
     "database-parsing/discard": "linhas(s) de dados",
     "database-parsing/discard-next": "Descartar primeira(s)",
     "database-parsing/parse": "linha(s) como nomes das colunas",
-    "database-parsing/parse-next": "Analisar próximo",
+    "database-parsing/parse-first": "Analisar próximo",
     "database-parsing/ignore": "linhas(s) no começo do arquivo",
     "database-parsing/create-proj": "Criar Projeto &raquo;",
     "database-parsing/ignore-first": "Ignorar primeira(s)",

--- a/extensions/database/module/langs/translation-sv.json
+++ b/extensions/database/module/langs/translation-sv.json
@@ -38,7 +38,7 @@
     "database-parsing/preview-button": "Uppdatera förhandsgranskning",
     "database-parsing/ignore-first": "Ignorera första",
     "database-parsing/ignore": "rad(er) i början av filen",
-    "database-parsing/parse-next": "Tolka nästa",
+    "database-parsing/parse-first": "Tolka nästa",
     "database-parsing/parse": "rad(er) som kolumnrubriker",
     "database-parsing/discard-next": "Släng första",
     "database-parsing/discard": "rad(er) av data",

--- a/extensions/database/module/langs/translation-tr.json
+++ b/extensions/database/module/langs/translation-tr.json
@@ -16,7 +16,7 @@
     "database-parsing/parse": "satırı, sütun başlığı olarak",
     "database-parsing/ignore": "satırı, dosyanın başındaki",
     "database-parsing/discard-next": "At, ilk",
-    "database-parsing/parse-next": "Ayrıştır, sonraki",
+    "database-parsing/parse-first": "Ayrıştır, sonraki",
     "database-parsing/ignore-first": "Yok say, ilk",
     "database-parsing/preview-button": "Ön&nbsp;izlemeyi&nbsp;güncelle",
     "database-parsing/option": "Seçenekler",

--- a/extensions/database/module/langs/translation-zh_Hans.json
+++ b/extensions/database/module/langs/translation-zh_Hans.json
@@ -40,7 +40,7 @@
     "database-parsing/preview-button": "更新&nbsp;预览",
     "database-parsing/disable-auto-preview": "关闭自动预览",
     "database-parsing/ignore-first": "忽略第一个",
-    "database-parsing/parse-next": "解析下一个",
+    "database-parsing/parse-first": "解析下一个",
     "database-parsing/parse": "作为列标题的行",
     "database-parsing/store-cell": "将空白单元格存储为空值",
     "database-source/alert-conn-name-invalid-character": "连接名称输入错误：输入中有非法字符。 仅 [a-zA-Z0-9._-] 允许",

--- a/extensions/gdata/module/langs/translation-ca.json
+++ b/extensions/gdata/module/langs/translation-ca.json
@@ -17,7 +17,7 @@
     "gdata-parsing/preview-button": "Actualitzar previsualització",
     "gdata-parsing/ignore-first": "Ignorar les primeres",
     "gdata-parsing/ignore": "línia/es al començament de l'arxiu",
-    "gdata-parsing/parse-next": "Analitzar les següents",
+    "gdata-parsing/parse-first": "Analitzar les següents",
     "gdata-parsing/parse": "línia/es com a capçaleres de columna",
     "gdata-parsing/discard-next": "Descartar les primeres",
     "gdata-parsing/discard": "fila/es de dades",

--- a/extensions/gdata/module/langs/translation-cs.json
+++ b/extensions/gdata/module/langs/translation-cs.json
@@ -22,7 +22,7 @@
     "gdata-parsing/discard": "řádek/řádky/řádků dat",
     "gdata-parsing/discard-next": "Vynechat počáteční(ch)",
     "gdata-parsing/parse": "řádek/řádky jako hlavičky sloupců",
-    "gdata-parsing/parse-next": "Analyzuj další(ch)",
+    "gdata-parsing/parse-first": "Analyzuj další(ch)",
     "gdata-parsing/ignore": "řádek/řádky/řádků na začátku souboru",
     "gdata-parsing/ignore-first": "Vynechat počáteční(ch)",
     "gdata-parsing/preview-button": "Aktualizovat&nbsp;náhled",

--- a/extensions/gdata/module/langs/translation-en.json
+++ b/extensions/gdata/module/langs/translation-en.json
@@ -21,7 +21,7 @@
     "gdata-parsing/disable-auto-preview": "Disable auto preview",
     "gdata-parsing/ignore-first": "Ignore first",
     "gdata-parsing/ignore": "line(s) at beginning of file",
-    "gdata-parsing/parse-next": "Parse next",
+    "gdata-parsing/parse-first": "Parse next",
     "gdata-parsing/parse": "line(s) as column headers",
     "gdata-parsing/discard-next": "Discard initial",
     "gdata-parsing/discard": "row(s) of data",

--- a/extensions/gdata/module/langs/translation-es.json
+++ b/extensions/gdata/module/langs/translation-es.json
@@ -22,7 +22,7 @@
     "gdata-parsing/discard": "filas de datos iniciales",
     "gdata-parsing/discard-next": "Descartar",
     "gdata-parsing/parse": "renglones como cabeceras de columnas",
-    "gdata-parsing/parse-next": "Analizar próximos",
+    "gdata-parsing/parse-first": "Analizar próximos",
     "gdata-parsing/ignore": "renglones al principio del archivo",
     "gdata-parsing/ignore-first": "Ignorar primeros",
     "gdata-parsing/preview-button": "Actualizar&nbsp;previsualización",

--- a/extensions/gdata/module/langs/translation-fr.json
+++ b/extensions/gdata/module/langs/translation-fr.json
@@ -22,7 +22,7 @@
     "gdata-parsing/preview-button": "Mettre à jour l’aperçu",
     "gdata-parsing/ignore-first": "Ignorer la ou les premières",
     "gdata-parsing/ignore": "ligne(s) du début du fichier",
-    "gdata-parsing/parse-next": "Analyser la ou les",
+    "gdata-parsing/parse-first": "Analyser la ou les",
     "gdata-parsing/parse": "ligne(s) suivante(s) comme entêtes de colonnes",
     "gdata-parsing/discard-next": "Ignorer la ou les",
     "gdata-parsing/discard": "première(s) ligne(s) de données",

--- a/extensions/gdata/module/langs/translation-he.json
+++ b/extensions/gdata/module/langs/translation-he.json
@@ -22,7 +22,7 @@
     "gdata-parsing/preview-button": "עדכון תצוגה מקדימה",
     "gdata-parsing/ignore-first": "להתעלם מ־",
     "gdata-parsing/ignore": "השורות הראשונות בתחילת הקובץ",
-    "gdata-parsing/parse-next": "לפענח את",
+    "gdata-parsing/parse-first": "לפענח את",
     "gdata-parsing/parse": "השורות הבאות ככותרות לעמודות",
     "gdata-parsing/discard-next": "התעלמות מ־",
     "gdata-parsing/discard": "שורות הנתונים הראשונות",

--- a/extensions/gdata/module/langs/translation-it.json
+++ b/extensions/gdata/module/langs/translation-it.json
@@ -22,7 +22,7 @@
     "gdata-parsing/preview-button": "Aggiorna&nbsp;la&nbsp;preview",
     "gdata-parsing/ignore-first": "Ignora le prime",
     "gdata-parsing/ignore": "linee all'inizio del file",
-    "gdata-parsing/parse-next": "Parsa le prossime",
+    "gdata-parsing/parse-first": "Parsa le prossime",
     "gdata-parsing/parse": "linee come nomi delle colonne",
     "gdata-parsing/discard-next": "Scarta le prime",
     "gdata-parsing/discard": "righe di dati",

--- a/extensions/gdata/module/langs/translation-ja.json
+++ b/extensions/gdata/module/langs/translation-ja.json
@@ -22,7 +22,7 @@
     "gdata-parsing/preview-button": "プレビューを更新",
     "gdata-parsing/ignore-first": "先頭を無視",
     "gdata-parsing/ignore": "行分",
-    "gdata-parsing/parse-next": "カラム名として解釈",
+    "gdata-parsing/parse-first": "カラム名として解釈",
     "gdata-parsing/parse": "行分",
     "gdata-parsing/discard-next": "先頭データを破棄",
     "gdata-parsing/discard": "行分",

--- a/extensions/gdata/module/langs/translation-ko.json
+++ b/extensions/gdata/module/langs/translation-ko.json
@@ -22,7 +22,7 @@
     "gdata-parsing/preview-button": "업데이트&nbsp;미리보기",
     "gdata-parsing/ignore-first": "처음을 무시",
     "gdata-parsing/ignore": "파일의 첫번째 줄(들)",
-    "gdata-parsing/parse-next": "다음 파싱",
+    "gdata-parsing/parse-first": "다음 파싱",
     "gdata-parsing/parse": "컬럼 헤더로 라인(들)을",
     "gdata-parsing/discard-next": "초기값을 무시",
     "gdata-parsing/discard": "데이터 줄수",

--- a/extensions/gdata/module/langs/translation-nb_NO.json
+++ b/extensions/gdata/module/langs/translation-nb_NO.json
@@ -22,7 +22,7 @@
     "gdata-parsing/preview-button": "Oppdater forhåndsvisning",
     "gdata-parsing/ignore-first": "Ignorer første",
     "gdata-parsing/ignore": "linje(ne) i begynnelsen av filen",
-    "gdata-parsing/parse-next": "Fortolk neste",
+    "gdata-parsing/parse-first": "Fortolk neste",
     "gdata-parsing/parse": "line(r) som kolonnerubrikker",
     "gdata-parsing/discard-next": "Forkast innledende",
     "gdata-parsing/discard": "rad(er) med data",

--- a/extensions/gdata/module/langs/translation-pl.json
+++ b/extensions/gdata/module/langs/translation-pl.json
@@ -16,7 +16,7 @@
     "gdata-parsing/conf-pars": "Konfiguracja opcji parsowania",
     "gdata-parsing/option": "Opcje",
     "gdata-parsing/store-row": "Przechowuj puste wiersze",
-    "gdata-parsing/parse-next": "Parsuj następny",
+    "gdata-parsing/parse-first": "Parsuj następny",
     "gdata-source/title": "Tytuł",
     "gdata-exporter/upload-error": "Błąd przesyłania: ",
     "gdata-exporter/uploading": "Przesyłanie…",

--- a/extensions/gdata/module/langs/translation-pt.json
+++ b/extensions/gdata/module/langs/translation-pt.json
@@ -16,7 +16,7 @@
     "gdata-import/auth-doc": "Documentos autorizados",
     "gdata-parsing/option": "Opções",
     "gdata-exporter/upload-google-sheets-success": "Projeto enviado para o Google Drive ",
-    "gdata-parsing/parse-next": "Analisar próximo",
+    "gdata-parsing/parse-first": "Analisar próximo",
     "gdata-parsing/worksheet": "Planilhas",
     "gdata-import/title": "Documentos públicos",
     "gdata-parsing/limit": "linhas(s) de dados",

--- a/extensions/gdata/module/langs/translation-pt_BR.json
+++ b/extensions/gdata/module/langs/translation-pt_BR.json
@@ -25,7 +25,7 @@
     "gdata-parsing/discard": "linhas(s) de dados",
     "gdata-parsing/discard-next": "Descartar primeira(s)",
     "gdata-parsing/parse": "linha(s) como nomes das colunas",
-    "gdata-parsing/parse-next": "Analisar próximo",
+    "gdata-parsing/parse-first": "Analisar próximo",
     "gdata-parsing/ignore": "linhas(s) no começo do arquivo",
     "gdata-parsing/ignore-first": "Ignorar primeira(s)",
     "gdata-parsing/preview-button": "Atualizar&nbsp;Pré-visualização",

--- a/extensions/gdata/module/langs/translation-pt_PT.json
+++ b/extensions/gdata/module/langs/translation-pt_PT.json
@@ -16,7 +16,7 @@
     "gdata-import/auth-doc": "Documentos autorizados",
     "gdata-parsing/option": "Opções",
     "gdata-exporter/upload-google-sheets-success": "Projeto enviado para o Google Drive ",
-    "gdata-parsing/parse-next": "Analisar próximo",
+    "gdata-parsing/parse-first": "Analisar próximo",
     "gdata-parsing/worksheet": "Planilhas",
     "gdata-import/title": "Documentos públicos",
     "gdata-parsing/limit": "linhas(s) de dados",

--- a/extensions/gdata/module/langs/translation-sv.json
+++ b/extensions/gdata/module/langs/translation-sv.json
@@ -22,7 +22,7 @@
     "gdata-parsing/preview-button": "Uppdatera förhandsgranskning",
     "gdata-parsing/ignore-first": "Ignorera första",
     "gdata-parsing/ignore": "raden(-erna) i början på filen",
-    "gdata-parsing/parse-next": "Parsa nästa",
+    "gdata-parsing/parse-first": "Parsa nästa",
     "gdata-parsing/parse": "rad(er) som kolumnrubriker",
     "gdata-parsing/discard-next": "Släng första",
     "gdata-parsing/discard": "rad(er) av data",

--- a/extensions/gdata/module/langs/translation-zh_Hans.json
+++ b/extensions/gdata/module/langs/translation-zh_Hans.json
@@ -18,7 +18,7 @@
     "gdata-parsing/disable-auto-preview": "禁止自动预览",
     "gdata-parsing/ignore-first": "忽略第一个",
     "gdata-parsing/ignore": "文件开头的行",
-    "gdata-parsing/parse-next": "解析下一个",
+    "gdata-parsing/parse-first": "解析下一个",
     "gdata-parsing/parse": "行作为列标题",
     "gdata-parsing/discard-next": "丢弃首字母",
     "gdata-parsing/discard": "数据行",

--- a/extensions/gdata/module/scripts/index/importing-controller.js
+++ b/extensions/gdata/module/scripts/index/importing-controller.js
@@ -154,7 +154,7 @@ Refine.GDataImportingController.prototype._showParsingPanel = function() {
   this._parsingPanelElmts.gdata_worksheet.html($.i18n('gdata-parsing/worksheet'));
   this._parsingPanelElmts.gdata_ignore_first.html($.i18n('gdata-parsing/ignore-first'));
   this._parsingPanelElmts.gdata_ignore.html($.i18n('gdata-parsing/ignore'));
-  this._parsingPanelElmts.gdata_parse_next.html($.i18n('gdata-parsing/parse-next'));
+  this._parsingPanelElmts.gdata_parse_next.html($.i18n('gdata-parsing/parse-first'));
   this._parsingPanelElmts.gdata_parse.html($.i18n('gdata-parsing/parse'));
   this._parsingPanelElmts.startOverButton.html($.i18n('gdata-parsing/start-over'));
   this._parsingPanelElmts.gdata_conf_pars.html($.i18n('gdata-parsing/conf-pars'));

--- a/main/tests/cypress/cypress/e2e/create-project/preview_project.cy.js
+++ b/main/tests/cypress/cypress/e2e/create-project/preview_project.cy.js
@@ -117,7 +117,7 @@ describe(__filename, function () {
     cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
     cy.get('table.data-table tr').eq(1).should('to.contain', '717');
   });
-  it('Tests parse-next of parsing options', function () {
+  it('Tests parse-first of parsing options', function () {
     navigateToProjectPreview();
     cy.get('input[bind="columnNamesCheckbox"]').check();
     cy.waitForImportUpdate();

--- a/main/webapp/modules/core/langs/translation-ar.json
+++ b/main/webapp/modules/core/langs/translation-ar.json
@@ -206,7 +206,7 @@
     "core-index-parser/rows-data": "صف (صفوف) من البيانات",
     "core-index-parser/discard-initial": "تجاهل الأولي",
     "core-index-parser/lines-header": "سطر/أسطر كرؤوس أعمدة",
-    "core-index-parser/parse-next": "تحليل التالي",
+    "core-index-parser/parse-first": "تحليل التالي",
     "core-index-parser/lines-beg": "أسطر/سطر في بداية الملف",
     "core-index-parser/ignore-first": "تجاهل أولاً",
     "core-index-lang/page-reload": "سيتم تحديث الصفحة لتطبيق التغيير.",

--- a/main/webapp/modules/core/langs/translation-ceb.json
+++ b/main/webapp/modules/core/langs/translation-ceb.json
@@ -115,7 +115,7 @@
     "core-index-lang/label": "Pili ug gusto nga pinulungan",
     "core-index-parser/parse-cell": "Gianalisar ang teksto sa <br/> mga numero, petsa, …",
     "core-index-parser/trim": "Trim leading &amp; 1 trailing whitespace from strings",
-    "core-index-parser/parse-next": "Sunod nga parse",
+    "core-index-parser/parse-first": "Sunod nga parse",
     "core-index-parser/commas": "Mga koma (CSV)",
     "core-index-parser/tabs": "mga tab  (TSV)",
     "core-index-parser/escape": "Tangtanga ang espesyal nga karakter uban ni \\",

--- a/main/webapp/modules/core/langs/translation-cs.json
+++ b/main/webapp/modules/core/langs/translation-cs.json
@@ -229,7 +229,7 @@
     "core-index-parser/rows-data": "řádek/řádky/řádků dat",
     "core-index-parser/discard-initial": "Zahodit počáteční",
     "core-index-parser/lines-header": "řádek/řádky/řádků jako popisky sloupců",
-    "core-index-parser/parse-next": "Zpracovat další",
+    "core-index-parser/parse-first": "Zpracovat další",
     "core-index-parser/lines-beg": "řádek/řádky/řádků na začátku souboru",
     "core-index-lang/page-reload": "Stránka se načte znovu, aby se projevily změny.",
     "core-index-open/edit-tags-desc": "Upravit štítky projektu (oddělujte mezerou nebo čárkou):",

--- a/main/webapp/modules/core/langs/translation-de.json
+++ b/main/webapp/modules/core/langs/translation-de.json
@@ -115,7 +115,7 @@
     "core-index-lang/label": "Bevorzugte Sprache auswählen",
     "core-index-parser/parse-cell": "Analysiere Zelltext in <br/>Zahlen, Datumsangaben, …",
     "core-index-parser/trim": "Führende &amp; nachgestellte Leerzeichen aus Zeichenfolgen entfernen",
-    "core-index-parser/parse-next": "Nächste analysieren",
+    "core-index-parser/parse-first": "Nächste analysieren",
     "core-index-parser/commas": "Kommas (CSV)",
     "core-index-parser/tabs": "Tabs (TSV)",
     "core-index-parser/escape": "Markiere Sonderzeichen mit \\",

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -140,7 +140,7 @@
     "core-index-parser/disable-auto-preview": "Disable auto preview",
     "core-index-parser/ignore-first": "Ignore first",
     "core-index-parser/lines-beg": "line(s) at beginning of file",
-    "core-index-parser/parse-next": "Parse next",
+    "core-index-parser/parse-first": "Parse first",
     "core-index-parser/lines-header": "line(s) as column headers",
     "core-index-parser/discard-initial": "Discard initial",
     "core-index-parser/rows-data": "row(s) of data",

--- a/main/webapp/modules/core/langs/translation-es.json
+++ b/main/webapp/modules/core/langs/translation-es.json
@@ -115,7 +115,7 @@
     "core-index-lang/lang-settings": "Configuración de idioma",
     "core-index-parser/parse-cell": "Procesar texto de celdas en números",
     "core-index-parser/trim": "Quitar espacios al inicio y final de las celdas",
-    "core-index-parser/parse-next": "Seleccionar primera(s)",
+    "core-index-parser/parse-first": "Seleccionar primera(s)",
     "core-index-parser/commas": "comas (CSV)",
     "core-index-parser/tabs": "tabulaciones (TSV)",
     "core-index-parser/store-source": "Cargar el origen del archivo",

--- a/main/webapp/modules/core/langs/translation-fi.json
+++ b/main/webapp/modules/core/langs/translation-fi.json
@@ -143,7 +143,7 @@
     "core-index-parser/disable-auto-preview": "Poista automaattinen esikatselu käytöstä",
     "core-index-parser/ignore-first": "Ohita ensin",
     "core-index-parser/lines-beg": "rivi(t) tiedoston alussa",
-    "core-index-parser/parse-next": "Jäsennä seuraava",
+    "core-index-parser/parse-first": "Jäsennä seuraava",
     "core-index-parser/discard-initial": "Hylkää alkuperäinen",
     "core-index-parser/rows-data": "tietorivi(t).",
     "core-index-parser/load-at-most": "Lataa enintään",

--- a/main/webapp/modules/core/langs/translation-fil.json
+++ b/main/webapp/modules/core/langs/translation-fil.json
@@ -115,7 +115,7 @@
     "core-index-lang/label": "Piliin ang ginustong wika",
     "core-index-parser/parse-cell": "Parse cell text sa <br/> 1numero, petsa, ...",
     "core-index-parser/trim": "Trim nangungunang & amp; 1 trailing whitespace mula sa mga string",
-    "core-index-parser/parse-next": "Parse susunod",
+    "core-index-parser/parse-first": "Parse susunod",
     "core-index-parser/commas": "mga kuwit (CSV)",
     "core-index-parser/tabs": "mga tab (TSV)",
     "core-index-parser/escape": "Eskapo ang mga espesyal na character na may \\",

--- a/main/webapp/modules/core/langs/translation-fr.json
+++ b/main/webapp/modules/core/langs/translation-fr.json
@@ -119,7 +119,7 @@
     "core-index-lang/label": "Choisir sa langue préférée",
     "core-index-parser/parse-cell": "Analyser le texte des cellules comme nombres",
     "core-index-parser/trim": "Supprimer les espaces de début et de fin",
-    "core-index-parser/parse-next": "Analyser la ou les",
+    "core-index-parser/parse-first": "Analyser la ou les",
     "core-index-parser/commas": "une virgule (CSV)",
     "core-index-parser/tabs": "une tabulation (TSV)",
     "core-index-parser/store-source": "Indiquer la source du fichier",

--- a/main/webapp/modules/core/langs/translation-he.json
+++ b/main/webapp/modules/core/langs/translation-he.json
@@ -92,7 +92,7 @@
     "core-index-lang/page-reload": "העמוד ייטען מחדש כדי להחיל את השינוי.",
     "core-index-parser/ignore-first": "להתעלם מ־",
     "core-index-parser/lines-beg": "השורות הראשונות בתחילת הקובץ",
-    "core-index-parser/parse-next": "לפענח את",
+    "core-index-parser/parse-first": "לפענח את",
     "core-index-parser/lines-header": "השורות הבאות ככותרות לעמודות",
     "core-index-parser/discard-initial": "התעלמות מ־",
     "core-index-parser/rows-data": "שורות הנתונים הראשונות",

--- a/main/webapp/modules/core/langs/translation-hu.json
+++ b/main/webapp/modules/core/langs/translation-hu.json
@@ -115,7 +115,7 @@
     "core-index-lang/lang-settings": "Nyelvi beállítások",
     "core-index-parser/parse-cell": "Cella tartalmának feldolgozása<br/>számokká, dátumokká, …",
     "core-index-parser/trim": "Szóközök törlése a karakterláncok elejéről és végéről",
-    "core-index-parser/parse-next": "Dolgozza fel a következő",
+    "core-index-parser/parse-first": "Dolgozza fel a következő",
     "core-index-parser/commas": "vessző (CSV)",
     "core-index-parser/tabs": "tabulátor (TSV)",
     "core-index-parser/escape": "Különleges karakterek feloldása ezzel \\",

--- a/main/webapp/modules/core/langs/translation-id.json
+++ b/main/webapp/modules/core/langs/translation-id.json
@@ -106,7 +106,7 @@
     "core-index-parser/rows-data": "baris data",
     "core-index-parser/discard-initial": "Buang inisial",
     "core-index-parser/lines-header": "baris sebagai header kolom",
-    "core-index-parser/parse-next": "Uraikan berikutnya",
+    "core-index-parser/parse-first": "Uraikan berikutnya",
     "core-index-parser/lines-beg": "baris di awal file",
     "core-index-parser/ignore-first": "Abaikan dulu",
     "core-index-lang/page-reload": "Halaman akan di-refresh untuk menerapkan perubahan.",

--- a/main/webapp/modules/core/langs/translation-it.json
+++ b/main/webapp/modules/core/langs/translation-it.json
@@ -115,7 +115,7 @@
     "core-index-lang/label": "Seleziona la lingua preferita",
     "core-index-parser/parse-cell": "Converti il testo delle<br/>celle in numeri",
     "core-index-parser/trim": "Elimina gli spazi all'inizio ed alla fine delle stringhe",
-    "core-index-parser/parse-next": "Analizza la/e prossima/e",
+    "core-index-parser/parse-first": "Analizza la/e prossima/e",
     "core-index-parser/commas": "virgole (CSV)",
     "core-index-parser/tabs": "tab (TSV)",
     "core-index-parser/store-source": "Salva la sorgente",

--- a/main/webapp/modules/core/langs/translation-ja.json
+++ b/main/webapp/modules/core/langs/translation-ja.json
@@ -115,7 +115,7 @@
     "core-index-lang/label": "言語を選択する",
     "core-index-parser/parse-cell": "セルを解析<br/>文字から数字",
     "core-index-parser/trim": "前後の空白文字を削除する",
-    "core-index-parser/parse-next": "カラム名として解釈",
+    "core-index-parser/parse-first": "カラム名として解釈",
     "core-index-parser/commas": "カンマ区切り（CSV）",
     "core-index-parser/tabs": "タブ（TSV）",
     "core-index-parser/escape": "特殊文字はバックスラッシュでエスケープしてください",

--- a/main/webapp/modules/core/langs/translation-nb_NO.json
+++ b/main/webapp/modules/core/langs/translation-nb_NO.json
@@ -129,7 +129,7 @@
     "core-index-parser/column-names-optional": "kommainndelt",
     "core-index-parser/ignore-first": "Ignorer første",
     "core-index-parser/lines-beg": "linje(r) på begynnelsen av filen",
-    "core-index-parser/parse-next": "Tolk neste",
+    "core-index-parser/parse-first": "Tolk neste",
     "core-index-parser/lines-header": "linje(r) som kolonneoverskrifter",
     "core-index-parser/discard-initial": "Forkast første",
     "core-index-parser/rows-data": "rad(er) med data",

--- a/main/webapp/modules/core/langs/translation-nl.json
+++ b/main/webapp/modules/core/langs/translation-nl.json
@@ -118,7 +118,7 @@
     "core-index-open/del-body": "Weet je zeker dat je het project \"$1\" wil verwijderen?",
     "core-index-open/warning-data-file": "U moet een databestand of een URL specificeren om te ontvangen.",
     "core-index-open/edit-tags-desc": "Projecttags bewerken (gescheiden door spatie of komma):",
-    "core-index-parser/parse-next": "Verwerk eerste",
+    "core-index-parser/parse-first": "Verwerk eerste",
     "core-index-parser/lines-header": "regel(s) als kolomkoppen",
     "core-index-parser/parse-cell": "Tekst naar getallen<br/>, kalenderdata, etc. omzetten",
     "core-index-parser/store-nulls": "Lege cellen als lege waarde opslaan",

--- a/main/webapp/modules/core/langs/translation-pl.json
+++ b/main/webapp/modules/core/langs/translation-pl.json
@@ -174,7 +174,7 @@
     "core-index-import/load-json-rows-error": "Parsowanie danych JSON nie powiodło się",
     "core-index-import/load-xml-rows-error": "Parsowanie danych XML nie powiodło się",
     "core-dialogs/starred": "Oznaczone gwiazdką",
-    "core-index-parser/parse-next": "Parsuj następny",
+    "core-index-parser/parse-first": "Parsuj następny",
     "core-dialogs/template-prefix": "Prefiks",
     "core-dialogs/content": "Treść",
     "core-dialogs/upload": "Prześlij",

--- a/main/webapp/modules/core/langs/translation-pt.json
+++ b/main/webapp/modules/core/langs/translation-pt.json
@@ -495,7 +495,7 @@
     "core-dialogs/long-format": "Formato local longo",
     "core-views/what-separator": "Qual separador é usado atualmente para separar os valores?",
     "core-buttons/close": "Fechar",
-    "core-index-parser/parse-next": "Analisar próximo",
+    "core-index-parser/parse-first": "Analisar próximo",
     "core-views/custom-numeric": "Faceta numérica personalizada…",
     "name": "Português",
     "core-views/match-other": "Corresponder outras células que tenham o mesmo conteúdo",

--- a/main/webapp/modules/core/langs/translation-pt_BR.json
+++ b/main/webapp/modules/core/langs/translation-pt_BR.json
@@ -115,7 +115,7 @@
     "core-index-lang/lang-settings": "Idioma",
     "core-index-parser/parse-cell": "Tentar analisar texto de<br>células como números",
     "core-index-parser/trim": "Cortar espaços no início e no final dos textos das células",
-    "core-index-parser/parse-next": "Analisar próximo",
+    "core-index-parser/parse-first": "Analisar próximo",
     "core-index-parser/commas": "vírgulas (CSV)",
     "core-index-parser/tabs": "tabs (TSV)",
     "core-index-parser/escape": "Ignorar caracteres especiais com \\",

--- a/main/webapp/modules/core/langs/translation-ru.json
+++ b/main/webapp/modules/core/langs/translation-ru.json
@@ -154,7 +154,7 @@
     "core-index-lang/label": "Выберите предпочтительный язык",
     "core-index-parser/parse-cell": "Парсить значение ячейки как<br/>числа, даты, …",
     "core-index-parser/trim": "Обрезать начальные &amp; конечные пробелы в строках",
-    "core-index-parser/parse-next": "Парсить следующие",
+    "core-index-parser/parse-first": "Парсить следующие",
     "core-index-parser/commas": "запятыми (CSV)",
     "core-index-parser/tabs": "табами (TSV)",
     "core-index-parser/store-source": "Сохранять источники файла",

--- a/main/webapp/modules/core/langs/translation-sv.json
+++ b/main/webapp/modules/core/langs/translation-sv.json
@@ -115,7 +115,7 @@
     "core-index-lang/page-reload": "Sidan laddas om för att ta ändringen i bruk.",
     "core-index-parser/ignore-first": "Ignorera första",
     "core-index-parser/lines-beg": "rad(erna) i början av filen",
-    "core-index-parser/parse-next": "Analysera nästa",
+    "core-index-parser/parse-waitForImportUpdate()": "Analysera nästa",
     "core-index-parser/lines-header": "rad(er) som kolumnrubriker",
     "core-index-parser/discard-initial": "Släng första",
     "core-index-parser/rows-data": "rad(er) av data",

--- a/main/webapp/modules/core/langs/translation-tl.json
+++ b/main/webapp/modules/core/langs/translation-tl.json
@@ -115,7 +115,7 @@
     "core-index-lang/label": "Pumili ng gustong lengguwahe",
     "core-index-parser/parse-cell": "I-parse ang texto ng cell sa<br/>mga numero, mga petsa, ...",
     "core-index-parser/trim": "Ang trim leading &amp; pag-trail ng whitespace mula sa mga strings",
-    "core-index-parser/parse-next": "I-parse sa susunod",
+    "core-index-parser/parse-first": "I-parse sa susunod",
     "core-index-parser/commas": "Mga koma (CSV)",
     "core-index-parser/tabs": "mga tab (TSV)",
     "core-index-parser/escape": "Iwasan ang espesyal na mga karakter na may \\",

--- a/main/webapp/modules/core/langs/translation-zh.json
+++ b/main/webapp/modules/core/langs/translation-zh.json
@@ -92,7 +92,7 @@
     "core-index-lang/page-reload": "将会刷新页面来应用这些更改.",
     "core-index-parser/ignore-first": "忽略文件首部的前",
     "core-index-parser/lines-beg": "行",
-    "core-index-parser/parse-next": "将其次的下",
+    "core-index-parser/parse-first": "将其次的下",
     "core-index-parser/lines-header": "line(s) 作为列头",
     "core-index-parser/discard-initial": "抛弃表格中的前",
     "core-index-parser/rows-data": "行",

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.js
@@ -132,7 +132,7 @@ Refine.ExcelParserUI.prototype._initialize = function() {
   $('#or-import-worksheet').text($.i18n('core-index-import/import-worksheet'));
   $('#or-import-ignore').text($.i18n('core-index-parser/ignore-first'));
   $('#or-import-lines').text($.i18n('core-index-parser/lines-beg'));
-  $('#or-import-parse').text($.i18n('core-index-parser/parse-next'));
+  $('#or-import-parse').text($.i18n('core-index-parser/parse-first'));
   $('#or-import-header').text($.i18n('core-index-parser/lines-header'));
   $('#or-import-discard').text($.i18n('core-index-parser/discard-initial'));
   $('#or-import-rows').text($.i18n('core-index-parser/rows-data'));

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/fixed-width-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/fixed-width-parser-ui.js
@@ -135,7 +135,7 @@ Refine.FixedWidthParserUI.prototype._initialize = function() {
   
   $('#or-import-ignore').text($.i18n('core-index-parser/ignore-first'));
   $('#or-import-lines').text($.i18n('core-index-parser/lines-beg'));
-  $('#or-import-parse').text($.i18n('core-index-parser/parse-next'));
+  $('#or-import-parse').text($.i18n('core-index-parser/parse-first'));
   $('#or-import-header').text($.i18n('core-index-parser/lines-header'));
   $('#or-import-discard').text($.i18n('core-index-parser/discard-initial'));
   $('#or-import-rows').text($.i18n('core-index-parser/rows-data'));

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/line-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/line-based-parser-ui.js
@@ -132,7 +132,7 @@ Refine.LineBasedParserUI.prototype._initialize = function() {
   $('#or-import-archive').html($.i18n('core-index-parser/store-archive'));
   $('#or-import-ignore').text($.i18n('core-index-parser/ignore-first'));
   $('#or-import-lines').text($.i18n('core-index-parser/lines-beg'));
-  $('#or-import-parse').text($.i18n('core-index-parser/parse-next'));
+  $('#or-import-parse').text($.i18n('core-index-parser/parse-first'));
   $('#or-import-header').text($.i18n('core-index-parser/lines-header'));
   $('#or-import-discard').text($.i18n('core-index-parser/discard-initial'));
   $('#or-import-rows').text($.i18n('core-index-parser/rows-data'));

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
@@ -156,7 +156,7 @@ Refine.SeparatorBasedParserUI.prototype._initialize = function() {
   
   $('#or-import-ignore').text($.i18n('core-index-parser/ignore-first'));
   $('#or-import-lines').text($.i18n('core-index-parser/lines-beg'));
-  $('#or-import-parse').text($.i18n('core-index-parser/parse-next'));
+  $('#or-import-parse').text($.i18n('core-index-parser/parse-first'));
   $('#or-import-header').text($.i18n('core-index-parser/lines-header'));
   $('#or-import-discard').text($.i18n('core-index-parser/discard-initial'));
   $('#or-import-rows').text($.i18n('core-index-parser/rows-data'));

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.js
@@ -120,7 +120,7 @@ Refine.WikitextParserUI.prototype._initialize = function() {
   this._optionContainerElmts.previewButton.html($.i18n('core-buttons/update-preview'));
   $('#or-disable-auto-preview').text($.i18n('core-index-parser/disable-auto-preview'));
   $('#or-import-wiki-base-url').text($.i18n('core-index-parser/wiki-base-url'));
-  $('#or-import-parse').text($.i18n('core-index-parser/parse-next'));
+  $('#or-import-parse').text($.i18n('core-index-parser/parse-first'));
   $('#or-import-header').text($.i18n('core-index-parser/lines-header'));
   $('#or-import-load').text($.i18n('core-index-parser/load-at-most'));
   $('#or-import-rows2').text($.i18n('core-index-parser/rows-data'));


### PR DESCRIPTION
64 changes staged for testing, changed "parse-next" to "parse-first". CTRL+SHIFT+F to search for all keywords containing "parse-next".

All Language files have been modified, however the translations have not been modified due to the lack of trust in google translate.

Fixes #{issue number here}

Changes proposed in this pull request:
- changed every translation file from "parse-next" to "parse-first"
- changed translation .json files in main/webapp to also reflect this change
- 
