### PR TITLE
project-permalink: keyboard support

### DIFF
--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -126,7 +126,7 @@ function initializeUI(uiState) {
   $("#or-proj-ext").text($.i18n('core-project/extensions'));
 
   $('#project-name-button').on('click',Refine._renameProject);
-  $('#project-permalink-button').on('mouseenter',function() {
+  $('#project-permalink-button').on('focus',function() {
     this.href = Refine.getPermanentLink();
   });
 


### PR DESCRIPTION
Instead of watching for 'mouseover' this checks for 'focus' which ensures both clicking and tabbing generates a new permalink.