### PR TITLE
now the default types are displayed with both name and id

### DIFF
--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -67,7 +67,7 @@ ReconStandardServicePanel.prototype._guessTypes = function(f) {
             if (defaultTypes.hasOwnProperty(id)) {
               self._types.push({
                 id: id,
-                name: defaultTypes[id].name
+                name: defaultTypes[id]
               });
             }
           }


### PR DESCRIPTION
Fixes #5907 

Changes proposed in this pull request:
- Both name and id are displayed for the default types now.

