### PR TITLE
Apply "Fix escaping of column names in SQL exporter (#5674)" again

### DIFF
--- a/main/src/com/google/refine/exporters/sql/SqlCreateBuilder.java
+++ b/main/src/com/google/refine/exporters/sql/SqlCreateBuilder.java
@@ -53,6 +53,10 @@ public class SqlCreateBuilder {
 
     }
 
+    public static String addQuotes(String columnName) {
+        return "\"" + columnName.replace("\"", "\"\"") + "\"";
+    }
+
     public String getCreateSQL() {
         if (logger.isDebugEnabled()) {
             logger.debug("Create SQL with columns: {}", columns);
@@ -82,9 +86,9 @@ public class SqlCreateBuilder {
                 if (name != null) {
                     if (trimColNames) {
                         String trimmedCol = name.replaceAll("[^a-zA-Z0-9_]", "_");
-                        createSB.append(trimmedCol + " ");
+                        createSB.append(addQuotes(trimmedCol) + " ");
                     } else {
-                        createSB.append(name + " ");
+                        createSB.append(addQuotes(name) + " ");
                     }
 
                     if (type.equals(SqlData.SQL_TYPE_VARCHAR)) {

--- a/main/src/com/google/refine/exporters/sql/SqlInsertBuilder.java
+++ b/main/src/com/google/refine/exporters/sql/SqlInsertBuilder.java
@@ -180,9 +180,9 @@ public class SqlInsertBuilder {
         }
 
         boolean trimColNames = options == null ? false : JSONUtilities.getBoolean(options, "trimColumnNames", false);
-        String colNamesWithSep = columns.stream().map(col -> col.replaceAll("[^a-zA-Z0-9_]", "_")).collect(Collectors.joining(","));
+        String colNamesWithSep = columns.stream().map(col -> SqlCreateBuilder.addQuotes(col.replaceAll("[^a-zA-Z0-9_]", "_"))).collect(Collectors.joining(","));
         if (!trimColNames) {
-            colNamesWithSep = columns.stream().collect(Collectors.joining(","));
+            colNamesWithSep = columns.stream().map(col -> SqlCreateBuilder.addQuotes(col)).collect(Collectors.joining(","));
         }
 
         String valuesString = values.toString();


### PR DESCRIPTION
I am reopening #5674 after merging it in master created some CI failures.

This reverts commit 3a25f127071e0e035b6e549f2970d38f92333e95 (my reversion of #5674).