### PR TITLE
Use column-removal operation after joining columns

### DIFF
--- a/main/src/main/java/org/openrefine/commands/column/RemoveColumnCommand.java
+++ b/main/src/main/java/org/openrefine/commands/column/RemoveColumnCommand.java
@@ -34,16 +34,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.openrefine.commands.column;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.openrefine.commands.Command;
 import org.openrefine.model.Project;
 import org.openrefine.operations.Operation;
 import org.openrefine.operations.column.ColumnRemovalOperation;
 import org.openrefine.process.Process;
+import org.openrefine.util.ParsingUtilities;
 
 public class RemoveColumnCommand extends Command {
 
@@ -58,9 +62,11 @@ public class RemoveColumnCommand extends Command {
         try {
             Project project = getProject(request);
 
-            String columnName = request.getParameter("columnName");
+            String columnNames = request.getParameter("columnNames");
 
-            Operation op = new ColumnRemovalOperation(columnName);
+            Operation op = new ColumnRemovalOperation(request.getParameter("columnName"),
+                    ParsingUtilities.mapper.readValue(columnNames, new TypeReference<List<String>>() {
+                    }));
             Process process = op.createProcess(project);
 
             performProcessAndRespond(request, response, project, process);

--- a/main/src/main/java/org/openrefine/commands/column/RemoveColumnCommand.java
+++ b/main/src/main/java/org/openrefine/commands/column/RemoveColumnCommand.java
@@ -65,7 +65,7 @@ public class RemoveColumnCommand extends Command {
             String columnNames = request.getParameter("columnNames");
 
             Operation op = new ColumnRemovalOperation(request.getParameter("columnName"),
-                    ParsingUtilities.mapper.readValue(columnNames, new TypeReference<List<String>>() {
+                    columnNames == null ? null : ParsingUtilities.mapper.readValue(columnNames, new TypeReference<List<String>>() {
                     }));
             Process process = op.createProcess(project);
 

--- a/main/tests/cypress/cypress/integration/project/undo_redo/extract.spec.js
+++ b/main/tests/cypress/cypress/integration/project/undo_redo/extract.spec.js
@@ -1,12 +1,12 @@
 const defaultInducedHistoryJson = [
   {
     op: 'core/column-removal',
-    columnName: 'NDB_No',
+    columnNames: ['NDB_No'],
     description: 'Remove column NDB_No',
   },
   {
     op: 'core/column-removal',
-    columnName: 'Shrt_Desc',
+    columnNames: ['Shrt_Desc'],
     description: 'Remove column Shrt_Desc',
   },
 ]
@@ -69,7 +69,7 @@ describe(__filename, function () {
       [
         {
           op: 'core/column-removal',
-          columnName: 'Shrt_Desc',
+          columnNames: ['Shrt_Desc'],
           description: 'Remove column Shrt_Desc',
         },
       ]
@@ -93,7 +93,7 @@ describe(__filename, function () {
       [
         {
           op: 'core/column-removal',
-          columnName: 'Shrt_Desc',
+          columnNames: ['Shrt_Desc'],
           description: 'Remove column Shrt_Desc',
         },
       ]

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
@@ -413,19 +413,14 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       // function called in a callback
       var deleteColumns = function() {
         if (deleteJoinedColumns) {
-          console.log (theProject);
-          var columnsToKeep = theProject.columnModel.columns
-          .map (function (col) {return col.name;})
-          .filter (function(colName) {
-            // keep the selected column if it contains the result
-            return (
-                (columnsToJoin.indexOf (colName) == -1) ||
-                ((writeOrCopy !="copy-to-new-column") && (colName == column.name)));
-            }); 
+          var columnsToDelete = columnsToJoin;
+          if (writeOrCopy != "copy-to-new-column") {
+            columnsToDelete = columnsToDelete.filter(colName => colName != column.name);
+          }
           Refine.postCoreProcess(
-              "reorder-columns",
+              "remove-column",
               null,
-              { "columnNames" : JSON.stringify(columnsToKeep) }, 
+              { "columnNames" : JSON.stringify(columnsToJoin) }, 
               { modelsChanged: true, rowIdsPreserved: true },
               { includeEngine: false }
           );

--- a/refine-workflow/src/main/java/org/openrefine/operations/column/ColumnRemovalOperation.java
+++ b/refine-workflow/src/main/java/org/openrefine/operations/column/ColumnRemovalOperation.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.openrefine.operations.column;
 
+import org.jsoup.helper.Validate;
 import org.openrefine.browsing.EngineConfig;
 import org.openrefine.model.ColumnModel;
 import org.openrefine.model.GridState;
@@ -47,54 +48,89 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.*;
+
 public class ColumnRemovalOperation extends ImmediateRowMapOperation {
 
-    final protected String _columnName;
+    final protected List<String> _columnNames;
 
-    @JsonCreator
-    public ColumnRemovalOperation(
-            @JsonProperty("columnName") String columnName) {
-        super(EngineConfig.ALL_ROWS);
-        _columnName = columnName;
+    /**
+     * Constructor.
+     *
+     * @param columnNames
+     *            list of column names to remove
+     */
+    public ColumnRemovalOperation(List<String> columnNames) {
+        this(null, columnNames);
     }
 
-    @JsonProperty("columnName")
-    public String getColumnName() {
-        return _columnName;
+    /**
+     * Constructor for JSON deserialization, which accepts "columnName" as a single column to remove, for compatibility
+     * with previous syntaxes.
+     */
+    @JsonCreator
+    public ColumnRemovalOperation(
+            @JsonProperty("columnName") String columnName,
+            @JsonProperty("columnNames") List<String> columnNames) {
+        super(EngineConfig.ALL_ROWS);
+        _columnNames = new ArrayList<>(columnNames == null ? Collections.emptyList() : columnNames);
+        if (columnName != null && !_columnNames.contains(columnName)) {
+            _columnNames.add(columnName);
+        }
+        Validate.isFalse(_columnNames.isEmpty(), "Empty list of columns to remove in column removal operation");
+    }
+
+    @JsonProperty("columnNames")
+    public List<String> getColumnName() {
+        return _columnNames;
     }
 
     @Override
     public String getDescription() {
-        return "Remove column " + _columnName;
+        return _columnNames.size() == 1 ? "Remove column " + _columnNames.get(0) : "Remove columns " + String.join(", ", _columnNames);
     }
 
     @Override
     public ColumnModel getNewColumnModel(GridState state, ChangeContext context) throws DoesNotApplyException {
         ColumnModel model = state.getColumnModel();
-        int columnIndex = columnIndex(model, _columnName);
-        return model.removeColumn(columnIndex);
+        for (String columnName : _columnNames) {
+            int columnIndex = columnIndex(model, columnName);
+            model = model.removeColumn(columnIndex);
+        }
+        return model;
     }
 
     @Override
     public RowInRecordMapper getPositiveRowMapper(GridState state, ChangeContext context) throws DoesNotApplyException {
-        int columnIndex = columnIndex(state.getColumnModel(), _columnName);
-        return mapper(columnIndex, state.getColumnModel().getKeyColumnIndex());
+        List<Integer> columnIndices = new ArrayList<>(_columnNames.size());
+        for (String columnName : _columnNames) {
+            int columnIndex = columnIndex(state.getColumnModel(), columnName);
+            columnIndices.add(columnIndex);
+        }
+        columnIndices.sort(Comparator.<Integer> naturalOrder().reversed());
+        return mapper(columnIndices, state.getColumnModel().getKeyColumnIndex());
     }
 
-    protected static RowInRecordMapper mapper(int columnIndex, int keyColumnIndex) {
+    protected static RowInRecordMapper mapper(List<Integer> columnIndices, int keyColumnIndex) {
         return new RowInRecordMapper() {
 
             private static final long serialVersionUID = -120614551816915787L;
 
             @Override
             public Row call(Record record, long rowId, Row row) {
-                return row.removeCell(columnIndex);
+                Row newRow = row;
+                // we know that the column indices are sorted in decreasing order,
+                // so it is fine to remove the cells in this way
+                for (int columnIndex : columnIndices) {
+                    newRow = newRow.removeCell(columnIndex);
+                }
+                return newRow;
             }
 
             @Override
             public boolean preservesRecordStructure() {
                 // TODO adapt for arbitrary key column index
-                return columnIndex > keyColumnIndex;
+                return columnIndices.get(columnIndices.size() - 1) > keyColumnIndex;
             }
 
         };

--- a/refine-workflow/src/test/java/org/openrefine/operations/column/ColumnRemovalOperationTests.java
+++ b/refine-workflow/src/test/java/org/openrefine/operations/column/ColumnRemovalOperationTests.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.openrefine.RefineTest;
@@ -79,15 +80,27 @@ public class ColumnRemovalOperationTests extends RefineTest {
     @Test
     public void serializeColumnRemovalOperation() throws Exception {
         String json = "{\"op\":\"core/column-removal\","
-                + "\"description\":\"Remove column my column\","
-                + "\"columnName\":\"my column\"}";
+                + "\"description\":\"Remove columns my column 1, my column 2\","
+                + "\"columnNames\":[\"my column 1\", \"my column 2\"]}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ColumnRemovalOperation.class), json,
                 ParsingUtilities.defaultWriter);
     }
 
     @Test
+    public void serializeColumnRemovalOperationOldFormat() throws Exception {
+        String json = "{\"op\":\"core/column-removal\","
+                + "\"description\":\"Remove column my column\","
+                + "\"columnName\":\"my column\"}";
+        String normalized = "{\"op\":\"core/column-removal\","
+                + "\"description\":\"Remove column my column\","
+                + "\"columnNames\":[\"my column\"]}";
+        TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ColumnRemovalOperation.class), normalized,
+                ParsingUtilities.defaultWriter);
+    }
+
+    @Test
     public void testRemoval() throws DoesNotApplyException, ParsingException {
-        Change SUT = new ColumnRemovalOperation("foo").createChange();
+        Change SUT = new ColumnRemovalOperation(Collections.singletonList("foo")).createChange();
         GridState applied = SUT.apply(initialState, mock(ChangeContext.class));
         List<IndexedRow> rows = applied.collectRows();
         Assert.assertEquals(applied.getColumnModel().getColumns(),
@@ -96,9 +109,20 @@ public class ColumnRemovalOperationTests extends RefineTest {
                 Arrays.asList(new Cell("a", null), new Cell("d", null)));
     }
 
+    @Test
+    public void testMultipleColumns() throws DoesNotApplyException {
+        Change SUT = new ColumnRemovalOperation(Arrays.asList("foo", "bar")).createChange();
+        GridState applied = SUT.apply(initialState, mock(ChangeContext.class));
+        List<IndexedRow> rows = applied.collectRows();
+        Assert.assertEquals(applied.getColumnModel().getColumns(),
+                Arrays.asList(new ColumnMetadata("hello")));
+        Assert.assertEquals(rows.get(0).getRow().getCells(),
+                Arrays.asList(new Cell("d", null)));
+    }
+
     @Test(expectedExceptions = DoesNotApplyException.class)
     public void testColumnNotFound() throws DoesNotApplyException, ParsingException {
-        Change SUT = new ColumnRemovalOperation("not_found").createChange();
+        Change SUT = new ColumnRemovalOperation(Collections.singletonList("not_found")).createChange();
         SUT.apply(initialState, mock(ChangeContext.class));
     }
 }


### PR DESCRIPTION
Closes #4055.

This generalizes the `row-removal` operation to support removing multiple columns at once, and uses this operation to remove the joined columns in the `Edit column -> Join columns` operation (when the user selected this option in the dialog).

This way, the JSON representation of the sequence of operation becomes:
```json
[
  {
    "op": "core/column-addition",
    "engineConfig": {
      "facets": [],
      "mode": "row-based"
    },
    "baseColumnName": "NDB_No",
    "expression": "join ([coalesce(cells['NDB_No'].value,''),coalesce(cells['Shrt_Desc'].value,'')],'')",
    "onError": "keep-original",
    "newColumnName": "joined",
    "columnInsertIndex": 1,
    "description": "Create column joined at index 1 based on column NDB_No using expression join ([coalesce(cells['NDB_No'].value,''),coalesce(cells['Shrt_Desc'].value,'')],'')"
  },
  {
    "op": "core/column-removal",
    "columnNames": [
      "NDB_No",
      "Shrt_Desc"
    ],
    "description": "Remove columns NDB_No, Shrt_Desc"
  }
]
```

This does not refer to the rest of the columns in the project, making it easier to generalize the workflow in other situations.

This is a prerequisite for #5559, whose Cypress tests will fail without this.