### PR TITLE
Fixed Flaky Test in clustering.binning.BinningClustererTests.testSerializeBinningClusterer

### DIFF
--- a/main/webapp/modules/core/langs/translation-nl.json
+++ b/main/webapp/modules/core/langs/translation-nl.json
@@ -1,5 +1,5 @@
 {
-    "name": "Engels",
+    "name": "Nederlands",
     "core-index/slogan": "Een krachtige tool om rommelige data te bewerken",
     "core-index/help": "Hulp",
     "core-index/about": "Over",

--- a/main/webapp/modules/core/langs/translation-pt.json
+++ b/main/webapp/modules/core/langs/translation-pt.json
@@ -630,7 +630,7 @@
     "core-views/choose-reconciliation-service": "Escolher um serviço de reconciliação",
     "core-dialogs/sel-and-ord": "Selecione e ordene as colunas para exportar",
     "core-views/rows": "linhas",
-    "core-index/download-now": "Baixe $1 agora.",
+    "core-index/download-now": "Descarregue $1 agora.",
     "core-index/pref-key": "Valor da chave de preferência:",
     "core-views/copy-recon2": "Copiar dados de reconciliação para outras colunas",
     "core-buttons/add-url": "Adicionar outra URL",


### PR DESCRIPTION
### What is the purpose of this PR
##### This PR fixes the error resulting from the flaky test: 
     com.google.refine.clustering.binning.BinningClustererTests#testSerializeBinningClusterer

### Why the test fail

- HashMap is unordered and it does not guarantee that the order will remain constant over time. Because of this the test failed when comparing two json strings where the actual json (formed by `HashMap`) order can be different from expected json order. 
- In BinningClustererTests#testSerializeBinningClusterer it calls computeClusters which is in BinningClusterer.java. Here it forms the json using HashMap and failed when expected and actual jsons are compared in TestUtils.java (assertEqualsAsJson)

### Reproduce the test failure
Run the test with `NonDex` maven plugin. The command to recreate the flaky test failures are:

- `mvn -pl main edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.google.refine.clustering.binning.BinningClustererTests#testSerializeBinningClusterer -DnondexRuns=10`
- Fixing the flaky test now may prevent flaky test failures in future Java versions.

### Expected results
The test should run successfully when run with `NonDex`.

### Actual Result
We get the following failure for test `com.google.refine.clustering.binning.BinningClustererTests#testSerializeBinningClusterer`
`[INFO] Using auto detected provider org.apache.maven.surefire.testng.TestNGProvider
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.google.refine.clustering.binning.BinningClustererTests
[ [ {        [ [ {
  "c" : 1,     "c" : 1,
  "v" : "a"    "v" : "c"
}, {         }, {
  "c" : 1,     "c" : 1,
  "v" : "à"    "v" : "ĉ"
} ], [ {     } ], [ {
  "c" : 1,     "c" : 1,
  "v" : "c"    "v" : "a"
}, {         }, {
  "c" : 1,     "c" : 1,
  "v" : "ĉ"    "v" : "à"
} ] ]        } ] ]
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 6.257 s <<< FAILURE! - in com.google.refine.clustering.binning.BinningClustererTests
[ERROR] com.google.refine.clustering.binning.BinningClustererTests.testSerializeBinningClusterer  Time elapsed: 3.376 s  <<< FAILURE!
java.lang.AssertionError: Objects above are not equal as JSON strings.`

### Fix

- Change the object type of `_map` from`HashMap` to `TreeMap` in method main.src.com.google.refine.clustering.binning.BinningClusterer.java


