### PR TITLE
Improve error handling in Apply operations dialog

### DIFF
--- a/main/src/main/java/org/openrefine/commands/history/ApplyOperationsCommand.java
+++ b/main/src/main/java/org/openrefine/commands/history/ApplyOperationsCommand.java
@@ -34,17 +34,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.openrefine.commands.history;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.openrefine.commands.Command;
+import org.openrefine.history.HistoryEntry;
 import org.openrefine.model.Project;
+import org.openrefine.model.changes.Change;
 import org.openrefine.operations.Operation;
 import org.openrefine.operations.UnknownOperation;
 import org.openrefine.process.Process;
+import org.openrefine.process.QuickHistoryEntryProcess;
 import org.openrefine.util.ParsingUtilities;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -62,37 +70,101 @@ public class ApplyOperationsCommand extends Command {
 
         Project project = getProject(request);
         String jsonString = request.getParameter("operations");
+        List<OperationApplicationResult> results = new ArrayList<>();
         try {
+
             ArrayNode a = ParsingUtilities.evaluateJsonStringToArrayNode(jsonString);
             int count = a.size();
             for (int i = 0; i < count; i++) {
                 if (a.get(i) instanceof ObjectNode) {
                     ObjectNode obj = (ObjectNode) a.get(i);
 
-                    reconstructOperation(project, obj);
+                    OperationApplicationResult applicationResult = applyOperation(project, obj);
+                    results.add(applicationResult);
+                    if ("failed".equals(applicationResult.status)) {
+                        respondJSON(response, new JsonResponse("error", results));
+                    }
                 }
             }
 
+            String code = "ok";
             if (project.getProcessManager().hasPending()) {
-                respond(response, "{ \"code\" : \"pending\" }");
-            } else {
-                respond(response, "{ \"code\" : \"ok\" }");
+                code = "pending";
             }
+            respondJSON(response, new JsonResponse(code, results));
         } catch (IOException e) {
             respondException(response, e);
         }
     }
 
-    protected void reconstructOperation(Project project, ObjectNode obj) throws IOException {
-        Operation operation = ParsingUtilities.mapper.convertValue(obj, Operation.class);
+    protected OperationApplicationResult applyOperation(Project project, JsonNode operationJson) {
+        Operation operation = null;
+        try {
+            operation = ParsingUtilities.mapper.convertValue(operationJson, Operation.class);
+        } catch (IllegalArgumentException e) {
+            return new OperationApplicationResult(e.getMessage());
+        }
+
         if (operation != null && !(operation instanceof UnknownOperation)) {
             try {
                 Process process = operation.createProcess(project);
-
-                project.getProcessManager().queueProcess(process);
+                OperationApplicationResult applicationResult = null;
+                if (process.isImmediate() && !project.getProcessManager().hasPending()) {
+                    HistoryEntry historyEntry = process.performImmediate();
+                    applicationResult = new OperationApplicationResult(historyEntry);
+                } else {
+                    project.getProcessManager().queueProcess(process);
+                    applicationResult = new OperationApplicationResult();
+                }
+                return applicationResult;
             } catch (Exception e) {
-                e.printStackTrace();
+                // TODO make catch block narrower, only catching certain expected exceptions
+                // such as DoesNotApplyException. This requires tightening the exceptions in the Process
+                // interface too.
+                return new OperationApplicationResult(e.getMessage());
             }
+        } else {
+            return new OperationApplicationResult("Operation could not be parsed");
+        }
+    }
+
+    protected static class OperationApplicationResult {
+
+        @JsonProperty("status")
+        final String status; // whether the operation is "applied", "pending" or "failed"
+        @JsonProperty("historyEntry")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        HistoryEntry historyEntry = null; // if the operation is "applied", the corresponding history entry
+        @JsonProperty("errorMessage")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String errorMessage = null; // any error message if applying the operation failed
+        // TODO let operations expose structured information when they fail
+
+        public OperationApplicationResult(HistoryEntry historyEntry) {
+            this.status = "applied";
+            this.historyEntry = historyEntry;
+        }
+
+        public OperationApplicationResult() {
+            this.status = "pending";
+        }
+
+        public OperationApplicationResult(String errorMessage) {
+            this.status = "failed";
+            this.errorMessage = errorMessage;
+        }
+    }
+
+    protected static class JsonResponse {
+
+        @JsonProperty("code")
+        String code; // whether all operation applications were successful
+        @JsonProperty("results")
+        List<OperationApplicationResult> results; // list of individual results for each operation
+
+        public JsonResponse(String code, List<OperationApplicationResult> results) {
+            this.code = code;
+            this.results = results;
         }
     }
 }

--- a/main/src/test/java/org/openrefine/commands/history/ApplyOperationsCommandTests.java
+++ b/main/src/test/java/org/openrefine/commands/history/ApplyOperationsCommandTests.java
@@ -2,23 +2,166 @@
 package org.openrefine.commands.history;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import javax.servlet.ServletException;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.openrefine.ProjectManager;
+import org.openrefine.commands.CSRFTokenFactory;
+import org.openrefine.commands.Command;
 import org.openrefine.commands.CommandTestBase;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
+import org.openrefine.expr.MetaParser;
+import org.openrefine.grel.Parser;
+import org.openrefine.model.Project;
+import org.openrefine.operations.OperationRegistry;
+import org.openrefine.operations.cell.MassEditOperation;
+import org.openrefine.util.ParsingUtilities;
+import org.openrefine.util.TestUtils;
+import org.testng.annotations.*;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 
 public class ApplyOperationsCommandTests extends CommandTestBase {
 
+    Project project;
+
     @BeforeMethod
-    public void setUpCommand() {
+    public void setUpDependencies() {
         command = new ApplyOperationsCommand();
+        OperationRegistry.registerOperation("core", "mass-edit", MassEditOperation.class);
+        project = createProject("test project",
+                new String[] { "foo", "bar" },
+                new Serializable[][] {
+                        { "hello", "world" },
+                        { null, 123 },
+                });
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void tearDownDependencies() {
+        project = null;
     }
 
     @Test
     public void testCSRFProtection() throws ServletException, IOException {
         command.doPost(request, response);
         assertCSRFCheckFailed();
+    }
+
+    @Test
+    public void testEmptyOperations() throws ServletException, IOException {
+        String operationsJson = "[]";
+        when(request.getParameter("operations")).thenReturn(operationsJson);
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("project")).thenReturn(Long.toString(project.getId()));
+
+        command.doPost(request, response);
+
+        String jsonResponse = writer.toString();
+
+        String expectedResponse = "{\"code\":\"ok\", \"results\":[] }";
+        TestUtils.assertEqualsAsJson(jsonResponse, expectedResponse);
+    }
+
+    @Test
+    public void testInvalidJson() throws ServletException, IOException {
+        String operationsJson = "[invalid_json";
+        when(request.getParameter("operations")).thenReturn(operationsJson);
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("project")).thenReturn(Long.toString(project.getId()));
+
+        command.doPost(request, response);
+
+        ObjectNode jsonResponse = (ObjectNode) ParsingUtilities.mapper.readTree(writer.toString());
+        // we cannot directly check the JSON for equality with a known object because it contains a timestamp and unique
+        // id
+        assertEquals(jsonResponse.get("code").asText(), "error");
+    }
+
+    @Test
+    public void testSuccessfullyApplyOneOperation() throws ServletException, IOException {
+        String operationsJson = "[" +
+                "  {\n" +
+                "    \"op\": \"core/mass-edit\",\n" +
+                "    \"engineConfig\": {\n" +
+                "      \"facets\": [],\n" +
+                "      \"mode\": \"row-based\",\n" +
+                "      \"aggregationLimit\": 1000\n" +
+                "    },\n" +
+                "    \"columnName\": \"bar\",\n" +
+                "    \"expression\": \"value\",\n" +
+                "    \"edits\": [\n" +
+                "      {\n" +
+                "        \"from\": [\n" +
+                "          \"world\"\n" +
+                "        ],\n" +
+                "        \"fromBlank\": false,\n" +
+                "        \"fromError\": false,\n" +
+                "        \"to\": \"monde\"\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"description\": \"Mass edit cells in column bar\"\n" +
+                "  }" +
+                "]";
+        when(request.getParameter("operations")).thenReturn(operationsJson);
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("project")).thenReturn(Long.toString(project.getId()));
+
+        command.doPost(request, response);
+
+        ObjectNode jsonResponse = (ObjectNode) ParsingUtilities.mapper.readTree(writer.toString());
+        // we cannot directly check the JSON for equality with a known object because it contains a timestamp and unique
+        // id
+        assertEquals(jsonResponse.get("code").asText(), "ok");
+        assertEquals(((ArrayNode) jsonResponse.get("results")).size(), 1);
+        assertEquals(((ArrayNode) jsonResponse.get("results")).get(0).get("status").asText(), "applied");
+        assertEquals(((ArrayNode) jsonResponse.get("results")).get(0).get("historyEntry").get("description").asText(),
+                "Mass edit cells in column bar");
+    }
+
+    @Test
+    public void testMismatchingOperation() throws ServletException, IOException {
+        String operationsJson = "[" +
+                "  {\n" +
+                "    \"op\": \"core/mass-edit\",\n" +
+                "    \"engineConfig\": {\n" +
+                "      \"facets\": [],\n" +
+                "      \"mode\": \"row-based\",\n" +
+                "      \"aggregationLimit\": 1000\n" +
+                "    },\n" +
+                "    \"columnName\": \"non_existent_column\",\n" +
+                "    \"expression\": \"value\",\n" +
+                "    \"edits\": [\n" +
+                "      {\n" +
+                "        \"from\": [\n" +
+                "          \"world\"\n" +
+                "        ],\n" +
+                "        \"fromBlank\": false,\n" +
+                "        \"fromError\": false,\n" +
+                "        \"to\": \"monde\"\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"description\": \"Mass edit cells in column non_existent_column\"\n" +
+                "  }" +
+                "]";
+        when(request.getParameter("operations")).thenReturn(operationsJson);
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("project")).thenReturn(Long.toString(project.getId()));
+
+        command.doPost(request, response);
+
+        ObjectNode jsonResponse = (ObjectNode) ParsingUtilities.mapper.readTree(writer.toString());
+        // we cannot directly check the JSON for equality with a known object because it contains a timestamp and unique
+        // id
+        assertEquals(jsonResponse.get("code").asText(), "error");
+        assertEquals(((ArrayNode) jsonResponse.get("results")).size(), 1);
+        assertEquals(((ArrayNode) jsonResponse.get("results")).get(0).get("status").asText(), "failed");
+        assertEquals(((ArrayNode) jsonResponse.get("results")).get(0).get("errorMessage").asText(),
+                "Column 'non_existent_column' does not exist");
     }
 }

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -403,6 +403,7 @@
     "core-project/extract-save": "Extract and save parts of your operation history as JSON that you can apply to this or other projects in the future.",
     "core-project/apply-operation": "Apply Operation History",
     "core-project/paste-json": "Paste an extracted JSON history of operations to perform:",
