### PR TITLE
project tags: expose tag name in a data attribute

### DIFF
--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -265,6 +265,7 @@ Refine.OpenProjectUI.prototype._renderProjects = function(data) {
     tags.map(function(tag){
         $("<span/>")
         .addClass("project-tag")
+        .attr("data-tag-name", tag)
         .text(tag)
         .appendTo(tagsCell);
         $(tr).addClass(tag);
@@ -362,6 +363,7 @@ Refine.OpenProjectUI.refreshProject = function(tr, metaData, project) {
             data.map(function(tag){
                 var tagsCell = $("<span/>")
                 .addClass("project-tag")
+                .attr("data-tag-name", tag)
                 .text(tag)
                 .appendTo(tagCol);
                 tagCol.parent().addClass(tag);
@@ -371,6 +373,7 @@ Refine.OpenProjectUI.refreshProject = function(tr, metaData, project) {
             data.split(",").map(function(tag){
                 var tagsCell = $("<span/>")
                 .addClass("project-tag")
+                .attr("data-tag-name", tag)
                 .text(tag)
                 .appendTo(tagCol);
                 tagCol.parent().addClass(tag);


### PR DESCRIPTION
This change adds a `data` attribute to project tags with the name of that tag so that one can give individual tags custom styles:

```css
.project-tag[data-tag-name="client-y"] {
  background: #0ab97e;
  ...
}
```

Previously you would need to do this with JavaScript to check the actual contents of the tag.