### PR TITLE
Attempt to fix the CI test matrix by pinning dependency versions

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: '14'
+          node-version: '16'
       - id: set-matrix
-        run: npm install --save glob && node main/tests/cypress/build-test-matrix.js
+        run: npm install --save glob@9.2.1 && node main/tests/cypress/build-test-matrix.js
         env:
           browsers: chrome
   ui_test:

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: '14'
       - id: set-matrix
-        run: npm install --save glob@8.1.0 && node main/tests/cypress/build-test-matrix.js
+        run: npm install --save glob@8.1.0 && node main/tests/cypress/build-test-matrix.js >> $GITHUB_OUTPUT
         env:
           browsers: chrome
   ui_test:

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -23,9 +23,9 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.6.0
         with:
-          node-version: '16'
+          node-version: '14'
       - id: set-matrix
-        run: npm install --save glob@9.2.1 && node main/tests/cypress/build-test-matrix.js
+        run: npm install --save glob@8.1.0 && node main/tests/cypress/build-test-matrix.js
         env:
           browsers: chrome
   ui_test:


### PR DESCRIPTION
The CI test matrix still fails, seemingly for a new reason, so this is an attempt to fix it.
