### PR TITLE
Added a fix to keep the facet height after performing various operations

### DIFF
--- a/main/webapp/modules/core/scripts/facets/list-facet.js
+++ b/main/webapp/modules/core/scripts/facets/list-facet.js
@@ -50,6 +50,7 @@ class ListFacet extends Facet {
 
     this._data = null;
 
+    this._initialHeightSet = false;
     this._initializeUI();
     this._update();
   };
@@ -401,14 +402,17 @@ class ListFacet extends Facet {
     this._renderBodyControls();
     this._elmts.bodyInnerDiv[0].scrollTop = scrollTop;
 
-    let innerList = this._elmts.bodyInnerDiv[0];
-    let innerHeight = innerList.clientHeight;
-    let defaultMaxHeight = 17*13;
+    if (!this._initialHeightSet) {
+      let innerList = this._elmts.bodyInnerDiv[0];
+      let innerHeight = innerList.clientHeight;
+      let defaultMaxHeight = 17 * 13;
 
-    if (innerHeight > defaultMaxHeight) {
-      this._elmts.bodyDiv.height(defaultMaxHeight+'px');
-    } else {
-      this._elmts.bodyDiv.height((innerHeight+1)+'px');
+      if (innerHeight > defaultMaxHeight) {
+        this._elmts.bodyDiv.height(defaultMaxHeight + 'px');
+      } else {
+        this._elmts.bodyDiv.height((innerHeight + 1) + 'px');
+      }
+      this._initialHeightSet = true;
     }
 
     var getChoice = function(elmt) {


### PR DESCRIPTION
Fixes #5606

Fixes the Regression from: https://github.com/OpenRefine/OpenRefine/pull/5514

The initial height is set when a facet is added.  The facet height is not adjusted in the following cases:
 - When other facet is added.
 - When other facet is deleted.
 - Include/Exclude Choice
 - Edit Choice -> Apply
 - Sort by: name count
 - Refresh
 - Cluster Choices -> Merge selected & Close
 - Resize/Min/Max Browser Window
 - Show/Hide Left Panel
 - Min/Max a facet