### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-server to 12.0.0.beta0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <butterfly.version>1.2.4</butterfly.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j.version>2.20.0</log4j.version>
-    <jetty.version>9.4.51.v20230217</jetty.version>
+    <jetty.version>12.0.0.beta0</jetty.version>
     <okhttp.version>4.10.0</okhttp.version>
     <jena.version>4.8.0</jena.version>
     <poi.version>5.2.3</poi.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-server 9.4.51.v20230217
- [CVE-2023-26049](https://www.oscs1024.com/hd/CVE-2023-26049)


### What did I do？
Upgrade org.eclipse.jetty:jetty-server from 9.4.51.v20230217 to 12.0.0.beta0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS