### PR TITLE
updated the error code

### DIFF
--- a/refine
+++ b/refine
@@ -140,7 +140,7 @@ check_running() {
         fi    
         
         if [ -z "${RUNNING}" ] ; then
-            error "Something is already running on $URL but doesn't seem to be OpenRefine. Maybe a proxy issue?"
+            error "OpenRefine isn't running on $URL. Maybe a proxy issue?"
         fi
     else
         RUNNING=""


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18mF3dyLVYfYFn8DBhGJijLl0X3VYGNs%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=9qMKnk7)
Fixes #5680 

Changes proposed in this pull request:
- The check running script is only checking if OpenRefine is running on the given interface, not if "something" is running, the error message should therefore, not say that something is already running there but rather give a more generic error. "OpenRefine isn't running on $URL."
- 
- 
