### PR TITLE
Fix for failing Cypress CI test

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/reconcile/actions/create_new_item_for_each.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/reconcile/actions/create_new_item_for_each.cy.js
@@ -51,6 +51,7 @@ describe('Create new item for each cell', () => {
           'Create a new item for each cell',
         ]);
 
+        cy.get('#dialog-recon-service-select').find('option').should('have.length.at.least', 1);
         cy.get('.dialog-container .dialog-footer button').contains('OK').click();
 
         // ensure column is reconciled


### PR DESCRIPTION
Fixes #5628

Changes proposed in this pull request:
-  Adds a check to make sure that there is at least one reconciliation service to select.