### PR TITLE
Widen scrutinizer regex pattern - fixes #5656 

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
@@ -20,7 +20,8 @@ public class FileNameScrutinizer extends EditScrutinizer {
 
     // see https://commons.wikimedia.org/wiki/Commons:File_naming
     public static final int maxFileNameBytes = 240;
-    public static final Pattern forbiddenFileNameChars = Pattern.compile(".*([\\p{Cc}]).*");
+    public static final Pattern forbiddenFileNameChars = Pattern.compile(
+            ".*([^ %!\"$&'()*,\\-./\\d:;=?@\\p{L}\\p{Mc}\\\\^_`~\\x80-\\xFF+]|%[0-9A-Fa-f]{2}|&[A-Za-z0-9\\x80-\\xff]+;|&#[0-9]+;|&#x[0-9A-Fa-f]+;).*");
 
     public static final String duplicateFileNamesInBatchType = "duplicate-file-names-in-batch";
     public static final String fileNamesAlreadyExistOnWikiType = "file-names-already-exist-on-wiki";

--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
@@ -90,9 +90,7 @@ public class FileNameScrutinizer extends EditScrutinizer {
                     issue.setProperty("max_length", Integer.toString(maxFileNameBytes));
                     addIssue(issue);
                 }
-            } catch (UnsupportedEncodingException e) {
-                e.printStackTrace();
-            }
+            } catch (UnsupportedEncodingException e) {}
 
             // Invalid characters
             Matcher matcher = forbiddenFileNameChars.matcher(fileName);

--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
@@ -90,7 +90,8 @@ public class FileNameScrutinizer extends EditScrutinizer {
                     issue.setProperty("max_length", Integer.toString(maxFileNameBytes));
                     addIssue(issue);
                 }
-            } catch (UnsupportedEncodingException e) {}
+            } catch (UnsupportedEncodingException e) {
+            }
 
             // Invalid characters
             Matcher matcher = forbiddenFileNameChars.matcher(fileName);

--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
@@ -9,6 +9,7 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -18,9 +19,8 @@ import java.util.stream.Collectors;
 public class FileNameScrutinizer extends EditScrutinizer {
 
     // see https://commons.wikimedia.org/wiki/Commons:File_naming
-    public static final int maxFileNameLength = 240;
-    public static final Pattern forbiddenFileNameChars = Pattern.compile(
-            ".*([^ %!\"$&'()*,\\-./0-9:;=?@A-Z\\\\^_`a-z~\\x80-\\xFF+]|%[0-9A-Fa-f]{2}|&[A-Za-z0-9\\x80-\\xff]+;|&#[0-9]+;|&#x[0-9A-Fa-f]+;).*");
+    public static final int maxFileNameBytes = 240;
+    public static final Pattern forbiddenFileNameChars = Pattern.compile(".*([\\p{Cc}]).*");
 
     public static final String duplicateFileNamesInBatchType = "duplicate-file-names-in-batch";
     public static final String fileNamesAlreadyExistOnWikiType = "file-names-already-exist-on-wiki";
@@ -78,15 +78,20 @@ public class FileNameScrutinizer extends EditScrutinizer {
                 seenFileNames.add(normalizedFileName);
             }
 
-            // check whether filenames exceed the maximum length (240 bytes, which we take to be 240 characters)
-            // TODO check for the length as bytes in the corresponding enconding (which one?)
+            // check whether filenames exceed the maximum length (240 bytes, coded as UTF-8)
             // see https://commons.wikimedia.org/wiki/Commons:File_naming
-            if (fileName.length() > maxFileNameLength) {
-                QAWarning issue = new QAWarning(fileNameTooLongType, null, QAWarning.Severity.CRITICAL,
-                        1);
-                issue.setProperty("example_filename", fileName);
-                issue.setProperty("max_length", Integer.toString(maxFileNameLength));
-                addIssue(issue);
+            try {
+                byte[] utf8Bytes = fileName.getBytes("UTF-8");
+                if (utf8Bytes.length > maxFileNameBytes) {
+                    QAWarning issue = new QAWarning(fileNameTooLongType, null,
+                            QAWarning.Severity.CRITICAL, 1);
+                    issue.setProperty("example_filename", fileName);
+                    // This is only accurate for 1 byte characters
+                    issue.setProperty("max_length", Integer.toString(maxFileNameBytes));
+                    addIssue(issue);
+                }
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
             }
 
             // Invalid characters

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
@@ -127,7 +127,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
     }
 
-    @Test(enabled = false) // Vertical bars should be allowed
+    @Test
     public void testInvalidCharactersInFilenameVerticalBar() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("vertical bars (|) are not allowed.png")
@@ -137,7 +137,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
     }
 
