### PR TITLE
Added fix for command line options in refine

### DIFF
--- a/refine
+++ b/refine
@@ -446,19 +446,19 @@ run() {
         fi
     fi
 
-freeRam=UNKNOWN
-if [ "$OS" = "macosx" ] ; then
-    freeRam=$(top -l 1 | grep PhysMem | awk '{print $6}' | tr -d M)
-elif [ "$OS" = "linux" ] ; then
-    freeRam=$(free -m | grep -oP '\d+' | head -n 1)
-fi
+    freeRam=UNKNOWN
+    if [ "$OS" = "macosx" ] ; then
+        freeRam=$(top -l 1 | grep PhysMem | awk '{print $6}' | tr -d M)
+    elif [ "$OS" = "linux" ] ; then
+        freeRam=$(free -m | grep -oP '\d+' | head -n 1)
+    fi
 
-echo "-------------------------------------------------------------------------------------------------"
-echo You have "$freeRam"M of free memory.
-echo Your current configuration is set to use $REFINE_MEMORY of memory.
-echo OpenRefine can run better when given more memory. Read our FAQ on how to allocate more memory here:
-echo https://openrefine.org/docs/manual/installing\#increasing-memory-allocation
-echo "-------------------------------------------------------------------------------------------------"
+    echo "-------------------------------------------------------------------------------------------------"
+    echo You have "$freeRam"M of free memory.
+    echo Your current configuration is set to use $REFINE_MEMORY of memory.
+    echo OpenRefine can run better when given more memory. Read our FAQ on how to allocate more memory here:
+    echo https://openrefine.org/docs/manual/installing\#increasing-memory-allocation
+    echo "-------------------------------------------------------------------------------------------------"
 
     if [ -d $REFINE_CLASSES_DIR ] ; then
         add_option "-Drefine.autoreload=true" "-Dbutterfly.autoreload=true"
@@ -549,8 +549,51 @@ if [ "$OS" = "windows" ] ; then
     SEP=";"
 fi
 
+# ----- Check for custom ini file /c option  ---------------------------------
+args=()
+while [ $# -ne 0 ] ; do
+  case "$1" in
+    -c) REFINE_INI_PATH="$2"; shift 2; continue;;
+    *) args+=("$1"); shift;;
+  esac
+done
 
-# ----- Make sure there is an appropriate java environment is available -------------
+# -- Read ini file ------------------------------------------------------------
+
+if [ -z $REFINE_INI_PATH ]; then
+  REFINE_INI_PATH=refine.ini
+fi
+
+echo "Using ${REFINE_INI_PATH} for configuration"
+load_configs $REFINE_INI_PATH
+
+# ----- Parse the command line args -------------------------------------------
+for ((i=0; i<${#args[@]}; i+=1)); do
+  arg="${args[i]}"
+  case "$arg" in
+    -h) echo 'blah'; usage;;
+    -p) ((i+=1)); REFINE_PORT="${args[i]}"; continue;;
+    -H) ((i+=1)); REFINE_HOST="${args[i]}"; continue;;
+    -i) ((i+=1)); REFINE_INTERFACE="${args[i]}"; continue;;
+    -w) ((i+=1)); REFINE_WEBAPP="${args[i]}"; continue;;
+    -d) ((i+=1)); REFINE_DATA_DIR="${args[i]}"; continue;;
+    -m) ((i+=1)); REFINE_MEMORY="${args[i]}"; REFINE_MIN_MEMORY="${args[i]}"; continue;;
+    -k) ((i+=1)); REFINE_GOOGLE_API_KEY="${args[i]}"; continue;;
+    -v) ((i+=1)); REFINE_VERBOSITY="${args[i]}"; continue;;
+    -x) ((i+=1)); REFINE_EXTRA_OPTS="${args[i]}"; continue;;
+    --debug) add_option '-Xdebug' '-Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n'; continue;;
+    --jmx) add_option '-Dcom.sun.management.jmxremote'; continue;;
+    -*) echo "Invalid option: $arg" >&2; exit 1;;
+    *) ACTION="$arg"; break;;
+  esac
+done
+
+
+if [ -z "$ACTION" ] ; then
+    ACTION="run"
+fi
+
+# --- Check Java --------------------------------------------------------------
 
 if [ "$OS" = "macosx" ] ; then
     if [ -z "$JAVA_HOME" ] ; then
@@ -571,45 +614,6 @@ if [ ! -x "$JAVA" ] ; then
 fi
 
 checkJavaMajorVersion
-
-# ----- Parse the command line args ------------------------------------------
-
-while [ $# -ne 0 ] ; do
-  case "$1" in
-	-h) usage;;
-    -p) shift; REFINE_PORT="$1"; shift; continue;;
-    -H) shift; REFINE_HOST="$1"; shift; continue;;
-    -i) shift; REFINE_INTERFACE="$1"; shift; continue;;
-    -w) shift; REFINE_WEBAPP="$1"; shift; continue;;
-    -d) shift; REFINE_DATA_DIR="$1"; shift; continue;;
-    -m) shift; REFINE_MEMORY="$1"; REFINE_MIN_MEMORY="$1"; shift; continue;;
-    -k) shift; REFINE_GOOGLE_API_KEY="$1"; shift; continue;;
-    -v) shift; REFINE_VERBOSITY="$1"; shift; continue;;
-    -x) shift; REFINE_EXTRA_OPTS="$1"; shift; continue;;
-    -c) shift; REFINE_INI_PATH="$1"; shift; continue;;
-    --debug) shift; add_option '-Xdebug' '-Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n'; continue;;
-    --jmx) shift; add_option '-Dcom.sun.management.jmxremote'; continue;;
-    -*) fail "Invalid option: $1";;
-    *) break;;
-  esac
-done
-
-if [ $# -ne 0 ] ; then
-    ACTION=$1; shift
-fi
-
-if [ -z "$ACTION" ] ; then
-    ACTION="run"
-fi
-
-# ----- Load configurations -------------------------------------
-
-if [ -z $REFINE_INI_PATH ]; then
-  REFINE_INI_PATH=refine.ini
-fi
-
-echo "Using ${REFINE_INI_PATH} for configuration"
-load_configs $REFINE_INI_PATH
 
 # ----- Verify and Set Required Environment Variables -------------------------
 

--- a/refine
+++ b/refine
@@ -564,6 +564,10 @@ if [ -z $REFINE_INI_PATH ]; then
   REFINE_INI_PATH=refine.ini
 fi
 
+if [ ! -f "$REFINE_INI_PATH" ]; then
+  error "$REFINE_INI_PATH is not a valid filename"
+fi
+
 echo "Using ${REFINE_INI_PATH} for configuration"
 load_configs $REFINE_INI_PATH
 
@@ -571,7 +575,7 @@ load_configs $REFINE_INI_PATH
 for ((i=0; i<${#args[@]}; i+=1)); do
   arg="${args[i]}"
   case "$arg" in
-    -h) echo 'blah'; usage;;
+    -h) usage;;
     -p) ((i+=1)); REFINE_PORT="${args[i]}"; continue;;
     -H) ((i+=1)); REFINE_HOST="${args[i]}"; continue;;
     -i) ((i+=1)); REFINE_INTERFACE="${args[i]}"; continue;;
@@ -587,7 +591,6 @@ for ((i=0; i<${#args[@]}; i+=1)); do
     *) ACTION="$arg"; break;;
   esac
 done
-
 
 if [ -z "$ACTION" ] ; then
     ACTION="run"

--- a/refine.bat
+++ b/refine.bat
@@ -60,7 +60,7 @@ goto :eof
 
 set OPTS=
 
-rem Check for custom ini file
+rem ----- Check for custom ini file /c option  --------------------------------
 
 set "REFINE_INI_PATH="
 set "FOUND_C="
@@ -74,7 +74,7 @@ for %%A in (%*) do (
 )
 
 :readIniFile
-rem --- Read ini file -----------------------------------------------
+rem --- Read ini file ---------------------------------------------------------
 if "!REFINE_INI_PATH!" == "" set REFINE_INI_PATH=refine.ini
 if not exist !REFINE_INI_PATH! (
  echo Error: "!REFINE_INI_PATH!" does not exist.
@@ -84,7 +84,7 @@ for /f "usebackq tokens=1,* delims== " %%a in (`type "!REFINE_INI_PATH!" ^| find
     set "%%a=%%b"
 )
 														 
-rem --- Argument parsing --------------------------------------------
+rem ----- Parse the command line args -----------------------------------------
 
 :loop
 if "%~1"=="" goto checkVars
@@ -104,7 +104,7 @@ if "%~1"=="/v" set "REFINE_VERBOSITY=%~2" & shift & shift & goto loop
 
 :checkVars
 
-rem --- Check JAVA_HOME ---------------------------------------------
+rem --- Check JAVA_HOME -------------------------------------------------------
 
 if not "%JAVA_HOME%" == "" goto gotJavaHome
 echo You must set JAVA_HOME to point at your Java Development Kit installation
@@ -117,7 +117,7 @@ echo.
 goto fail
 :gotJavaHome			
 
-rem --- Fold in Environment Vars --------------------------------------------
+rem ----- Verify and Set Required Environment Variables -----------------------
 
 if not "%JAVA_OPTIONS%" == "" goto gotJavaOptions
 set JAVA_OPTIONS=


### PR DESCRIPTION
Fixes #5776
Fixes #5773

Changes proposed in this pull request:
- Allow JAVA_HOME to be set from the ini.
- Give command line options precedence over the ini.
- Clean up consistency in some wording between refine.bat and refine scripts.

Tested on Ubuntu Linux:
```
./refine
./refine -h
./refine run
./refine test
./refine clean
./refine build
./refine -c my.ini
./refine -c my.ini run
./refine -c missing.ini
./refine -m 8192m
./refine -c my.ini -m 8192m
./refine -m 8192m -c my.ini
./refine -c missing.ini -m 8192m
./refine -p 3344 -i 127.0.0.2 -m 8192m --debug --jmx
./refine -c my.ini -p 3344 -i 127.0.0.2 -m 8192m --debug --jmx
```



