### PR TITLE
Use wmic for getting free ram in refine.bat

### DIFF
--- a/refine.bat
+++ b/refine.bat
@@ -228,14 +228,14 @@ if %JAVA_RELEASE% GTR 17 (
 )
 
 echo Getting Free Ram...
-for /f "tokens=2 delims=:" %%i in ('systeminfo ^| findstr /C:"Available Physical Memory"') do (set freeRam=%%i)
+for /f "tokens=2 delims==" %%i in ('wmic OS get FreePhysicalMemory /Value') do set /a freeRam=%%i/1024
 (
 echo ----------------------- 
 echo PROCESSOR_ARCHITECTURE = %PROCESSOR_ARCHITECTURE%
 echo JAVA_HOME = %JAVA_HOME%
 echo java release = %JAVA_RELEASE%
 echo java -version = %JAVA_VERSION%
-echo freeRam = %freeRam%
+echo freeRam = %freeRam% MB
 echo REFINE_MEMORY = %REFINE_MEMORY%
 echo ----------------------- 
 ) > support.log


### PR DESCRIPTION
Changes proposed in this pull request:
- Make refine.bat use `wmic` to get the available free memory instead of the inefficient `systeminfo ^| findstr /C:"Available Physical Memory"`.

WMIC (Windows Management Instrumentation Command-line) is a command-line interface for the Windows Management Instrumentation (WMI) technology. It has been available since Windows Server 2003 and Windows XP/Vista/7 and later.

On my desktop the time for 'Getting Free Ram' went from 2.5 seconds to instant.  For my laptop, it went from 3.5 seconds to almost instant.

Before:
![Command prompt before 2 hidden](https://user-images.githubusercontent.com/42903164/226829670-5c65367a-6c60-494c-bf69-44a22b518e94.gif)


After:
![Command prompt after 2 hidden](https://user-images.githubusercontent.com/42903164/226829659-2b88109c-a88a-4b39-b5d0-5c03f535414b.gif)
