### PR TITLE
Add support for JSON Objects to forEachIndex() control

### DIFF
--- a/main/resources/com/google/refine/grel/ControlEvalError.properties
+++ b/main/resources/com/google/refine/grel/ControlEvalError.properties
@@ -1,5 +1,5 @@
 filter=First argument is not an array
-foreach_index=First argument to forEach is not an array
+foreach_index=First argument to forEachIndex is not an array
 foreach=First argument to forEach is not an array or JSON object
 for_range=First, second, and third arguments of forRange must all be numbers
 
@@ -12,3 +12,4 @@ expects_five_args={0} expects five arguments
 expects_second_arg_var_name={0} expects second argument to be a variable name
 expects_second_arg_index_var_name={0} expects second argument to be the index's variable name
 expects_third_arg_element_var_name={0} expects second argument to be the element's variable name
+expects_second_third_args_different={0} expects the second and third arguments to be different variable names

--- a/main/resources/com/google/refine/grel/ControlEvalError.properties
+++ b/main/resources/com/google/refine/grel/ControlEvalError.properties
@@ -1,5 +1,5 @@
 filter=First argument is not an array
-foreach_index=First argument to forEachIndex is not an array
+foreach_index=First argument to forEachIndex is not an array or JSON object
 foreach=First argument to forEach is not an array or JSON object
 for_range=First, second, and third arguments of forRange must all be numbers
 

--- a/main/src/com/google/refine/grel/ast/VariableExpr.java
+++ b/main/src/com/google/refine/grel/ast/VariableExpr.java
@@ -66,7 +66,13 @@ public class VariableExpr implements Evaluable {
         return _name;
     }
 
+    @Override
     public boolean equals(Object other) {
         return other instanceof VariableExpr && getName().equals(((VariableExpr) other).getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return _name.hashCode();
     }
 }

--- a/main/src/com/google/refine/grel/ast/VariableExpr.java
+++ b/main/src/com/google/refine/grel/ast/VariableExpr.java
@@ -45,7 +45,11 @@ public class VariableExpr implements Evaluable {
     final protected String _name;
 
     public VariableExpr(String name) {
-        _name = name;
+        if (name != null || !name.isEmpty()) {
+            _name = name;
+        } else {
+            throw new IllegalArgumentException("Illegal variable name ");
+        }
     }
 
     @Override
@@ -60,5 +64,9 @@ public class VariableExpr implements Evaluable {
 
     public String getName() {
         return _name;
+    }
+
+    public boolean equals(Object other) {
+        return other instanceof VariableExpr && getName().equals(((VariableExpr) other).getName());
     }
 }

--- a/main/src/com/google/refine/grel/controls/ForEachIndex.java
+++ b/main/src/com/google/refine/grel/controls/ForEachIndex.java
@@ -38,6 +38,8 @@ import java.util.List;
 import java.util.Properties;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.util.JsonValueConverter;
@@ -59,6 +61,8 @@ public class ForEachIndex implements Control {
         } else if (!(args[2] instanceof VariableExpr)) {
             // variable name";
             return ControlEvalError.expects_third_arg_element_var_name(ControlFunctionRegistry.getControlName(this));
+        } else if (args[1].equals(args[2])) {
+            return ControlEvalError.expects_second_third_args_different(ControlFunctionRegistry.getControlName(this));
         }
         return null;
     }
@@ -69,7 +73,7 @@ public class ForEachIndex implements Control {
         if (ExpressionUtils.isError(o)) {
             return o;
         } else if (!ExpressionUtils.isArrayOrCollection(o) && !(o instanceof ArrayNode)) {
-            return ControlEvalError.foreach_index();
+            return new EvalError(ControlEvalError.foreach_index());
         }
 
         String indexName = ((VariableExpr) args[1]).getName();

--- a/main/tests/server/src/com/google/refine/grel/controls/ForEachIndexTests.java
+++ b/main/tests/server/src/com/google/refine/grel/controls/ForEachIndexTests.java
@@ -67,7 +67,7 @@ public class ForEachIndexTests extends RefineTest {
     public void testInvalidParams() throws ParsingException {
         bindings = new Properties();
         bindings.put("v", "");
-        assertParseException("forEachIndex('test', v, v, v)");
+        assertParseException("forEachIndex('test', v, v)");
         assertParseException("forEachIndex([], 1, 1, 1)", "Didn't throw a ParsingException for wrong argument type");
         assertParseException("forEachIndex([], v, v, v)", "Didn't throw ParsingException for duplicate variables");
         assertParseException("forEachIndex([], v, v)", "Didn't throw a ParsingException for 3 arguments");
@@ -75,6 +75,25 @@ public class ForEachIndexTests extends RefineTest {
         assertParseException("forEachIndex([])", "Didn't throw a ParsingException for 1 argument");
     }
 
+    @Test
+    public void testForEachJsonObject() throws ParsingException {
+        String json = "{"
+                + "\"2511\": {\"parent_area\": null, \"generation_high\": 40, \"all_names\": {}, \"id\": 2511, \"codes\": {\"ons\": \"00AB\", \"gss\": \"E09000002\", \"local-authority-eng\": \"BDG\", \"local-authority-canonical\": \"BDG\", \"unit_id\": \"10949\"}, \"name\": \"Barking and Dagenham Borough Council\", \"country\": \"E\", \"type_name\": \"London borough\", \"generation_low\": 1, \"country_name\": \"England\", \"type\": \"LBO\"},"
+                + "\"2247\": {\"parent_area\": null, \"generation_high\": 40, \"all_names\": {}, \"id\": 2247, \"codes\": {\"unit_id\": \"41441\"}, \"name\": \"Greater London Authority\", \"country\": \"E\", \"type_name\": \"Greater London Authority\", \"generation_low\": 1, \"country_name\": \"England\", \"type\": \"GLA\"},"
+                + "\"8706\": {\"parent_area\": 2511, \"generation_high\": 40, \"all_names\": {}, \"id\": 8706, \"codes\": {\"ons\": \"00ABGH\", \"gss\": \"E05000036\", \"unit_id\": \"10936\"}, \"name\": \"Mayesbrook\", \"country\": \"E\", \"type_name\": \"London borough ward\", \"generation_low\": 1, \"country_name\": \"England\", \"type\": \"LBW\"}"
+                + "}";
+
+        String[] test = { "forEachIndex('" + json + "'.parseJson(), k, v, v.id).sort().join(',')", "2247,2511,8706" };
+        bindings = new Properties();
+        bindings.put("k", "");
+        bindings.put("v", "");
+        parseEval(bindings, test);
+
+        String[] test2 = { "forEachIndex('" + json + "'.parseJson(), k, v, k).sort().join(',')", "2247,2511,8706" };
+        parseEval(bindings, test2);
+        String[] test3 = { "forEachIndex('" + json + "'.parseJson(), k, v, k.toNumber()==v.id).join(',')", "true,true,true" };
+        parseEval(bindings, test3);
+    }
 
     @Test
     public void testForEachIndexArray() throws ParsingException {


### PR DESCRIPTION
Fixes #3147

I'm on the fence as to whether this should be a separate control (name TBD), as I originally spec'd, or if rolling the functionality into the existing `forEachIndex` is close enough semantically given that the array index and the object key are both performing essentially the same function. This pull request adopts the latter approach. Doing it the other way would basically involve cloning the code, giving it a new function name, and making the error messages more specific.

Changes proposed in this pull request:
- add tests for `forEachIndex`
- enhance error checking to reject using the same variable name for both index and value
- add support for JSON objects withe same structure, but the object key instead of the array index returned in the index/key variable
