### PR TITLE
CSS Migration Fix

### DIFF
--- a/main/webapp/modules/core/styles/index.css
+++ b/main/webapp/modules/core/styles/index.css
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   margin: 0 1em;
   font-style: italic;
   font-size: 110%;
-  color: var(--text-tertiary);
+  color: var(--text-quarternary);
 }
 
 #left-panel-body {

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -85,7 +85,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   padding: 0 0 13px 0;
   background: var(--fill-primary);
   border: 1px solid var(--chrome-primary);
-  color: var(--text-tertiary);
+  color: var(--text-quarternary);
   border-radius: var(--rounded-corners-radius);
 }
 

--- a/main/webapp/modules/core/styles/theme.css
+++ b/main/webapp/modules/core/styles/theme.css
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   --text-primary: black;
   --text-secondary: #222;
   --text-tertiary: #777;
+  --text-quarternary: #444;
   --link-primary: #11c;
   --link-secondary: #4272db;
   --chrome-primary: #bcf;


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes a regression introduced by #5525, where the slogan text and the browsing panel help text (using facets/filters window) both look lighter.
- Added the CSS variable `text-quarternary` that replaces the LESS variable `@near_black` and its usages.

Slogan before:
![Slogan before](https://user-images.githubusercontent.com/42903164/211140888-b578b951-c341-40fd-aa1d-79b166b8ff12.png)

Slogan after:
![Slogan After](https://user-images.githubusercontent.com/42903164/211140890-56363cbf-53e4-48c6-906e-234db15a2a47.png)

Browsing panel before:
![Browsing panel help before](https://user-images.githubusercontent.com/42903164/211140897-d8b2dca0-4422-479c-97df-9c7566fc5de6.png)

Browsing panel after:
![Browsing panel help After](https://user-images.githubusercontent.com/42903164/211140902-368a8506-b8de-4cb9-8e7d-08a4600cdf3c.png)
