### PR TITLE
Made the invalid action output for the Linux refine script consistent with refine.bat

### DIFF
--- a/refine
+++ b/refine
@@ -731,7 +731,7 @@ case "$ACTION" in
   windows_dist) windows_dist $1;;
   linux_dist) linux_dist $1;;
   dist) dist $1;;
-  *) usage; ;;
+  *) echo "Unknown Refine command called \"$ACTION\", type \"./refine -h\" for proper usage.";;
 esac
 
 # ----------- end of file --------------------

--- a/refine.bat
+++ b/refine.bat
@@ -186,7 +186,6 @@ rem ----- Respond to the action ------------------------------------------------
 
 set ACTION=%1
 setlocal
-%@Try%
 if ""%ACTION%"" == ""build"" goto doMvn
 if ""%ACTION%"" == ""server_test"" goto doMvn
 if ""%ACTION%"" == ""extensions_test"" goto doMvn
@@ -194,11 +193,8 @@ if ""%ACTION%"" == ""test"" goto doMvn
 if ""%ACTION%"" == ""clean"" goto doMvn
 if ""%ACTION%"" == ""run"" goto doRun
 if ""%ACTION%"" == """" goto doRun
-%@EndTry%
-:@Catch
   echo Unknown Refine command called "%1", type "refine /?" for proper usage.
   exit /B 1
-:@EndCatch
 
 :doRun
 rem --- Checking Java Version  ------------------------------------------


### PR DESCRIPTION
Changes proposed in this pull request:
- Made the invalid action output for the Linux refine script consistent with the refine.bat script, and cleaned up some extra comments in refine.bat.