### PR TITLE
Invoke Maven in batch mode in CI to avoid progress info in logs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Check Java linting
       id: java_linting
       run: |
-        mvn compile formatter:validate javadoc:javadoc -Ddoclint=all
+        mvn -B compile formatter:validate javadoc:javadoc -Ddoclint=all
 
     - name: Configure connections to databases
       id: configure_db_connections
@@ -86,7 +86,7 @@ jobs:
         PGPASSWORD: postgres
 
     - name: Build and test with Maven
-      run: mvn jacoco:prepare-agent test
+      run: mvn -B jacoco:prepare-agent test
 
   windows_server_tests:
     runs-on: windows-latest
@@ -107,10 +107,10 @@ jobs:
     - name: Check Java linting
       id: java_linting
       run: |
-        mvn formatter:validate
+        mvn -B formatter:validate
 
     - name: Build and test with Maven
-      run: mvn jacoco:prepare-agent test
+      run: mvn -B jacoco:prepare-agent test
 
   prepare_ui_test_matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -160,13 +160,13 @@ jobs:
       run: cd main/webapp && npm install
       
     - name: Build and test with Maven
-      run: mvn jacoco:prepare-agent test
+      run: mvn -B jacoco:prepare-agent test
 
     - name: Install webapp dependencies
       run: cd main/webapp && npm install
 
     - name: Generate dist files
-      run: mvn package -DskipTests=true
+      run: mvn -B package -DskipTests=true
 
   mac_test_and_deploy:
     runs-on: macos-12
@@ -212,13 +212,13 @@ jobs:
       run: cd main/webapp && npm install
       
     - name: Build and test
-      run: mvn test
+      run: mvn -B test
       env:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
     - name: Package and upload to OSSRH
       run: |
-        mvn package deploy -DskipTests=true -DrepositoryId=ossrh -Dapple.notarization.username=$APPLE_USERNAME -Dapple.notarization.password=$APPLE_PASSWORD -Dapple.notarization.team.id=$APPLE_TEAM_ID
+        mvn -B package deploy -DskipTests=true -DrepositoryId=ossrh -Dapple.notarization.username=$APPLE_USERNAME -Dapple.notarization.password=$APPLE_PASSWORD -Dapple.notarization.team.id=$APPLE_TEAM_ID
       env:
         OSSRH_USER: ${{ secrets.OSSRH_USER }}
         OSSRH_PASS: ${{ secrets.OSSRH_PASS }}


### PR DESCRIPTION
This reduces the log size in the CI by avoiding the duplication of download progress lines:
```
Progress (1): 1.4/2.1 MB
Progress (1): 1.5/2.1 MB
Progress (1): 1.5/2.1 MB
Progress (1): 1.5/2.1 MB
Progress (1): 1.6/2.1 MB
Progress (1): 1.6/2.1 MB
Progress (1): 1.6/2.1 MB
Progress (1): 1.7/2.1 MB
Progress (1): 1.7/2.1 MB
Progress (1): 1.7/2.1 MB
Progress (1): 1.8/2.1 MB
Progress (1): 1.8/2.1 MB
Progress (1): 1.8/2.1 MB
Progress (1): 1.9/2.1 MB
Progress (1): 1.9/2.1 MB
Progress (1): 1.9/2.1 MB
Progress (1): 2.0/2.1 MB
Progress (1): 2.0/2.1 MB
Progress (1): 2.0/2.1 MB
```

