### PR TITLE
fix(sec): upgrade org.xerial:sqlite-jdbc to 3.41.2.2

### DIFF
--- a/extensions/database/pom.xml
+++ b/extensions/database/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.39.3.0</version>
+      <version>3.41.2.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.xerial:sqlite-jdbc 3.39.3.0
- [CVE-2023-32697](https://www.oscs1024.com/hd/CVE-2023-32697)


### What did I do？
Upgrade org.xerial:sqlite-jdbc from 3.39.3.0 to 3.41.2.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS