### PR TITLE
Apply operation json from a file

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -406,7 +406,7 @@
     "core-project/operation-history-json": "Operation history JSON",
     "core-project/extract-save": "Extract and save parts of your operation history as JSON that you can apply to this or other projects in the future.",
     "core-project/apply-operation": "Apply Operation History",
-    "core-project/paste-json": "Paste an extracted JSON history of operations to perform:",
+    "core-project/paste-json": "Select a file or paste an extracted JSON history of operations to perform:",
     "core-project/percent-complete": "$1% complete",
     "core-project/other-processes": "($1 other pending {{plural:$1|process|processes}})",
     "core-project/cancel-all": "{{plural:$1|Cancel|Cancel All}}",

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -3,7 +3,7 @@
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body" bind="dialogBody">
       <div class="dialog-instruction"><label for="textareaId" bind="or_proj_pasteJson"></label></div>
-      <input type="file" id="file-input" bind="operationJsonButton"/>
+      <input type="file" id="file-input" bind="operationJsonButton" style="margin-bottom: 8px;"/>
       <div class="input-container"><textarea spellcheck="false" wrap="off" bind="textarea" id="textareaId" class="history-operation-json" style="min-width: 764px"></textarea></div>
     </div>
     <div class="dialog-footer" bind="dialogFooter">

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -10,7 +10,6 @@
     <button class="button" bind="cancelButton"></button>
     <button class="button" bind="operationJsonButton"></button>
     <input type="file" id="file-input" style="display:none;">
-    <pre id="file-contents"></pre>
     </div>
   </div>
 </div>

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -3,13 +3,12 @@
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body" bind="dialogBody">
       <div class="dialog-instruction"><label for="textareaId" bind="or_proj_pasteJson"></label></div>
-      <input type="file" id="file-input" bind="operationJsonButton"/>
+      <input type="file" id="file-input" bind="operationJsonButton" class="upload-json"/>
       <div class="input-container"><textarea spellcheck="false" wrap="off" bind="textarea" id="textareaId" class="history-operation-json" style="min-width: 764px"></textarea></div>
     </div>
     <div class="dialog-footer" bind="dialogFooter">
     <button class="button" bind="applyButton"></button>
     <button class="button" bind="cancelButton"></button>
-    <input type="file" id="file-input" style="display:none;">
     </div>
   </div>
 </div>

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -8,7 +8,7 @@
     <div class="dialog-footer" bind="dialogFooter">
     <button class="button" bind="applyButton"></button>
     <button class="button" bind="cancelButton"></button>
+    <button class="button" bind="operationJsonButton"></button>
     </div>
   </div>
 </div>
-

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -8,7 +8,8 @@
     <div class="dialog-footer" bind="dialogFooter">
     <button class="button" bind="applyButton"></button>
     <button class="button" bind="cancelButton"></button>
-    <button class="button" bind="operationJsonButton"></button>
+    <button class="button" id="upload-btn" bind="operationJsonButton"></button>
+    <input type="file" id="file-input" style="display:none;">
     </div>
   </div>
 </div>

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -3,12 +3,12 @@
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body" bind="dialogBody">
       <div class="dialog-instruction"><label for="textareaId" bind="or_proj_pasteJson"></label></div>
+      <button class="button" bind="operationJsonButton"></button>
       <div class="input-container"><textarea spellcheck="false" wrap="off" bind="textarea" id="textareaId" class="history-operation-json" style="min-width: 764px"></textarea></div>
     </div>
     <div class="dialog-footer" bind="dialogFooter">
     <button class="button" bind="applyButton"></button>
     <button class="button" bind="cancelButton"></button>
-    <button class="button" bind="operationJsonButton"></button>
     <input type="file" id="file-input" style="display:none;">
     </div>
   </div>

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -8,8 +8,9 @@
     <div class="dialog-footer" bind="dialogFooter">
     <button class="button" bind="applyButton"></button>
     <button class="button" bind="cancelButton"></button>
-    <button class="button" id="upload-btn" bind="operationJsonButton"></button>
+    <button class="button" bind="operationJsonButton"></button>
     <input type="file" id="file-input" style="display:none;">
+    <pre id="file-contents"></pre>
     </div>
   </div>
 </div>

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -3,7 +3,7 @@
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body" bind="dialogBody">
       <div class="dialog-instruction"><label for="textareaId" bind="or_proj_pasteJson"></label></div>
