### PR TITLE
Made it so numeric facets are properly refreshed when switching tabs

### DIFF
--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -198,6 +198,9 @@ BrowsingEngine.prototype.addFacet = function(type, config, options) {
          if (facet.facet.checkInitialHeight) {
            facet.facet.checkInitialHeight();
          }
+         if (facet.facet instanceof RangeFacet) {
+           facet.facet.render();
+         }
        }
      }
   });

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -195,11 +195,10 @@ BrowsingEngine.prototype.addFacet = function(type, config, options) {
      let activeTabId = ui.newTab.children('a').attr("href");
      if (activeTabId === '#refine-tabs-facets') {
        for (let facet of this._facets) {
-         if (facet.facet.checkInitialHeight) {
-           facet.facet.checkInitialHeight();
-         }
-         if (facet.facet instanceof RangeFacet) {
+         if (facet.facet.render) {
            facet.facet.render();
+         } else if (facet.facet instanceof ListFacet) {
+           facet.facet.checkInitialHeight();
          }
        }
      }

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -197,7 +197,7 @@ BrowsingEngine.prototype.addFacet = function(type, config, options) {
        for (let facet of this._facets) {
          if (facet.facet.render) {
            facet.facet.render();
-         } else if (facet.facet instanceof ListFacet) {
+         } else if (facet.facet.checkInitialHeight) {
            facet.facet.checkInitialHeight();
          }
        }


### PR DESCRIPTION
Changes proposed in this pull request:
- Made it so numeric facets are properly refreshed when switching tabs from the undo/redo history tab.

Before:
![Numeric slider facet before](https://user-images.githubusercontent.com/42903164/231265777-8a0be247-620d-4d1c-bee2-24619f92826b.gif)


After:
![Numeric slider facet after](https://user-images.githubusercontent.com/42903164/231263782-f96df6e9-c9dd-4da4-8d0d-bbf1e653d07b.gif)
