### PR TITLE
Migrate to temurin and use cache with java-setup

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -44,19 +44,12 @@ jobs:
           echo "CYPRESS_RECORD_KEY=$(echo YzE3ZDU4OGItZTBkOC00ZjJmLTg4NjYtNzJmNmFmYmRhNGQxCg== | base64 -d)" >> $GITHUB_ENV
           echo "CYPRESS_PROJECT_ID=s5du3k" >> $GITHUB_ENV
 
-      - name: Restore dependency cache
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
       - name: Set up Java 11
         uses: actions/setup-java@v3
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
+          cache: 'maven'
 
       - name: Build OpenRefine
         run: ./refine build
@@ -136,22 +129,16 @@ jobs:
       run: |
         echo "COVERALLS_TOKEN=$(echo eUVUVGRHOFJhQm9GMFJBYTNibjVhcWFEblpac1lmMlE3Cg== | base64 -d)" >> $GITHUB_ENV
 
-    - name: Restore dependency cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-            ${{ runner.os }}-maven-
-
     - name: Set up Java 11
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 11
+        cache: 'maven'
         server-id: ossrh
         server-username: OSSRH_USER
         server-password: OSSRH_PASS
+        
 
     - name: Install genisoimage and jq
       run: sudo apt-get install genisoimage jq
@@ -187,19 +174,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Restore dependency cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-            ${{ runner.os }}-maven-
-
     - name: Set up Java 17
       uses: actions/setup-java@v3
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 17
+        cache: 'maven'
         server-id: ossrh
         server-username: OSSRH_USER
         server-password: OSSRH_PASS


### PR DESCRIPTION
Fixes #5569

Changes proposed in this pull request:
- removes extra maven cache setup
- adds maven cache to java-setup
- migrates to `temurin` Java distribution
