### PR TITLE
Fixes #5567 Migrate PR workflow to JDK Eclipse Temurin

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
 
     - name: Check Java linting
@@ -115,7 +115,7 @@ jobs:
     - name: Set up Java 17
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 17
 
     - name: Check Java linting
@@ -170,7 +170,7 @@ jobs:
       - name: Set up Java 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
 
       - name: Build OpenRefine


### PR DESCRIPTION
Fixes #5567 

Changes proposed in this pull request:
-  replaces `adopt` with `temurin` for Java distribution

@wetneb Should this also be replaced in the other workflows?
