### PR TITLE
add an outline to tab buttons when focused

### DIFF
--- a/main/webapp/modules/core/styles/jquery-ui-overrides.css
+++ b/main/webapp/modules/core/styles/jquery-ui-overrides.css
@@ -41,6 +41,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   color: inherit;
 }
 
+.ui-tabs-tab:focus {
+  outline: #86A8DF auto 5px; /* color of native browser outlines */
+}
+
 .ui-tabs .ui-tabs-nav {
   padding: 0 var(--padding-normal);
 }


### PR DESCRIPTION
jQueryUI uses a combination of `li`/`a` to build it's tabLists rather than `button` as a result(one of many) it does not get an outline when focused.

This adds such an outline manually using CSS. You can test this by just tabbing through the interface, when the tab navigation buttons now are focused they have an outline just like other elements.