### PR TITLE
Do not insert non-breaking space in clustered values

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
@@ -217,7 +217,7 @@ ClusteringDialog.prototype._renderTable = function(clusters) {
             var choices = cluster.choices;
             var onClick = function() {
               var parent = $(this).closest("tr");
-              var value = $(this).text();
+              var value = $(this).attr('data-value');
               cluster.value = value;
 
               parent.find("input[type='text']").val(value);
@@ -230,6 +230,7 @@ ClusteringDialog.prototype._renderTable = function(clusters) {
                 var li = document.createElement('li');
                 var entry = entryTemplate.cloneNode();
                 entry.textContent = choice.v.toString().replaceAll(' ', '\xa0');
+                entry.setAttribute('data-value', choice.v.toString());
                 entry.addEventListener('click', onClick);
                 li.append(entry);
                 if (choice.c > 1) {


### PR DESCRIPTION
Closes #5581.

This stores the original clustered value as a DOM `data-` attribute, keeping it separate from the rendered value (where spaces are made non-breaking).

I intend to include this fix in 3.7-beta3.
