### PR TITLE
Refactor row count handling for ProjectMetadata. Remove from GetRows.

### DIFF
--- a/main/src/com/google/refine/ProjectManager.java
+++ b/main/src/com/google/refine/ProjectManager.java
@@ -130,10 +130,12 @@ public abstract class ProjectManager {
      */
     public void registerProject(Project project, ProjectMetadata projectMetadata) {
         synchronized (this) {
+            // Row count is duplicated in metadata, so make sure it is up-to-date
+            projectMetadata.setRowCount(project.rows.size());
             _projects.put(project.id, project);
             _projectsMetadata.put(project.id, projectMetadata);
             if (_projectsTags == null)
-                _projectsTags = new HashMap<String, Integer>();
+                _projectsTags = new HashMap<>();
             String[] tags = projectMetadata.getTags();
             if (tags != null) {
                 for (String tag : tags) {

--- a/main/src/com/google/refine/ProjectMetadata.java
+++ b/main/src/com/google/refine/ProjectMetadata.java
@@ -328,8 +328,16 @@ public class ProjectMetadata {
 
     @JsonIgnore
     public void setRowCount(int rowCount) {
-        this._rowCount = rowCount;
+        setRowCountInternal(rowCount);
         updateModified();
+    }
+
+    /**
+     * Set row count without updating the last modified time. Internal use only!
+     */
+    @JsonIgnore
+    public void setRowCountInternal(int rowCount) {
+        this._rowCount = rowCount;
     }
 
     @JsonIgnore
@@ -349,6 +357,7 @@ public class ProjectMetadata {
     @JsonIgnore
     public void setUserMetadata(ArrayNode userMetadata) {
         this._userMetadata = userMetadata;
+        updateModified();
     }
 
     private void updateUserMetadata(String metaName, String valueString) {

--- a/main/src/com/google/refine/commands/project/SetProjectTagsCommand.java
+++ b/main/src/com/google/refine/commands/project/SetProjectTagsCommand.java
@@ -99,9 +99,8 @@ public class SetProjectTagsCommand extends Command {
             }
         }
 
-        // Lets update the project tags
+        // Let's update the project tags
         metadata.setTags(polishedTags.toArray(new String[polishedTags.size()]));
-        metadata.updateModified();
 
         respond(response, "{ \"code\" : \"ok\" }");
     }

--- a/main/src/com/google/refine/commands/row/GetRowsCommand.java
+++ b/main/src/com/google/refine/commands/row/GetRowsCommand.java
@@ -207,7 +207,7 @@ public class GetRowsCommand extends Command {
                 filteredRecords.accept(project, visitor);
             }
 
-            // Pool all the recons occuring in the rows seen
+            // Pool all the recons occurring in the rows seen
             for (WrappedRow wr : rwv.results) {
                 for (Cell c : wr.row.cells) {
                     if (c != null && c.recon != null) {
@@ -224,11 +224,6 @@ public class GetRowsCommand extends Command {
             ParsingUtilities.defaultWriter.writeValue(writer, result);
             if (callback != null) {
                 writer.write(")");
-            }
-
-            // metadata refresh for row mode and record mode
-            if (project.getMetadata() != null) {
-                project.getMetadata().setRowCount(project.rows.size());
             }
         } catch (Exception e) {
             respondException(response, e);

--- a/main/src/com/google/refine/model/Project.java
+++ b/main/src/com/google/refine/model/Project.java
@@ -263,6 +263,10 @@ public class Project {
     public void update() {
         columnModel.update();
         recordModel.update(this);
+        // Old projects may have a row count of 0, but we don't want the act of filling this in to change modified time.
+        if (getMetadata() != null) {
+            getMetadata().setRowCountInternal(rows.size());
+        }
     }
 
     // wrapper of processManager variable to allow unit testing

--- a/main/src/com/google/refine/model/Project.java
+++ b/main/src/com/google/refine/model/Project.java
@@ -65,7 +65,7 @@ public class Project {
     final static protected Map<String, Class<? extends OverlayModel>> s_overlayModelClasses = new HashMap<String, Class<? extends OverlayModel>>();
 
     final public long id;
-    final public List<Row> rows = new ArrayList<Row>();
+    final public List<Row> rows = new ArrayList<>();
     final public ColumnModel columnModel = new ColumnModel();
     final public RecordModel recordModel = new RecordModel();
     final public Map<String, OverlayModel> overlayModels = new HashMap<String, OverlayModel>();
@@ -80,11 +80,19 @@ public class Project {
         return System.currentTimeMillis() + Math.round(Math.random() * 1000000000000L);
     }
 
+    /**
+     * Create a new project with a generated unique ID
+     */
     public Project() {
-        id = generateID();
-        history = new History(this);
+        this(generateID());
     }
 
+    /**
+     * Create a new project with the given ID. For testing ONLY.
+     *
+     * @param id
+     *            long ID to be assigned the new project
+     */
     protected Project(long id) {
         this.id = id;
         this.history = new History(this);

--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -178,8 +178,8 @@ public class RefineTest {
 
         List<Exception> exceptions = new ArrayList<Exception>();
         importer.parseOneFile(project, metadata, job, "filesource", new StringReader(input), -1, options, exceptions);
-        project.update();
         ProjectManager.singleton.registerProject(project, metadata);
+        project.update();
 
         projects.add(project);
         importingJobs.add(job);

--- a/main/tests/server/src/com/google/refine/history/HistoryTests.java
+++ b/main/tests/server/src/com/google/refine/history/HistoryTests.java
@@ -33,10 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.history;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
@@ -98,9 +95,10 @@ public class HistoryTests extends RefineTest {
 
         SUT.addEntry(entry);
 
-        verify(projectManager, times(1)).getProject(Mockito.anyLong());
+        verify(projectManager, atLeastOnce()).getProject(Mockito.anyLong());
         verify(entry, times(1)).apply(proj);
-        verify(projectMetadata, times(1)).updateModified();
+        verify(projectMetadata, atLeastOnce()).setRowCount(0);
+        verify(projectMetadata, atLeastOnce()).updateModified();
         Assert.assertEquals(SUT.getLastPastEntries(1).get(0), entry);
     }
 

--- a/main/tests/server/src/com/google/refine/model/ProjectStub.java
+++ b/main/tests/server/src/com/google/refine/model/ProjectStub.java
@@ -35,6 +35,12 @@ package com.google.refine.model;
 
 public class ProjectStub extends Project {
 
+    /**
+     * Public version of protected constructor in the super class for testing purposes only.
+     *
+     * @param id
+     *            create project with the given ID rather than generating a new one.
+     */
     public ProjectStub(long id) {
         super(id);
     }


### PR DESCRIPTION
Fixes #1380 Fixes #5387 Probably fixes #3475

Changes proposed in this pull request:
- refactor row counter maintenance in ProjectMetadata so it's done when row list is updated rather than on every GetRows command. (#1380)
- Update row count when project is created/registered (#5387)
- Update row count for when opening legacy projects which were created before row count was stored in metadata (but do it in a way that doesn't change the Modified date for the project)

