### PR TITLE
change the language tab-url

### DIFF
--- a/main/webapp/modules/core/scripts/index/lang-settings-ui.js
+++ b/main/webapp/modules/core/scripts/index/lang-settings-ui.js
@@ -48,7 +48,7 @@ Refine.SetLanguageUI = function(elmt) {
 };
 
 Refine.actionAreas.push({
-	id : "lang-settings",
+	id : "language-settings",
 	label : $.i18n('core-index-lang/lang-settings'),
 	uiClass : Refine.SetLanguageUI
 });


### PR DESCRIPTION
given that the ActionArea's IDs are now used in  the URL let's not use an abbreviation.
