### PR TITLE
Remove maximum Java version on Windows.

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -443,7 +443,6 @@
               <jre>
                 <path>%JAVA_HOME%;%PATH%</path>
                 <minVersion>${java.minversion}</minVersion>
-                <maxVersion>${java.maxversion}</maxVersion>
                 <initialHeapSize>512</initialHeapSize>
                 <maxHeapSize>2048</maxHeapSize>
                 <opts>

--- a/pom.xml
+++ b/pom.xml
@@ -139,10 +139,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-	<version>${maven-compiler-plugin.version}</version>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <source>${java.minversion}</source>
-          <target>${java.minversion}</target>
+          <release>${java.minversion}</release>
           <encoding>UTF-8</encoding>
           <showDeprecation>false</showDeprecation>
         </configuration>


### PR DESCRIPTION
This hopefully fixes #5583, but makes sense independently of it I think.

As mentioned in the issue, the upper bound on Java compatibility is only based on what we test for. Given that Java runtime environments are generally very backwards compatible, it feels wrong to me to refuse launching if Java is more recent than the versions of Java we test OpenRefine with. So I would just propose to drop this maximum version altogether.

I would propose to include this in a 3.7.3 release.