### PR TITLE
Fetch URLs modal: do not focus on the expression input by default

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
@@ -129,9 +129,7 @@ ExpressionPreviewDialog.Widget = function(
         .val(this.expression)
         .on("keyup change input",function(){
             self._scheduleUpdate();
-        })
-        .trigger('select')
-        .trigger('focus');
+        });
 
     this._elmts.or_dialog_expr.html($.i18n('core-dialogs/expression'));
     this._elmts.or_dialog_lang.html($.i18n('core-dialogs/language'));


### PR DESCRIPTION
The dialog itself gets focus since #5578, and setting a focus a few inputs after other ones like the column name makes it much harder to use this dialog with the keyboard as you mush use Shift+Ctrl+Tab rather than just Tab for navigating.