### PR TITLE
Refine bat consistency cleanup

### DIFF
--- a/refine.bat
+++ b/refine.bat
@@ -79,56 +79,20 @@ set OPTS=
 rem --- Argument parsing --------------------------------------------
 
 :loop
-if ""%1"" == """" goto readIniFile
-if ""%1"" == ""/?"" goto usage
-if ""%1"" == ""/h"" goto usage
-if ""%1"" == ""/p"" goto arg-p
-if ""%1"" == ""/i"" goto arg-i
-if ""%1"" == ""/H"" goto arg-H
-if ""%1"" == ""/w"" goto arg-w
-if ""%1"" == ""/d"" goto arg-d
-if ""%1"" == ""/m"" goto arg-m
-if ""%1"" == ""/x"" goto arg-x
-if ""%1"" == ""/c"" goto arg-c
-goto readIniFile
-
-:arg-p
-set REFINE_PORT=%2
-goto shift2loop
-
-:arg-i
-set REFINE_INTERFACE=%2
-goto shift2loop
-
-:arg-H
-set REFINE_HOST=%2
-goto shift2loop
-
-:arg-w
-set REFINE_WEBAPP=%2
-goto shift2loop
-
-:arg-m
-set REFINE_MEMORY=%2
-set REFINE_MIN_MEMORY=%2
-goto shift2loop
-
-:arg-d
-set OPTS=%OPTS% -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n
-goto shift2loop
-
-:arg-x
-set OPTS=%OPTS% -Dcom.sun.management.jmxremote
-goto shift2loop
-
-:arg-c
-set REFINE_INI_PATH=%~2
-goto shift2loop
-
-:shift2loop
-shift
-shift
-goto loop
+if "%~1"=="" goto readIniFile
+if "%~1"=="/?" goto usage
+if "%~1"=="/h" goto usage
+if "%~1"=="/p" set "REFINE_PORT=%~2" & shift & goto loop
+if "%~1"=="/i" set "REFINE_INTERFACE=%~2" & shift & goto loop
+if "%~1"=="/H" set "REFINE_HOST=%~2" & shift & goto loop
+if "%~1"=="/w" set "REFINE_WEBAPP=%~2" & shift & goto loop
+if "%~1"=="/m" set "REFINE_MEMORY=%~2" & set "REFINE_MIN_MEMORY=%~2" & shift & goto loop
+if "%~1"=="/d" set "REFINE_DATA_DIR=%~2" & shift & goto loop
+if "%~1"=="/debug" set "OPTS=%OPTS% -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n" & shift & goto loop
+if "%~1"=="/x" set "REFINE_EXTRA_OPTS=%~2" & shift & goto loop
+if "%~1"=="/jmx" set "OPTS=%OPTS% -Dcom.sun.management.jmxremote" & shift & goto loop
+if "%~1"=="/c" set "REFINE_INI_PATH=%~2" & shift & goto loop
+if "%~1"=="/v" set "REFINE_VERBOSITY=%~2" & shift & goto loop
 
 :readIniFile
 
@@ -205,9 +169,18 @@ if not "%REFINE_CLASSES_DIR%" == "" goto gotClassesDir
 set REFINE_CLASSES_DIR=server\classes
 :gotClassesDir
 
+if not "%REFINE_DATA_DIR%" == "" set OPTS=%OPTS% -Drefine.data_dir=%REFINE_DATA_DIR%
+
 if not "%REFINE_LIB_DIR%" == "" goto gotLibDir
 set REFINE_LIB_DIR=server\target\lib
 :gotLibDir
+
+if not "%REFINE_VERBOSITY%" == "" goto gotVerbosity
+set REFINE_VERBOSITY=info
+:gotVerbosity
+set OPTS=%OPTS% -Drefine.verbosity=%REFINE_VERBOSITY%
+
+if not "%REFINE_EXTRA_OPTS%" == "" set OPTS=%OPTS% -D%REFINE_EXTRA_OPTS%
 
 if "%GDATA_CLIENT_ID%" == "" goto skipGDataCredentials
 if "%GDATA_CLIENT_SECRET%" == "" goto skipGDataCredentials

--- a/refine.bat
+++ b/refine.bat
@@ -59,7 +59,8 @@ echo.
 echo  "/debug" enable JVM debugging (on port 8000)
 echo.
 echo  "/jmx" enable JMX monitoring (for jconsole and jvisualvm)
-echo "and <action> is one of
+echo.
+echo  and <action> is one of
 echo.
 echo   build ..................... Build OpenRefine
 echo   run ....................... Run OpenRefine (using only "refine" or "./refine" will also start OpenRefine)

--- a/refine.bat
+++ b/refine.bat
@@ -60,7 +60,7 @@ echo  "/debug" enable JVM debugging (on port 8000)
 echo.
 echo  "/jmx" enable JMX monitoring (for jconsole and jvisualvm)
 echo.
-echo  and <action> is one of
+echo  "and <action>" is one of
 echo.
 echo   build ..................... Build OpenRefine
 echo   run ....................... Run OpenRefine (using only "refine" or "./refine" will also start OpenRefine)

--- a/refine.bat
+++ b/refine.bat
@@ -42,16 +42,23 @@ echo.
 echo  "/w <path>" path to the webapp
 echo     default src\main\webapp
 echo.
-echo  "/d" enable JVM debugging (on port 8000)
+echo  "/d <path>" path to the data directory
+echo     default: OS dependent
 echo.
 echo  "/m <memory>" max memory heap size to use
 echo     default: 1400M
 echo.
-echo  "/x" enable JMX monitoring (for jconsole and friends)
+echo  "v <level>" verbosity level [from low to high: error,warn,info,debug,trace]
+echo.
+echo  "/x <name=value>" additional configuration parameters to pass to OpenRefine
+echo     default: [none]
 echo.
 echo  "/c <path>" path to the refine.ini file
 echo     default .\refine.ini
 echo.
+echo  "/debug" enable JVM debugging (on port 8000)
+echo.
+echo  "/jmx" enable JMX monitoring (for jconsole and jvisualvm)
 echo "and <action> is one of
 echo.
 echo   build ..................... Build OpenRefine
@@ -82,17 +89,17 @@ rem --- Argument parsing --------------------------------------------
 if "%~1"=="" goto readIniFile
 if "%~1"=="/?" goto usage
 if "%~1"=="/h" goto usage
-if "%~1"=="/p" set "REFINE_PORT=%~2" & shift & goto loop
-if "%~1"=="/i" set "REFINE_INTERFACE=%~2" & shift & goto loop
-if "%~1"=="/H" set "REFINE_HOST=%~2" & shift & goto loop
-if "%~1"=="/w" set "REFINE_WEBAPP=%~2" & shift & goto loop
-if "%~1"=="/m" set "REFINE_MEMORY=%~2" & set "REFINE_MIN_MEMORY=%~2" & shift & goto loop
-if "%~1"=="/d" set "REFINE_DATA_DIR=%~2" & shift & goto loop
+if "%~1"=="/p" set "REFINE_PORT=%~2" & shift & shift & goto loop
+if "%~1"=="/i" set "REFINE_INTERFACE=%~2" & shift & shift & goto loop
+if "%~1"=="/H" set "REFINE_HOST=%~2" & shift & shift & goto loop
+if "%~1"=="/w" set "REFINE_WEBAPP=%~2" & shift & shift & goto loop
+if "%~1"=="/m" set "REFINE_MEMORY=%~2" & set "REFINE_MIN_MEMORY=%~2" & shift & shift & goto loop
+if "%~1"=="/d" set "REFINE_DATA_DIR=%~2" & shift & shift & goto loop
 if "%~1"=="/debug" set "OPTS=%OPTS% -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n" & shift & goto loop
-if "%~1"=="/x" set "REFINE_EXTRA_OPTS=%~2" & shift & goto loop
+if "%~1"=="/x" set "REFINE_EXTRA_OPTS=%~2" & shift & shift & goto loop
 if "%~1"=="/jmx" set "OPTS=%OPTS% -Dcom.sun.management.jmxremote" & shift & goto loop
-if "%~1"=="/c" set "REFINE_INI_PATH=%~2" & shift & goto loop
-if "%~1"=="/v" set "REFINE_VERBOSITY=%~2" & shift & goto loop
+if "%~1"=="/c" set "REFINE_INI_PATH=%~2" & shift & shift & goto loop
+if "%~1"=="/v" set "REFINE_VERBOSITY=%~2" & shift & shift & goto loop
 
 :readIniFile
 

--- a/refine.bat
+++ b/refine.bat
@@ -48,7 +48,7 @@ echo.
 echo  "/m <memory>" max memory heap size to use
 echo     default: 1400M
 echo.
-echo  "v <level>" verbosity level [from low to high: error,warn,info,debug,trace]
+echo  "/v <level>" verbosity level [from low to high: error,warn,info,debug,trace]
 echo.
 echo  "/x <name=value>" additional configuration parameters to pass to OpenRefine
 echo     default: [none]


### PR DESCRIPTION
Fixes #5359

Changes proposed in this pull request:
- Moved functionality of `/d` to `/debug` and `/x` to `/jmx` for refine.bat.
- Implemented `/d`, `/v` and `/x` for refine.bat.
- Cleaned up some of the argument parsing to be more clear and concise.
- Changed the usage statement to reflect the changes.