### PR TITLE
Update TestNG to 7.7.1 - fixes CVE-2022-4065

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>7.6.1</version>
+      <version>${testng.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <guava.version>31.1-jre</guava.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <juniversalchardet.version>2.4.0</juniversalchardet.version>
-    <testng.version>7.6.1</testng.version>
+    <testng.version>7.7.1</testng.version>
     <httpmime.version>4.5.14</httpmime.version>
     <owasp-encoder.version>1.2.3</owasp-encoder.version>
     <jasypt.version>1.9.3</jasypt.version>


### PR DESCRIPTION
Resolves Dependabot alert 110
https://github.com/OpenRefine/OpenRefine/security/dependabot/110 which Dependabot was unable to generate a PR for.


It's a little bit worrying that Dependabot didn't alert on any of the other uses of TestNG where the version was specified via a variable, but only the one that was hardcoded. 

This switches the `benchmark` project to use the variable and updates it to a version that doesn't have the vulnerability.