### PR TITLE
issue#5394 -- Updated SelectXML.Java

### DIFF
--- a/main/src/com/google/refine/expr/functions/xml/SelectXml.java
+++ b/main/src/com/google/refine/expr/functions/xml/SelectXml.java
@@ -71,7 +71,7 @@ public class SelectXml implements Function {
 
     @Override
     public String getParams() {
-        return "string s, element e";
+        return "element e, string s";
     }
 
     @Override


### PR DESCRIPTION
This change reflects the issue listed under #5394. getParams() has been changed such that the element and string positions are swapped.

Fixes #5394

Changes proposed in this pull request:
- getParams() has been changed such that the element and string positions are swapped.
