### PR TITLE
Add `/Applications` shortcut to macOS dmg file

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -206,6 +206,14 @@ jobs:
         gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
         gpg-passphrase: GPG_PASSPHRASE
 
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3' 
+
+    - name: Install dmgbuild
+      run: pip install dmgbuild
+
     - name: Decrypt Apple certificates
       run: |
         gpg --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}" --output .github/workflows/release/apple_cert.cer --decrypt packaging/apple_certs/apple_cert.cer.enc

--- a/packaging/dmg_settings.py
+++ b/packaging/dmg_settings.py
@@ -1,0 +1,181 @@
+import os.path
+import plistlib
+
+#
+# Example settings file for dmgbuild
+#
+
+# Use like this: dmgbuild -s settings.py "Test Volume" test.dmg
+
+# You can actually use this file for your own application (not just TextEdit)
+# by doing e.g.
+#
+#   dmgbuild -s settings.py -D app=/path/to/My.app "My Application" MyApp.dmg
+
+# .. Useful stuff ..............................................................
+
+application = defines.get("app", "OpenRefine.app")  # noqa: F821
+appname = os.path.basename(application)
+
+
+def icon_from_app(app_path):
+    plist_path = os.path.join(app_path, "Contents", "Info.plist")
+    with open(plist_path, "rb") as f:
+        plist = plistlib.load(f)
+    icon_name = plist["CFBundleIconFile"]
+    icon_root, icon_ext = os.path.splitext(icon_name)
+    if not icon_ext:
+        icon_ext = ".icns"
+    icon_name = icon_root + icon_ext
+    return os.path.join(app_path, "Contents", "Resources", icon_name)
+
+
+# .. Basics ....................................................................
+
+# Uncomment to override the output filename
+# filename = 'test.dmg'
+
+# Uncomment to override the output volume name
+# volume_name = 'Test'
+
+# Volume format (see hdiutil create -help)
+format = defines.get("format", "UDBZ")  # noqa: F821
+
+# Compression level (if relevant)
+compression_level = 9
+
+# Volume size
+size = defines.get("size", None)  # noqa: F821
+
+# Files to include
+files = [application]
+
+# Symlinks to create
+symlinks = {"Applications": "/Applications"}
+
+# Files to hide
+# hide = [ 'Secret.data' ]
+
+# Files to hide the extension of
+# hide_extension = [ 'README.rst' ]
+
+# Volume icon
+#
+# You can either define icon, in which case that icon file will be copied to the
+# image, *or* you can define badge_icon, in which case the icon file you specify
+# will be used to badge the system's Removable Disk icon. Badge icons require
+# pyobjc-framework-Quartz.
+#
+# icon = '/path/to/icon.icns'
+badge_icon = icon_from_app(application)
+
+# Where to put the icons
+icon_locations = {appname: (140, 120), "Applications": (500, 120)}
+
+# .. Window configuration ......................................................
+
+# Background
+#
+# This is a STRING containing any of the following:
+#
+#    #3344ff          - web-style RGB color
+#    #34f             - web-style RGB color, short form (#34f == #3344ff)
+#    rgb(1,0,0)       - RGB color, each value is between 0 and 1
+#    hsl(120,1,.5)    - HSL (hue saturation lightness) color
+#    hwb(300,0,0)     - HWB (hue whiteness blackness) color
+#    cmyk(0,1,0,0)    - CMYK color
+#    goldenrod        - X11/SVG named color
+#    builtin-arrow    - A simple built-in background with a blue arrow
+#    /foo/bar/baz.png - The path to an image file
+#
+# The hue component in hsl() and hwb() may include a unit; it defaults to
+# degrees ('deg'), but also supports radians ('rad') and gradians ('grad'
+# or 'gon').
+#
+# Other color components may be expressed either in the range 0 to 1, or
+# as percentages (e.g. 60% is equivalent to 0.6).
+background = "builtin-arrow"
+
+show_status_bar = False
+show_tab_view = False
+show_toolbar = False
+show_pathbar = False
+show_sidebar = False
+sidebar_width = 180
+
+# Window position in ((x, y), (w, h)) format
+window_rect = ((100, 100), (640, 280))
+
+# Select the default view; must be one of
+#
+#    'icon-view'
+#    'list-view'
+#    'column-view'
+#    'coverflow'
+#
+default_view = "icon-view"
+
+# General view configuration
+show_icon_preview = False
+
+# Set these to True to force inclusion of icon/list view settings (otherwise
+# we only include settings for the default view)
+include_icon_view_settings = "auto"
+include_list_view_settings = "auto"
+
+# .. Icon view configuration ...................................................
+
+arrange_by = None
+grid_offset = (0, 0)
+grid_spacing = 100
+scroll_position = (0, 0)
+label_pos = "bottom"  # or 'right'
+text_size = 16
+icon_size = 128
+
+# .. List view configuration ...................................................
+
+# Column names are as follows:
+#
+#   name
+#   date-modified
+#   date-created
+#   date-added
+#   date-last-opened
+#   size
+#   kind
+#   label
+#   version
+#   comments
+#
+list_icon_size = 16
+list_text_size = 12
+list_scroll_position = (0, 0)
+list_sort_by = "name"
+list_use_relative_dates = True
+list_calculate_all_sizes = (False,)
+list_columns = ("name", "date-modified", "size", "kind", "date-added")
+list_column_widths = {
+    "name": 300,
+    "date-modified": 181,
+    "date-created": 181,
+    "date-added": 181,
+    "date-last-opened": 181,
+    "size": 97,
+    "kind": 115,
+    "label": 100,
+    "version": 75,
+    "comments": 300,
+}
+list_column_sort_directions = {
+    "name": "ascending",
+    "date-modified": "descending",
+    "date-created": "descending",
+    "date-added": "descending",
+    "date-last-opened": "descending",
+    "size": "descending",
+    "kind": "ascending",
+    "label": "ascending",
+    "version": "ascending",
+    "comments": "ascending",
+}

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -360,13 +360,14 @@
                 </exec>
 
                 <!-- Create DMG (Mac OS X) -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="hdiutil">
-                    <arg value="create"/>
-                    <arg value="-noanyowners"/>
-                    <arg value="-imagekey"/>
-                    <arg value="zlib-level=9"/>
-                    <arg value="-srcfolder"/>
-                    <arg value="${mac.build.directory}"/>
+                <exec dir="${project.build.directory}" os="Mac OS X" executable="python3">
+                    <arg value="-m"/>
+                    <arg value="dmgbuild"/>
+                    <arg value="-s"/>
+                    <arg value="../dmg_settings.py"/>
+                    <arg value="-D"/>
+                    <arg value="app=${mac.build.directory}/OpenRefine.app"/>
+                    <arg value="OpenRefine"/>
                     <arg value="${mac.dmg.path}"/>
                 </exec>
 


### PR DESCRIPTION
Fixes #5205

Changes proposed in this pull request:
- Use [dmgbuild](https://github.com/dmgbuild/dmgbuild) to create macOS dmg file with a shortcut to `/Applications` and a simple arrow background (can be changed to something else if you design a better background image).

<img width="752" alt="image" src="https://user-images.githubusercontent.com/1556054/206375047-21b789ff-fbb8-458e-8337-9f9706af5725.png">

