### PR TITLE
Update launch4j-maven-plugin to 2.3.2, for #5583

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -421,26 +421,7 @@
       <plugin>
         <groupId>com.akathist.maven.plugins.launch4j</groupId>
         <artifactId>launch4j-maven-plugin</artifactId>
-        <version>2.1.3</version>
-
-            <!-- This is a clean snapshot of launch4j's master branch,
-                which includes fixes to Java discovery that we need
-                to support recent versions of Java.
-                When the maven plugin is updated to use launch4j-3.13,
-                this can be removed. -->
-        <dependencies>
-          <dependency>
-            <groupId>net.sf.launch4j</groupId>
-            <artifactId>launch4j</artifactId>
-            <classifier>core</classifier>
-            <version>3.14</version>
-          </dependency>
-          <dependency>
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
-          <version>1.4.19</version>
-        </dependency>
-        </dependencies>
+        <version>2.3.2</version>
         <executions>
           <execution>
             <id>l4j-clui-without-jre</id>
@@ -463,7 +444,6 @@
                 <path>%JAVA_HOME%;%PATH%</path>
                 <minVersion>${java.minversion}</minVersion>
                 <maxVersion>${java.maxversion}</maxVersion>
-                <bundledJreAsFallback>false</bundledJreAsFallback>
                 <initialHeapSize>512</initialHeapSize>
                 <maxHeapSize>2048</maxHeapSize>
                 <opts>


### PR DESCRIPTION
For #5583 (not sure it fixes it - I will ask folks to try the snapshot release once merged, and if that works I would backport this to 3.7)

Apparently dependabot did not propose this update although the version we are using is already quite a few months old. I am not sure why. Given #5667 it looks like this is not the only dependency that gets skipped.
