### PR TITLE
ignore .gitignore file in the extension directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ node_modules/
 
 # Ignore the node_modules folder as they are dependencies to be installed by end-user
 main/webapp/node_modules
+
+# Ignore .gitignore among extensions as it can be used to ignore custom extensions
+
+extensions/.gitignore


### PR DESCRIPTION
Having a .gitignore file ignoring either extension folders or symlinks can be super useful during development. For example when testing extension compatibility with ones changes.
