### PR TITLE
Made CI skip Coveralls if Java files aren't changed

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,10 +26,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
 
       - name: Get changed files
         id: getfiles
@@ -148,7 +144,7 @@ jobs:
     - name: Build and test with Maven
       run: |
         skipTestsFlag=""
-        if [[ "${{ needs.check_java_src_changes.outputs.changed }}" == 'true' ]]; then
+        if [[ "${{ needs.check_java_src_changes.outputs.changed }}" != 'true' ]]; then
           skipTestsFlag="-DskipTests=true"
         fi
         mvn -B $skipTestsFlag jacoco:prepare-agent test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,7 +17,66 @@ on:
 permissions: read-all
 
 jobs:
+  check_java_src_changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+    env:
+      DIRECTORIES: 'main/src/* extensions/jython/src/* extensions/wikidata/src/* extensions/database/src/* extensions/phonetic/src/* extensions/gdata/src/*'
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: getfiles
+        run: |
+          echo "::set-output name=files::$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})"
+          echo "Files changed: $files"
+
+      - name: Get directories of changed files
+        id: getdirs
+        run: |
+          declare -A dirArray
+          for file in ${{ steps.getfiles.outputs.files }}
+          do
+            dir=$(dirname "$file")
+            dirArray["$dir"]=1
+          done
+          echo "::set-output name=dirs::${!dirArray[@]}"
+          echo "Directories changed: $dirs"
+
+      - name: Check if java source directories were modified
+        id: filter
+        run: |
+          changed='false'
+          for dir in ${{ steps.getdirs.outputs.dirs }}
+          do
+            for directory in ${{ env.DIRECTORIES }}
+            do
+              # If there's a wildcard in the directory from DIRECTORIES
+              if [[ "$directory" == *"*"* ]]; then
+                baseDir="${directory/\/*/}"
+                if [[ "$dir" == "$baseDir"* ]]; then
+                  changed='true'
+                  echo "Java Source Directory $dir was modified"
+                  break 2
+                fi
+              else
+                if [[ "$dir" == "$directory" ]]; then
+                  changed='true'
+                  echo "Java Source Directory $dir was modified"
+                  break 2
+                fi
+              fi
+            done
+          done
+          echo "::set-output name=changed::$changed"
+
   linux_server_tests:
+    needs: check_java_src_changes
     strategy:
       matrix:
         java: [ 11, 17 ]
@@ -86,13 +145,20 @@ jobs:
         PGPASSWORD: postgres
 
     - name: Build and test with Maven
-      run: mvn -B jacoco:prepare-agent test
+      run: |
+        skipTestsFlag=""
+        if [[ "${{ needs.check_java_src_changes.outputs.changed }}" == 'true' ]]; then
+          skipTestsFlag="-DskipTests=true"
+        fi
+        mvn -B $skipTestsFlag jacoco:prepare-agent test
 
     - name: Submit test coverage to Coveralls
+      if: needs.check_java_src_changes.outputs.changed != 'true'
       run: |
         mvn jacoco:report coveralls:report -DrepoToken=${{ env.COVERALLS_TOKEN }} -DpullRequest=${{ github.event.number }} -DfailOnServiceError=false
 
   windows_server_tests:
+    needs: check_java_src_changes
     runs-on: windows-latest
 
     steps:
@@ -114,7 +180,12 @@ jobs:
         mvn -B formatter:validate
 
     - name: Build and test with Maven
-      run: mvn -B jacoco:prepare-agent test
+      run: |
+        skipTestsFlag=""
+        if [[ "${{ needs.check_java_src_changes.outputs.changed }}" != 'true' ]]; then
+          skipTestsFlag="-DskipTests=true"
+        fi
+        mvn -B $skipTestsFlag jacoco:prepare-agent test
 
   prepare_e2e_test_matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
   check_java_src_changes:
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.filter.outputs.changed }}
+      changed: ${{ steps.check_changes.outputs.changed }}
     env:
       DIRECTORIES: 'main/src/* extensions/jython/src/* extensions/wikidata/src/* extensions/database/src/* extensions/phonetic/src/* extensions/gdata/src/*'
 
@@ -29,40 +29,25 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Get all changed files
-        id: getfiles
+        id: get_changed_files
         uses: jitterbit/get-changed-files@v1
 
-      - name: Echo all changed files
+      - name: Check changes
+        id: check_changes
         run: |
-          echo "Files changed:"
-          echo "${{ steps.getfiles.outputs.all }}"
-
-      - name: Get directories of changed files
-        id: getdirs
-        run: |
-          declare -A dirArray
-          for file in ${{ steps.getfiles.outputs.all }}
+          echo "Checking for changes in the directories: $DIRECTORIES"
+          changed='false'
+          for file in ${{ steps.get_changed_files.outputs.all }}
           do
             dir=$(dirname "$file")
-            dirArray["$dir"]=1
-          done
-          dirs=${!dirArray[@]}
-          echo "::set-output name=dirs::$dirs"
-          echo "Directories changed: $dirs"
-
-      - name: Check if certain directories were modified
-        id: filter
-        run: |
-          changed='false'
-          for dir in ${{ steps.getdirs.outputs.dirs }}
-          do
             if echo "${{ env.DIRECTORIES }}" | grep -q "$dir"
             then
               changed='true'
               break
             fi
           done
