### PR TITLE
Removed unneeded commands and lines in the Linux refine script

### DIFF
--- a/refine
+++ b/refine
@@ -537,8 +537,6 @@ ui_tests() {
     echo ""
     echo "Killing OpenRefine"
     /bin/kill -9 $REFINE_PID
-    echo "Killing Reconciliation Server"
-    /bin/kill -9 $RECONCILE_SERVER_PID
     echo "Cleaning up"
     rm -rf "$REFINE_DATA_DIR"
 

--- a/refine
+++ b/refine
@@ -114,33 +114,6 @@ check_downloaders() {
     fi
 }
 
-check_unzip() {
-    UNZIP="`command -v unzip 2> /dev/null`"
-    
-    if [ -z "$UNZIP" ] ; then
-        error "We need 'unzip' present in PATH to expand external dependencies."
-    fi
-}
-    
-check_python() {
-    PYTHON="`command -v python 2> /dev/null`"
-    if [ -z "$PYTHON" ] ; then
-        error "This action requires you to have 'python' installed and present in your PATH. You can download it for free at http://www.python.org/"
-    fi
-    PYTHON_VERSION="`$PYTHON --version 2>&1 | cut -f 2 -d ' ' | cut -f 1,2 -d .`"
-    if [ "$PYTHON_VERSION" != "2.6" ] && [ "$PYTHON_VERSION" != "2.7" ]; then
-        error "This action requires Python version 2.6.x. or 2.7.x. You can download it for free at http://www.python.org/"
-    fi
-}
-
-check_pywin32() {
-    PYWIN32="`$PYTHON -c 'import win32api' 2>&1`"
-
-    if [ ! -z "$PYWIN32" ] ; then
-        error "This action requires you to have 'pywin32' windows extensions for Python installed on your machine. You can download it for free at http://sourceforge.net/projects/pywin32/"
-    fi
-}
-
 check_running() {
     check_downloaders
     URL="http://${REFINE_HOST_INTERNAL}:${REFINE_PORT}/"
@@ -226,27 +199,6 @@ download() {
     fi
 }
 
-tool_download() {
-    URL=$1
-    FILE=$2
-    DIR=$3
-    
-    cd $REFINE_TOOLS_DIR
-        if [ ! -f "$FILE" ] ; then
-            download $URL $FILE
-        fi
-        if [ ! -d "$DIR" ] ; then
-            if [ -z "`echo $FILE | sed 's@.*.tar.gz$@@' | sed 's@.*.tgz$@@'`" ] ; then
-                tar xzf $FILE || error "Error while expanding $FILE"
-            fi
-            if [ -z "`echo $FILE | sed 's@.*.zip$@@'`" ] ; then
-                check_unzip
-                $UNZIP -q $FILE || error "Error while expanding $FILE"
-            fi
-        fi
-    cd ..
-}
-
 load_data() {
     FILE=$1
     NAME=$2
@@ -322,48 +274,6 @@ mvn_prepare() {
         MVN="$MVN_HOME/bin/mvn"
     fi
 }
-
-appengine_prepare() {
-    if [ -z "$APPENGINE_HOME" ] ; then
-        error "You have to have the APPENGINE_HOME environment variable set and pointing to the local installation of the Google AppEngine SDK."
-    elif [ ! -f "$APPENGINE_HOME/bin/appcfg.sh" ] ; then
-        error "Environment variable APPENGINE_HOME is set to '$APPENGINE_HOME' which doesn't point to a valid Google App Engine SDK."
-    fi
-    APPENGINE="$APPENGINE_HOME/bin/appcfg.sh"
-    APPENGINE_LOCAL="$APPENGINE_HOME/bin/dev_appserver.sh"
-    
-    ANT_PARAMS="$ANT_PARAMS -Dappengine.sdk.dir=$APPENGINE_HOME"
-}
-   
-virtualenv_prepare() {
-    check_python
-
-    VIRTUALENV_DIR="virtualenv-1.9.1"
-    VIRTUALENV_FILE="${VIRTUALENV_DIR}.tar.gz"
-    VIRTUALENV_URL="http://pypi.python.org/packages/source/v/virtualenv/${VIRTUALENV_FILE}"
-
-    tool_download $VIRTUALENV_URL $VIRTUALENV_FILE $VIRTUALENV_DIR
-    
-    PYTHON_LOCAL="$REFINE_TOOLS_DIR/python"
-    if [ "$OS" = "windows" ] ; then
-        PYTHON_LOCAL="${PYTHON_LOCAL}_win"
-    fi
-    
-    if [ ! -d "$PYTHON_LOCAL" ] ; then
-        $PYTHON $REFINE_TOOLS_DIR/$VIRTUALENV_DIR/virtualenv.py $PYTHON_LOCAL
-    fi
-    
-    PYTHON_HOME="`pwd`/$PYTHON_LOCAL"
-
-    if [ "$OS" = "windows" ] ; then
-        PYTHON="$PYTHON_HOME/Scripts/python.exe"
-        PYTHON_INSTALL="$PYTHON_HOME/Scripts/easy_install.exe"
-    else 
-        PYTHON="$PYTHON_HOME/bin/python"
-        PYTHON_INSTALL="$PYTHON_HOME/bin/easy_install"
-    fi
-}
-    
 # ----------------------------------------------------------------------------------------------
 
 do_mvn() {

--- a/refine
+++ b/refine
@@ -71,18 +71,6 @@ and <action> is one of
    server_test ......................... Run only the server tests
    extensions_test ..................... Run only the extensions tests
    ui_tests ............................ Run only the UI tests
-   
-   broker .............................. Run OpenRefine Broker
-   
-   broker_appengine_run <id> <ver> ..... Run OpenRefine Broker for Google App Engine in local server
-   broker_appengine_upload <id> <ver> .. Upload OpenRefine to Google App Engine
-   
-   findbugs ............................ Run Findbugs against OpenRefine
-   pmd ................................. Run PMD against OpenRefine
-   cpd ................................. Run Copy/Paste Detection against OpenRefine
-   jslint .............................. Run JSlint against OpenRefine
-
-   whitespace <extension> .............. Normalize whitespace in files with the given extension
 
    mac_dist <version> .................. Make MacOSX binary distribution
    windows_dist <version> .............. Make Windows binary distribution
@@ -490,12 +478,6 @@ test() {
 
 
 ui_tests() {
-    download http://okfnlabs.org/reconcile-csv/dist/reconcile-csv-0.1.2.jar ./tools/reconcile-csv-0.1.2.jar
-    RECONCILE_SERVER_CMD="$JAVA -Xmx2g -jar ./tools/reconcile-csv-0.1.2.jar  ./main/tests/cypress/cypress/fixtures/csv-reconcile-species.csv scientific_name taxon_id"
-    echo "Starting reconcile-csv-0.1.2 ..."
-    $RECONCILE_SERVER_CMD 2>&1 &
-    RECONCILE_SERVER_PID="$!"
-
     get_revision
 
     CYPRESS_RECORD=0
@@ -640,131 +622,6 @@ run() {
         "${RUN_CMD[@]}" &
         REFINE_PID="$!"
     fi
-}
-
-broker_build() {
-    build_prepare
-    get_revision
-    # TODO migrate to Maven
-    $MVN prepare_broker
-}
-
-broker_run() {
-    FORK=$1
-
-    if [ ! -d "broker/core/WEB-INF/lib" ] ; then
-        broker_build
-        echo ""
-    fi
-
-    if [ -d $REFINE_CLASSES_DIR ] ; then
-        add_option "-Drefine.autoreload=true" "-Dbutterfly.autoreload=true"
-        add_option "-Drefine.development=true"
-    fi
-
-    add_option "-Drefine.webapp=broker/core"
-    add_option "-Drefine.headless=true"
-
-    add_option "-Drefine.port=$REFINE_PORT"
-    add_option "-Drefine.host=0.0.0.0"
-
-    LIB_PATHS=`cat server/classpath.txt`
-    CLASSPATH="$REFINE_CLASSES_DIR${SEP}$LIB_PATHS"
-
-    RUN_CMD="$JAVA -cp $CLASSPATH $OPTS com.google.refine.Refine"
-
-    #echo "$RUN_CMD"
-    #echo ""
-
-    echo "Starting OpenRefine Broker at 'http://0.0.0.0:${REFINE_PORT}/'"
-    echo ""
-
-    if [ -z "$FORK" ] ; then
-        exec $RUN_CMD
-    else
-        $RUN_CMD &
-        REFINE_PID="$!"
-    fi
-
-}
-
-broker_appengine_build() {
-    appengine_prepare
-    get_revision
-
-    MVN_PARAMS="-Dappengine.sdk.dir=${APPENGINE_HOME}"
-
-    if [ "$1" ] ; then
-        MVN_PARAMS="$MVN_PARAMS -Dappengine.app_id=$1"
-    fi
-
-    if [ "$2" ] ; then
-        MVN_PARAMS="$MVN_PARAMS -Dappengine.version=$2"
-    fi
-
-    # TODO migrate this to Maven
-    $MVN prepare_broker_appengine
-}
-
-broker_appengine_upload() {
-    broker_appengine_build $1 $2
-    "$APPENGINE" update "$REFINE_BUILD_DIR/broker/appengine"
-}
-
-broker_appengine_run() {
-    broker_appengine_build $1 $2
-    "$APPENGINE_LOCAL" "$REFINE_BUILD_DIR/broker/appengine"
-}
-
-findbugs() {
-    findbugs_prepare
-
-    MVN_PARAMS="-Dfindbugs.dir=${REFINE_TOOLS_DIR}/${FINDBUGS_DIR}"
-    ant findbugs
-
-    display "$REFINE_BUILD_DIR/reports/findbugs.html"
-}
-
-pmd() {
-    pmd_prepare
-
-    ANT_PARAMS="-Dpmd.dir=${REFINE_TOOLS_DIR}/${PMD_DIR}"
-    ant pmd
-
-    display "$REFINE_BUILD_DIR/reports/pmd.html"
-}
-
-cpd() {
-    pmd_prepare
-
-    ANT_PARAMS="-Dpmd.dir=${REFINE_TOOLS_DIR}/${PMD_DIR}"
-    ant cpd
-
-    display "$REFINE_BUILD_DIR/reports/cpd.txt"
-}
-
-jslint() {
-    jslint_prepare
-
-    ANT_PARAMS="-Djslint.dir=${REFINE_TOOLS_DIR}/${JSLINT_DIR}"
-    ant jslint
-
-    display "$REFINE_BUILD_DIR/reports/jslint.txt"
-}
-
-whitespace() {
-    [ $# -gt 0 ] || usage
-
-    for i in `find . -name *.$1`; do
-        # expand tabs to spaces
-        expand -t 4 < $i > $i.1
-
-        # convert DOS to UNIX newlines
-        tr -d '\r' < $i.1 > $i.2
-
-        rm $i $i.1
-        mv $i.2 $i
-    done
 }
 
 checkJavaMajorVersion() {
@@ -987,7 +844,6 @@ fi
 case "$ACTION" in
   build) build_prepare; do_mvn process-resources; do_mvn compile\ test-compile;;
   clean) do_mvn clean;;
-  whitespace) whitespace $1;;
   test) test $1;;
   tests) test $1;;
   ui_tests) ui_tests;;    
@@ -995,14 +851,7 @@ case "$ACTION" in
   server_tests) server_test $1;;  
   extensions_test) extensions_test $1;;
   extensions_tests) extensions_test $1;;
-  findbugs) findbugs;;  
-  pmd) pmd;;  
-  cpd) cpd;;  
-  jslint) jslint;;  
-  run) run;;  
-  broker) broker_run;;
-  broker_appengine_run) broker_appengine_run $1 $2;;
-  broker_appengine_upload) broker_appengine_upload $1 $2;;
+  run) run;;
   mac_dist) mac_dist $1;;
   windows_dist) windows_dist $1;;
   linux_dist) linux_dist $1;;


### PR DESCRIPTION
Fixes #5586

Changes proposed in this pull request:
- Remove the following obsolete commands from the Linux refine script: 
  - Linters/Formatters: `findbugs`, `pmd`, `cpd`, `jslint`, and `whitespace`.
  - OpenRefine Broker: `broker`, `broker_appengine_upload`, and `broker_appengine_run`.
  - `reconcile_server` lines in `ui_tests`.