+    "core-project/some-operations-applied-but-error": "$1 {{plural:$1|operation|operations}} ran successfully but an error was encountered in the next one: $2. The following operations were not executed.",
     "core-project/percent-complete": "$1% complete",
     "core-project/other-processes": "($1 other pending {{plural:$1|process|processes}})",
     "core-project/cancel-all": "{{plural:$1|Cancel|Cancel All}}",

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -325,6 +325,25 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
               // Something might have already been done and so it's good to update
               Refine.update({ everythingChanged: true });
             }
+            // show pill notification for the last operation to have been successfully applied
+            var latestHistoryEntry = null;
+            for (let operationResult of o.results) {
+              if (operationResult.historyEntry) {
+                latestHistoryEntry = operationResult.historyEntry;
+              }
+            }
+            if (latestHistoryEntry) {
+              ui.processPanel.showUndo(latestHistoryEntry);
+            }
+          },
+          onError: function(o) {
+            var operationsApplied = o.results.length - 1;
+            var errorMessage = o.results[o.results.length - 1].errorMessage;
+            if (operationsApplied) {
+                errorMessage = $.i18n('core-project/some-operations-applied-but-error', operationsApplied, errorMessage);
+                Refine.update({ everythingChanged: true });
+            }
+            alert(errorMessage);
           }
         }
     );

--- a/refine-model/src/main/java/org/openrefine/util/ParsingUtilities.java
+++ b/refine-model/src/main/java/org/openrefine/util/ParsingUtilities.java
@@ -284,15 +284,12 @@ public class ParsingUtilities {
         return null;
     }
 
-    public static ArrayNode evaluateJsonStringToArrayNode(String parameter) {
-        try {
-            JsonNode tree = mapper.readTree(parameter);
-            if (tree instanceof ArrayNode) {
-                return (ArrayNode) tree;
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
+    public static ArrayNode evaluateJsonStringToArrayNode(String parameter) throws IOException {
+        JsonNode tree = mapper.readTree(parameter);
+        if (tree instanceof ArrayNode) {
+            return (ArrayNode) tree;
+        } else {
+            throw new IllegalArgumentException("Expected a JSON array");
         }
-        return null;
     }
 }

--- a/refine-workflow/src/test/java/org/openrefine/importers/TsvCsvImporterTests.java
+++ b/refine-workflow/src/test/java/org/openrefine/importers/TsvCsvImporterTests.java
@@ -46,6 +46,8 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+
 public class TsvCsvImporterTests extends ImporterTest {
 
     @BeforeTest
@@ -628,7 +630,7 @@ public class TsvCsvImporterTests extends ImporterTest {
     protected void prepareOptions(
             String sep, int limit, int skip, int ignoreLines,
             int headerLines, boolean guessValueType, boolean ignoreQuotes,
-            String quoteCharacter, String columnNames, boolean multiLine) {
+            String quoteCharacter, String columnNames, boolean multiLine) throws IOException {
 
         options.put("separator", sep);
         options.put("quoteCharacter", quoteCharacter);


### PR DESCRIPTION
This is a first step towards #5539 and #5540 (but does not close either of them).

When an operation cannot be executed because its JSON representation is invalid or it does not apply to the given project, the corresponding error is reported to the user and the following operations are not executed.
Before this PR, errors were reported in the server logs and all operations were attempted even if a previous one failed (see #5540).

This is not meant to be a final UX, I plan to do many other improvements of this dialog. This first behaviour is just to make sure we can reuse the logic behind the dialog to apply operations everywhere else in the tool, for #5539.
