### PR TITLE
Added a fix to prevent the facet choices dialog from bleeding over the dialog window on resize

### DIFF
--- a/main/webapp/modules/core/scripts/facets/list-facet.js
+++ b/main/webapp/modules/core/scripts/facets/list-facet.js
@@ -223,7 +223,7 @@ class ListFacet extends Facet {
   _copyChoices() {
     var self = this;
     var frame = DialogSystem.createDialog();
-    frame.width("600px");
+    frame.css({"min-width" : "600px"});
 
     var header = $('<div></div>').addClass("dialog-header").text($.i18n('core-facets/facet-choices')).appendTo(frame);
     var body = $('<div></div>').addClass("dialog-body").appendTo(frame);


### PR DESCRIPTION
Changes proposed in this pull request:
- Added a fix to prevent the facet choices dialog from bleeding over the dialog window on resize.

Before:
![image](https://user-images.githubusercontent.com/42903164/218243510-cb4b8189-ea39-4265-805d-62bfadf0351c.png)

After:
![Facet Choices resize fix](https://user-images.githubusercontent.com/42903164/218243745-9e8fd6a3-0cdc-43b8-8b68-01a494252292.gif)

