### PR TITLE
Don't swallow exception on error. Refs #5772

### DIFF
--- a/main/src/com/google/refine/ProjectMetadata.java
+++ b/main/src/com/google/refine/ProjectMetadata.java
@@ -382,6 +382,7 @@ public class ProjectMetadata {
             updateUserMetadata(metaName, valueString);
         } catch (SecurityException | IllegalArgumentException | IllegalAccessException e) {
             logger.error(ExceptionUtils.getFullStackTrace(e));
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
Fix error handling issue highlighted in #5772. 

Doesn't fix the underlying bug, but will correctly report the error back to the client.

