### PR TITLE
Support for resizing columns

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -94,6 +94,8 @@ DataTableColumnHeaderUI.prototype._startResizing = function(clickEvent) {
   state.columnName = self._column.name;
   state.originalWidth = self._col.width();
   state.originalPosition = clickEvent.pageX;
+  // for conversion from px to em
+  state.emFactor = parseFloat(getComputedStyle($(".data-table-container colgroup")[0]).fontSize);
 
   $('body')
       .on('mousemove', DataTableColumnHeaderUI.mouseMoveListener)
@@ -122,7 +124,9 @@ DataTableColumnHeaderUI.mouseReleaseListener = function(e) {
   }
   var state = DataTableColumnHeaderUI.resizingState;
   if (state.dragging) {
-    DataTableView.columnWidthCache.set(state.columnName, state.col.width());
+    var totalMovement = e.pageX - state.originalPosition;
+    var newWidth = state.originalWidth + totalMovement;
+    state.col.width((newWidth / state.emFactor) + 'em');
     state.dragging = false;
     $('body')
         .off('mousemove', DataTableColumnHeaderUI.mouseMoveListener)

--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -76,6 +76,7 @@ $(function() {
       var totalMovement = e.pageX - state.originalPosition;
       var newWidth = state.originalWidth + totalMovement;
       state.col.width(newWidth);
+
       e.preventDefault();
     }
   }).on('mouseup', function(e) {
@@ -104,21 +105,18 @@ DataTableColumnHeaderUI.prototype._render = function() {
     self._createMenuForColumnHeader(this);
   });
 
-  elmts.resizer.on('mousedown', function(e) {
-    // only capture left clicks
-    if (e.button !== 0) {
-      return;
-    }
-    e.preventDefault();
-    var state = DataTableColumnHeaderUI.resizingState;
-    state.dragging = true;
-    state.col = self._col;
-    state.columnName = self._column.name;
-    state.originalWidth = self._col.width();
-    state.originalPosition = e.pageX;
-  });
-
   self.updateColumnStats();
+};
+
+DataTableColumnHeaderUI.prototype._startResizing = function(clickEvent) {
+  var self = this;
+  clickEvent.preventDefault();
+  var state = DataTableColumnHeaderUI.resizingState;
+  state.dragging = true;
+  state.col = self._col;
+  state.columnName = self._column.name;
+  state.originalWidth = self._col.width();
+  state.originalPosition = clickEvent.pageX;
 };
 
 DataTableColumnHeaderUI.prototype.updateColumnStats = function() {

--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -106,6 +106,9 @@ DataTableColumnHeaderUI.mouseMoveListener = function(e) {
   if (state.dragging) {
     var totalMovement = e.pageX - state.originalPosition;
     var newWidth = state.originalWidth + totalMovement;
+    if (state.col.css('min-width')) {
+      state.col.css('min-width', '');
+    }
     state.col.width(newWidth);
 
     e.preventDefault();

--- a/main/webapp/modules/core/scripts/views/data-table/column-header.html
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header.html
@@ -1,3 +1,2 @@
 <div class="column-header-title"><a class="column-header-menu" bind="dropdownMenu"></a><span class="column-header-name" bind="nameContainer"></span></div>
 <div bind="reconStatsContainer" class="recon-stats-container"></div>
-<div class="column-header-resizer" bind="resizer"></div>

--- a/main/webapp/modules/core/scripts/views/data-table/column-header.html
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header.html
@@ -1,2 +1,3 @@
 <div class="column-header-title"><a class="column-header-menu" bind="dropdownMenu"></a><span class="column-header-name" bind="nameContainer"></span></div>
 <div bind="reconStatsContainer" class="recon-stats-container"></div>
+<div class="column-header-resizer" bind="resizer"></div>

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -101,11 +101,21 @@ DataTableView.prototype.render = function() {
   var oldTableDiv = this._div.find(".data-table-container");
   var scrollLeft = (oldTableDiv.length > 0) ? oldTableDiv[0].scrollLeft : 0;
 
+  // utility to convert px widths to em.
+  // The factor is computed only on demand (and once) because it might trigger some
+  // DOM rendering given that it uses computed styles
+  var emFactor = null;
+  var getEmFactor = function() {
+    if (emFactor === null) {
+      emFactor = parseFloat(getComputedStyle($(".data-table-container colgroup")[0]).fontSize);
+    }
+    return emFactor;
+  };
   // store the current width of each column to be able to restore it later
-  this._div.find("colgroup col").each(function(index) {
+  this._div.find(".data-table-container col").each(function(index) {
     var column = $(this);
     if (column.data('name')) {
-      var width = column.width();
+      var width = column.width() / getEmFactor();
       DataTableView.columnWidthCache.set(column.data('name'), width);
     }
   });
@@ -431,7 +441,7 @@ DataTableView.prototype._renderTableHeader = function(tableHeader, colGroup) {
         .appendTo(colGroup);
     var cachedWidth = DataTableView.columnWidthCache.get(column.name);
     if (cachedWidth !== undefined && !self._collapsedColumnNames.hasOwnProperty(column.name)) {
-      col.width(cachedWidth + 'px');
+      col.width(cachedWidth + 'em');
     } else {
       // Not set in CSS directly because the user needs to be able to override that by dragging 
       col.css('min-width', '5em');

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -101,6 +101,15 @@ DataTableView.prototype.render = function() {
   var oldTableDiv = this._div.find(".data-table-container");
   var scrollLeft = (oldTableDiv.length > 0) ? oldTableDiv[0].scrollLeft : 0;
 
+  // store the current width of each column to be able to restore it later
+  this._div.find("colgroup col").each(function(index) {
+    var column = $(this);
+    if (column.data('name')) {
+      var width = column.width();
+      DataTableView.columnWidthCache.set(column.data('name'), width);
+    }
+  });
+
   var html = $(
     '<div class="viewpanel-header">' +
       '<div class="viewpanel-rowrecord" bind="rowRecordControls">'+$.i18n('core-views/show-as')+': ' +
@@ -418,6 +427,7 @@ DataTableView.prototype._renderTableHeader = function(tableHeader, colGroup) {
     $(th).addClass("column-header").attr('title', column.name);
     var col = $('<col>')
         .attr('span', 1)
+        .data('name', column.name)
         .appendTo(colGroup);
     var cachedWidth = DataTableView.columnWidthCache.get(column.name);
     if (cachedWidth !== undefined && !self._collapsedColumnNames.hasOwnProperty(column.name)) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -420,17 +420,41 @@ DataTableView.prototype._renderTableHeader = function(tableHeader, colGroup) {
         .attr('span', 1)
         .appendTo(colGroup);
     var cachedWidth = DataTableView.columnWidthCache.get(column.name);
-    if (cachedWidth !== undefined) {
+    if (cachedWidth !== undefined && !self._collapsedColumnNames.hasOwnProperty(column.name)) {
         col.width(cachedWidth + 'px');
     }
     if (self._collapsedColumnNames.hasOwnProperty(column.name)) {
-      $(th).html("&nbsp;").on('click',function(evt) {
+      $(th).html("&nbsp;").on('mousedown',function(evt) {
         delete self._collapsedColumnNames[column.name];
         self.render();
       });
     } else {
       var columnHeaderUI = new DataTableColumnHeaderUI(self, column, index, th, col);
       self._columnHeaderUIs.push(columnHeaderUI);
+
+      // add resizing controls
+      var resizerLeft = $('<div></div>').addClass('column-header-resizer-left')
+            .appendTo(th);
+      resizerLeft.on('mousedown', function(e) {
+        // only capture left clicks
+        if (e.button !== 0) {
+          return;
+        }
+        columnHeaderUI._startResizing(e);
+      });
+
+      // add resizing control for the previous column (if uncollapsed)
+      if (index > 0 && !self._collapsedColumnNames.hasOwnProperty(columns[index-1].name)) {
+        var resizerRight = $('<div></div>').addClass('column-header-resizer-right')
+              .appendTo(th);
+        resizerRight.on('mousedown', function(e) {
+          // only capture left clicks
+          if (e.button !== 0) {
+            return;
+          }
+          self._columnHeaderUIs[index - 1]._startResizing(e);
+        });
+      }
     }
   };
 

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -431,7 +431,10 @@ DataTableView.prototype._renderTableHeader = function(tableHeader, colGroup) {
         .appendTo(colGroup);
     var cachedWidth = DataTableView.columnWidthCache.get(column.name);
     if (cachedWidth !== undefined && !self._collapsedColumnNames.hasOwnProperty(column.name)) {
-        col.width(cachedWidth + 'px');
+      col.width(cachedWidth + 'px');
+    } else {
+      // Not set in CSS directly because the user needs to be able to override that by dragging 
+      col.css('min-width', '5em');
     }
     if (self._collapsedColumnNames.hasOwnProperty(column.name)) {
       $(th).html("&nbsp;").on('mousedown',function(evt) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -422,8 +422,6 @@ DataTableView.prototype._renderTableHeader = function(tableHeader, colGroup) {
     var cachedWidth = DataTableView.columnWidthCache.get(column.name);
     if (cachedWidth !== undefined) {
         col.width(cachedWidth + 'px');
-    } else {
-        col.css('max-width', '200px');
     }
     if (self._collapsedColumnNames.hasOwnProperty(column.name)) {
       $(th).html("&nbsp;").on('click',function(evt) {

--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -113,6 +113,23 @@ th {
   text-align: left;
 }
 
+.column-header-title {
+  overflow: hidden;
+  text-overflow: clip;
+}
+
+th .column-header-resizer {
+  display: block;
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  cursor: col-resize;
+  width: 6px;
+}
+
 table.data-header-table>tbody>tr>td {
   overflow: hidden !important;
 }
@@ -146,14 +163,13 @@ table.data-table td.column-header, table.data-table th.column-header {
 }
 
 .column-header-name {
-  margin: 0 0 0 21px;
   padding: 4px 0 0 0;
-  display: block;
+  display: inline-block;
+  position: absolute;
 }
 
 a.column-header-menu {
-  float: left;
-  display: block;
+  display: inline-block;
   margin: 0 4px 0 0;
   width: 17px;
   height: 19px;
@@ -191,7 +207,7 @@ div.data-table-cell-content {
   line-height: 1.2;
   color: #222;
   position: relative;
-  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 div.data-table-cell-content-numeric {

--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -120,16 +120,23 @@ th {
   text-overflow: clip;
 }
 
-th .column-header-resizer {
+th .column-header-resizer-left, th .column-header-resizer-right {
   display: block;
   position: absolute;
   top: 0;
-  right: 0;
   height: 100%;
   margin: 0;
   padding: 0;
   cursor: col-resize;
   width: 6px;
+}
+
+th .column-header-resizer-left {
+  right: 0;
+}
+
+th .column-header-resizer-right {
+  left: 0;
 }
 
 table.data-header-table>tbody>tr>td {

--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -69,6 +69,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   padding: 0;
   font-size: 1.05em;
   border-collapse: separate;
+  width: max-content;
 }
 
 .data-table td, .data-table-header td, .data-table-header th {
@@ -79,6 +80,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   border-bottom: 0.02rem dotted #ddd;
   border-right: 0.02rem solid #ddd;
   position: relative;
+  max-width: 300px;
 }
 
 .data-table-header td, .data-table-header th {

--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -216,6 +216,7 @@ div.data-table-cell-content {
   line-height: 1.2;
   color: #222;
   position: relative;
+  white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 


### PR DESCRIPTION
Fixes #4806. This is an attempt to add support for resizing columns.

![resizing](https://github.com/OpenRefine/OpenRefine/assets/309908/7ca42df4-8e46-4ac7-a1c6-4fc6c5d3bd51)


It is not ready yet because the initial sizing of the columns has changed and is likely to be less appropriate in some cases. But I would already welcome feedback about the approach!
The initial sizing has changed because I needed to change the way textual content is wrapped inside cells (and in column headers), to allow for columns to resize correctly. This has an effect on the initial sizing as well.

Some details about the approach:
* to change the size of a column, one can either apply inline CSS to the `<th>` and all the `<td>`s in that column, or use the dedicated `<col>` element. The latter felt cleaner (only applying style in one place) but maybe the other approach has other advantages?
* to handle the resizing itself, one could try using the `resize` CSS property, but translating the effects of that to the entire column seems a little hacky. Instead I went for manual handling in Javascript using event listeners for mouse clicks and moves. Not sure it is the best approach though!
* The column sizing should be preserved when paginating or updating the grid (which might mean columns getting added / removed / renamed) so I implemented a rather simple solution by remembering which column name was associated with which width. It will fail to remember the column width when renaming a column, but maybe that's not so critical. I wonder if this information should be persisted (perhaps in the project-level preference store).

Why do this in 4.0 and not in master:
* while the change is conceptually simple, there is a lot of potential to break things in some use cases - so I'd rather not put this in the stable release series
* I am hoping that this change (combined with capping the row height) will help make table layouts more predictable and therefore make real-time updates of the grid more acceptable (for #5541). Because at the moment I am refreshing periodically the grid when some cell values have not yet been computed by a long-running operation, and doing so can result in big layout changes which are disruptive for the user as they are done without any action from them.

How to improve the initial column widths:
* one lazy approach would be to say that we do not actually care that much about the initial column widths as long as they can be changed easily by the user - maybe invest time into persisting those column widths instead. Arguably the sizing strategy will also be impacted by #1440, which I would also tackle as a follow-up - so maybe it's worth waiting for that to tackle this initial sizing.
* another lazy approach would be to just set equal column widths initially. That's apparently what Google Sheets does. Not amazing but perhaps better than wonky and unpredictable heuristics?
* we could gather some statistics about the maximum and/or average length of the content stored in each column (either backend or frontend side) and come up with some heuristics to come up with sensible initial column lengths.
* one could try to revert my word wrapping changes in CSS, so that the initial sizing of the grid is left unchanged, and only apply those CSS rules once the user starts resizing a column. I think this is likely to have some bad side effects such as content jumping around rather unpredictably at the beginning of the resizing, making it less smooth.
* other approaches?

Another question is how to show column names when they do not fit in the header. For now they are just truncated and one can see the full column name by hovering.
![image](https://github.com/OpenRefine/OpenRefine/assets/309908/82b32571-aef5-4857-a464-61ad0c5fe4c5)

Another question is whether the fact that columns are resizable should be made more visible with some sort of visual hint that the boundary between the headers can be dragged.

Also, the boundary is currently only draggable if you click slightly to the left of it, and I find that not so convenient to use: clicking slightly to the right should also work.

cc @lozanaross 