### PR TITLE
Improve SQL bad keyword detection - fixes #6019

### DIFF
--- a/extensions/database/module/langs/translation-cs.json
+++ b/extensions/database/module/langs/translation-cs.json
@@ -48,7 +48,6 @@
     "database-source/alert-connection-edit": "Připojení bylo upraveno",
     "database-source/form-validation-failure": "Nová podpoba připojení není platná!",
     "database-source/alert-invalid-query-select": "Dotaz musí začínat klíčovým slovem SELECT",
-    "database-source/alert-invalid-query-keyword": "Dotaz nemůže obsahovat klíčové slovo pro manipulaci s daty:",
     "database-source/alert-query": "Musíte zadat validní dotaz",
     "database-source/alert-initial-database": "Musíte určit výchozí databázi",
     "database-source/alert-connection-name": "Musíte určit název připojení",

--- a/extensions/database/module/langs/translation-en.json
+++ b/extensions/database/module/langs/translation-en.json
@@ -11,7 +11,6 @@
     "database-source/alert-connection-name": "You must specify a connection name",
     "database-source/alert-initial-database": "You must specify an initial database",
     "database-source/alert-query": "You must specify a valid query",
-    "database-source/alert-invalid-query-keyword": "Query cannot contain data manipulation keyword:",
     "database-source/alert-invalid-query-select": "Query must start with SELECT Keyword",
     "database-source/form-validation-failure": "New connection form invalid!",
     "database-source/alert-connection-edit": "Connection edited",

--- a/extensions/database/module/langs/translation-en_GB.json
+++ b/extensions/database/module/langs/translation-en_GB.json
@@ -38,7 +38,6 @@
     "database-source/alert-connection-edit": "Connection edited",
     "database-source/form-validation-failure": "New connection form invalid!",
     "database-source/alert-invalid-query-select": "Query must start with SELECT Keyword",
-    "database-source/alert-invalid-query-keyword": "Query cannot contain data manipulation keyword:",
     "database-source/alert-connection-name": "You must specify a connection name",
     "database-source/alert-query": "You must specify a valid query",
     "database-source/alert-initial-database": "You must specify an initial database",

--- a/extensions/database/module/langs/translation-es.json
+++ b/extensions/database/module/langs/translation-es.json
@@ -13,7 +13,6 @@
     "database-source/alert-host": "Debe especificar un host de base de datos",
     "database-source/alert-password": "Tienes que especificar una contraseña de base de datos",
     "database-source/alert-connection-name": "Debe especificar un nombre de conexión",
-    "database-source/alert-invalid-query-keyword": "La consulta no puede contener palabras clave de manipulación de datos:",
     "database-source/alert-initial-database": "Debe especificar una base de datos inicial",
     "database-source/alert-query": "Debe especificar una consulta válida",
     "database-source/databaseFileNameLabel": "Archivo de base de datos",

--- a/extensions/database/module/langs/translation-fa.json
+++ b/extensions/database/module/langs/translation-fa.json
@@ -13,5 +13,4 @@
     "database-source/alert-port": "باید یک پورت پایگاه داده را مشخص کنید",
     "database-source/alert-initial-database": "‏باید یک پایگاه داده اصلی را مشخص کنید",
     "database-source/alert-invalid-query-select": "عبارت پرس و جو باید با کلیدواژه SELECT شروع شود",
-    "database-source/alert-invalid-query-keyword": "‏عبارت پرس و جو نمی‌تواند دارای کلیدواژه‌های مدیریت داده‌ها باشد"
 }

--- a/extensions/database/module/langs/translation-fr.json
+++ b/extensions/database/module/langs/translation-fr.json
@@ -11,7 +11,6 @@
     "database-source/alert-connection-name": "Vous devez spécifier un nom de connexion",
     "database-source/alert-initial-database": "Vous devez spécifier une base de données initiale",
     "database-source/alert-query": "Vous devez spécifier une requête valide",
-    "database-source/alert-invalid-query-keyword": "La requête ne peut pas contenir ce mot clé destiné à manipuler la base de données :",
     "database-source/alert-invalid-query-select": "La requête doit débuter par le mot-clé SELECT",
     "database-source/form-validation-failure": "Le nouveau formulaire de connexion est invalide !",
     "database-source/alert-connection-edit": "La connexion a été éditée avec succès",

--- a/extensions/database/module/langs/translation-he.json
+++ b/extensions/database/module/langs/translation-he.json
@@ -48,7 +48,6 @@
     "database-source/alert-connection-edit": "החיבור נערך",
     "database-source/form-validation-failure": "טופס החיבור החדש שגוי!",
     "database-source/alert-invalid-query-select": "שאילתה חייבת להתחיל במילת המפתח SELECT (בחירה)",
