### PR TITLE
ensure the clipboard import input does not overflow in narrow windows

### DIFF
--- a/main/webapp/modules/core/styles/index/default-importing-sources.css
+++ b/main/webapp/modules/core/styles/index/default-importing-sources.css
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 }
 
 #default-importing-clipboard-textarea {
-  width: 50em;
+  width: 100%;
+  max-width: 50em;
   height: 30em;
 }


### PR DESCRIPTION
Before:
![Screenshot 2023-03-29 at 19-02-57 OpenRefine](https://user-images.githubusercontent.com/2631719/228614226-4a107a3a-f98e-43fc-940b-a047a106a977.png)