-          echo "::set-output name=changed::$changed"
+          echo "Changed: $changed"
+          echo "changed=$changed" >> $GITHUB_OUTPUT
 
   linux_server_tests:
     needs: check_java_src_changes

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -142,7 +142,7 @@ jobs:
         mvn -B $skipTestsFlag jacoco:prepare-agent test
 
     - name: Submit test coverage to Coveralls
-      if: needs.check_java_src_changes.outputs.changed != 'true'
+      if: needs.check_java_src_changes.outputs.changed == 'true'
       run: |
         mvn jacoco:report coveralls:report -DrepoToken=${{ env.COVERALLS_TOKEN }} -DpullRequest=${{ github.event.number }} -DfailOnServiceError=false
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,15 +30,16 @@ jobs:
 
       - name: Get all changed files
         id: get_changed_files
-        uses: jitterbit/get-changed-files@v1
+        uses: tj-actions/changed-files@v36.1.0
 
       - name: Check changes
         id: check_changes
         run: |
           echo "Checking for changes in the directories: $DIRECTORIES"
           changed='false'
-          for file in ${{ steps.get_changed_files.outputs.all }}
+          for file in ${{ steps.get_changed_files.outputs.all_changed_files }}
           do
+            echo "$file"
             dir=$(dirname "$file")
             if echo "${{ env.DIRECTORIES }}" | grep -q "$dir"
             then

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,7 +39,6 @@ jobs:
           changed='false'
           for file in ${{ steps.get_changed_files.outputs.all_changed_files }}
           do
-            echo "$file"
             dir=$(dirname "$file")
             if echo "${{ env.DIRECTORIES }}" | grep -q "$dir"
             then
@@ -155,13 +154,14 @@ jobs:
         mvn -B formatter:validate
 
     - name: Build and test with Maven
+      shell: pwsh
       run: |
-        skipTestsFlag=""
-        if [[ "${{ needs.check_java_src_changes.outputs.changed }}" != 'true' ]]; then
-          skipTestsFlag="-DskipTests=true"
-        fi
+        $skipTestsFlag = ""
+        if ("${{ needs.check_java_src_changes.outputs.changed }}" -ne "true") {
+          $skipTestsFlag = "-DskipTests=true"
+        }
         mvn -B $skipTestsFlag jacoco:prepare-agent test
-
+        
   prepare_e2e_test_matrix:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,50 +25,42 @@ jobs:
       DIRECTORIES: 'main/src/* extensions/jython/src/* extensions/wikidata/src/* extensions/database/src/* extensions/phonetic/src/* extensions/gdata/src/*'
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v3
 
-      - name: Get changed files
+      - name: Get all changed files
         id: getfiles
+        uses: jitterbit/get-changed-files@v1
+
+      - name: Echo all changed files
         run: |
-          echo "::set-output name=files::$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }})"
-          echo "Files changed: $files"
+          echo "Files changed:"
+          echo "${{ steps.getfiles.outputs.all }}"
 
       - name: Get directories of changed files
         id: getdirs
         run: |
           declare -A dirArray
-          for file in ${{ steps.getfiles.outputs.files }}
+          for file in ${{ steps.getfiles.outputs.all }}
           do
             dir=$(dirname "$file")
             dirArray["$dir"]=1
           done
-          echo "::set-output name=dirs::${!dirArray[@]}"
+          dirs=${!dirArray[@]}
+          echo "::set-output name=dirs::$dirs"
           echo "Directories changed: $dirs"
 
-      - name: Check if java source directories were modified
+      - name: Check if certain directories were modified
         id: filter
         run: |
           changed='false'
           for dir in ${{ steps.getdirs.outputs.dirs }}
           do
-            for directory in ${{ env.DIRECTORIES }}
-            do
-              # If there's a wildcard in the directory from DIRECTORIES
-              if [[ "$directory" == *"*"* ]]; then
-                baseDir="${directory/\/*/}"
-                if [[ "$dir" == "$baseDir"* ]]; then
-                  changed='true'
-                  echo "Java Source Directory $dir was modified"
-                  break 2
-                fi
-              else
-                if [[ "$dir" == "$directory" ]]; then
-                  changed='true'
-                  echo "Java Source Directory $dir was modified"
-                  break 2
-                fi
-              fi
-            done
+            if echo "${{ env.DIRECTORIES }}" | grep -q "$dir"
+            then
+              changed='true'
+              break
+            fi
           done
           echo "::set-output name=changed::$changed"
 


### PR DESCRIPTION
Part of https://github.com/OpenRefine/OpenRefine/issues/5909.

Added job that gets the list of changed files and checks if any are within one of the java directories, then changed=true, otherwise false.

If the Java source is changed, then Java tests are run and the Coveralls report is run.

Changes proposed in this pull request:
- Made it so Coveralls are skipped on CI if no Java files are altered.