### PR TITLE
Run PR CI on merge commits and not on original PR branch

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -56,9 +56,6 @@ jobs:
         echo "COVERALLS_TOKEN=$(echo eUVUVGRHOFJhQm9GMFJBYTNibjVhcWFEblpac1lmMlE3Cg== | base64 -d)" >> $GITHUB_ENV
 
     - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
 
     - name: Set up Java ${{ matrix.java }}
       uses: actions/setup-java@v3
@@ -97,9 +94,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
 
     - name: Set up Java 17
       uses: actions/setup-java@v3
@@ -122,9 +116,6 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Setup Node
         uses: actions/setup-node@v3.6.0
         with:
@@ -141,9 +132,6 @@ jobs:
       matrix: ${{fromJSON(needs.prepare_e2e_test_matrix.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Set up secrets
         run: |


### PR DESCRIPTION
For #5909.

I am not sure why we were previously running the CI checks on the PR branch itself and not on the merge of the PR branch with master, which is the default behavior. That default makes sense to me since it is more faithful to the end result of the merge.

The reason it is related to #5909 is that it creates spurious coverage decreases as in https://coveralls.io/builds/60565681 (see the file [TransposeColumnsIntoRowsOperation.java](https://coveralls.io/builds/60565681/source?filename=main%2Fsrc%2Fcom%2Fgoogle%2Frefine%2Foperations%2Fcell%2FTransposeColumnsIntoRowsOperation.java#L80), whose coverage increased in master and therefore is reported as a decrease of coverage).