### PR TITLE
Reenable Coveralls upload

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -88,6 +88,10 @@ jobs:
     - name: Build and test with Maven
       run: mvn jacoco:prepare-agent test
 
+    - name: Submit test coverage to Coveralls
+      run: |
+        mvn jacoco:report coveralls:report -DrepoToken=${{ env.COVERALLS_TOKEN }} -DpullRequest=${{ github.event.number }}
+
   windows_server_tests:
     runs-on: windows-latest
 


### PR DESCRIPTION
It worked once, so perhaps it's fixed?

This reverts commit bfa8c9af756c5efe570b653067811eadd57bd12d.

Fixes #5013 

Changes proposed in this pull request:
- reenables Coveralls upload. 



