### PR TITLE
header: move "OpenRefine" header text from image

### DIFF
--- a/main/webapp/modules/core/about.html
+++ b/main/webapp/modules/core/about.html
@@ -59,7 +59,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   </head>
   <body>
     <div id="header">
-      <a id="app-home-button" href="./"><img alt="OpenRefine" src="images/logo-openrefine-550.png" height="29" /></a>
+      <a id="app-home-button" href="./">
+        <img aria-hidden="true" src="images/logo-gem-126.png" width="30" />
+        <h1>OpenRefine</h1>
+      </a>
     </div>
 
     <div id="body-info">

--- a/main/webapp/modules/core/about.js
+++ b/main/webapp/modules/core/about.js
@@ -4,6 +4,5 @@ $("#contributors").text($.i18n('core-about/contributors'));
 $("#definition").text($.i18n('core-about/definition'));
 $("#history-openrefine").html($.i18n('core-about/history' ,'http://www.metaweb.com/' ,'Metaweb Technologies,Inc.', 'http://www.google.com/','Google' ));
 $("#thanks").text($.i18n('core-about/thanks'));
-
-
+$('#app-home-button').attr('title', $.i18n('core-index/navigate-home'));
  

--- a/main/webapp/modules/core/error.vt
+++ b/main/webapp/modules/core/error.vt
@@ -42,7 +42,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   </head>
   <body>
     <div id="header">
-      <a id="app-home-button" href="/"><img alt="OpenRefine" src="/images/logo-openrefine-550.png" height="29" /></a>
+      <a id="app-home-button" href="./" title="Navigate to the home screen">
+        <img aria-hidden="true" src="images/logo-gem-126.png" width="30" />
+        <h1>OpenRefine</h1>
+      </a>
     </div>
     <div id="body-info">
       <h1>Something went wrong!</h1>

--- a/main/webapp/modules/core/index.vt
+++ b/main/webapp/modules/core/index.vt
@@ -44,7 +44,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </head>
 <body>
   <div id="header">
-    <img alt="OpenRefine" src="images/logo-openrefine-550.png" height="29" />
+    <img alt="OpenRefine logo" src="images/logo-gem-126.png" width="30" />
+    <h1>OpenRefine</h1>
     <span id="slogan"></span>
   </div>
   

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -45,6 +45,7 @@
     "core-index/customMetadata": "Custom metadata (JSON)",
     "core-index/id": "Project ID",
     "core-index/importOptionMetadata": "Import option metadata (JSON)",
+    "core-index/navigate-home": "Navigate to the home screen",
     "core-index-create/create-proj": "Create project",
     "core-index-create/starting": "Starting",
     "core-index-create/done": "Done.",

--- a/main/webapp/modules/core/preferences.vt
+++ b/main/webapp/modules/core/preferences.vt
@@ -43,7 +43,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 </head>
 <body>
   <div id="header">
-    <a id="app-home-button" href="./"><img alt="OpenRefine" src="images/logo-openrefine-550.png" height="29" /></a>
+    <a id="app-home-button" href="./">
+      <img aria-hidden="true" src="images/logo-gem-126.png" width="30" />
+      <h1>OpenRefine</h1>
+    </a>
   </div>
 
   <div id="body-info">

--- a/main/webapp/modules/core/project.vt
+++ b/main/webapp/modules/core/project.vt
@@ -45,7 +45,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   </head>
   <body>
     <div id="header">
-      <a id="app-home-button" href="./"><img alt="OpenRefine" src="images/logo-openrefine-550.png" height="29" /></a>
+      <a id="app-home-button" href="./">
+        <img aria-hidden="true" src="images/logo-gem-126.png" width="30" />
+        <h1>OpenRefine</h1>
+      </a>
       <div id="project-title">
         <span id="project-name-button" class="app-path-section"></span>
         <a id="project-permalink-button" href="javascript:{}" class="secondary"></a>

--- a/main/webapp/modules/core/scripts/preferences.js
+++ b/main/webapp/modules/core/scripts/preferences.js
@@ -118,6 +118,7 @@ function populatePreferences(prefs) {
 
   $("#or-proj-starting").text($.i18n('core-project/starting')+"...");
   $('<h1>').text($.i18n('core-index/preferences')).appendTo(body);
+  $('#app-home-button').attr('title', $.i18n('core-index/navigate-home'));
 
   var table = $('<table>')
   .addClass("list-table")

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -113,8 +113,6 @@ function resizeAll() {
 function initializeUI(uiState) {
   $("#loading-message").hide();
   $("#notification-container").hide();
-  $("#project-title").show();
-  $("#project-controls").show();
   $("#body").show();
 
   $("#or-proj-open").text($.i18n('core-project/open')+"...");
@@ -131,6 +129,8 @@ function initializeUI(uiState) {
   $('#project-permalink-button').on('mouseenter',function() {
     this.href = Refine.getPermanentLink();
   });
+
+  $('#app-home-button').attr('title', $.i18n('core-index/navigate-home'));
 
   Refine.setTitle();
 

--- a/main/webapp/modules/core/styles/common.css
+++ b/main/webapp/modules/core/styles/common.css
@@ -277,15 +277,30 @@ a img {
 
 #header {
   height: 40px;
-  margin: 10px;
-  position: relative;
-  overflow: hidden;
+  padding: 10px;
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+#header h1 {
+  margin: 0 .2em;
+  color: var(--text-primary);
+  font-family: serif;
+  font-size: 1.8em; /* to avoid being styled by pure.css from the database extension */
+}
+
+#header img {
+  height: 30px;
 }
 
 #app-home-button {
-  position: absolute;
-  top: 0;
-  left: 0;
+  display: flex;
+  align-items: center;
+}
+
+#app-home-button:hover {
+  text-decoration: none;
 }
 
 #body-info {

--- a/main/webapp/modules/core/styles/index.css
+++ b/main/webapp/modules/core/styles/index.css
@@ -40,7 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 }
 
 #slogan {
-  margin: 0 1em;
+  margin-left: 1em;
   font-style: italic;
   font-size: 110%;
   color: var(--text-tertiary);

--- a/main/webapp/modules/core/styles/project.css
+++ b/main/webapp/modules/core/styles/project.css
@@ -35,22 +35,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   display: none;
 }
 
-#project-title, #project-controls {
-  position: absolute;
-  top: 0;
-  display: none;
-}
-
 #project-title {
-  left: 140px;
-  height: 40px;
-  padding: 4px 0 0 0;
   font-size: 1.6em;
 }
 
 #project-controls {
-  right: 0;
-  height: 40px;
+  margin-left: auto;
   font-size: 1.3em;
 }
 


### PR DESCRIPTION
So that the background and foreground text can be styled.

side effects:
 - minor style changes (acceptable in my opinion)
 - accessibility improvements
 - dropped some absolute positioning
 - fixed a bug causing the slogan to shift from the left during page load

Part of #3017 