### PR TITLE
improve readability of the no-projects message

### DIFF
--- a/main/webapp/modules/core/styles/index/open-project-ui.css
+++ b/main/webapp/modules/core/styles/index/open-project-ui.css
@@ -79,8 +79,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #projects-container .message {
   padding: var(--padding-loose);
   font-size: 170%;
-  line-height: 1.5em;
-  opacity: 0.2;
 }
 
 #projects-container>table thead th:nth-child(1) {


### PR DESCRIPTION
Before:
![Screenshot 2023-03-13 at 14-04-29 OpenRefine](https://user-images.githubusercontent.com/2631719/224710215-2f22d90d-6f7a-4f67-93dc-311dbf0b9675.png)

After:
![Screenshot 2023-03-13 at 14-04-13 OpenRefine](https://user-images.githubusercontent.com/2631719/224710297-a4b32bb5-1775-4e08-bf44-4de52885888c.png)
