### PR TITLE
Don't write newly read projects before they're modified

### DIFF
--- a/main/src/com/google/refine/ProjectMetadata.java
+++ b/main/src/com/google/refine/ProjectMetadata.java
@@ -137,6 +137,7 @@ public class ProjectMetadata {
 
     public ProjectMetadata(Instant created, Instant modified, String name) {
         this(created);
+        _modified = modified;
         _name = name;
     }
 

--- a/main/src/com/google/refine/io/FileProjectManager.java
+++ b/main/src/com/google/refine/io/FileProjectManager.java
@@ -47,7 +47,6 @@ import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import com.google.refine.util.LocaleUtils;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -57,12 +56,14 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import com.google.refine.ProjectManager;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.history.HistoryEntryManager;
 import com.google.refine.model.Project;
 import com.google.refine.preference.PreferenceStore;
 import com.google.refine.preference.TopList;
+import com.google.refine.util.LocaleUtils;
 import com.google.refine.util.ParsingUtilities;
 
 public class FileProjectManager extends ProjectManager {
@@ -322,7 +323,7 @@ public class FileProjectManager extends ProjectManager {
     protected boolean saveToFile(File file) throws IOException {
         OutputStream stream = new FileOutputStream(file);
         List<Long> modified = getModifiedProjectIds();
-        boolean saveWasNeeded = (modified.size() > 0) || (_preferenceStore.isDirty());
+        boolean saveWasNeeded = (modified.size() > 0) || (_preferenceStore.isDirty() || projectRemoved);
         try {
             // writeValue(OutputStream) is documented to use JsonEncoding.UTF8
             ParsingUtilities.defaultWriter.writeValue(stream, this);

--- a/main/src/com/google/refine/io/FileProjectManager.java
+++ b/main/src/com/google/refine/io/FileProjectManager.java
@@ -266,39 +266,50 @@ public class FileProjectManager extends ProjectManager {
     @Override
     protected void saveWorkspace() {
         synchronized (this) {
-            // TODO refactor this so that we check if the save is needed before writing to the file!
-            File tempFile = new File(_workspaceDir, "workspace.temp.json");
-            try {
-                if (!saveToFile(tempFile)) {
-                    // If the save wasn't really needed, just keep what we had
-                    tempFile.delete();
-                    logger.info("Skipping unnecessary workspace save");
-                    return;
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-
-                logger.warn("Failed to save workspace");
+            List<Long> modified = getModifiedProjectIds();
+            boolean saveNeeded = (modified.size() > 0) || _preferenceStore.isDirty() || projectRemoved;
+            if (!saveNeeded) {
+                logger.info("Skipping unnecessary workspace save");
                 return;
             }
-            // set the workspace to owner-only readable, because it can contain credentials
-            tempFile.setReadable(false, false);
-            tempFile.setReadable(true, true);
+            File tempFile = saveWorkspaceToTempFile();
+            if (tempFile == null) return;
             File file = new File(_workspaceDir, "workspace.json");
             File oldFile = new File(_workspaceDir, "workspace.old.json");
 
             if (oldFile.exists()) {
-                oldFile.delete();
+                if (!oldFile.delete()) {
+                    logger.warn("Failed to delete previous backup workspace.old.json");
+                }
             }
 
             if (file.exists()) {
-                file.renameTo(oldFile);
+                if (!file.renameTo(oldFile)) {
+                    logger.error("Failed to rename workspace.json to workspace.old.json");
+                }
             }
 
-            tempFile.renameTo(file);
+            if (!tempFile.renameTo(file)) {
+                logger.error("Failed to rename new temp workspace file to workspace.json");
+            }
             projectRemoved = false;
             logger.info("Saved workspace");
         }
+    }
+
+    private File saveWorkspaceToTempFile() {
+        File tempFile = new File(_workspaceDir, "workspace.temp.json");
+        try {
+            saveToFile(tempFile);
+        } catch (Exception e) {
+            e.printStackTrace();
+            logger.warn("Failed to save workspace");
+            return null;
+        }
+        // set the workspace to owner-only readable, because it can contain credentials
+        tempFile.setReadable(false, false);
+        tempFile.setReadable(true, true);
+        return tempFile;
     }
 
     protected List<Long> getModifiedProjectIds() {
@@ -320,18 +331,12 @@ public class FileProjectManager extends ProjectManager {
         }
     }
 
-    protected boolean saveToFile(File file) throws IOException {
-        OutputStream stream = new FileOutputStream(file);
-        List<Long> modified = getModifiedProjectIds();
-        boolean saveWasNeeded = (modified.size() > 0) || (_preferenceStore.isDirty() || projectRemoved);
-        try {
+    protected void saveToFile(File file) throws IOException {
+        try (OutputStream stream = new FileOutputStream(file)) {
             // writeValue(OutputStream) is documented to use JsonEncoding.UTF8
             ParsingUtilities.defaultWriter.writeValue(stream, this);
-            saveProjectMetadata(modified);
-        } finally {
-            stream.close();
+            saveProjectMetadata(getModifiedProjectIds());
         }
-        return saveWasNeeded;
     }
 
     @Override

--- a/main/src/com/google/refine/io/ProjectMetadataUtilities.java
+++ b/main/src/com/google/refine/io/ProjectMetadataUtilities.java
@@ -167,6 +167,8 @@ public class ProjectMetadataUtilities {
 
     static protected ProjectMetadata loadFromFile(File metadataFile) throws Exception {
         Reader reader = new InputStreamReader(new FileInputStream(metadataFile), StandardCharsets.UTF_8);
-        return ParsingUtilities.mapper.readValue(reader, ProjectMetadata.class);
+        ProjectMetadata metadata = ParsingUtilities.mapper.readValue(reader, ProjectMetadata.class);
+        metadata.setLastSave(); // No need to write it until it has been modified
+        return metadata;
     }
 }

--- a/main/src/com/google/refine/io/ProjectMetadataUtilities.java
+++ b/main/src/com/google/refine/io/ProjectMetadataUtilities.java
@@ -85,11 +85,8 @@ public class ProjectMetadataUtilities {
     }
 
     protected static void saveToFile(ProjectMetadata projectMeta, File metadataFile) throws IOException {
-        Writer writer = new OutputStreamWriter(new FileOutputStream(metadataFile), StandardCharsets.UTF_8);
-        try {
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(metadataFile), StandardCharsets.UTF_8)) {
             ParsingUtilities.saveWriter.writeValue(writer, projectMeta);
-        } finally {
-            writer.close();
         }
     }
 

--- a/main/tests/server/src/com/google/refine/io/FileProjectManagerTests.java
+++ b/main/tests/server/src/com/google/refine/io/FileProjectManagerTests.java
@@ -27,7 +27,6 @@
 
 package com.google.refine.io;
 
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.*;
 
@@ -56,7 +55,7 @@ public class FileProjectManagerTests {
     @BeforeMethod
     public void createDirectory() throws IOException {
         workspaceDir = TestUtils.createTempDirectory("openrefine-test-workspace-dir");
-        workspaceFile = File.createTempFile(workspaceDir.getPath(), "workspace.json");
+        workspaceFile = new File(workspaceDir, "workspace.json");
     }
 
     protected class FileProjectManagerStub extends FileProjectManager {
@@ -112,13 +111,13 @@ public class FileProjectManagerTests {
     @Test
     public void deleteProjectAndSaveWorkspace() throws IOException {
         FileProjectManager manager = new FileProjectManagerStub(workspaceDir);
-        manager.saveToFile(workspaceFile);
+        manager.saveWorkspace();
         manager.deleteProject(5555);
-        manager.saveToFile(workspaceFile);
+        manager.saveWorkspace();
 
         InputStream inputStream = new FileInputStream(workspaceFile);
         JsonObject json = JSON.parse(inputStream);
-        assertTrue(json.get("projectIDs").getAsArray().isEmpty());
+        assertTrue(json.get("projectIDs").getAsArray().isEmpty(), "deleted project still in workspace.json");
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/io/FileProjectManagerTests.java
+++ b/main/tests/server/src/com/google/refine/io/FileProjectManagerTests.java
@@ -136,19 +136,22 @@ public class FileProjectManagerTests {
         manager.saveWorkspace();
         long idA = manager.getProjectID("A");
         long idB = manager.getProjectID("B");
-        Path pathA = Paths.get(workspaceDir.getAbsolutePath(), String.valueOf(idA) + ".project", "metadata.json");
-        Path pathB = Paths.get(workspaceDir.getAbsolutePath(), String.valueOf(idB) + ".project", "metadata.json");
+
+        Path pathA = Paths.get(manager.getProjectDir(idA).getAbsolutePath(), ProjectMetadata.DEFAULT_FILE_NAME);
+        Path pathB = Paths.get(manager.getProjectDir(idB).getAbsolutePath(), ProjectMetadata.DEFAULT_FILE_NAME);
         File metaAFile = pathA.toFile();
         File metaBFile = pathB.toFile();
         long timeBeforeA = metaAFile.lastModified();
         long timeBeforeB = metaBFile.lastModified();
+        // Reload fresh copy of the workspace
+        manager = new FileProjectManager(workspaceDir);
         Thread.sleep(1000);
         manager.getProjectMetadata(idA).setName("ModifiedA");
         manager.saveWorkspace();
         long timeAfterA = metaAFile.lastModified();
         long timeAfterB = metaBFile.lastModified();
-        assertEquals(timeBeforeB, timeAfterB);
-        assertNotEquals(timeBeforeA, timeAfterA);
+        assertEquals(timeBeforeB, timeAfterB, "Unmodified project written when it didn't need to be");
+        assertNotEquals(timeBeforeA, timeAfterA, "Modified project not written");
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/io/FileProjectManagerTests.java
+++ b/main/tests/server/src/com/google/refine/io/FileProjectManagerTests.java
@@ -158,10 +158,8 @@ public class FileProjectManagerTests {
         FileProjectManager manager = new FileProjectManagerStub(workspaceDir);
 
         File tempDir = TestUtils.createTempDirectory("openrefine-project-import-zip-slip-test");
-        try {
+        try (InputStream stream = FileProjectManagerTests.class.getClassLoader().getResourceAsStream("zip-slip.tar")) {
             File subDir = new File(tempDir, "dest");
-            InputStream stream = FileProjectManagerTests.class.getClassLoader().getResourceAsStream("zip-slip.tar");
-
             assertThrows(IllegalArgumentException.class, () -> manager.untar(subDir, stream));
         } finally {
             tempDir.delete();


### PR DESCRIPTION
Fixes #3805

Changes proposed in this pull request:
- Repairs constructor which sets modified date on projects
- Adds test coverage to make sure we don't write newly read projects before they're modified
- initializes the lastSaved timestamp on project load (#3805)
- check for and log errors on file renames & deletes
- refactor to decide if file write is needed upfront rather than writing file and throwing it away if unneeded
- fix test from PR #4796 to correctly test project removal
- write out workspace on project removal (fixes regression which re-broke #1418)
