### PR TITLE
Refresh SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 
 Our core team will try their best to fix any valid vulnerability that is reported to them.
 
-You can privately report a vulnerability to us by sending a report by [creating a security advisory on GitHub](https://github.com/OpenRefine/OpenRefine/security/advisories/new). This report will be kept private while it is being assessed by the team.
+You can privately report a vulnerability to the OpenRefine team by [creating a security advisory on GitHub](https://github.com/OpenRefine/OpenRefine/security/advisories/new). This report will be kept private while it is being assessed by the team.
 
-Keep in mind that OpenRefine is designed to run locally on a users PC, while also making network calls across the internet only upon a users choice or command.
+Keep in mind that OpenRefine is designed to run locally on a user's PC, while also making network calls across the internet only upon a user's choice or command.
 As such, certain vulnerabilities might not apply to OpenRefine's design. In doubt, please submit a report anyway.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,12 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.5.x   | :white_check_mark: |
-| <= 3.4   | :x:                |
+| 3.7.x   | :white_check_mark: |
+| <= 3.6   | :x:                |
 
 ## Reporting a Vulnerability
 
-You can privately report a vulnerability to us by sending a report to this private mailing list [mailto:openrefine-coredev@googlegroups.com](mailto:openrefine-coredev@googlegroups.com)
+You can privately report a vulnerability to us by sending a report to this private mailing list [mailto:advisory.committee@openrefine.org](mailto:advisory.committee@openrefine.org)
 
 Our core team will try their best to fix any valid vulnerability that is reported to them.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,10 +9,9 @@
 
 ## Reporting a Vulnerability
 
-You can privately report a vulnerability to us by sending a report to this private mailing list [mailto:advisory.committee@openrefine.org](mailto:advisory.committee@openrefine.org)
-
 Our core team will try their best to fix any valid vulnerability that is reported to them.
 
-Keep in mind that OpenRefine is designed to run locally on a users PC, while also making network calls across the internet only upon a users choice or command.
+You can privately report a vulnerability to us by sending a report by [creating a security advisory on GitHub](https://github.com/OpenRefine/OpenRefine/security/advisories/new). This report will be kept private while it is being assessed by the team.
 
-As such, certain vulnerabilities might not apply to OpenRefine's design.
+Keep in mind that OpenRefine is designed to run locally on a users PC, while also making network calls across the internet only upon a users choice or command.
+As such, certain vulnerabilities might not apply to OpenRefine's design. In doubt, please submit a report anyway.


### PR DESCRIPTION
- replace mention of broken mailing list by the advisory committee. We can also consider establishing other groups or email aliases in the future - the priority for me is to have something that actually works
- update supported versions (we probably should add it as a step in the release instructions to keep this up to date)