### PR TITLE
menu buttons in the extension-bar can now be opened with the keyboard

### DIFF
--- a/main/webapp/modules/core/scripts/project/extension-bar.js
+++ b/main/webapp/modules/core/scripts/project/extension-bar.js
@@ -70,7 +70,7 @@ ExtensionBar.prototype._initializeUI = function() {
 ExtensionBar.prototype._createMenuButton = function(label, submenu) {
   var self = this;
 
-  var menuItem = $("<a>").addClass("button").append('<span class="button-menu">' + label + '</span>');
+  var menuItem = $("<button>").append('<span class="button-menu">' + label + '</span>');
 
   menuItem.on('click',function(evt) {
     MenuSystem.createAndShowStandardMenu(


### PR DESCRIPTION
tab to select, enter to open(the menu system is not yet keyboard accessible so you can't select or trigger an action)
