### PR TITLE
Preserve pagination settings when using undo/redo.

### DIFF
--- a/main/src/main/java/org/openrefine/commands/history/UndoRedoCommand.java
+++ b/main/src/main/java/org/openrefine/commands/history/UndoRedoCommand.java
@@ -39,7 +39,9 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.openrefine.commands.Command;
+import org.openrefine.history.GridPreservation;
 import org.openrefine.model.Project;
 
 public class UndoRedoCommand extends Command {
@@ -68,11 +70,23 @@ public class UndoRedoCommand extends Command {
         }
 
         try {
-            project.getHistory().undoRedo(lastDoneID);
+            GridPreservation gridPreservation = project.getHistory().undoRedo(lastDoneID);
 
-            respond(response, "{ \"code\" : \"ok\" }");
+            respondJSON(response, new Response(gridPreservation));
         } catch (Exception e) {
             respondException(response, e);
+        }
+    }
+
+    private static class Response {
+
+        @JsonProperty("gridPreservation")
+        final GridPreservation gridPreservation;
+        @JsonProperty("code")
+        final String code = "ok";
+
+        protected Response(GridPreservation gridPreservation) {
+            this.gridPreservation = gridPreservation;
         }
     }
 }

--- a/main/src/test/java/org/openrefine/commands/history/UndoRedoCommandTests.java
+++ b/main/src/test/java/org/openrefine/commands/history/UndoRedoCommandTests.java
@@ -2,23 +2,79 @@
 package org.openrefine.commands.history;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import javax.servlet.ServletException;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.openrefine.browsing.EngineConfig;
+import org.openrefine.commands.Command;
 import org.openrefine.commands.CommandTestBase;
