### PR TITLE
Removed the support log in refine.bat and added a "free memory" banner to refine.bat

### DIFF
--- a/refine.bat
+++ b/refine.bat
@@ -160,12 +160,12 @@ set REFINE_WEBAPP=main\webapp
 set OPTS=%OPTS% -Drefine.webapp=%REFINE_WEBAPP%
 
 for /f "tokens=2 delims==" %%i in ('wmic OS get FreePhysicalMemory /Value') do set /a freeRam=%%i/1024
-echo "-------------------------------------------------------------------------------------------------"
+echo -------------------------------------------------------------------------------------------------
 echo You have %freeRam%M of free memory.
 echo Your current configuration is set to use %REFINE_MEMORY% of memory.
 echo OpenRefine can run better when given more memory. Read our FAQ on how to allocate more memory here:
 echo https://openrefine.org/docs/manual/installing\#increasing-memory-allocation
-echo "-------------------------------------------------------------------------------------------------"
+echo -------------------------------------------------------------------------------------------------
 
 if not "%REFINE_CLASSES_DIR%" == "" goto gotClassesDir
 set REFINE_CLASSES_DIR=server\classes

--- a/refine.bat
+++ b/refine.bat
@@ -159,6 +159,14 @@ set REFINE_WEBAPP=main\webapp
 :gotWebApp
 set OPTS=%OPTS% -Drefine.webapp=%REFINE_WEBAPP%
 
+for /f "tokens=2 delims==" %%i in ('wmic OS get FreePhysicalMemory /Value') do set /a freeRam=%%i/1024
+echo "-------------------------------------------------------------------------------------------------"
+echo You have %freeRam%M of free memory.
+echo Your current configuration is set to use %REFINE_MEMORY% of memory.
+echo OpenRefine can run better when given more memory. Read our FAQ on how to allocate more memory here:
+echo https://openrefine.org/docs/manual/installing\#increasing-memory-allocation
+echo "-------------------------------------------------------------------------------------------------"
+
 if not "%REFINE_CLASSES_DIR%" == "" goto gotClassesDir
 set REFINE_CLASSES_DIR=server\classes
 :gotClassesDir
@@ -234,19 +242,6 @@ if %JAVA_RELEASE% LSS 11 (
 if %JAVA_RELEASE% GTR 17 (
     echo WARNING: OpenRefine is not tested and not recommended for use with Java versions greater than 17.
 )
-rem --- Log for troubleshooting ------------------------------------------
-echo Getting Free Ram...
-for /f "tokens=2 delims==" %%i in ('wmic OS get FreePhysicalMemory /Value') do set /a freeRam=%%i/1024
-(
-echo ----------------------- 
-echo PROCESSOR_ARCHITECTURE = %PROCESSOR_ARCHITECTURE%
-echo JAVA_HOME = %JAVA_HOME%
-echo java release = %JAVA_RELEASE%
-echo java -version = %JAVA_VERSION%
-echo freeRam = %freeRam% MB
-echo REFINE_MEMORY = %REFINE_MEMORY%
-echo ----------------------- 
-) > support.log
 
 set CLASSPATH="%REFINE_CLASSES_DIR%;%REFINE_LIB_DIR%\*"
 %JAVA% -cp %CLASSPATH% %OPTS% -Djava.library.path=%REFINE_LIB_DIR%/native/windows com.google.refine.Refine


### PR DESCRIPTION
Fixes #5795

Changes proposed in this pull request:
- Removed the support log in refine.bat and added a "free memory" banner to refine.bat.
```
-------------------------------------------------------------------------------------------------
You have 6275M of free memory.
Your current configuration is set to use 1400M of memory.
OpenRefine can run better when given more memory. Read our FAQ on how to allocate more memory here:
https://openrefine.org/docs/manual/installing\#increasing-memory-allocation
-------------------------------------------------------------------------------------------------
Java 17 (17.0.2)
22:33:51.883 [            refine_server] Starting Server bound to '127.0.0.1:3333' (0ms)
22:33:51.889 [            refine_server] refine.memory size: 1400M JVM Max heap: 1468006400 bytes (6ms)
```
