### PR TITLE
Fix initial facet height when facets are added while the facet panel is not visible

### DIFF
--- a/main/webapp/modules/core/scripts/facets/list-facet.js
+++ b/main/webapp/modules/core/scripts/facets/list-facet.js
@@ -123,6 +123,23 @@ class ListFacet extends Facet {
     this._update();
   };
 
+  checkInitialHeight() {
+    if (this._elmts) {
+      let innerList = this._elmts.bodyInnerDiv[0];
+      if (!this._initialHeightSet && innerList.offsetHeight !== 0) {
+        let innerHeight = innerList.offsetHeight;
+        let defaultMaxHeight = 17 * 13;
+
+        if (innerHeight > defaultMaxHeight) {
+          this._elmts.bodyDiv.height(defaultMaxHeight + 'px');
+        } else {
+          this._elmts.bodyDiv.height((innerHeight + 1) + 'px');
+        }
+        this._initialHeightSet = true;
+      }
+    }
+  }
+
   _reSortChoices() {
     this._data.choices.sort(this._options.sort === "name" ?
         function(a, b) {
@@ -402,18 +419,7 @@ class ListFacet extends Facet {
     this._renderBodyControls();
     this._elmts.bodyInnerDiv[0].scrollTop = scrollTop;
 
-    if (!this._initialHeightSet) {
-      let innerList = this._elmts.bodyInnerDiv[0];
-      let innerHeight = innerList.clientHeight;
-      let defaultMaxHeight = 17 * 13;
-
-      if (innerHeight > defaultMaxHeight) {
-        this._elmts.bodyDiv.height(defaultMaxHeight + 'px');
-      } else {
-        this._elmts.bodyDiv.height((innerHeight + 1) + 'px');
-      }
-      this._initialHeightSet = true;
-    }
+    this.checkInitialHeight();
 
     var getChoice = function(elmt) {
       var index = parseInt(elmt.attr("choiceIndex"),10);

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -191,6 +191,16 @@ BrowsingEngine.prototype.addFacet = function(type, config, options) {
   this._facets.push({ elmt: elmt, facet: facet });
 
   ui.leftPanelTabs.tabs();
+  ui.leftPanelTabs.on( "tabsactivate", ( event, ui ) =>  {
+     let activeTabId = ui.newTab.children('a').attr("href");
+     if (activeTabId === '#refine-tabs-facets') {
+       for (let facet of this._facets) {
+         if (facet.facet.checkInitialHeight) {
+           facet.facet.checkInitialHeight();
+         }
+       }
+     }
+  });
 
   Refine.update({ engineChanged: true });
 };


### PR DESCRIPTION
Fixes #5749
Changes proposed in this pull request:
- Made it so the initial facet height is properly set when facets are added when the facet panel is not visible.
- Add callback on jQuery event "tabsactivate". If the new active tab is a facet tab, then set the initial height for all facets (if not already set).

![facet-initial-height-when-hidden](https://user-images.githubusercontent.com/42903164/229448815-2d8f9aea-f836-425e-be9a-c5331187d462.gif)

