### PR TITLE
Fix for the flaky cancel button Cypress test

### DIFF
--- a/main/tests/cypress/cypress/support/e2e.js
+++ b/main/tests/cypress/cypress/support/e2e.js
@@ -19,6 +19,7 @@ import './openrefine_api';
 import './ext_wikibase';
 
 let token;
+let loadedProjectIds = [];
 // Hide fetch/XHR requests
 const app = window.top;
 if (!app.document.head.querySelector('[data-hide-command-log-request]')) {
@@ -33,7 +34,7 @@ if (!app.document.head.querySelector('[data-hide-command-log-request]')) {
 beforeEach(() => {
   cy.wrap(token, { log: false }).as('token');
   cy.wrap(token, { log: false }).as('deletetoken');
-  cy.wrap([], { log: false }).as('loadedProjectIds');
+  cy.wrap(loadedProjectIds, { log: false }).as('loadedProjectIds');
 });
 
 afterEach(() => {


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixes flaky cancel button Cypress test that shows up in the dashboard:

![image](https://user-images.githubusercontent.com/42903164/219544886-96a3fe77-1d6e-4746-baae-aa7a29255a79.png)
![image](https://user-images.githubusercontent.com/42903164/219544920-2371651c-153b-42f0-9185-1ce775c91a60.png)