-    "database-source/alert-invalid-query-keyword": "השאילתה לא יכולה להכיל מילת מפתח שמשנה נתונים:",
     "database-source/alert-query": "עליך לציין שאילתה תקפה",
     "database-source/alert-initial-database": "עליך לציין מסד נתונים ראשוני",
     "database-source/alert-connection-name": "עליך לציין שם לחיבור",

--- a/extensions/database/module/langs/translation-id.json
+++ b/extensions/database/module/langs/translation-id.json
@@ -48,7 +48,6 @@
     "database-source/alert-connection-edit": "Koneksi diubah",
     "database-source/form-validation-failure": "Form koneksi baru tidak valid!",
     "database-source/alert-invalid-query-select": "Kueri harus dimulai dengan kata kunci SELECT",
-    "database-source/alert-invalid-query-keyword": "Kueri tidak bisa mengandung kata kunci manipulasi data:",
     "database-source/alert-query": "Anda harus menentukan sebuah kueri yang valid",
     "database-source/alert-initial-database": "Anda harus menentukan basis data awal",
     "database-source/alert-connection-name": "Anda harus membuat nama koneksi",

--- a/extensions/database/module/langs/translation-it.json
+++ b/extensions/database/module/langs/translation-it.json
@@ -10,7 +10,6 @@
     "database-source/alert-connection-name": "È necessario impostare un nome alla connessione",
     "database-source/alert-initial-database": "È necessario specificare un database iniziale",
     "database-source/alert-query": "È necessario impostare una query valida",
-    "database-source/alert-invalid-query-keyword": "La query non può contenere keyword di manipolazione dati:",
     "database-source/alert-invalid-query-select": "La query deve iniziare con la keyword SELECT",
     "database-source/alert-connection-edit": "Connessione modificata",
     "database-source/connectionNameLabel": "Nome",

--- a/extensions/database/module/langs/translation-ja.json
+++ b/extensions/database/module/langs/translation-ja.json
@@ -10,7 +10,6 @@
     "database-source/alert-connection-name": "connection nameを指定してください",
     "database-source/alert-initial-database": "最初のデータベースを指定してください",
     "database-source/alert-query": "有効なクエリーを設定してください",
-    "database-source/alert-invalid-query-keyword": "クエリーにデータ操作語があります:",
     "database-source/alert-invalid-query-select": "クエリーはSELECTで始まります",
     "database-source/form-validation-failure": "接続フォームが無効です!",
     "database-source/alert-connection-edit": "接続の設定に成功しました",

--- a/extensions/database/module/langs/translation-ko.json
+++ b/extensions/database/module/langs/translation-ko.json
@@ -10,7 +10,6 @@
     "database-source/alert-connection-name": "접속이름을 지정해야 합니다",
     "database-source/alert-initial-database": "초기 데이터베이스를 지정해야 합니다",
     "database-source/alert-query": "유효한 쿼리를 지정해야 합니다",
-    "database-source/alert-invalid-query-keyword": "쿼리는 데이터 조작 키워드를 포함할 수 없습니다:",
     "database-source/alert-invalid-query-select": "쿼리는 SELECT 키워드로 시작해야 합니다",
     "database-source/form-validation-failure": "신규 접속이 유효하지 않습니다!",
     "database-source/alert-connection-edit": "접속이 성공적으로 편집되었습니다",

--- a/extensions/database/module/langs/translation-ml.json
+++ b/extensions/database/module/langs/translation-ml.json
@@ -21,7 +21,6 @@
     "database-source/alert-query": "താങ്കൾ സാധുവായ ഒരു ചോദ്യം വ്യക്തമാക്കണം",
     "database-source/alert-connection-edit": "കണക്ഷൻ തിരുത്തി",
     "database-source/alert-password": "താങ്കൾ ഒരു ഡാറ്റാബേസ് രഹസ്യ കോഡ്‌ സൂചിപ്പിക്കണം",
-    "database-source/alert-invalid-query-keyword": "അന്വേഷണത്തിൽ ഡാറ്റ കൃത്രിമത്വ കീവേഡ് അടങ്ങിയിരിക്കരുത്:",
     "database-source/alert-initial-database": "താങ്കൾ ഒരു പ്രാരംഭ ഡാറ്റാബേസ് വ്യക്തമാക്കണം",
     "database-source/alert-invalid-query-select": "ക്വറി SELECT എന്ന വാക്ക് വച്ച് തുടങ്ങണം",
     "database-source/form-validation-failure": "പുതിയ കണക്ഷൻ ഫോം അസാധുവാണ്!",

