### PR TITLE
CSV Byte Order Mark (BOM) support. Fixes #1241

### DIFF
--- a/main/src/com/google/refine/importers/TextFormatGuesser.java
+++ b/main/src/com/google/refine/importers/TextFormatGuesser.java
@@ -34,13 +34,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
 
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.CharMatcher;
 import com.google.refine.importing.FormatGuesser;
+import com.google.refine.importing.ImportingUtilities;
 
 public class TextFormatGuesser implements FormatGuesser {
 
@@ -51,7 +51,7 @@ public class TextFormatGuesser implements FormatGuesser {
     @Override
     public String guess(File file, String encoding, String seedFormat) {
         try (InputStream fis = new FileInputStream(file)) {
-            if (isCompressed(file)) {
+            if (ImportingUtilities.isCompressed(file)) {
                 return "binary";
             }
             ;
@@ -130,21 +130,6 @@ public class TextFormatGuesser implements FormatGuesser {
             e.printStackTrace();
         }
         return null;
-    }
-
-    private boolean isCompressed(File file) throws IOException {
-        // Check for common compressed file types to protect ourselves from binary data
-        try (InputStream is = new FileInputStream(file)) {
-            byte[] magic = new byte[4];
-            int count = is.read(magic);
-            if (count == 4 && Arrays.equals(magic, new byte[] { 0x50, 0x4B, 0x03, 0x04 }) || // zip
-                    Arrays.equals(magic, new byte[] { 0x50, 0x4B, 0x07, 0x08 }) ||
-                    (magic[0] == 0x1F && magic[1] == (byte) 0x8B) // gzip
-            ) {
-                return true;
-            }
-        }
-        return false;
     }
 
 }

--- a/main/src/com/google/refine/importing/EncodingGuesser.java
+++ b/main/src/com/google/refine/importing/EncodingGuesser.java
@@ -1,31 +1,32 @@
 
 package com.google.refine.importing;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
-import org.mozilla.universalchardet.UniversalDetector;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang.StringUtils;
+import org.mozilla.universalchardet.UnicodeBOMInputStream;
+import org.mozilla.universalchardet.UniversalDetector;
 
 import com.google.refine.util.JSONUtilities;
 
 /**
- * This class tries to find the correct encoding based on the http://site.icu-project.org/ and the icu4j library
- * http://site.icu-project.org/home/why-use-icu4j.
+ * This class tries to find the correct encoding based on https://github.com/albfernandez/juniversalchardet which is a
+ * Java port of Mozilla's universalchardet library
+ * https://hg.mozilla.org/mozilla-central/file/tip/extensions/universalchardet/
  * 
  * @author <a href="mailto:kontakt@stundzig.de">Steffen Stundzig</a>
  */
 public final class EncodingGuesser {
 
-    public final static void guess(final ImportingJob job)
-            throws FileNotFoundException, IOException {
+    public static final String UTF_8_BOM = "UTF-8-BOM";
+
+    public static void guess(final ImportingJob job)
+            throws IOException {
         ObjectNode retrievalRecord = job.getRetrievalRecord();
         if (retrievalRecord != null) {
             ArrayNode fileRecords = JSONUtilities.getArray(retrievalRecord, "files");
@@ -38,9 +39,13 @@ public final class EncodingGuesser {
                     if (StringUtils.isBlank(encoding)) {
                         String location = JSONUtilities.getString(record, "location", null);
                         if (location != null) {
-                            try (InputStream is = new BufferedInputStream(
+                            try (UnicodeBOMInputStream is = new UnicodeBOMInputStream(
                                     new FileInputStream(new File(job.getRawDataDir(), location)))) {
                                 String detected = UniversalDetector.detectCharset(is);
+                                UnicodeBOMInputStream.BOM bom = is.getBOM();
+                                if (UnicodeBOMInputStream.BOM.UTF_8.equals(bom)) {
+                                    detected = UTF_8_BOM;
+                                }
                                 if (detected != null) {
                                     JSONUtilities.safePut(record, "encoding", detected);
                                 }

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.importing;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -69,7 +71,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
-import org.apache.commons.compress.compressors.lzma.LZMACompressorInputStream;
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.ProgressListener;
@@ -84,6 +85,7 @@ import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.mozilla.universalchardet.UnicodeBOMInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -349,7 +351,6 @@ public class ImportingUtilities {
                         if (httpClient.getResponse(urlString, null, responseHandler) != null) {
                             archiveCount++;
                         }
-                        ;
                         downloadCount++;
                     } else {
                         // Fallback handling for non HTTP connections (only FTP?)
@@ -435,19 +436,19 @@ public class ImportingUtilities {
 
         update.totalExpectedSize += length;
 
-        progress.setProgress("Downloading " + url.toString(),
+        progress.setProgress("Downloading " + url, // TODO: Localize
                 calculateProgressPercent(update.totalExpectedSize, update.totalRetrievedSize));
 
         long actualLength = saveStreamToFile(stream, file, update);
         JSONUtilities.safePut(fileRecord, "size", actualLength);
         if (actualLength == 0) {
-            throw new IOException("No content found in " + url.toString());
+            throw new IOException("No content found in " + url);
         } else if (length >= 0) {
             update.totalExpectedSize += (actualLength - length);
         } else {
             update.totalExpectedSize += actualLength;
         }
-        progress.setProgress("Saving " + url.toString() + " locally",
+        progress.setProgress("Saving " + url + " locally", // TODO: Localize
                 calculateProgressPercent(update.totalExpectedSize, update.totalRetrievedSize));
         return postProcessRetrievedFile(rawDataDir, file, fileRecord, fileRecords, progress);
     }
@@ -528,11 +529,23 @@ public class ImportingUtilities {
             encoding = commonEncoding;
         }
         if (encoding != null) {
-            try {
-                return new InputStreamReader(inputStream, encoding);
-            } catch (UnsupportedEncodingException e) {
-                // Ignore and fall through
+
+            // Special case for UTF-8 with BOM
+            if (EncodingGuesser.UTF_8_BOM.equals(encoding)) {
+                try {
+                    return new InputStreamReader(new UnicodeBOMInputStream(inputStream, true), UTF_8);
+                } catch (IOException e) {
+                    throw new RuntimeException("Exception from UnicodeBOMInputStream", e);
+                }
+            } else {
+                try {
+                    return new InputStreamReader(inputStream, encoding);
+                } catch (UnsupportedEncodingException e) {
+                    // This should never happen since they picked from a list of supported encodings
+                    throw new RuntimeException("Unsupported encoding: " + encoding, e);
+                }
             }
+
         }
         return new InputStreamReader(inputStream);
     }
@@ -677,7 +690,7 @@ public class ImportingUtilities {
                     || "application/x-zip-compressed".equals(contentType)
                     || "application/zip".equals(contentType)
                     || "application/x-compressed".equals(contentType)
-                    || "multipar/x-zip".equals(contentType)) {
+                    || "multipart/x-zip".equals(contentType)) {
                 return new ZipInputStream(new FileInputStream(file));
             } else if (fileName.endsWith(".kmz")) {
                 return new ZipInputStream(new FileInputStream(file));
@@ -689,11 +702,26 @@ public class ImportingUtilities {
 
     private static boolean isFileGZipped(File file) {
         int magic = 0;
-        try (RandomAccessFile raf = new RandomAccessFile(file, "r");) {
+        try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
             magic = raf.read() & 0xff | ((raf.read() << 8) & 0xff00);
         } catch (IOException ignored) {
         }
         return magic == GZIPInputStream.GZIP_MAGIC;
+    }
+
+    public static boolean isCompressed(File file) throws IOException {
+        // Check for common compressed file types to protect ourselves from binary data
+        try (InputStream is = new FileInputStream(file)) {
+            byte[] magic = new byte[4];
+            int count = is.read(magic);
+            if (count == 4 && Arrays.equals(magic, new byte[] { 0x50, 0x4B, 0x03, 0x04 }) || // zip
+                    Arrays.equals(magic, new byte[] { 0x50, 0x4B, 0x07, 0x08 }) ||
+                    (magic[0] == 0x1F && magic[1] == (byte) 0x8B) // gzip
+            ) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // FIXME: This is wasteful of space and time. We should try to process on the fly
@@ -888,7 +916,7 @@ public class ImportingUtilities {
                 }
             }
 
-            // If nothing matches the best format but we have some files,
+            // If nothing matches the best format, but we have some files,
             // then select them all
             if (fileSelectionIndexes.size() == 0 && count > 0) {
                 for (int i = 0; i < count; i++) {

--- a/main/tests/data/csv-with-bom.csv
+++ b/main/tests/data/csv-with-bom.csv
@@ -1,0 +1,3 @@
+﻿ColA,ColB
+A1,B1
+A2,B2

--- a/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
@@ -56,7 +56,6 @@ import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.entity.mime.StringBody;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
-import org.checkerframework.checker.units.qual.A;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -110,7 +109,7 @@ public class ImportingUtilitiesTests extends ImporterTest {
         File dirA = new File(tempDir, "a");
         dirA.mkdir();
         File conflicting = new File(dirA, "dummy");
-        conflicting.createNewFile();
+        Assert.assertTrue(conflicting.createNewFile());
 
         File allocated = ImportingUtilities.allocateFile(dirA, ".././a/dummy");
         Assert.assertEquals(allocated, new File(dirA, "dummy-2"));


### PR DESCRIPTION
Fixes #1241

* UTF-8-BOM to the encoding guesser
* Add support for stripping the BOM to the importer
