### PR TITLE
Bump maven-jacoco-plugin from 0.8.8 to 0.8.10

### DIFF
--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -50,7 +50,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.8</version>
+        <version>0.8.10</version>
         <executions>
             <execution>
                 <id>prepare-agent</id>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
     <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
-    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.10</jacoco-maven-plugin.version>
     <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
     <surefire.version>3.1.2</surefire.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>


### PR DESCRIPTION
Bumps maven-jacoco-plugin from 0.8.8 to 0.8.10 to try to fix a build error in https://github.com/OpenRefine/OpenRefine/pull/5969  which is failing in JaCoCo with an error:

```
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 64
```
JaCoCo 0.8.9 officially adds support for Java 19 and 20
Ref: https://github.com/jacoco/jacoco/releases/tag/v0.8.9
