### PR TITLE
Fixed project metadata dialog so it doesn't jump to the top left corner when it is dragged

### DIFF
--- a/main/webapp/modules/core/scripts/index/edit-metadata-dialog.js
+++ b/main/webapp/modules/core/scripts/index/edit-metadata-dialog.js
@@ -132,10 +132,6 @@ EditMetadataDialog.prototype._createDialog = function() {
     
     this._metaDataUIs.push(new this._MetadataUI(tr, k, v, flatMetadata.id));
   }
-  
-  // $(".dialog-container").css("top", Math.round(($(".dialog-overlay").height() - $(frame).height()) / 2) + "px");
-
-  $(".dialog-container").css({"top":"50%","left":"50%","transform":"translate(-50%, -50%)"});
 };
 
 EditMetadataDialog.prototype._dismiss = function() {


### PR DESCRIPTION
Fixes #5774

Changes proposed in this pull request:
- Removed code from #4527 that caused a regression in the dialog for project metadata that caused it to jump to the top left of the screen when being dragged.

After:
![Project metadata after dialog drag](https://user-images.githubusercontent.com/42903164/230287513-25e9e520-82d2-46c5-91b4-5aea4656081c.gif)

