### PR TITLE
set HTML document language based on load-language

### DIFF
--- a/main/webapp/modules/core/index.vt
+++ b/main/webapp/modules/core/index.vt
@@ -31,7 +31,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -->
-<html lang="en">
+<html>
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/main/webapp/modules/core/preferences.vt
+++ b/main/webapp/modules/core/preferences.vt
@@ -31,7 +31,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -->
-<html lang="en">
+<html>
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/main/webapp/modules/core/project.vt
+++ b/main/webapp/modules/core/project.vt
@@ -31,7 +31,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -->
-<html lang="en">
+<html>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/main/webapp/modules/core/scripts/util/i18n.js
+++ b/main/webapp/modules/core/scripts/util/i18n.js
@@ -34,6 +34,7 @@ I18NUtil.init = function (module) {
         }
     });
     $.i18n().load(dictionary, lang);
+    $('html').attr('lang', lang.replace('_', '-'));
     if (module === 'core') {
       $.i18n({locale: lang});
     }


### PR DESCRIPTION
Prior to this it was always set to English causing it to be wrong whenever another GUI language were in use.