### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 

### DIFF
--- a/extensions/database/pom.xml
+++ b/extensions/database/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.5.0</version>
+      <version>42.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.5.0
- [CVE-2022-41946](https://www.oscs1024.com/hd/CVE-2022-41946)


### What did I do？
Upgrade org.postgresql:postgresql from 42.5.0 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS