### PR TITLE
Skip Wikibase edits on deleted items

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
@@ -173,12 +173,18 @@ public class EditBatchProcessor {
                 // Existing entities
                 EntityUpdate entityUpdate;
                 if (update.requiresFetchingExistingState()) {
-                    entityUpdate = update.toEntityUpdate(currentDocs.get(update.getEntityId().getId()));
+                    String entityId = update.getEntityId().getId();
+                    if (currentDocs.get(entityId) != null) {
+                        entityUpdate = update.toEntityUpdate(currentDocs.get(entityId));
+                    } else {
+                        logger.warn(String.format("Skipping editing of %s as it could not be retrieved", entityId));
+                        entityUpdate = null;
+                    }
                 } else {
                     entityUpdate = update.toEntityUpdate(null);
                 }
 
-                if (!entityUpdate.isEmpty()) { // skip updates which do not change anything
+                if (entityUpdate != null && !entityUpdate.isEmpty()) { // skip updates which do not change anything
                     editor.editEntityDocument(entityUpdate, false, summary, tags);
                 }
                 // custom code for handling our custom updates to mediainfo, which cover editing more than Wikibase

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
@@ -24,10 +24,7 @@
 
 package org.openrefine.wikibase.editing;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
@@ -121,6 +118,23 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         NewEntityLibrary expectedLibrary = new NewEntityLibrary();
         expectedLibrary.setId(1234L, "Q1234");
         assertEquals(expectedLibrary, library);
+    }
+
+    @Test
+    public void testDeletedItem() throws IOException, MediaWikiApiErrorException, InterruptedException {
+        String id = "Q389";
+        ItemIdValue qid = Datamodel.makeWikidataItemIdValue(id);
+        MonolingualTextValue description = Datamodel.makeMonolingualTextValue("village in Nepal", "en");
+        EntityEdit edit = new ItemEditBuilder(qid).addDescription(description, true).build();
+        List<EntityEdit> batch = Collections.singletonList(edit);
+        when(fetcher.getEntityDocuments(Collections.singletonList(id))).thenReturn(Collections.emptyMap());
+
+        EditBatchProcessor processor = new EditBatchProcessor(fetcher, editor, connection, batch, library,
+                summary, maxlag, tags, 10, 60);
+        assertEquals(processor.progress(), 0);
+        processor.performEdit();
+        assertEquals(processor.progress(), 100);
+        verify(editor, times(0)).editEntityDocument(any(), anyBoolean(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
Fixes #5385.

In general I try to stay away from working on Wikibase integration in OpenRefine at the moment, but this bug feels pretty important and easy to solve.