### PR TITLE
Enhance forRange to accept negative increments (#5520)

### DIFF
--- a/main/src/com/google/refine/grel/controls/ForRange.java
+++ b/main/src/com/google/refine/grel/controls/ForRange.java
@@ -69,7 +69,7 @@ public class ForRange implements Control {
         } else if (ExpressionUtils.isError(stepO)) {
             return stepO;
         } else if (!(fromO instanceof Number) || !(toO instanceof Number) || !(stepO instanceof Number)) {
-            return ControlEvalError.for_range();
+            return new EvalError(ControlEvalError.for_range());
         }
 
         String indexName = ((VariableExpr) args[3]).getName();
@@ -83,32 +83,46 @@ public class ForRange implements Control {
                 long step = ((Number) stepO).longValue();
                 double to = ((Number) toO).doubleValue();
 
-                if (!((from < to && step > 0) || (from > to && step < 0))) {
+                if (step == 0) {
                     return new EvalError(EvalErrorMessage.invalid_arg());
                 }
 
-                int rangeSize = (int) Math.ceil(Math.abs(from - to) / Math.abs(step));
-                for (int i = 0; i < rangeSize; i++) {
-                    bindings.put(indexName, from);
-                    Object r = args[4].evaluate(bindings);
-                    results.add(r);
-                    from += step;
+                if (step <= Math.abs(from - to)) {
+                    while (from < to && step > 0) {
+                        bindings.put(indexName, from);
+                        Object r = args[4].evaluate(bindings);
+                        results.add(r);
+                        from += step;
+                    }
+                    while (from > to && step < 0) {
+                        bindings.put(indexName, from);
+                        Object r = args[4].evaluate(bindings);
+                        results.add(r);
+                        from += step;
+                    }
                 }
             } else {
                 double from = ((Number) fromO).doubleValue();
                 double step = ((Number) stepO).doubleValue();
                 double to = ((Number) toO).doubleValue();
 
-                if (!((from < to && step > 0) || (from > to && step < 0))) {
+                if (step == 0) {
                     return new EvalError(EvalErrorMessage.invalid_arg());
                 }
 
-                int rangeSize = (int) Math.ceil(Math.abs(from - to) / Math.abs(step));
-                for (int i = 0; i < rangeSize; i++) {
-                    bindings.put(indexName, from);
-                    Object r = args[4].evaluate(bindings);
-                    results.add(r);
-                    from += step;
+                if (step <= Math.abs(from - to)) {
+                    while (from < to && step > 0) {
+                        bindings.put(indexName, from);
+                        Object r = args[4].evaluate(bindings);
+                        results.add(r);
+                        from += step;
+                    }
+                    while (from > to && step < 0) {
+                        bindings.put(indexName, from);
+                        Object r = args[4].evaluate(bindings);
+                        results.add(r);
+                        from += step;
+                    }
                 }
             }
             return results.toArray();

--- a/main/src/com/google/refine/grel/controls/ForRange.java
+++ b/main/src/com/google/refine/grel/controls/ForRange.java
@@ -40,10 +40,7 @@ import java.util.Properties;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
-import com.google.refine.grel.Control;
-import com.google.refine.grel.ControlDescription;
-import com.google.refine.grel.ControlEvalError;
-import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.*;
 import com.google.refine.grel.ast.VariableExpr;
 
 public class ForRange implements Control {
@@ -86,27 +83,31 @@ public class ForRange implements Control {
                 long step = ((Number) stepO).longValue();
                 double to = ((Number) toO).doubleValue();
 
-                while (from < to) {
+                if (!((from < to && step > 0) || (from > to && step < 0))) {
+                    return new EvalError(EvalErrorMessage.invalid_arg());
+                }
+
+                int rangeSize = (int) Math.ceil(Math.abs(from - to) / Math.abs(step));
+                for (int i = 0; i < rangeSize; i++) {
                     bindings.put(indexName, from);
-
                     Object r = args[4].evaluate(bindings);
-
                     results.add(r);
-
                     from += step;
                 }
             } else {
-                double from = ((Number) fromO).longValue();
-                double step = ((Number) stepO).longValue();
+                double from = ((Number) fromO).doubleValue();
+                double step = ((Number) stepO).doubleValue();
                 double to = ((Number) toO).doubleValue();
 
-                while (from < to) {
+                if (!((from < to && step > 0) || (from > to && step < 0))) {
+                    return new EvalError(EvalErrorMessage.invalid_arg());
+                }
+
+                int rangeSize = (int) Math.ceil(Math.abs(from - to) / Math.abs(step));
+                for (int i = 0; i < rangeSize; i++) {
                     bindings.put(indexName, from);
-
                     Object r = args[4].evaluate(bindings);
-
                     results.add(r);
-
                     from += step;
                 }
             }

--- a/main/src/com/google/refine/grel/controls/ForRange.java
+++ b/main/src/com/google/refine/grel/controls/ForRange.java
@@ -87,14 +87,15 @@ public class ForRange implements Control {
                     return new EvalError(EvalErrorMessage.invalid_arg());
                 }
 
-                if (step <= Math.abs(from - to)) {
-                    while (from < to && step > 0) {
+                if (step > 0) {
+                    while (from < to) {
                         bindings.put(indexName, from);
                         Object r = args[4].evaluate(bindings);
                         results.add(r);
                         from += step;
                     }
-                    while (from > to && step < 0) {
+                } else {
+                    while (from > to) {
                         bindings.put(indexName, from);
                         Object r = args[4].evaluate(bindings);
                         results.add(r);
@@ -110,14 +111,15 @@ public class ForRange implements Control {
                     return new EvalError(EvalErrorMessage.invalid_arg());
                 }
 
-                if (step <= Math.abs(from - to)) {
-                    while (from < to && step > 0) {
+                if (step > 0) {
+                    while (from < to) {
                         bindings.put(indexName, from);
                         Object r = args[4].evaluate(bindings);
                         results.add(r);
                         from += step;
                     }
-                    while (from > to && step < 0) {
+                } else {
+                    while (from > to) {
                         bindings.put(indexName, from);
                         Object r = args[4].evaluate(bindings);
                         results.add(r);

--- a/main/tests/server/src/com/google/refine/grel/controls/ForRangeTests.java
+++ b/main/tests/server/src/com/google/refine/grel/controls/ForRangeTests.java
@@ -27,15 +27,55 @@
 
 package com.google.refine.grel.controls;
 
+import com.google.refine.RefineTest;
+import com.google.refine.expr.*;
+import com.google.refine.model.Project;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.refine.util.TestUtils;
 
-public class ForRangeTests {
+import java.util.Properties;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class ForRangeTests extends RefineTest {
 
     @Test
     public void serializeForRange() {
         String json = "{\"description\":\"Iterates over the variable v starting at \\\"from\\\", incrementing by \\\"step\\\" each time while less than \\\"to\\\". At each iteration, evaluates expression e, and pushes the result onto the result array.\",\"params\":\"number from, number to, number step, variable v, expression e\",\"returns\":\"array\"}";
         TestUtils.isSerializedTo(new ForRange(), json);
+    }
+
+    @Test
+    public void testForRangeArray() throws ParsingException {
+        String test[] = { "forRange(10.5,8,-0.5,v,v).join(',')", "10.5,10.0,9.5,9.0,8.5" };
+        bindings = new Properties();
+        bindings.put("v", "");
+        parseEval(bindings, test);
+    }
+
+    @Test
+    public void testEvalError() {
+        bindings = new Properties();
+        bindings.put("v", "");
+        String tests[] = {
+                "forRange(10,0,1,v,v)",
+                "forRange(0,10,-1,v,v)",
+                "forRange(10,10,-1,v,v)",
+                "forRange(10,0,0,v,v)",
+        };
+        for (String test : tests) {
+            try {
+                Evaluable eval = MetaParser.parse("grel:" + test);
+                Object result = eval.evaluate(bindings);
+                Assert.assertTrue(result instanceof EvalError);
+            } catch (ParsingException e) {
+                Assert.fail("Unexpected parse failure: " + test);
+            }
+        }
     }
 }

--- a/main/tests/server/src/com/google/refine/grel/controls/ForRangeTests.java
+++ b/main/tests/server/src/com/google/refine/grel/controls/ForRangeTests.java
@@ -76,7 +76,7 @@ public class ForRangeTests extends RefineTest {
 
     @Test
     public void testForRangeWithFloatingPointValues() throws ParsingException {
-        String test[] = { "forRange(0,0.6,0.1,v,v).join(',')", "0.0,0.1,0.2,0.3,0.4,0.5" };
+        String test[] = { "forRange(0,0.6,0.1,v,v.toString('%.3f')).join(',')", "0.000,0.100,0.200,0.300,0.400,0.500" };
         bindings = new Properties();
         bindings.put("v", "");
         parseEval(bindings, test);
@@ -85,7 +85,6 @@ public class ForRangeTests extends RefineTest {
     @Test
     public void testForRangeWithImpossibleStep() {
         String tests[] = {
-                "forRange(0,10,15,v,v).join(',')",
                 "forRange(0,10,-1,v,v).join(',')",
                 "forRange(10,0,1,v,v).join(',')"
         };
@@ -96,6 +95,24 @@ public class ForRangeTests extends RefineTest {
                 Evaluable eval = MetaParser.parse("grel:" + test);
                 Object result = eval.evaluate(bindings);
                 Assert.assertEquals(result.toString(), "", "Wrong result for expression: " + test);
+            } catch (ParsingException e) {
+                Assert.fail("Unexpected parse failure: " + test);
+            }
+        }
+    }
+
+    @Test
+    public void testForRangeWithStepBiggerThanRange() {
+        String tests[] = {
+                "forRange(0,10,15,v,v).join(',')"
+        };
+        bindings = new Properties();
+        bindings.put("v", "");
+        for (String test : tests) {
+            try {
+                Evaluable eval = MetaParser.parse("grel:" + test);
+                Object result = eval.evaluate(bindings);
+                Assert.assertEquals(result.toString(), "0", "Wrong result for expression: " + test);
             } catch (ParsingException e) {
                 Assert.fail("Unexpected parse failure: " + test);
             }

--- a/main/tests/server/src/com/google/refine/grel/controls/ForRangeTests.java
+++ b/main/tests/server/src/com/google/refine/grel/controls/ForRangeTests.java
@@ -51,23 +51,67 @@ public class ForRangeTests extends RefineTest {
     }
 
     @Test
-    public void testForRangeArray() throws ParsingException {
-        String test[] = { "forRange(10.5,8,-0.5,v,v).join(',')", "10.5,10.0,9.5,9.0,8.5" };
+    public void testForRangeWithPositiveIncrement() throws ParsingException {
+        String test[] = { "forRange(0,6,1,v,v).join(',')", "0,1,2,3,4,5" };
         bindings = new Properties();
         bindings.put("v", "");
         parseEval(bindings, test);
     }
 
     @Test
-    public void testEvalError() {
+    public void testForRangeWithNegativeIncrement() throws ParsingException {
+        String test[] = { "forRange(6,0,-1,v,v).join(',')", "6,5,4,3,2,1" };
         bindings = new Properties();
         bindings.put("v", "");
+        parseEval(bindings, test);
+    }
+
+    @Test
+    public void testForRangeWithSameStartAndEndValues() throws ParsingException {
+        String test[] = { "forRange(10,10,1,v,v).join(',')", "" };
+        bindings = new Properties();
+        bindings.put("v", "");
+        parseEval(bindings, test);
+    }
+
+    @Test
+    public void testForRangeWithFloatingPointValues() throws ParsingException {
+        String test[] = { "forRange(0,0.6,0.1,v,v).join(',')", "0.0,0.1,0.2,0.3,0.4,0.5" };
+        bindings = new Properties();
+        bindings.put("v", "");
+        parseEval(bindings, test);
+    }
+
+    @Test
+    public void testForRangeWithImpossibleStep() {
         String tests[] = {
-                "forRange(10,0,1,v,v)",
-                "forRange(0,10,-1,v,v)",
-                "forRange(10,10,-1,v,v)",
+                "forRange(0,10,15,v,v).join(',')",
+                "forRange(0,10,-1,v,v).join(',')",
+                "forRange(10,0,1,v,v).join(',')"
+        };
+        bindings = new Properties();
+        bindings.put("v", "");
+        for (String test : tests) {
+            try {
+                Evaluable eval = MetaParser.parse("grel:" + test);
+                Object result = eval.evaluate(bindings);
+                Assert.assertEquals(result.toString(), "", "Wrong result for expression: " + test);
+            } catch (ParsingException e) {
+                Assert.fail("Unexpected parse failure: " + test);
+            }
+        }
+    }
+
+    @Test
+    public void testEvalError() {
+        String tests[] = {
+                "forRange(test,0,1,v,v)",
+                "forRange(0,test,1,v,v)",
+                "forRange(10,0,test,v,v)",
                 "forRange(10,0,0,v,v)",
         };
+        bindings = new Properties();
+        bindings.put("v", "");
         for (String test : tests) {
             try {
                 Evaluable eval = MetaParser.parse("grel:" + test);


### PR DESCRIPTION
Fixes #5520

Changes proposed in this pull request:
- forRange can work with a negative increment.
- Fixes the bug to support both integer and floating point values.
- To reject invalid arguments and return an error message instead of an empty array.