### PR TITLE
Update deprecated method for Mockito initMocks()

### DIFF
--- a/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
@@ -59,7 +59,7 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
 
     @BeforeMethod
     public void setUp() throws IOException {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         File dir = DBExtensionTestUtils.createTempDirectory("OR_DBExtension_Test_WorkspaceDir");
         FileProjectManager.initialize(dir);
@@ -226,7 +226,7 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
             @Optional(DEFAULT_MYSQL_PORT) String mySqlDbPort, @Optional(DEFAULT_MYSQL_USER) String mySqlDbUser,
             @Optional(DEFAULT_MYSQL_PASSWORD) String mySqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String mySqlTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mySqlDbHost);

--- a/extensions/database/tests/src/com/google/refine/extension/database/cmd/ConnectCommandTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/cmd/ConnectCommandTest.java
@@ -45,7 +45,7 @@ public class ConnectCommandTest extends DBExtensionTests {
             @Optional(DEFAULT_MYSQL_PORT) String mySqlDbPort, @Optional(DEFAULT_MYSQL_USER) String mySqlDbUser,
             @Optional(DEFAULT_MYSQL_PASSWORD) String mySqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String mySqlTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mySqlDbHost);

--- a/extensions/database/tests/src/com/google/refine/extension/database/cmd/ConnectCommandTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/cmd/ConnectCommandTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
@@ -39,13 +40,15 @@ public class ConnectCommandTest extends DBExtensionTests {
     private DatabaseConfiguration testDbConfig;
     // private String testTable;
 
+    private AutoCloseable closeable;
+
     @BeforeTest
     @Parameters({ "mySqlDbName", "mySqlDbHost", "mySqlDbPort", "mySqlDbUser", "mySqlDbPassword", "mySqlTestTable" })
     public void beforeTest(@Optional(DEFAULT_MYSQL_DB_NAME) String mySqlDbName, @Optional(DEFAULT_MYSQL_HOST) String mySqlDbHost,
             @Optional(DEFAULT_MYSQL_PORT) String mySqlDbPort, @Optional(DEFAULT_MYSQL_USER) String mySqlDbUser,
             @Optional(DEFAULT_MYSQL_PASSWORD) String mySqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String mySqlTestTable) {
 
-        MockitoAnnotations.openMocks(this);
+        closeable = MockitoAnnotations.openMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mySqlDbHost);
@@ -106,5 +109,8 @@ public class ConnectCommandTest extends DBExtensionTests {
                         ObjectNode.class),
                 ParsingUtilities.mapper.readValue(sw.toString(), ObjectNode.class));
     }
-
+    
+    @AfterTest public void releaseMocks() throws Exception {
+        closeable.close();
+    }
 }

--- a/extensions/database/tests/src/com/google/refine/extension/database/cmd/ExecuteQueryCommandTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/cmd/ExecuteQueryCommandTest.java
@@ -45,7 +45,7 @@ public class ExecuteQueryCommandTest extends DBExtensionTests {
             @Optional(DEFAULT_MYSQL_PORT) String mySqlDbPort, @Optional(DEFAULT_MYSQL_USER) String mySqlDbUser,
             @Optional(DEFAULT_MYSQL_PASSWORD) String mySqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String mySqlTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mySqlDbHost);
         testDbConfig.setDatabaseName(mySqlDbName);

