### PR TITLE
Fix jetty dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     versions:
     - "> 1.4.12"
     - "< 2"
-  - dependency-name: "jetty-*"
+  - dependency-name: "org.eclipse.jetty:jetty-*"
     versions:
       - ">= 10.0.0"
   - dependency-name: "formatter-maven-plugin"


### PR DESCRIPTION
To avoid PRs like #6032, which require changes in Butterfly first.