### PR TITLE
Make project initialization requests in parallel

### DIFF
--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -194,55 +194,45 @@ Refine.setTitle = function(status) {
 };
 
 Refine.reinitializeProjectData = function(f, fError) {
-  $.getJSON(
-    "command/core/get-project-metadata?" + $.param({ project: theProject.id }), null,
-    function(data) {
-      if (data.status == "error") {
-        alert(data.message);
-        if (fError) {
-          fError();
-        }
-      } else {
-        theProject.metadata = data;
-        $.getJSON(
-          "command/core/get-models?" + $.param({ project: theProject.id }), null,
-          function(data) {
-            if (data.status == "error") {
-              alert(data.message);
-              if (fError) {
-                fError();
-              }
-            } else {
-              for (var n in data) {
-                if (data.hasOwnProperty(n)) {
-                  theProject[n] = data[n];
-                }
-              }
-              $.post(
-                "command/core/get-all-preferences", null,
-                function(preferences) {
-                  if (preferences.status == "error") {
-                    alert(preferences.message);
-                    if (fError) {
-                      fError();
-                    }
-                  } else {
-                    if (preferences != null) {
-                      thePreferences = preferences;
-                    }
-                    f();
-                  }
-                },
-                'json'
-              );
-            }
-          },
-          'json'
-        );
+  function handleError(status, message, fError) {
+    if (status === "error") {
+      alert(message);
+      if (fError) {
+        fError();
       }
-    },
-    'json'
-  );
+      return true;
+    }
+    return false;
+  }
+
+  $.when(
+    $.getJSON("command/core/get-project-metadata?" + $.param({ project: theProject.id }), null),
+    $.getJSON("command/core/get-models?" + $.param({ project: theProject.id }), null),
+    $.getJSON("command/core/get-all-preferences", null),
+  ).done(function(metadata, models, preferences) {
+    metadata = metadata[0], models = models[0], preferences = preferences[0];
+    if (
+      handleError(metadata.status, metadata.message, fError) ||
+      handleError(models.status, models.message, fError) ||
+      handleError(preferences.status, preferences.message, fError)
+    ) {
+      return;
+    }
+
+    theProject.metadata = metadata;
+
+    for (var n in models) {
+      if (models.hasOwnProperty(n)) {
+        theProject[n] = models[n];
+      }
+    }
+
+    if (preferences) {
+      thePreferences = preferences;
+    }
+
+    f();
+  });
 };
 
 Refine.getPreference = function(key, defaultValue) {


### PR DESCRIPTION
Prior to this the UI would make a call to `get-project-metadata`, then when it finished to `get-models`, then to `get-all-preferences` during project initialization. Now all these requests are all made in parallel, greatly speeding up project initialization.