### PR TITLE
Added a fix to stop the facets panel from shifting on refresh

### DIFF
--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -240,7 +240,7 @@ BrowsingEngine.prototype.update = function(onDone) {
   this._elmts.help.hide();
 
   this._elmts.header.show();
-  this._elmts.controls.css("visibility", "hidden");
+  this._elmts.controls.css("display", "none");
   this._elmts.indicator.css("display", "block");
 
   $.post(
@@ -268,7 +268,7 @@ BrowsingEngine.prototype.update = function(onDone) {
       self._elmts.errors.css("display", "none");
       if (self._facets.length > 0) {
         self._elmts.header.show();
-        self._elmts.controls.css("visibility", "visible");
+        self._elmts.controls.css("display", "block");
 
         self.resize();
       } else {

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -52,13 +52,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .browsing-panel-indicator {
   display: none;
   position: relative;
-  width: 50%;
   margin: 5px;
-  top: 0em;
-  left: 20%;
+  top: 0;
   text-align: center;
   background-color: var(--background-primary);
-  padding: 4px 4px;
+  padding: 5px 5px;
   border-radius: 4px;
   border: 1px solid #ccc;
 }

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -70,7 +70,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .browsing-panel-controls {
   position: relative;
   padding: var(--padding-normal);
-  visibility: hidden;
   text-align: right;
 }
 


### PR DESCRIPTION
Fixes #5610

Changes proposed in this pull request:
- Added a fix to stop the facets panel from shifting on refresh as shown below:

After:
![image](https://user-images.githubusercontent.com/42903164/217459098-78cbab61-54cd-45a2-aeca-ae09e3df8465.png)
