### PR TITLE
Make it possible to set custom headers using only the keyboard when fetching urls

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -603,7 +603,7 @@
     "core-views/throttle-delay": "Throttle delay",
     "core-views/milli": "milliseconds",
     "core-views/url-fetch": "Formulate the URLs to fetch:",
-    "core-views/http-headers": "HTTP headers to be used when fetching URLs:",
+    "core-views/http-headers": "HTTP headers to be used when fetching URLs",
     "core-views/enter-col-name": "Enter new column name",
     "core-views/join-col": "Join columns…",
     "core-views/split-col": "Split column $1 into several columns",

--- a/main/webapp/modules/core/scripts/views/data-table/add-column-by-fetching-urls-dialog.html
+++ b/main/webapp/modules/core/scripts/views/data-table/add-column-by-fetching-urls-dialog.html
@@ -22,9 +22,12 @@
 	     <input type="checkbox" name="dialog-cache-responses" id="$add-column-cache-responses" checked="checked" />
 		<label for="$add-column-cache-responses" bind="or_views_cacheResponses"></label></td>
         </tr>
-        <tr><td colspan="4"><span bind="or_views_httpHeaders"></span>
-          <span class="toggle-text" bind="or_views_httpHeadersShowHide"></span>
-          $HTTP_HEADERS_WIDGET$
+        <tr><td colspan="4">
+          <details>
+            <summary bind="or_views_httpHeaders"></summary>
+            $HTTP_HEADERS_WIDGET$
+          </details>
+          <span class="toggle-text" bind=""></span>
         </td></tr>
         <tr><td colspan="4"><h3><span bind="or_views_urlFetch"></span></h3></td></tr>
         <tr><td colspan="4">$EXPRESSION_PREVIEW_WIDGET$</td></tr>

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
@@ -123,16 +123,6 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     elmts.or_views_storeErr.text($.i18n('core-views/store-err'));
     elmts.or_views_cacheResponses.text($.i18n('core-views/cache-responses'));
     elmts.or_views_httpHeaders.text($.i18n('core-views/http-headers'));
-    elmts.or_views_httpHeadersShowHide.text($.i18n('core-views/show'));
-    elmts.or_views_httpHeadersShowHide.on('click',function() {
-                                                          $( ".set-httpheaders-container" ).toggle( "slow", function() {
-                                                            if ($(this).is(':visible')) {
-                                                              elmts.or_views_httpHeadersShowHide.text($.i18n('core-views/hide'));
-                                                            } else {
-                                                              elmts.or_views_httpHeadersShowHide.text($.i18n('core-views/show'));
-                                                            }
-                                                          });
-                                                        });
     elmts.or_views_urlFetch.text($.i18n('core-views/url-fetch'));
     elmts.okButton.html($.i18n('core-buttons/ok'));
     elmts.cancelButton.text($.i18n('core-buttons/cancel'));

--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -383,10 +383,6 @@ a.data-table-flag-off {
   color: var(--light-grey);
 }
 
-.set-httpheaders-container {
-  display: none;
-}
-
 .set-httpheaders-container label {
   display: inline-block;
   width: 15%;


### PR DESCRIPTION
This swaps a custom `<details>` implementation for a HTML based one making it keyboard accessiable.