--- a/extensions/database/module/langs/translation-nb_NO.json
+++ b/extensions/database/module/langs/translation-nb_NO.json
@@ -43,7 +43,6 @@
     "database-parsing/limit": "rad(er) med data",
     "database-parsing/store-row": "Lagre blanke rader",
     "database-parsing/store-cell": "Lagre blanke celler som null",
-    "database-source/alert-invalid-query-keyword": "Spørring kan ikke inneholde datamanipuleringsnøkkelord:",
     "database-source/form-validation-failure": "Nytt tilkoblingsskjema ugyldig!",
     "database-parsing/worksheet": "Regneark",
     "database-source/databaseHostPlaceholder": "Skriv inn databasetjener eller IP",

--- a/extensions/database/module/langs/translation-nl.json
+++ b/extensions/database/module/langs/translation-nl.json
@@ -9,7 +9,6 @@
     "database-source/alert-user": "Je moet een databasegebruiker opgeven",
     "database-source/alert-password": "Je moet een wachtwoord voor de database opgeven",
     "database-source/alert-query": "Je moet een geldige query opgeven",
-    "database-source/alert-invalid-query-keyword": "De query mag niet het volgende datamanipulatie-trefwoord bevatten:",
     "database-source/alert-invalid-query-select": "De query moet met het woord SELECT beginnen",
     "database-source/form-validation-failure": "Nieuw verbindingsformulier is ongeldig!",
     "database-source/alert-connection-edit": "Verbinding is bewerkt",

--- a/extensions/database/module/langs/translation-pl.json
+++ b/extensions/database/module/langs/translation-pl.json
@@ -31,7 +31,6 @@
     "database-source/alert-db-port-invalid-character": "Błąd portu bazy danych: Wprowadzono zabronione znaki. Dozwolone jedynie cyfry.",
     "database-source/alert-db-host-invalid-character": "Błąd hosta bazy danych: Wprowadzono zabronione znaki. Dozwolone jedynie znaki alfanumeryczne",
     "database-source/alert-conn-name-invalid-character": "Błąd wprowadzenia nazwy połączenia: Wprowadzono zabronione znaki. Dozwolone tylko [a-zA-Z0-9._-]",
-    "database-source/alert-invalid-query-keyword": "Kwerenda nie może zawierać słowa kluczowego manipulacji danymi:",
     "database-source/alert-query": "Musisz określić prawidłowe zapytanie",
     "database-source/alert-initial-database": "Musisz określić początkową bazę danych",
     "database-source/form-validation-failure": "Błędna nowa forma połączenia!",

--- a/extensions/database/module/langs/translation-pt.json
+++ b/extensions/database/module/langs/translation-pt.json
@@ -33,7 +33,6 @@
     "database-parsing/discard-next": "Descartar primeira(s)",
     "database-source/databaseNameLabel": "Nome do banco de dados",
     "database-source/alert-port": "Deve definir uma porta de banco de dados",
-    "database-source/alert-invalid-query-keyword": "A consulta não pode conter palavra-chave de manipulação de dados:",
     "database-source/databasePasswordPlaceholder": "Digite a palavra-passe do banco de dados",
     "database-source/connectionNamePlaceholder": "Digite um novo nome de conexão",
     "database-source/databaseFileNamePlaceholder": "Digite o caminho completo do ficheiro de banco de dados",

--- a/extensions/database/module/langs/translation-pt_BR.json
+++ b/extensions/database/module/langs/translation-pt_BR.json
@@ -47,7 +47,6 @@
     "database-source/alert-connection-edit": "Conexão editada",
     "database-source/form-validation-failure": "Formulário de nova conexão inválido!",
     "database-source/alert-invalid-query-select": "A consulta deve começar com a palavra-chave SELECT",
-    "database-source/alert-invalid-query-keyword": "A consulta não pode conter palavra-chave de manipulação de dados:",
     "database-source/alert-query": "Você deve definir uma consulta válida",
     "database-source/alert-initial-database": "Você deve definir um banco de dados inicial",
     "database-source/alert-connection-name": "Você deve definir um nome de conexão",

--- a/extensions/database/module/langs/translation-sv.json
+++ b/extensions/database/module/langs/translation-sv.json
@@ -10,7 +10,6 @@
     "database-source/alert-connection-name": "Du måste ange ett anslutningsnamn",
     "database-source/alert-initial-database": "Du måste ange en första databas",
     "database-source/alert-query": "Du måste ange en giltig fråga",
