### PR TITLE
Restore recon stats rendering in 4.0

### DIFF
--- a/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/clear_reconciliation_data.spec.js
+++ b/main/tests/cypress/cypress/integration/project/grid/column/reconcile/actions/clear_reconciliation_data.spec.js
@@ -19,9 +19,9 @@ describe('Clear reconciliation data', () => {
         cy.get('table.data-table').should('not.to.contain', 'Choose new match');
         cy.get('table.data-table').should('not.to.contain', 'Create new item');
 
-        // the green bar for matched item should be invisible
+        // the green bar for matched item should not be there anymore
         cy.get(
             'table.data-table thead div.column-header-recon-stats-matched'
-        ).should('not.be.visible');
+        ).should('not.exist');
     });
 });

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -165,8 +165,9 @@ function initializeUI(uiState) {
 
   $(window).on("resize", resizeAll);
 
-  // this is needed even if there are no facets, to fetch the column stats
-  Refine.update({ engineChanged: true });
+  if (uiState.facets) {
+    Refine.update({ engineChanged: true });
+  }
 }
 
 Refine._showHideLeftPanel = function() {

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -165,9 +165,8 @@ function initializeUI(uiState) {
 
   $(window).on("resize", resizeAll);
 
-  if (uiState.facets) {
-    Refine.update({ engineChanged: true });
-  }
+  // this is needed even if there are no facets, to fetch the column stats
+  Refine.update({ engineChanged: true });
 }
 
 Refine._showHideLeftPanel = function() {

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -145,6 +145,8 @@ BrowsingEngine.prototype._initializeUI = function() {
     self._elmts.aggregationLimitInput.attr('disabled', !self._aggregationLimitEnabled);
     self.update();
   });
+
+  self.update();
 };
 
 BrowsingEngine.prototype._updateFacetOrder = function() {
@@ -292,7 +294,9 @@ BrowsingEngine.prototype.update = function(onDone) {
 
       if (theProject.columnStats !== data.columnStats) {
         theProject.columnStats = data.columnStats;
-        ui.dataTableView.updateTableHeader();
+        if (ui.dataTableView) {
+          ui.dataTableView.updateColumnStats();
+        }
       }
 
       self._elmts.indicator.css("display", "none");

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -260,11 +260,14 @@ BrowsingEngine.prototype.update = function(onDone) {
   var self = this;
 
   this._elmts.aggregationLimitLabel.text(this._mode == 'row-based' ? 'Row limit: ' : 'Record limit: '); // TODO i18n
-  this._elmts.help.hide();
 
-  this._elmts.header.show();
-  this._elmts.controls.css("visibility", "hidden");
-  this._elmts.indicator.css("display", "block");
+  if (self._facets.length > 0) {
+    // set up waiting UI
+    this._elmts.help.hide();
+    this._elmts.header.show();
+    this._elmts.controls.css("visibility", "hidden");
+    this._elmts.indicator.css("display", "block");
+  }
 
   $.post(
     "command/core/compute-facets?" + $.param({ project: theProject.id }),
@@ -285,6 +288,11 @@ BrowsingEngine.prototype.update = function(onDone) {
 
       for (var i = 0; i < facetData.length; i++) {
         self._facets[i].facet.updateState(facetData[i]);
+      }
+
+      if (theProject.columnStats !== data.columnStats) {
+        theProject.columnStats = data.columnStats;
+        ui.dataTableView.updateTableHeader();
       }
 
       self._elmts.indicator.css("display", "none");

--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -70,12 +70,12 @@ DataTableColumnHeaderUI.prototype._render = function() {
     self._createMenuForColumnHeader(this);
   });
 
-  if ("reconStats" in this._column) {
-    var stats = this._column.reconStats;
-    if (stats.nonBlanks > 0) {
-      var newPercent = Math.ceil(100 * stats.newTopics / stats.nonBlanks);
-      var matchPercent = Math.ceil(100 * stats.matchedTopics / stats.nonBlanks);
-      var unreconciledPercent = Math.ceil(100 * (stats.nonBlanks - stats.matchedTopics - stats.newTopics) / stats.nonBlanks);
+  if (theProject.columnStats && theProject.columnStats.length > self._columnIndex) {
+    var stats = theProject.columnStats[self._columnIndex];
+    if (stats.reconciled > 0) {
+      var newPercent = Math.ceil(100 * stats['new'] / stats.nonBlanks);
+      var matchPercent = Math.ceil(100 * stats.matched / stats.nonBlanks);
+      var unreconciledPercent = Math.ceil(100 * (stats.nonBlanks - stats.matched - stats['new']) / stats.nonBlanks);
       var title = $.i18n('core-views/recon-stats', matchPercent, newPercent, unreconciledPercent);
 
       var whole = $('<div>')
@@ -85,12 +85,12 @@ DataTableColumnHeaderUI.prototype._render = function() {
 
       $('<div>')
       .addClass("column-header-recon-stats-blanks")
-      .width(Math.round((stats.newTopics + stats.matchedTopics) * 100 / stats.nonBlanks) + "%")
+      .width(Math.round((stats['new'] + stats.matched) * 100 / stats.nonBlanks) + "%")
       .appendTo(whole);
 
       $('<div>')
       .addClass("column-header-recon-stats-matched")
-      .width(Math.round(stats.matchedTopics * 100 / stats.nonBlanks) + "%")
+      .width(Math.round(stats.matched * 100 / stats.nonBlanks) + "%")
       .appendTo(whole);
     }
   }

--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -70,6 +70,13 @@ DataTableColumnHeaderUI.prototype._render = function() {
     self._createMenuForColumnHeader(this);
   });
 
+  self.updateColumnStats();
+};
+
+DataTableColumnHeaderUI.prototype.updateColumnStats = function() {
+  var self = this;
+  var container = $(this._td).find('.recon-stats-container');
+  container.empty();
   if (theProject.columnStats && theProject.columnStats.length > self._columnIndex) {
     var stats = theProject.columnStats[self._columnIndex];
     if (stats.reconciled > 0) {
@@ -81,7 +88,7 @@ DataTableColumnHeaderUI.prototype._render = function() {
       var whole = $('<div>')
       .addClass("column-header-recon-stats-bar")
       .attr("title", title)
-      .appendTo(elmts.reconStatsContainer.show());
+      .appendTo(container);
 
       $('<div>')
       .addClass("column-header-recon-stats-blanks")
@@ -94,7 +101,8 @@ DataTableColumnHeaderUI.prototype._render = function() {
       .appendTo(whole);
     }
   }
-};
+
+}
 
 DataTableColumnHeaderUI.prototype._createMenuForColumnHeader = function(elmt) {
   var self = this;

--- a/main/webapp/modules/core/scripts/views/data-table/column-header.html
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header.html
@@ -1,2 +1,2 @@
 <div class="column-header-title"><a class="column-header-menu" bind="dropdownMenu"></a><span class="column-header-name" bind="nameContainer"></span></div>
-<div style="display:none;" bind="reconStatsContainer"></div>
+<div bind="reconStatsContainer" class="recon-stats-container"></div>

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -155,11 +155,11 @@ DataTableView.prototype.render = function() {
   elmts.dataTableContainer[0].scrollLeft = scrollLeft;
 };
 
-DataTableView.prototype.updateTableHeader = function() {
+DataTableView.prototype.updateColumnStats = function() {
   var self = this;
-  var tableHeader = self._div.find(".data-table-header")
-  tableHeader.empty();
-  self._renderTableHeader(tableHeader);
+  for (let columnHeaderUI of self._columnHeaderUIs) {
+    columnHeaderUI.updateColumnStats();
+  }
 }
 
 DataTableView.prototype._renderSortingControls = function(sortingControls) {
@@ -439,7 +439,6 @@ DataTableView.prototype._renderTableHeader = function(tableHeader) {
     createColumnHeader(columns[i], i);
   }
 }
-
 
 DataTableView.prototype._showRows = function(paginationOptions, onDone) {
   var self = this;

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -155,6 +155,13 @@ DataTableView.prototype.render = function() {
   elmts.dataTableContainer[0].scrollLeft = scrollLeft;
 };
 
+DataTableView.prototype.updateTableHeader = function() {
+  var self = this;
+  var tableHeader = self._div.find(".data-table-header")
+  tableHeader.empty();
+  self._renderTableHeader(tableHeader);
+}
+
 DataTableView.prototype._renderSortingControls = function(sortingControls) {
   var self = this;
 
@@ -298,37 +305,7 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
    *------------------------------------------------------------
    */
 
-  var trHead = tableHeader.insertRow(tableHeader.rows.length);
-  DOM.bind(
-      $(trHead.appendChild(document.createElement("th")))
-      .attr("colspan", "3")
-      .addClass("column-header")
-      .html(
-        '<div class="column-header-title">' +
-          '<a class="column-header-menu" bind="dropdownMenu"></a><span class="column-header-name">'+$.i18n('core-views/all')+'</span>' +
-        '</div>'
-      )
-  ).dropdownMenu.on('click',function() {
-    self._createMenuForAllColumns(this);
-  });
-  this._columnHeaderUIs = [];
-  var createColumnHeader = function(column, index) {
-    var th = trHead.appendChild(document.createElement("th"));
-    $(th).addClass("column-header").attr('title', column.name);
-    if (self._collapsedColumnNames.hasOwnProperty(column.name)) {
-      $(th).html("&nbsp;").on('click',function(evt) {
-        delete self._collapsedColumnNames[column.name];
-        self.render();
-      });
-    } else {
-      var columnHeaderUI = new DataTableColumnHeaderUI(self, column, index, th);
-      self._columnHeaderUIs.push(columnHeaderUI);
-    }
-  };
-
-  for (var i = 0; i < columns.length; i++) {
-    createColumnHeader(columns[i], i);
-  }
+  self._renderTableHeader(tableHeader);
 
   /*------------------------------------------------------------
    *  Data Cells
@@ -425,6 +402,44 @@ DataTableView.prototype._renderDataTables = function(table, tableHeader) {
     renderRow(tr, r, row, even);
   }
 };
+
+DataTableView.prototype._renderTableHeader = function(tableHeader) {
+  var self = this;
+  var columns = theProject.columnModel.columns;
+  var trHead = document.createElement('tr');
+  tableHeader.append(trHead);
+  DOM.bind(
+      $(trHead.appendChild(document.createElement("th")))
+      .attr("colspan", "3")
+      .addClass("column-header")
+      .html(
+        '<div class="column-header-title">' +
+          '<a class="column-header-menu" bind="dropdownMenu"></a><span class="column-header-name">'+$.i18n('core-views/all')+'</span>' +
+        '</div>'
+      )
+  ).dropdownMenu.on('click',function() {
+    self._createMenuForAllColumns(this);
+  });
+  this._columnHeaderUIs = [];
+  var createColumnHeader = function(column, index) {
+    var th = trHead.appendChild(document.createElement("th"));
+    $(th).addClass("column-header").attr('title', column.name);
+    if (self._collapsedColumnNames.hasOwnProperty(column.name)) {
+      $(th).html("&nbsp;").on('click',function(evt) {
+        delete self._collapsedColumnNames[column.name];
+        self.render();
+      });
+    } else {
+      var columnHeaderUI = new DataTableColumnHeaderUI(self, column, index, th);
+      self._columnHeaderUIs.push(columnHeaderUI);
+    }
+  };
+
+  for (var i = 0; i < columns.length; i++) {
+    createColumnHeader(columns[i], i);
+  }
+}
+
 
 DataTableView.prototype._showRows = function(paginationOptions, onDone) {
   var self = this;


### PR DESCRIPTION
Fixes #4350.

This renders recon stats in column headers, restoring the existing behaviour. The difference is that those recon statistics are not stored statically in column metadata anymore, but are computed dynamically like facet statistics. For efficiency reasons, this is done at the same time (in the same HTTP request) as facet statistics, so that the same pass on the dataset can be used to gather the statistics.

It would be relatively straightforward to extend this to display more than reconciliation statistics, such as datatypes, but I am leaving this as is for now because this requires a larger design effort.

I am anticipating that some Cypress tests might not work as expected, so marking this as draft.