-      <input type="file" id="file-input" bind="operationJsonButton" class="upload-json"/>
+      <input type="file" id="file-input" bind="operationJsonButton"/>
       <div class="input-container"><textarea spellcheck="false" wrap="off" bind="textarea" id="textareaId" class="history-operation-json" style="min-width: 764px"></textarea></div>
     </div>
     <div class="dialog-footer" bind="dialogFooter">

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -3,7 +3,7 @@
     <div class="dialog-header" bind="dialogHeader"></div>
     <div class="dialog-body" bind="dialogBody">
       <div class="dialog-instruction"><label for="textareaId" bind="or_proj_pasteJson"></label></div>
-      <button class="button" bind="operationJsonButton"></button>
+      <input type="file" id="file-input" bind="operationJsonButton"/>
       <div class="input-container"><textarea spellcheck="false" wrap="off" bind="textarea" id="textareaId" class="history-operation-json" style="min-width: 764px"></textarea></div>
     </div>
     <div class="dialog-footer" bind="dialogFooter">

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -290,11 +290,10 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
   elmts.or_proj_pasteJson.html($.i18n('core-project/paste-json'));
 
   elmts.operationJsonButton.on('click', async function() {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = '.json'; // optional file types
-    input.onchange = async function() {
-      const file = input.files[0];
+    const fileInput = document.querySelector('#file-input');
+    fileInput.accept = '.json'; // optional file types
+    fileInput.onchange = async function() {
+      const file = fileInput.files[0];
       const reader = new FileReader();
       reader.onload = function(e) {
         const fileContent = JSON.parse(e.target.result);
@@ -305,11 +304,11 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
         }
       };
       reader.addEventListener('error', function() {
-        alert('Error : Failed to read file');
+        alert('Error: Failed to read file');
     });
       reader.readAsText(file);
     };
-    input.click();
+    fileInput.click();
   });
   
   

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -339,34 +339,21 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
     DialogSystem.dismissUntil(level - 1);
   });
 
-  $(document).ready(function() {
-    // Trigger the file input when the button is clicked
-    $('#upload-btn').click(function() {
-      $('#file-input').click();
-    });
-    
-    // Upload the file when the user selects it
-    $('#file-input').change(function() {
-      var file = $('#file-input')[0].files[0];
-      var formData = new FormData();
-      formData.append('file', file);
-      
-      $.ajax({
-        url: 'core-index-import/locate-files', // The URL of the script that handles the file upload
-        type: 'POST',
-        data: formData,
-        processData: false,
-        contentType: false,
-        success: function(response) {
-          // Handle the server's response
-          console.log(response);
-        },
-        error: function(jqXHR, textStatus, errorMessage) {
-          // Handle any errors that occur during the upload
-          console.log(errorMessage);
-        }
+  elmts.operationJsonButton.on('click', async function() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json'; // optional file types
+    input.onchange = async function() {
+      const file = input.files[0];
+      const formData = new FormData();
+      formData.append("file", file);
+      const response = await fetch("/upload", {
+        method: "POST",
+        body: formData,
       });
-    });
+      console.log(response);
+    };
+    input.click();
   });
 
   var level = DialogSystem.showDialog(frame);

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -197,6 +197,7 @@ HistoryPanel.prototype._showExtractOperationsDialog = function(json) {
 
   elmts.dialogHeader.html($.i18n('core-project/extract-history'));
   elmts.textarea.attr('aria-label',$.i18n('core-project/operation-history-json'))
+  //elmts.fileInput.attr('aria-label',$.i18n('core-project/upload-json'))
   elmts.or_proj_extractSave.html($.i18n('core-project/extract-save'));
   elmts.selectAllButton.html($.i18n('core-buttons/select-all'));
   elmts.deselectAllButton.html($.i18n('core-buttons/deselect-all'));
@@ -290,17 +291,17 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
   elmts.or_proj_pasteJson.html($.i18n('core-project/paste-json'));
 
   elmts.operationJsonButton.on('click', async function() {
-    const fileInput = document.querySelector('#file-input');
-    fileInput.accept = '.json'; // optional file types
+    const fileInput = document.getElementById('file-input');
+    //const fileInput = elmts.file_input.upload_json;
+    fileInput.accept = '.json';
     fileInput.onchange = async function() {
       const file = fileInput.files[0];
       const reader = new FileReader();
       reader.onload = function(e) {
         const fileContent = JSON.parse(e.target.result);
-        const textAreaElement = document.querySelector('#textareaId')
+        const textAreaElement = elmts.textarea[0];
         if (textAreaElement) {
           textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
-
         }
       };
       reader.addEventListener('error', function() {

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -347,14 +347,17 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
       const file = input.files[0];
       const reader = new FileReader();
       reader.onload = function(e) {
-        const fileContent = e.target.result;
-        console.log(fileContent);
+        const fileContent = JSON.parse(e.target.result);
+        const textAreaElement = document.querySelector('#textareaId')
+        if (textAreaElement) {
+          textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
+
+        }
       };
       reader.readAsText(file);
     };
     input.click();
-  });
-
+});
   var level = DialogSystem.showDialog(frame);
 
   elmts.textarea.trigger('focus');

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -288,10 +288,34 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
   
   elmts.dialogHeader.html($.i18n('core-project/apply-operation'));
   elmts.or_proj_pasteJson.html($.i18n('core-project/paste-json'));
+
+  elmts.operationJsonButton.on('click', async function() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json'; // optional file types
+    input.onchange = async function() {
+      const file = input.files[0];
+      const reader = new FileReader();
+      reader.onload = function(e) {
+        const fileContent = JSON.parse(e.target.result);
+        const textAreaElement = document.querySelector('#textareaId')
+        if (textAreaElement) {
+          textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
+
+        }
+      };
+      reader.addEventListener('error', function() {
+        alert('Error : Failed to read file');
+    });
+      reader.readAsText(file);
+    };
+    input.click();
+  });
+  
   
   elmts.applyButton.html($.i18n('core-buttons/perform-op'));
   elmts.cancelButton.html($.i18n('core-buttons/cancel'));
-  elmts.operationJsonButton.html($.i18n('core-buttons/upload'));
+  elmts.operationJsonButton.html($.i18n('core-buttons/select'));
 
   var fixJson = function(json) {
     json = json.trim();
@@ -339,28 +363,6 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
     DialogSystem.dismissUntil(level - 1);
   });
 
-  elmts.operationJsonButton.on('click', async function() {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = '.json'; // optional file types
-    input.onchange = async function() {
-      const file = input.files[0];
-      const reader = new FileReader();
-      reader.onload = function(e) {
-        const fileContent = JSON.parse(e.target.result);
-        const textAreaElement = document.querySelector('#textareaId')
-        if (textAreaElement) {
-          textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
-
-        }
-      };
-      reader.addEventListener('error', function() {
-        alert('Error : Failed to read file');
-    });
-      reader.readAsText(file);
-    };
-    input.click();
-  });
   var level = DialogSystem.showDialog(frame);
 
   elmts.textarea.trigger('focus');

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -303,7 +303,7 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
             textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
           }
         } catch (error) {
-            window.alert($.i18n('core-project/json-invalid')+".");
+            window.alert($.i18n('core-project/json-invalid'));
           }
       };
       reader.readAsText(file);

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -291,6 +291,7 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
   
   elmts.applyButton.html($.i18n('core-buttons/perform-op'));
   elmts.cancelButton.html($.i18n('core-buttons/cancel'));
+  elmts.operationJsonButton.html($.i18n('core-buttons/upload'));
 
   var fixJson = function(json) {
     json = json.trim();

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -303,7 +303,7 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
             textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
           }
         } catch (error) {
-            window.alert($.i18n('core-index-import/warning-data-file'));
+            window.alert($.i18n('core-project/json-invalid')+".");
           }
       };
       reader.readAsText(file);

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -339,6 +339,36 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
     DialogSystem.dismissUntil(level - 1);
   });
 
+  $(document).ready(function() {
+    // Trigger the file input when the button is clicked
+    $('#upload-btn').click(function() {
+      $('#file-input').click();
+    });
+    
+    // Upload the file when the user selects it
+    $('#file-input').change(function() {
+      var file = $('#file-input')[0].files[0];
+      var formData = new FormData();
+      formData.append('file', file);
+      
+      $.ajax({
+        url: 'core-index-import/locate-files', // The URL of the script that handles the file upload
+        type: 'POST',
+        data: formData,
+        processData: false,
+        contentType: false,
+        success: function(response) {
+          // Handle the server's response
+          console.log(response);
+        },
+        error: function(jqXHR, textStatus, errorMessage) {
+          // Handle any errors that occur during the upload
+          console.log(errorMessage);
+        }
+      });
+    });
+  });
+
   var level = DialogSystem.showDialog(frame);
 
   elmts.textarea.trigger('focus');

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -345,13 +345,12 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
     input.accept = '.json'; // optional file types
     input.onchange = async function() {
       const file = input.files[0];
-      const formData = new FormData();
-      formData.append("file", file);
-      const response = await fetch("/upload", {
-        method: "POST",
-        body: formData,
-      });
-      console.log(response);
+      const reader = new FileReader();
+      reader.onload = function(e) {
+        const fileContent = e.target.result;
+        console.log(fileContent);
+      };
+      reader.readAsText(file);
     };
     input.click();
   });

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -197,7 +197,6 @@ HistoryPanel.prototype._showExtractOperationsDialog = function(json) {
 
   elmts.dialogHeader.html($.i18n('core-project/extract-history'));
   elmts.textarea.attr('aria-label',$.i18n('core-project/operation-history-json'))
-  //elmts.fileInput.attr('aria-label',$.i18n('core-project/upload-json'))
   elmts.or_proj_extractSave.html($.i18n('core-project/extract-save'));
   elmts.selectAllButton.html($.i18n('core-buttons/select-all'));
   elmts.deselectAllButton.html($.i18n('core-buttons/deselect-all'));

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -303,10 +303,8 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
             textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
           }
         } catch (error) {
-          {
             window.alert($.i18n('core-index-import/warning-data-file'));
           }
-        }
       };
       reader.readAsText(file);
     };

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -291,8 +291,8 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
   elmts.or_proj_pasteJson.html($.i18n('core-project/paste-json'));
 
   elmts.operationJsonButton.on('click', async function() {
-    const fileInput = document.getElementById('file-input');
-    //const fileInput = elmts.file_input.upload_json;
+    //const fileInput = document.getElementById('file-input');
+    const fileInput = elmts.operationJsonButton[0];
     fileInput.accept = '.json';
     fileInput.onchange = async function() {
       const file = fileInput.files[0];

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -296,15 +296,18 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
       const file = fileInput.files[0];
       const reader = new FileReader();
       reader.onload = function(e) {
-        const fileContent = JSON.parse(e.target.result);
-        const textAreaElement = elmts.textarea[0];
-        if (textAreaElement) {
-          textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
+        try {
+          const fileContent = JSON.parse(e.target.result);
+          const textAreaElement = elmts.textarea[0];
+          if (textAreaElement) {
+            textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
+          }
+        } catch (error) {
+          {
+            window.alert($.i18n('core-index-import/warning-data-file'));
+          }
         }
       };
-      reader.addEventListener('error', function() {
-        alert($.i18n('Error: Failed to read file'));
-    });
       reader.readAsText(file);
     };
     fileInput.click();

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -291,7 +291,6 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
   elmts.or_proj_pasteJson.html($.i18n('core-project/paste-json'));
 
   elmts.operationJsonButton.on('click', async function() {
-    //const fileInput = document.getElementById('file-input');
     const fileInput = elmts.operationJsonButton[0];
     fileInput.accept = '.json';
     fileInput.onchange = async function() {

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -360,7 +360,7 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
       reader.readAsText(file);
     };
     input.click();
-});
+  });
   var level = DialogSystem.showDialog(frame);
 
   elmts.textarea.trigger('focus');

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -303,7 +303,7 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
         }
       };
       reader.addEventListener('error', function() {
-        alert('Error: Failed to read file');
+        alert($.i18n('Error: Failed to read file'));
     });
       reader.readAsText(file);
     };

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -354,6 +354,9 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
 
         }
       };
+      reader.addEventListener('error', function() {
+        alert('Error : Failed to read file');
+    });
       reader.readAsText(file);
     };
     input.click();

--- a/main/webapp/modules/core/styles/common.css
+++ b/main/webapp/modules/core/styles/common.css
@@ -64,6 +64,7 @@ table {
 
 input, select {
   vertical-align: middle;
+  margin-bottom: 8px;
 }
 
 body {

--- a/main/webapp/modules/core/styles/common.css
+++ b/main/webapp/modules/core/styles/common.css
@@ -347,10 +347,6 @@ a img {
   margin: 0.4em;
 }
 
-#file-input {
-  margin-bottom: 8px;
-}
-
 input[type="checkbox"], input[type="radio"], select {
   vertical-align: baseline;
 }

--- a/main/webapp/modules/core/styles/common.css
+++ b/main/webapp/modules/core/styles/common.css
@@ -64,7 +64,6 @@ table {
 
 input, select {
   vertical-align: middle;
-  margin-bottom: 8px;
 }
 
 body {
@@ -346,6 +345,10 @@ a img {
 
 #body-info li {
   margin: 0.4em;
+}
+
+#file-input {
+  margin-bottom: 8px;
 }
 
 input[type="checkbox"], input[type="radio"], select {


### PR DESCRIPTION
Fixes #5022

Changes proposed in this pull request:

-     "Import" button added to the Apply Operation History dialogue
-     On clicking import, the user prompted to upload the file
-     Once the file is uploaded the content (assuming can be read correctly) is populated into the operation history window
-     User can then click "Perform operations" as usual

So far I have been able to create the Upload button but when I try to upload the file nothing happens because I need the correct URL to download the file in line 355. Let me know your suggestions on how to best approach this. Thanks.