### PR TITLE
Fixed the memory usage display to show up correctly on project creation

### DIFF
--- a/main/src/com/google/refine/importing/ImportingJob.java
+++ b/main/src/com/google/refine/importing/ImportingJob.java
@@ -121,7 +121,7 @@ public class ImportingJob {
             }
             JSONUtilities.safePut(progress, "message", message);
             JSONUtilities.safePut(progress, "percent", percent);
-            JSONUtilities.safePut(progress, "memory", Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() / 1048576);
+            JSONUtilities.safePut(progress, "memory", (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / 1048576);
             JSONUtilities.safePut(progress, "maxmemory", Runtime.getRuntime().maxMemory() / 1048576);
         }
     }


### PR DESCRIPTION
Fixes #5665

(Regression introduced by https://github.com/OpenRefine/OpenRefine/pull/5222 )

When I made an original change to make the memory% more accurate, it seemed to be working, but now it is broken, and parenthesis are required for the order of operations.  Looks like it finally works as intended now since the memory% increases as more rows are read in.  If you hit 100% on a large CSV file, the JVM will start thrashing and possibly get an OutOfMemory error.

Before:
![23millionrows-progress-bug](https://user-images.githubusercontent.com/42903164/222860900-3ee61260-e284-4d20-9614-e07f8d91f291.gif)

After:
![23millionrows-progress-fixed](https://user-images.githubusercontent.com/42903164/222860898-45b69eab-6783-48b1-a860-1ab96d695868.gif)