-    "database-source/alert-invalid-query-keyword": "Fråga kan inte innehålla nyckelord för datamanipulering:",
     "database-source/alert-invalid-query-select": "Frågan måste börja med nyckelordet SELECT",
     "database-source/form-validation-failure": "Ny anslutningsform är ogiltig!",
     "database-source/alert-connection-edit": "Anslutning redigerad",

--- a/extensions/database/module/langs/translation-tr.json
+++ b/extensions/database/module/langs/translation-tr.json
@@ -52,7 +52,6 @@
     "database-source/alert-connection-edit": "Bağlantı düzenlendi",
     "database-source/form-validation-failure": "Yeni bağlantı formu geçersiz!",
     "database-source/alert-invalid-query-select": "Sorgu, SELECT anahtar sözcüğüyle başlamalıdır",
-    "database-source/alert-invalid-query-keyword": "Sorgu, veri işleme anahtar sözcüğü içeremez:",
     "database-source/alert-query": "Geçerli bir sorgu belirtmelisiniz",
     "database-source/alert-initial-database": "Bir başlangıç veri tabanı belirtmelisiniz",
     "database-source/alert-connection-name": "Bir bağlantı adı belirtmelisiniz",

--- a/extensions/database/module/langs/translation-zh_Hans.json
+++ b/extensions/database/module/langs/translation-zh_Hans.json
@@ -10,7 +10,6 @@
     "database-source/alert-connection-name": "你必须指定一个连接名称",
     "database-source/alert-initial-database": "你必须指定一个初始数据库",
     "database-source/alert-query": "你必须指定一个有效的查询",
-    "database-source/alert-invalid-query-keyword": "任何数据库查询语句均不能够包含数据操作关键字：",
     "database-source/alert-invalid-query-select": "查询语句必须从 SELECT 关键字开始",
     "database-source/form-validation-failure": "无效的新建连接表！",
     "database-source/alert-connection-edit": "连接已编辑",

--- a/extensions/database/module/scripts/index/database-source-ui.js
+++ b/extensions/database/module/scripts/index/database-source-ui.js
@@ -191,45 +191,14 @@ Refine.DatabaseSourceUI.prototype.focus = function() {
 };
 
 Refine.DatabaseSourceUI.prototype.validateQuery = function(query) {
-     //alert("query::" + query);
      if(!query || query.length <= 0 ) {
          window.alert($.i18n('database-source/alert-query'));
          return false;
      }
-    
-     var allCapsQuery = query.toUpperCase();
-    
-     if(allCapsQuery.indexOf('DROP') > -1){
-         window.alert($.i18n('database-source/alert-invalid-query-keyword') + " DROP");
-         return false;
-     }else if(allCapsQuery.indexOf('TRUNCATE') > -1){
-         window.alert($.i18n('database-source/alert-invalid-query-keyword') + " TRUNCATE");
-         return false;
-     }else if(allCapsQuery.indexOf('DELETE') > -1){
-         window.alert($.i18n('database-source/alert-invalid-query-keyword') + " DELETE");
-         return false;
-     }else if(allCapsQuery.indexOf('ROLLBACK') > -1){
-         window.alert($.i18n('database-source/alert-invalid-query-keyword') + " ROLLBACK");
-         return false;
-     }else if(allCapsQuery.indexOf('SHUTDOWN') > -1){
-         window.alert($.i18n('database-source/alert-invalid-query-keyword') + " SHUTDOWN");
-         return false;
-     }else if(allCapsQuery.indexOf('INSERT') > -1){
-         window.alert($.i18n('database-source/alert-invalid-query-keyword') + " INSERT");
-         return false;
-     }else if(allCapsQuery.indexOf('ALTER') > -1){
-         window.alert($.i18n('database-source/alert-invalid-query-keyword') + " ALTER");
-         return false;
-     }else if(allCapsQuery.indexOf('UPDATE') > -1){
-         window.alert($.i18n('database-source/alert-invalid-query-keyword') + " UPDATE");
-         return false;
-     }
-
-     if(!allCapsQuery.startsWith('SELECT')) {
+     if(!query.toUpperCase().startsWith('SELECT')) {
          window.alert($.i18n('database-source/alert-invalid-query-select'));
          return false;
      }
-
      return true;
 };
 


### PR DESCRIPTION
Fixes #6019

Changes proposed in this pull request:
- Make SQL bad keyword detection more reliable by using regex instead of substring
- Improve localization by not using string concatenation to build messages

BUT I'm not convinced that we shouldn't just remove all this code since it's almost impossible to do reliably and could give users/administrators a false sense of security. They should be using their DB admin privs to restrict user access.