### PR TITLE
make dialogs focusable

### DIFF
--- a/main/webapp/modules/core/scripts/util/dialog.js
+++ b/main/webapp/modules/core/scripts/util/dialog.js
@@ -76,6 +76,15 @@ DialogSystem.showDialog = function(elmt, onCancel) {
 
   DialogSystem.setupEscapeKeyHandling();
 
+  elmt.attr("aria-role", "dialog");
+  var dialogHeader = elmt.find(".dialog-header");
+  if (dialogHeader.length && dialogHeader[0].id) {
+    elmt.attr("aria-labeledby", dialogHeader[0].id);
+  }
+
+  elmt.attr("tabindex", -1);
+  elmt.focus();
+
   return level;
 };
 


### PR DESCRIPTION
Makes dialogs focus-able, makes it possible
to use dialog headers as modal labels, and
automatically set focus when a dialog is displayed.

