### PR TITLE
Fixes #5620 adds "bytes" to end of logger string

### DIFF
--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -173,7 +173,7 @@ class RefineServer extends Server {
 
         String memory = Configurations.get("refine.memory");
         if (memory != null) {
-            logger.info("refine.memory size: " + memory + " JVM Max heap: " + Runtime.getRuntime().maxMemory());
+            logger.info("refine.memory size: " + memory + " JVM Max heap: " + Runtime.getRuntime().maxMemory() + " bytes");
         }
 
         HttpConfiguration httpConfig = new HttpConfiguration();


### PR DESCRIPTION
Fixes #5620

Changes proposed in this pull request:
- adds "bytes" to end of logger string for `JVM Max Heap:` label

