### PR TITLE
Fixed the alignment of the slogan text to line up with the logo text

### DIFF
--- a/main/webapp/modules/core/styles/index.css
+++ b/main/webapp/modules/core/styles/index.css
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #slogan {
   margin-left: 1em;
+  margin-top: .5em;
   font-style: italic;
   font-size: 110%;
   color: var(--text-quarternary);


### PR DESCRIPTION
Changes proposed in this pull request:
- Changed the alignment of the slogan text to line up with the logo text as shown below:

Before:
![slogan alignment before](https://user-images.githubusercontent.com/42903164/213116594-b03d2c87-f520-4844-bee8-8faf873ee2ab.png)

After:
![slogan alignment after](https://user-images.githubusercontent.com/42903164/213116624-49868f19-b7f5-452a-8f94-234c3944779d.png)
