### PR TITLE
Made it so dialogs cannot be dragged past the top of the window

### DIFF
--- a/main/webapp/modules/core/scripts/util/dialog.js
+++ b/main/webapp/modules/core/scripts/util/dialog.js
@@ -63,7 +63,7 @@ DialogSystem.showDialog = function(elmt, onCancel) {
   container.css("top", Math.round((top < 0 ) ? 5 : top) + "px");
   elmt.css("visibility", "visible");
 
-  container.draggable({ handle: '.dialog-header', cursor: 'move' });
+  container.draggable({ handle: '.dialog-header', containment: [ -4096, 0, 4096, 4096 ], cursor: 'move' });
 
   var layer = {
     overlay: overlay,

--- a/main/webapp/modules/core/scripts/util/dialog.js
+++ b/main/webapp/modules/core/scripts/util/dialog.js
@@ -63,7 +63,7 @@ DialogSystem.showDialog = function(elmt, onCancel) {
   container.css("top", Math.round((top < 0 ) ? 5 : top) + "px");
   elmt.css("visibility", "visible");
 
-  container.draggable({ handle: '.dialog-header', containment: [ -4096, 0, 4096, 4096 ], cursor: 'move' });
+  container.draggable({ handle: '.dialog-header', containment: [ -32768, 0, 32768, 32768 ], cursor: 'move' });
 
   var layer = {
     overlay: overlay,


### PR DESCRIPTION
Fixes #5714

Changes proposed in this pull request:
- Set containment property to prevent user from dragging jQuery UI dialogs above the top of the browser window.

 I originally tried `containment: 'window'` but that didn't work as expected because the dialog-container is the full width of the browser window, so it prevented the user from moving the dialog left or right. So instead of that, I am setting a containment box with top = 0 to prevent the user from dragging the dialog above the top of the screen.  The bottom, right, and left boundaries are set sufficiently large that so user's can drag in those directions without limit on 4k displays.
 
 After:
 
![Dialog boundary top](https://user-images.githubusercontent.com/42903164/227345063-282885ef-f14e-4686-a80d-e44f4acb5562.gif)
