### PR TITLE
Add workflow to unassign contributors from good first issues after a delay

### DIFF
--- a/.github/workflows/unassign_issues.yml
+++ b/.github/workflows/unassign_issues.yml
@@ -2,7 +2,7 @@ name: Unassign contributors from issues after a delay
 
 on:
   schedule:
-    cron: '0 0 * * *'
+    - cron: '39 4 * * *'
 
 jobs:
   # Best used in combination with actions/stale to assign a Stale label

--- a/.github/workflows/unassign_issues.yml
+++ b/.github/workflows/unassign_issues.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   # Best used in combination with actions/stale to assign a Stale label
   
-  unassign-issues-labeled-waiting-for-contributor-after-7-days-of-inactivity:
+  unassign-good-first-issues-after-90-days-of-inactivity:
     name: Unassign issues labeled "good first issue" after 90 days of inactivity.
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unassign_issues.yml
+++ b/.github/workflows/unassign_issues.yml
@@ -1,0 +1,20 @@
+name: Unassign contributors from issues after a delay
+
+on:
+  schedule:
+    cron: '0 0 * * *'
+
+jobs:
+  # Best used in combination with actions/stale to assign a Stale label
+  
+  unassign-issues-labeled-waiting-for-contributor-after-7-days-of-inactivity:
+    name: Unassign issues labeled "good first issue" after 90 days of inactivity.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: boundfoxstudios/action-unassign-contributor-after-days-of-inactivity@main
+        with:
+          last-activity: 90 # After how many days the issue should get unassigned
+          labels: 'good first issue' # Only search for issues containing this labels (comma-separated)
+          exempt-assignees: '' # Exempt some assignees from being unassigned (comma-separated)
+          labels-to-remove: '' # Labels to remove after unassigning an issue (comma-separated)
+          message: 'Automatically unassigned after 90 days of inactivity.'


### PR DESCRIPTION
Closes #5609
