### PR TITLE
Always including the default types

### DIFF
--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -55,7 +55,7 @@ ReconStandardServicePanel.prototype._guessTypes = function(f) {
       if (data.code && data.code === 'ok') {
         self._types = data.types;
 
-        if (self._types.length === 0 && "defaultTypes" in self._service) {
+        if (self._types.length === 0 || "defaultTypes" in self._service) {
           var defaultTypes = {};
           $.each(self._service.defaultTypes, function() {
             defaultTypes[this.id] = this.name;


### PR DESCRIPTION
Fixes #4224 

Changes proposed in this pull request:
- Default types available in the manifest are always included in the types list where as previously we only included default types when we did not have any option left.

