### PR TITLE
Fixes #5569 Use 'cache' feature in setup-java step.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -60,19 +60,12 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-    - name: Restore dependency cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-            ${{ runner.os }}-maven-
-
     - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
+        cache: 'maven'
 
     - name: Check Java linting
       id: java_linting
@@ -104,19 +97,12 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
         repository: ${{ github.event.pull_request.head.repo.full_name }}
 
-    - name: Restore dependency cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-            ${{ runner.os }}-maven-
-
     - name: Set up Java 17
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 17
+        cache: 'maven'
 
     - name: Check Java linting
       id: java_linting
@@ -159,19 +145,12 @@ jobs:
           echo "CYPRESS_RECORD_KEY=$(echo YzE3ZDU4OGItZTBkOC00ZjJmLTg4NjYtNzJmNmFmYmRhNGQxCg== | base64 -d)" >> $GITHUB_ENV
           echo "CYPRESS_PROJECT_ID=s5du3k" >> $GITHUB_ENV
 
-      - name: Restore dependency cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Set up Java 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
+          cache: 'maven'
 
       - name: Build OpenRefine
         run: ./refine build


### PR DESCRIPTION
Fixes #5569

Changes proposed in this pull request:
- removes separate actions/cache for java-setup steps.
- adds `cache` config to java-setup action.
- but keeps actions/cache setup for Yarn.  I think this is wise?