### PR TITLE
Filter empty tokens to match doc. Fixes #5587

### DIFF
--- a/main/tests/server/src/com/google/refine/expr/functions/strings/SplitTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/SplitTests.java
@@ -28,10 +28,14 @@
 package com.google.refine.expr.functions.strings;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.util.regex.Pattern;
 
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
+import com.google.refine.expr.EvalError;
 import com.google.refine.util.TestUtils;
 
 public class SplitTests extends RefineTest {
@@ -41,6 +45,16 @@ public class SplitTests extends RefineTest {
         assertEquals(invoke("split", "a,,b,c,d", ","), new String[] { "a", "b", "c", "d" });
         assertEquals(invoke("split", "a,,b,c,d", ",", true), new String[] { "a", "", "b", "c", "d" });
         assertEquals(invoke("split", "", ","), new String[] {});
-        assertEquals(invoke("split", ",,,", ","), new String[] { "" }); // TODO: Should this return an empty array?
+        assertEquals(invoke("split", ",,,", ","), new String[] {});
+        assertEquals(invoke("split", " a b c ", " "), new String[] { "a", "b", "c" });
+        assertEquals(invoke("split", " a b  c ", " "), new String[] { "a", "b", "c" });
+        assertEquals(invoke("split", " a b  c ", " ", true), new String[] { "", "a", "b", "", "c", "" });
+        // Third argument must be boolean, not a string which looks like a boolean (or anything else)
+        assertTrue(invoke("split", " a b  c ", " ", "true") instanceof EvalError);
+
+        assertEquals(invoke("split", " a b  c ", Pattern.compile("[\\W]+")), new String[] { "a", "b", "c" });
+        // Pattern.split() has the unusual behavior of returning an empty token when there's a leading pattern match
+        assertEquals(invoke("split", " a b  c ", Pattern.compile("[\\W]+"), true), new String[] { "", "a", "b", "c" });
+
     }
 }


### PR DESCRIPTION
Fixes #5587

Changes proposed in this pull request:
- Changes `split()` to filter trailing empty token when there's a trailing string separator and leading empty token when there's a leading pattern separator match.
- 
- 

Note in the diff that I actually noted the anomalous behavior when I wrote the original tests, but never investigated (and just wrote the test to match the current, rather than documented, behavior.