### PR TITLE
Increase dynamic range of multinomial() function - fixes #5695

### DIFF
--- a/main/src/com/google/refine/expr/functions/math/FactN.java
+++ b/main/src/com/google/refine/expr/functions/math/FactN.java
@@ -61,7 +61,7 @@ public class FactN implements Function {
 
     }
 
-    /*
+    /**
      * Calculates the factorial of an integer, i, for a decreasing step of n. e.g. A double factorial would have a step
      * of 2. Returns 1 for zero and negative integers.
      */

--- a/main/tests/server/src/com/google/refine/grel/GrelTests.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTests.java
@@ -141,7 +141,15 @@ public class GrelTests extends RefineTest {
                 { "2<=2", "true" },
                 { "3<=2", "false" },
                 { "0/0", "NaN" },
-//                { "", "" }, 
+                { "fact(4)", "24" },
+                { "fact(20)", "2432902008176640000" }, // limit for Java longs
+                { "fact(21)", "java.lang.ArithmeticException: Integer overflow computing factorial" },
+                { "multinomial(1, 3)", "4" },
+                { "multinomial(0, 4)", "1" },
+                { "multinomial(18, 2)", "190" }, // limit for Java longs
+                { "multinomial(18, 3)", "1330" }, // test BigInteger support
+                { "multinomial(3, 5, 2)", "2520" },
+//                { "", "" },
         };
         for (String[] test : tests) {
             parseEval(bindings, test);


### PR DESCRIPTION
Fixes #5695

Resolves CodeQL warning about narrowing conversion and uses BigInteger for intermediary values to avoid overflow unless absolutely necessary. Allows sum of terms to exceed 20 in some cases. (20! is limit of Java long)