--- a/extensions/database/tests/src/com/google/refine/extension/database/cmd/SavedConnectionCommandTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/cmd/SavedConnectionCommandTest.java
@@ -66,7 +66,7 @@ public class SavedConnectionCommandTest extends DBExtensionTests {
 
     @BeforeMethod
     public void setUp() throws IOException {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         File dir = DBExtensionTestUtils.createTempDirectory("OR_DBExtension_Test_WorkspaceDir");
         FileProjectManager.initialize(dir);
@@ -101,7 +101,7 @@ public class SavedConnectionCommandTest extends DBExtensionTests {
             @Optional(DEFAULT_MYSQL_PORT) String mySqlDbPort, @Optional(DEFAULT_MYSQL_USER) String mySqlDbUser,
             @Optional(DEFAULT_MYSQL_PASSWORD) String mySqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String mySqlTestTable) {
 
-        // MockitoAnnotations.initMocks(this);
+        // MockitoAnnotations.openMocks(this);
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mySqlDbHost);
         testDbConfig.setDatabaseName(mySqlDbName);

--- a/extensions/database/tests/src/com/google/refine/extension/database/cmd/TestConnectCommandTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/cmd/TestConnectCommandTest.java
@@ -45,7 +45,7 @@ public class TestConnectCommandTest extends DBExtensionTests {
             @Optional(DEFAULT_MYSQL_PORT) String mySqlDbPort, @Optional(DEFAULT_MYSQL_USER) String mySqlDbUser,
             @Optional(DEFAULT_MYSQL_PASSWORD) String mySqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String mySqlTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mySqlDbHost);

--- a/extensions/database/tests/src/com/google/refine/extension/database/cmd/TestQueryCommandTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/cmd/TestQueryCommandTest.java
@@ -45,7 +45,7 @@ public class TestQueryCommandTest extends DBExtensionTests {
             @Optional(DEFAULT_MYSQL_PORT) String mySqlDbPort, @Optional(DEFAULT_MYSQL_USER) String mySqlDbUser,
             @Optional(DEFAULT_MYSQL_PASSWORD) String mySqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String mySqlTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mySqlDbHost);
         testDbConfig.setDatabaseName(mySqlDbName);

--- a/extensions/database/tests/src/com/google/refine/extension/database/mariadb/MariaDBConnectionManagerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/mariadb/MariaDBConnectionManagerTest.java
@@ -27,7 +27,7 @@ public class MariaDBConnectionManagerTest extends DBExtensionTests {
             @Optional(DEFAULT_MARIADB_PORT) String mariaDbPort, @Optional(DEFAULT_MARIADB_USER) String mariaDbUser,
             @Optional(DEFAULT_MARIADB_PASSWORD) String mariaDbPassword, @Optional(DEFAULT_TEST_TABLE) String mariaDbTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mariaDbHost);

--- a/extensions/database/tests/src/com/google/refine/extension/database/mariadb/MariaDBDatabaseServiceTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/mariadb/MariaDBDatabaseServiceTest.java
@@ -33,7 +33,7 @@ public class MariaDBDatabaseServiceTest extends DBExtensionTests {
             @Optional(DEFAULT_MARIADB_PORT) String mariaDbPort, @Optional(DEFAULT_MARIADB_USER) String mariaDbUser,
             @Optional(DEFAULT_MARIADB_PASSWORD) String mariaDbPassword, @Optional(DEFAULT_TEST_TABLE) String mariaDbTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mariaDbHost);

--- a/extensions/database/tests/src/com/google/refine/extension/database/mysql/MySQLConnectionManagerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/mysql/MySQLConnectionManagerTest.java
@@ -27,7 +27,7 @@ public class MySQLConnectionManagerTest extends DBExtensionTests {
             @Optional(DEFAULT_MYSQL_PORT) String mySqlDbPort, @Optional(DEFAULT_MYSQL_USER) String mySqlDbUser,
             @Optional(DEFAULT_MYSQL_PASSWORD) String mySqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String mySqlTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mySqlDbHost);

--- a/extensions/database/tests/src/com/google/refine/extension/database/mysql/MySQLDatabaseServiceTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/mysql/MySQLDatabaseServiceTest.java
@@ -32,7 +32,7 @@ public class MySQLDatabaseServiceTest extends DBExtensionTests {
             @Optional(DEFAULT_MYSQL_PORT) String mySqlDbPort, @Optional(DEFAULT_MYSQL_USER) String mySqlDbUser,
             @Optional(DEFAULT_MYSQL_PASSWORD) String mySqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String mySqlTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(mySqlDbHost);

--- a/extensions/database/tests/src/com/google/refine/extension/database/pgsql/PgSQLConnectionManagerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/pgsql/PgSQLConnectionManagerTest.java
@@ -27,7 +27,7 @@ public class PgSQLConnectionManagerTest extends DBExtensionTests {
             @Optional(DEFAULT_PGSQL_PORT) String pgSqlDbPort, @Optional(DEFAULT_PGSQL_USER) String pgSqlDbUser,
             @Optional(DEFAULT_PGSQL_PASSWORD) String pgSqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String pgSqlTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(pgSqlDbHost);

--- a/extensions/database/tests/src/com/google/refine/extension/database/pgsql/PgSQLDatabaseServiceTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/pgsql/PgSQLDatabaseServiceTest.java
@@ -32,7 +32,7 @@ public class PgSQLDatabaseServiceTest extends DBExtensionTests {
             @Optional(DEFAULT_PGSQL_PORT) String pgSqlDbPort, @Optional(DEFAULT_PGSQL_USER) String pgSqlDbUser,
             @Optional(DEFAULT_PGSQL_PASSWORD) String pgSqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String pgSqlTestTable) {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseHost(pgSqlDbHost);
         testDbConfig.setDatabaseName(pgSqlDbName);

--- a/extensions/database/tests/src/com/google/refine/extension/database/sqlite/SQLiteConnectionManagerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/sqlite/SQLiteConnectionManagerTest.java
@@ -52,7 +52,7 @@ public class SQLiteConnectionManagerTest extends DBExtensionTests {
             @Optional(DEFAULT_TEST_TABLE) String sqliteTestTable)
             throws DatabaseServiceException, SQLException {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseName(sqliteDbName);

--- a/extensions/database/tests/src/com/google/refine/extension/database/sqlite/SQLiteDatabaseServiceTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/sqlite/SQLiteDatabaseServiceTest.java
@@ -54,7 +54,7 @@ public class SQLiteDatabaseServiceTest extends DBExtensionTests {
             @Optional(DEFAULT_TEST_TABLE) String sqliteTestTable)
             throws DatabaseServiceException, SQLException {
 
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         testDbConfig = new DatabaseConfiguration();
         testDbConfig.setDatabaseName(sqliteDbName);
         testDbConfig.setDatabaseType(SQLiteDatabaseService.DB_NAME);

--- a/main/src/com/google/refine/expr/ExpressionUtils.java
+++ b/main/src/com/google/refine/expr/ExpressionUtils.java
@@ -142,6 +142,11 @@ public class ExpressionUtils {
             return ((ArrayNode) v).toString();
         } else if (v instanceof ObjectNode) {
             return ((ObjectNode) v).toString();
+        } else if (v instanceof List) {
+            return isStorable(v) ? (Serializable) v : new EvalError(
+                  "Stored Error: Your expression created an Array."
+                + "Only Number, String, Boolean, OffsetDateTime can be stored in a cell."
+                + "HINT: try appending to your expression: .join(', ') to store as a String.");
         } else {
             return isStorable(v) ? (Serializable) v : new EvalError(v.getClass().getSimpleName() + " value not storable");
         }

--- a/main/src/com/google/refine/expr/ExpressionUtils.java
+++ b/main/src/com/google/refine/expr/ExpressionUtils.java
@@ -142,11 +142,6 @@ public class ExpressionUtils {
             return ((ArrayNode) v).toString();
         } else if (v instanceof ObjectNode) {
             return ((ObjectNode) v).toString();
-        } else if (v instanceof List) {
-            return isStorable(v) ? (Serializable) v : new EvalError(
-                  "Stored Error: Your expression created an Array."
-                + "Only Number, String, Boolean, OffsetDateTime can be stored in a cell."
-                + "HINT: try appending to your expression: .join(', ') to store as a String.");
         } else {
             return isStorable(v) ? (Serializable) v : new EvalError(v.getClass().getSimpleName() + " value not storable");
         }


### PR DESCRIPTION
Changes proposed in this pull request:

- Deprecated.  Use openMocks(Object) instead.
- Updates it for database extension testing.
- https://javadoc.io/doc/org.mockito/mockito-core/5.3.1/org/mockito/MockitoAnnotations.html
