### PR TITLE
fix the tab order for reconciliation create and match buttons

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
@@ -55,17 +55,17 @@ class ReconCellRenderer {
               var liSpan = $('<span></span>').appendTo(li);
 
               $('<a href="javascript:{}">&nbsp;</a>')
-              .addClass("data-table-recon-match-similar")
-              .attr("title", $.i18n('core-views/match-all-cells'))
-              .appendTo(liSpan).on('click',function(evt) {
-                self.doMatchTopicToSimilarCells(candidate, cellIndex, cell);
-              });
-
-              $('<a href="javascript:{}">&nbsp;</a>')
               .addClass("data-table-recon-match")
               .attr("title", $.i18n('core-views/match-this-cell') )
               .appendTo(liSpan).on('click',function(evt) {
                 self.doMatchTopicToOneCell(candidate, rowIndex, cellIndex, cell, cellUI);
+              });
+
+              $('<a href="javascript:{}">&nbsp;</a>')
+              .addClass("data-table-recon-match-similar")
+              .attr("title", $.i18n('core-views/match-all-cells'))
+              .appendTo(liSpan).on('click',function(evt) {
+                self.doMatchTopicToSimilarCells(candidate, cellIndex, cell);
               });
 
               var a = $('<a></a>')
@@ -95,18 +95,19 @@ class ReconCellRenderer {
           }
 
           var liNew = $('<div></div>').addClass("data-table-recon-candidate").appendTo(ul);
-          $('<a href="javascript:{}">&nbsp;</a>')
-          .addClass("data-table-recon-match-similar")
-          .attr("title", $.i18n('core-views/create-topic-cells'))
-          .appendTo(liNew).on('click',function(evt) {
-            self.doMatchNewTopicToSimilarCells(cellIndex, cell);
-          });
 
           $('<a href="javascript:{}">&nbsp;</a>')
           .addClass("data-table-recon-match")
           .attr("title", $.i18n('core-views/create-topic-cell'))
           .appendTo(liNew).on('click',function(evt) {
             self.doMatchNewTopicToOneCell(rowIndex, cellIndex, cell, cellUI);
+          });
+
+          $('<a href="javascript:{}">&nbsp;</a>')
+          .addClass("data-table-recon-match-similar")
+          .attr("title", $.i18n('core-views/create-topic-cells'))
+          .appendTo(liNew).on('click',function(evt) {
+            self.doMatchNewTopicToSimilarCells(cellIndex, cell);
           });
 
           $('<span>').text($.i18n('core-views/create-topic')).appendTo(liNew);


### PR DESCRIPTION
This fixes the tab order for the two reconciliation create buttons:

[Screencast from 2023-03-14 16-16-09.webm](https://user-images.githubusercontent.com/2631719/225048095-c2e2e8bd-41c5-4dae-ad54-a82f61bbe0e9.webm)

Previously the order would be reverse, as in the right button being focused before the left one.