### PR TITLE
Fix accessor for "record" field in lists of WrappedRows (output by cross function)

### DIFF
--- a/main/src/com/google/refine/expr/WrappedRow.java
+++ b/main/src/com/google/refine/expr/WrappedRow.java
@@ -60,8 +60,6 @@ public class WrappedRow implements HasFields {
         } else if ("index".equals(name)) {
             return rowIndex;
         } else if ("record".equals(name)) {
-            int rowIndex = (Integer) bindings.get("rowIndex");
-
             return new WrappedRecord(project.recordModel.getRecordOfRow(rowIndex));
         } else if ("columnNames".equals(name)) {
             Project project = (Project) bindings.get("project");

--- a/main/src/com/google/refine/expr/WrappedRow.java
+++ b/main/src/com/google/refine/expr/WrappedRow.java
@@ -62,8 +62,6 @@ public class WrappedRow implements HasFields {
         } else if ("record".equals(name)) {
             return new WrappedRecord(project.recordModel.getRecordOfRow(rowIndex));
         } else if ("columnNames".equals(name)) {
-            Project project = (Project) bindings.get("project");
-
             return project.columnModel.getColumnNames();
         } else {
             return row.getField(name, bindings);

--- a/main/src/com/google/refine/expr/functions/Cross.java
+++ b/main/src/com/google/refine/expr/functions/Cross.java
@@ -59,13 +59,13 @@ public class Cross implements Function {
             // if 2nd argument is omitted or set to "", use the current project name
             Object targetProjectName = "";
             boolean isCurrentProject = false;
-            if (args.length < 2 || args[1].equals("")) {
+            if (args.length < 2 || "".equals(args[1])) {
                 isCurrentProject = true;
             } else {
                 targetProjectName = args[1];
             }
             // if 3rd argument is omitted or set to "", use the index column
-            Object targetColumnName = args.length < 3 || args[2].equals("") ? INDEX_COLUMN_NAME : args[2];
+            Object targetColumnName = args.length < 3 || "".equals(args[2]) ? INDEX_COLUMN_NAME : args[2];
 
             long targetProjectID;
             ProjectLookup lookup;

--- a/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2018, OpenRefine contributors
+ * Copyright (C) 2018,2023 OpenRefine contributors
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Properties;
 
 import org.slf4j.LoggerFactory;
@@ -218,9 +219,21 @@ public class CrossTests extends RefineTest {
      */
     @Test
     public void crossFunctionOneToManyTest() throws Exception {
-        Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", "john", "My Address Book", "friend")).get(1)).row);
+        List<WrappedRow> rows = (((List<WrappedRow>) invoke("cross", "john", "My Address Book", "friend")));
+        assertEquals(rows.size(), 2);
+        Row row = rows.get(1).row;
         String address = row.getCell(1).value.toString();
         assertEquals(address, "999 XXXXXX St.");
+    }
+
+    /**
+     * Check that record field accessor works for a list of WrappedRecords
+     * (technically not a cross() test, but this is pretty much the only place they're used)
+     */
+    @Test
+    public void crossFunctionRecordFieldLookup() throws Exception {
+        String test[] = { "'john'.cross('My Address Book', 'friend').record.index.toString()", "[0, 2]" };
+        parseEval(bindings, test);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
@@ -53,7 +53,8 @@ import com.google.refine.model.Row;
  */
 public class CrossTests extends RefineTest {
 
-    private static OffsetDateTime dateTimeValue = OffsetDateTime.parse("2017-05-12T05:45:00+00:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    private static final String ERROR_MSG = "cross expects a cell or value, a project name to look up (optional), and a column name in that project (optional)";
+    private static final OffsetDateTime dateTimeValue = OffsetDateTime.parse("2017-05-12T05:45:00+00:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 
     @Override
     @BeforeTest
@@ -369,8 +370,15 @@ public class CrossTests extends RefineTest {
      */
     @Test
     public void crossFunctionNonLiteralValue() throws Exception {
-        assertEquals(((EvalError) invoke("cross", null, "My Address Book", "friend")).message,
-                "cross expects a cell or value, a project name to look up (optional), and a column name in that project (optional)");
+        assertEquals(((EvalError) invoke("cross", null, "My Address Book", "friend")).message, ERROR_MSG);
+    }
+
+    @Test
+    public void crossFunctionNullParams() throws Exception {
+        assertEquals(((EvalError) invoke("cross", "dummy", null, null)).message, ERROR_MSG);
+        assertEquals(((EvalError) invoke("cross", "dummy", null)).message, ERROR_MSG);
+        assertEquals(((EvalError) invoke("cross", "dummy", null, "test")).message, ERROR_MSG);
+        assertEquals(((EvalError) invoke("cross", "dummy", 1.0, 1)).message, ERROR_MSG);
     }
 
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
@@ -234,8 +234,27 @@ public class CrossTests extends RefineTest {
      */
     @Test
     public void crossFunctionRecordFieldLookup() throws Exception {
-        String test[] = { "'john'.cross('My Address Book', 'friend').record.index.toString()", "[0, 2]" };
-        parseEval(bindings, test);
+        String tests[][] = {
+                { "'john'.cross('My Address Book', 'friend').cells[0]['friend'].value", "john" },
+                { "'john'.cross('My Address Book', 'friend').index.toString()", "[0, 2]" },
+                { "'john'.cross('My Address Book', 'friend').columnNames[0].toString()", "[friend, address]" },
+                // Make sure delegation from WrappedRow to Row works
+                { "'john'.cross('My Address Book', 'friend').flagged.toString()", "[false, false]" },
+                { "'john'.cross('My Address Book', 'friend').starred.toString()", "[false, false]" },
+                // Unknown field names return null value rather than an error
+                { "'john'.cross('My Address Book', 'friend').foo.toString()", "[null, null]" },
+                // TODO: I'm not sure what record.cells is supposed to return. Returning single valued lists seems weird
+                { "'john'.cross('My Address Book', 'friend').record.cells['friend'].value.toString()", "[[john], [john]]" },
+                { "'john'.cross('My Address Book', 'friend').record.index.toString()", "[0, 2]" },
+                { "'john'.cross('My Address Book', 'friend').record.fromRowIndex.toString()", "[0, 2]" },
+                { "'john'.cross('My Address Book', 'friend').record.toRowIndex.toString()", "[1, 3]" },
+                { "'john'.cross('My Address Book', 'friend').record.rowCount.toString()", "[1, 1]" },
+                // Below returns null on error intentionally
+                { "'john'.cross('My Address Book', 'friend').record.foo.toString()", "[null, null]" },
+        };
+        for (String[] test : tests) {
+            parseEval(bindings, test);
+        }
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.expr.functions;
 
+import static org.testng.Assert.assertEquals;
+
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Properties;
@@ -45,7 +47,6 @@ import com.google.refine.expr.WrappedRow;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
-import com.google.refine.util.TestUtils;
 
 /**
  * Test cases for cross function.
@@ -118,14 +119,14 @@ public class CrossTests extends RefineTest {
     @Test
     public void crossFunctionMissingProject() throws Exception {
         String nonExistentProject = "NOPROJECT";
-        Assert.assertEquals(((EvalError) invoke("cross", "Anne", nonExistentProject, "friend")).message,
+        assertEquals(((EvalError) invoke("cross", "Anne", nonExistentProject, "friend")).message,
                 "Unable to find project with name: " + nonExistentProject);
     }
 
     @Test
     public void crossFunctionMultipleProjects() throws Exception {
         String duplicateProjectName = "Duplicate";
-        Assert.assertEquals(((EvalError) invoke("cross", "Anne", duplicateProjectName, "friend")).message,
+        assertEquals(((EvalError) invoke("cross", "Anne", duplicateProjectName, "friend")).message,
                 "2 projects found with name: " + duplicateProjectName);
     }
 
@@ -133,7 +134,7 @@ public class CrossTests extends RefineTest {
     public void crossFunctionMissingColumn() throws Exception {
         String nonExistentColumn = "NoColumn";
         String projectName = "My Address Book";
-        Assert.assertEquals(((EvalError) invoke("cross", "mary", projectName, nonExistentColumn)).message,
+        assertEquals(((EvalError) invoke("cross", "mary", projectName, nonExistentColumn)).message,
                 "Unable to find column " + nonExistentColumn + " in project " + projectName);
     }
 
@@ -144,7 +145,7 @@ public class CrossTests extends RefineTest {
         WrappedCell lookup = new WrappedCell(project, "recipient", c);
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", lookup, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "50 Broadway Ave.");
+        assertEquals(address, "50 Broadway Ave.");
     }
 
     /**
@@ -158,7 +159,7 @@ public class CrossTests extends RefineTest {
         WrappedCell lookup = new WrappedCell(project, "recipient", c);
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", lookup, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "50 Broadway Ave.");
+        assertEquals(address, "50 Broadway Ave.");
     }
 
     @Test
@@ -166,49 +167,49 @@ public class CrossTests extends RefineTest {
     public void crossFunctionOneArgumentTest() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 0)).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "mary");
+        assertEquals(address, "mary");
     }
 
     @Test
     public void crossFunctionOneArgumentTest1() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 0, "")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "mary");
+        assertEquals(address, "mary");
     }
 
     @Test
     public void crossFunctionOneArgumentTest2() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 1, "", "")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "john");
+        assertEquals(address, "john");
     }
 
     @Test
     public void crossFunctionTwoArgumentTest() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", "lamp", "", "gift")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "mary");
+        assertEquals(address, "mary");
     }
 
     @Test
     public void crossFunctionTwoArgumentTest1() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 0, "My Address Book")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "120 Main St.");
+        assertEquals(address, "120 Main St.");
     }
 
     @Test
     public void crossFunctionTwoArgumentTest2() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 0, "My Address Book", "")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "120 Main St.");
+        assertEquals(address, "120 Main St.");
     }
 
     @Test
     public void crossFunctionOneToOneTest() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", "mary", "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "50 Broadway Ave.");
+        assertEquals(address, "50 Broadway Ave.");
     }
 
     /**
@@ -218,7 +219,7 @@ public class CrossTests extends RefineTest {
     public void crossFunctionOneToManyTest() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", "john", "My Address Book", "friend")).get(1)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "999 XXXXXX St.");
+        assertEquals(address, "999 XXXXXX St.");
     }
 
     @Test
@@ -233,7 +234,7 @@ public class CrossTests extends RefineTest {
         WrappedCell lookup = new WrappedCell(project, "recipient", c);
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", lookup, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "dateTime");
+        assertEquals(address, "dateTime");
     }
 
     @Test
@@ -243,7 +244,7 @@ public class CrossTests extends RefineTest {
         WrappedCell lookup = new WrappedCell(project, "recipient", c);
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", lookup, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "integer");
+        assertEquals(address, "integer");
     }
 
     @Test
@@ -253,28 +254,28 @@ public class CrossTests extends RefineTest {
         WrappedCell lookup = new WrappedCell(project, "recipient", c);
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", lookup, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "boolean");
+        assertEquals(address, "boolean");
     }
 
     @Test
     public void crossFunctionIntegerArgumentTest() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 1600, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "integer");
+        assertEquals(address, "integer");
     }
 
     @Test
     public void crossFunctionIntegerArgumentTest1() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 1600L, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "integer");
+        assertEquals(address, "integer");
     }
 
     @Test
     public void crossFunctionIntegerArgumentTest2() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", "1600", "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "integer");
+        assertEquals(address, "integer");
     }
 
     /**
@@ -290,63 +291,63 @@ public class CrossTests extends RefineTest {
     public void crossFunctionLongArgumentTest() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 123456789123456789L, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "long");
+        assertEquals(address, "long");
     }
 
     @Test
     public void crossFunctionLongArgumentTest1() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", "123456789123456789", "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "long");
+        assertEquals(address, "long");
     }
 
     @Test
     public void crossFunctionDoubleArgumentTest() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 3.14, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "double");
+        assertEquals(address, "double");
     }
 
     @Test
     public void crossFunctionDoubleArgumentTest1() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", 3.14f, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "double");
+        assertEquals(address, "double");
     }
 
     @Test
     public void crossFunctionDoubleArgumentTest2() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", "3.14", "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "double");
+        assertEquals(address, "double");
     }
 
     @Test
     public void crossFunctionDateTimeArgumentTest() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", dateTimeValue, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "dateTime");
+        assertEquals(address, "dateTime");
     }
 
     @Test
     public void crossFunctionDateTimeArgumentTest1() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", dateTimeValue.toString(), "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "dateTime");
+        assertEquals(address, "dateTime");
     }
 
     @Test
     public void crossFunctionBooleanArgumentTest() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", true, "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "boolean");
+        assertEquals(address, "boolean");
     }
 
     @Test
     public void crossFunctionBooleanArgumentTest1() throws Exception {
         Row row = (((WrappedRow) ((HasFieldsListImpl) invoke("cross", "true", "My Address Book", "friend")).get(0)).row);
         String address = row.getCell(1).value.toString();
-        Assert.assertEquals(address, "boolean");
+        assertEquals(address, "boolean");
     }
 
     /**
@@ -368,7 +369,7 @@ public class CrossTests extends RefineTest {
      */
     @Test
     public void crossFunctionNonLiteralValue() throws Exception {
-        Assert.assertEquals(((EvalError) invoke("cross", null, "My Address Book", "friend")).message,
+        assertEquals(((EvalError) invoke("cross", null, "My Address Book", "friend")).message,
                 "cross expects a cell or value, a project name to look up (optional), and a column name in that project (optional)");
     }
 

--- a/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
@@ -55,7 +55,8 @@ import com.google.refine.model.Row;
 public class CrossTests extends RefineTest {
 
     private static final String ERROR_MSG = "cross expects a cell or value, a project name to look up (optional), and a column name in that project (optional)";
-    private static final OffsetDateTime dateTimeValue = OffsetDateTime.parse("2017-05-12T05:45:00+00:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+    private static final OffsetDateTime dateTimeValue = OffsetDateTime.parse("2017-05-12T05:45:00+00:00",
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME);
 
     @Override
     @BeforeTest
@@ -227,8 +228,9 @@ public class CrossTests extends RefineTest {
     }
 
     /**
-     * Check that record field accessor works for a list of WrappedRecords
-     * (technically not a cross() test, but this is pretty much the only place they're used)
+     * Check that record field accessor works for a list of WrappedRecords.
+     *
+     * (Technically not a cross() test, but this is pretty much the only place they're used)
      */
     @Test
     public void crossFunctionRecordFieldLookup() throws Exception {


### PR DESCRIPTION
Fixes #5633

Changes proposed in this pull request:
- Refactor to use static import for asserts so that we won't have a mix of styles in the module (separate commit)
- Fix NullPointerException when null parameters are passed and add a test for the condition (discovered while debugging)
- Fix `record` field access for lists of WrappedRows (only used by `cross()` so test added there)