+import org.openrefine.expr.MetaParser;
+import org.openrefine.grel.Parser;
+import org.openrefine.model.Project;
+import org.openrefine.model.changes.Change;
+import org.openrefine.operations.OnError;
+import org.openrefine.operations.Operation;
+import org.openrefine.operations.OperationRegistry;
+import org.openrefine.operations.cell.FillDownOperation;
+import org.openrefine.operations.cell.MassEditOperation;
+import org.openrefine.operations.cell.TextTransformOperation;
+import org.openrefine.util.ParsingUtilities;
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.when;
+
 public class UndoRedoCommandTests extends CommandTestBase {
 
+    Project project;
+
     @BeforeMethod
-    public void setUpCommand() {
+    public void setUpCommand() throws Change.DoesNotApplyException, Operation.NotImmediateOperationException {
         command = new UndoRedoCommand();
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+
+        // set up a project with two changes
+        project = createProject("my project",
+                new String[] { "foo", "bar" },
+                new Serializable[][] {
+                        { "test", 23L },
+                        { null, 42L },
+                        { "record", "banana" },
+                        { null, "apple" }
+                });
+        // the first one preserves records
+        TextTransformOperation transform = new TextTransformOperation(
+                EngineConfig.ALL_ROWS,
+                "foo",
+                "grel:value.toString() + \"_concat\"",
+                OnError.StoreError,
+                false,
+                0);
+        project.getHistory().addEntry(1234L, "Transform", transform, transform.createChange());
+        // the second one only rows
+        FillDownOperation fillDown = new FillDownOperation(EngineConfig.ALL_RECORDS, "foo");
+        project.getHistory().addEntry(5678L, "Fill down", fillDown, fillDown.createChange());
     }
 
     @Test
     public void testCSRFProtection() throws ServletException, IOException {
         command.doPost(request, response);
         assertCSRFCheckFailed();
+    }
+
+    @Test
+    public void testUndo() throws ServletException, IOException {
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("project")).thenReturn(Long.toString(project.getId()));
+        when(request.getParameter("lastDoneID")).thenReturn("1234");
+
+        command.doPost(request, response);
+
+        ObjectNode jsonResponse = (ObjectNode) ParsingUtilities.mapper.readTree(writer.toString());
+        Assert.assertEquals(jsonResponse.get("code").asText(), "ok");
+        Assert.assertEquals(jsonResponse.get("gridPreservation").asText(), "preserves-rows");
     }
 }

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -177,11 +177,16 @@ HistoryPanel.prototype._render = function() {
 HistoryPanel.prototype._onClickHistoryEntry = function(evt, entry, lastDoneID) {
   var self = this;
 
+  var updateOptions = { everythingChanged: true, warnAgainstHistoryErasure: false };
   Refine.postCoreProcess(
       "undo-redo",
       { lastDoneID: lastDoneID },
       null,
-      { everythingChanged: true, warnAgainstHistoryErasure: false }
+      updateOptions,
+      { onDone: function(o) {
+        updateOptions.rowIdsPreserved = o.gridPreservation !== 'no-row-preservation';
+        updateOptions.recordIdsPreserved = o.gridPreservation === 'preserves-records';
+      }}
   );
 };
 

--- a/main/webapp/modules/core/scripts/project/process-panel.js
+++ b/main/webapp/modules/core/scripts/project/process-panel.js
@@ -113,11 +113,16 @@ ProcessPanel.prototype.showUndo = function(historyEntry) {
 
 ProcessPanel.prototype.undo = function() {
   if (this._latestHistoryEntry !== null) {
+    var updateOptions = { everythingChanged: true, warnAgainstHistoryErasure: false };
     Refine.postCoreProcess(
         "undo-redo",
         { undoID: this._latestHistoryEntry.id },
         null,
-        { everythingChanged: true, warnAgainstHistoryErasure: false }
+        updateOptions,
+        { onDone: function(o) {
+          updateOptions.rowIdsPreserved = o.gridPreservation !== 'no-row-preservation';
+          updateOptions.recordIdsPreserved = o.gridPreservation === 'preserves-records';
+        }}
     );
   }
 };

--- a/modules/refine-model/src/main/java/org/openrefine/history/GridPreservation.java
+++ b/modules/refine-model/src/main/java/org/openrefine/history/GridPreservation.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Metadata encoding the properties of a {@link org.openrefine.model.changes.Change}, to characterize how it transforms
  * the grid. This is useful to the UI, to determine if and how it can preserve the scrolling position in the grid.
  */
-public enum GridPreservation {
+public enum GridPreservation implements Comparable<GridPreservation> {
     /**
      * No guarantees are asserted about the transformation.
      */

--- a/modules/refine-model/src/main/java/org/openrefine/history/History.java
+++ b/modules/refine-model/src/main/java/org/openrefine/history/History.java
@@ -36,6 +36,7 @@ package org.openrefine.history;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -325,14 +326,32 @@ public class History {
         }
     }
 
-    synchronized public void undoRedo(long lastDoneEntryID) throws DoesNotApplyException {
+    /**
+     * Rewinds or brings the history forward.
+     *
+     * @param lastDoneEntryID
+     *            the id of the last change to be performed before the desired state of the project. Use 0L for the
+     *            initial state.
+     * @return the degree to which the grid was preserved while changing the position in the history
+     * @throws DoesNotApplyException
+     *             if the application of changes required for this move did not succeed
+     */
+    synchronized public GridPreservation undoRedo(long lastDoneEntryID) throws DoesNotApplyException {
+        int oldPosition = _position;
         if (lastDoneEntryID == 0) {
             _position = 0;
         } else {
             _position = entryIndex(lastDoneEntryID) + 1;
             getGrid(_position);
         }
+
+        GridPreservation gridPreservation = _position == oldPosition ? GridPreservation.PRESERVES_RECORDS
+                : _entries.subList(Math.min(oldPosition, _position), Math.max(oldPosition, _position)).stream()
+                        .map(item -> item.getGridPreservation() == null ? GridPreservation.NO_ROW_PRESERVATION : item.getGridPreservation())
+                        .min(Comparator.naturalOrder()).get();
+
         updateCachedPosition();
+        return gridPreservation;
     }
 
     synchronized public long getPrecedingEntryID(long entryID) {

--- a/modules/refine-model/src/test/java/org/openrefine/history/HistoryTests.java
+++ b/modules/refine-model/src/test/java/org/openrefine/history/HistoryTests.java
@@ -135,6 +135,10 @@ public class HistoryTests {
         when(secondEntry.getChange()).thenReturn(secondChange);
         when(newEntry.getChange()).thenReturn(newChange);
 
+        when(firstEntry.getGridPreservation()).thenReturn(GridPreservation.PRESERVES_RECORDS);
+        when(secondEntry.getGridPreservation()).thenReturn(GridPreservation.PRESERVES_ROWS);
+        when(newEntry.getGridPreservation()).thenReturn(GridPreservation.NO_ROW_PRESERVATION);
+
         entries = Arrays.asList(firstEntry, secondEntry);
     }
 
@@ -151,19 +155,21 @@ public class HistoryTests {
         verify(history.getCurrentGrid(), times(1)).cache();
         Assert.assertEquals(history.getEntries(), entries);
 
-        history.undoRedo(secondChangeId);
+        GridPreservation gridPreservation = history.undoRedo(secondChangeId);
 
         Assert.assertEquals(history.getPosition(), 2);
         Assert.assertEquals(history.getCachedPosition(), 1); // the second operation is not expensive
         Assert.assertEquals(history.getCurrentGrid(), finalState);
         Assert.assertEquals(history.getEntries(), entries);
+        Assert.assertEquals(gridPreservation, GridPreservation.PRESERVES_ROWS);
 
-        history.undoRedo(0);
+        GridPreservation gridPreservation2 = history.undoRedo(0);
 
         Assert.assertEquals(history.getPosition(), 0);
         Assert.assertEquals(history.getCachedPosition(), 0);
         Assert.assertEquals(history.getCurrentGrid(), initialState);
         Assert.assertEquals(history.getEntries(), entries);
+        Assert.assertEquals(gridPreservation2, GridPreservation.PRESERVES_ROWS);
 
         // All changes were called only once
         verify(firstChange, times(1)).apply(eq(initialState), any());


### PR DESCRIPTION
Fixes #572.

When the sequence of operations undone or redone all preserve rows (or records, if in records mode), the pagination settings are preserved.
