### PR TITLE
Fix locale loading in the frontend

### DIFF
--- a/main/webapp/modules/core/scripts/util/i18n.js
+++ b/main/webapp/modules/core/scripts/util/i18n.js
@@ -1,8 +1,5 @@
 I18NUtil = {};
 
-var lang = (navigator.language).split("-")[0];
-var dictionary = "";
-
 /*
    Initialize i18n and load message translation file from the server.
 
@@ -10,6 +7,9 @@ var dictionary = "";
    clicking on 'Language Settings' on the landing page.
 */
 I18NUtil.init = function (module) {
+    var lang = (navigator.language).split("-")[0];
+    var dictionary = "";
+
     $.ajax({
         url: "command/core/load-language?",
         type: "POST",

--- a/main/webapp/modules/core/scripts/util/i18n.js
+++ b/main/webapp/modules/core/scripts/util/i18n.js
@@ -34,5 +34,7 @@ I18NUtil.init = function (module) {
         }
     });
     $.i18n().load(dictionary, lang);
-    $.i18n({locale: lang});
+    if (module === 'core') {
+      $.i18n({locale: lang});
+    }
 }


### PR DESCRIPTION
This prevents failing i18n loads for extensions from changing the language of the rest of the interface, resulting in untranslated text (falling back to the message codes themselves).

Closes #5750. (See more detailed diagnosis of the problem in https://github.com/OpenRefine/OpenRefine/issues/5750#issuecomment-1489890024)

I would like to release this soon in 3.7.2.