-    @Test(enabled = false) // HTML escaped entities should be allowed
+    @Test
     public void testInvalidCharactersInFilenameHTMLEscaped() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("HTML escaped entities such as &nbsp; are not allowed.png")

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
@@ -67,7 +67,57 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         assertWarningsRaised(FileNameScrutinizer.fileNameTooLongType);
     }
 
-    @Test
+    @Test() // Vertical bars should be allowed
+    public void testInvalidCharactersInFilenameTab() throws IOException, MediaWikiApiErrorException {
+        MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
+                .addFileName("Tabs (\t) are not allowed.png")
+                .build();
+
+        scrutinize(edit);
+        assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
+    }
+
+    @Test() // Vertical bars should be allowed
+    public void testInvalidCharactersInFilenameNewLine() throws IOException, MediaWikiApiErrorException {
+        MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
+                .addFileName("New lines (\n) are not allowed.png")
+                .build();
+
+        scrutinize(edit);
+        assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
+    }
+
+    @Test() // Vertical bars should be allowed
+    public void testInvalidCharactersInFilenameCarriageReturn() throws IOException, MediaWikiApiErrorException {
+        MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
+                .addFileName("Carriage returns (\r) are not allowed.png")
+                .build();
+
+        scrutinize(edit);
+        assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
+    }
+
+    @Test() // Vertical bars should be allowed
+    public void testInvalidCharactersInFilenameFormFeed() throws IOException, MediaWikiApiErrorException {
+        MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
+                .addFileName("Form feeds (\f) are not allowed.png")
+                .build();
+
+        scrutinize(edit);
+        assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
+    }
+
+    @Test() // Vertical bars should be allowed
+    public void testInvalidCharactersInFilenameBackspace() throws IOException, MediaWikiApiErrorException {
+        MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
+                .addFileName("Backspaces (\b) are not allowed.png")
+                .build();
+
+        scrutinize(edit);
+        assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
+    }
+
+    @Test(enabled = false) // Vertical bars should be allowed
     public void testInvalidCharactersInFilenameVerticalBar() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("vertical bars (|) are not allowed.png")
@@ -77,7 +127,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
     }
 
-    @Test
+    @Test(enabled = false) // HTML escaped entities should be allowed
     public void testInvalidCharactersInFilenameHTMLEscaped() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("HTML escaped entities such as &nbsp; are not allowed.png")

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
@@ -67,7 +67,17 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         assertWarningsRaised(FileNameScrutinizer.fileNameTooLongType);
     }
 
-    @Test() // Vertical bars should be allowed
+    @Test()
+    public void testValidCharactersInFilenameOdiaScript() throws IOException, MediaWikiApiErrorException {
+        MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
+                .addFileName("ଫାଇଲ.wav")
+                .build();
+
+        scrutinize(edit);
+        assertNoWarningRaised();
+    }
+
+    @Test()
     public void testInvalidCharactersInFilenameTab() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Tabs (\t) are not allowed.png")
@@ -77,7 +87,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
     }
 
-    @Test() // Vertical bars should be allowed
+    @Test()
     public void testInvalidCharactersInFilenameNewLine() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("New lines (\n) are not allowed.png")
@@ -87,7 +97,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
     }
 
-    @Test() // Vertical bars should be allowed
+    @Test()
     public void testInvalidCharactersInFilenameCarriageReturn() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Carriage returns (\r) are not allowed.png")
@@ -97,7 +107,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
     }
 
-    @Test() // Vertical bars should be allowed
+    @Test()
     public void testInvalidCharactersInFilenameFormFeed() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Form feeds (\f) are not allowed.png")
@@ -107,7 +117,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         assertWarningsRaised(FileNameScrutinizer.invalidCharactersInFileNameType);
     }
 
-    @Test() // Vertical bars should be allowed
+    @Test()
     public void testInvalidCharactersInFilenameBackspace() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Backspaces (\b) are not allowed.png")


### PR DESCRIPTION
Fixes #5656 

Hi there!
I've been working on the issue, thanks for your help in the issue thread

Changes proposed in this pull request:
- I updated the regex to only disallow control characters, \\p{Cc} will match control characters (ranges 0x00-0x1F and 0x7F-0x9F)
- I updated the validation for the file name length in bytes, encoded as UTF-8
- I updated the tests, adding some that should raise warnings and disabling testInvalidCharactersInFilenameVerticalBar and testInvalidCharactersInFilenameHTMLEscaped

Please let me know what you think
