### PR TITLE
Bump cypress from 12.17.4 to 13.1.0

### DIFF
--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.8.1
         with:
-          node-version: '14'
+          node-version: '16'
       - id: set-matrix
         run: npm install --save glob@8.1.0 && node main/tests/cypress/build-test-matrix.js >> $GITHUB_OUTPUT
         env:
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3.8.1
         with:
-          node-version: '14'
+          node-version: '16'
 
       - name: Restore Tests dependency cache
         uses: actions/cache@v3

--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
@@ -2,6 +2,24 @@
  * Those tests are generic test to ensure the general behavior of the various facets components
  * It's using "text facet" as it is the most simple facet
  */
+
+const clickFacetAction = (text, action, setVisibility = false) => {
+  cy.getFacetContainer('Shrt_Desc')
+      .contains(text)
+      .parent()
+      .within(() => {
+        const elem = cy.contains(action);
+
+        if (setVisibility) {
+          elem.invoke('css', 'visibility', 'visible');
+        }
+        elem.click();
+        if (setVisibility) {
+          elem.invoke('css', 'visibility', 'hidden');
+        }
+      });
+};
+
 describe(__filename, function () {
   it('Verify facets panel (left-panel) appears with no facets yet', function () {
     cy.loadAndVisitProject('food.small');
@@ -197,52 +215,24 @@ describe(__filename, function () {
     cy.getFacetContainer('Water').contains('0.24');
   });
 
-  it('Test include/exlude filters', function () {
-    // Because the toggle of include/exclude buttons is unstable
-    // we force include/exclude to be visible
-    // This test focus solely on ensuring that filters are effectively applied to the grid
+  it('Test include/exclude filters', function () {
     cy.loadAndVisitProject('food.small');
     cy.columnActionClick('Shrt_Desc', ['Facet', 'Text facet']);
 
-    // include ALLSPICE,GROUND, and check rows
-    cy.getFacetContainer('Shrt_Desc')
-      .contains('ALLSPICE,GROUND')
-      .parent()
-      .trigger('mouseover')
-      .contains('include')
-      .click();
-    cy.getCell(0, 'Shrt_Desc').should('to.contain', 'ALLSPICE,GROUND');
+    clickFacetAction('ALLSPICE,GROUND', 'include', true);
+    cy.getCell(0, 'Shrt_Desc').should('contain', 'ALLSPICE,GROUND');
     cy.get('#tool-panel').contains('1 matching rows');
 
-    cy.wait(0);
-    // include CELERY SEED, and check rows
-    cy.getFacetContainer('Shrt_Desc')
-      .contains('ANISE SEED')
-      .parent()
-      .trigger('mouseover')
-      .contains('include')
-      .click();
-    cy.getCell(1, 'Shrt_Desc').should('to.contain', 'ANISE SEED');
+    clickFacetAction('ANISE SEED', 'include', true);
+    cy.getCell(1, 'Shrt_Desc').should('contain', 'ANISE SEED');
     cy.get('#tool-panel').contains('2 matching rows');
 
-    cy.wait(0);
-    // include a third one, CELERY SEED, and check rows
-    cy.getFacetContainer('Shrt_Desc')
-      .contains('BUTTER OIL,ANHYDROUS')
-      .parent()
-      .trigger('mouseover')
-      .contains('include')
-      .click();
-    cy.getCell(0, 'Shrt_Desc').should('to.contain', 'BUTTER OIL,ANHYDROUS'); // this row is added first
+    clickFacetAction('BUTTER OIL,ANHYDROUS', 'include', true);
+    cy.getCell(0, 'Shrt_Desc').should('contain', 'BUTTER OIL,ANHYDROUS');
     cy.get('#tool-panel').contains('3 matching rows');
-    
-    cy.wait(0);
-    // EXCLUDE ALLSPICE,GROUND
-    cy.getFacetContainer('Shrt_Desc')
-      .contains('ALLSPICE,GROUND')
-      .parent()
-      .contains('exclude')
-      .click();
+
+    cy.wait(100);
+    clickFacetAction('ALLSPICE,GROUND', 'exclude');
     cy.get('#tool-panel').contains('2 matching rows');
   });
 
@@ -251,12 +241,7 @@ describe(__filename, function () {
     cy.columnActionClick('Shrt_Desc', ['Facet', 'Text facet']);
 
     // do a basic facetting, expect 1 row
-    cy.getFacetContainer('Shrt_Desc')
-      .contains('ALLSPICE,GROUND')
-      .parent()
-      .trigger('mouseover')
-      .contains('include')
-      .click();
+    clickFacetAction('ALLSPICE,GROUND','include',true);
     cy.getCell(0, 'Shrt_Desc').should('to.contain', 'ALLSPICE,GROUND');
     cy.get('#tool-panel').contains('1 matching rows');
 
@@ -280,12 +265,7 @@ describe(__filename, function () {
     cy.columnActionClick('Shrt_Desc', ['Facet', 'Text facet']);
 
     // do a basic facetting, expect 1 row
-    cy.getFacetContainer('Shrt_Desc')
-      .contains('ALLSPICE,GROUND')
-      .parent()
-      .trigger('mouseover')
-      .contains('include')
-      .click();
+    clickFacetAction('ALLSPICE,GROUND','include',true);
     cy.get('#tool-panel').contains('1 matching rows');
 
     // now reset, expect 199
@@ -341,11 +321,12 @@ describe(__filename, function () {
     cy.get('div.facet-body-inner > div:nth-child(8)')
         .contains('15.87')
         .parent()
-        .trigger('mouseover')
-        .find('a.facet-choice-edit')
-        .contains('edit')
-        .should('be.visible')
-        .click();
+        .within(() => {
+          const elem = cy.contains('edit');
+          elem.invoke('css', 'visibility', 'visible');
+          elem.click();
+          elem.invoke('css', 'visibility', 'hidden');
+        });
 
     // mass edit all cells that have Water = 15.87
     cy.get('.data-table-cell-editor textarea').type(50);

--- a/main/tests/cypress/package.json
+++ b/main/tests/cypress/package.json
@@ -6,7 +6,7 @@
     "author": "OpenRefine",
     "private": true,
     "engines": {
-        "node": ">=14.0.0",
+        "node": ">=16.0.0",
         "npm":  ">=8.11.0",
         "yarn": ">=1.22.15"
     },
@@ -16,7 +16,7 @@
         "lint": "prettier --check . && eslint ."
     },
     "dependencies": {
-        "cypress": "12.17.4",
+        "cypress": "13.1.0",
         "cypress-file-upload": "^5.0.8"
     },
     "devDependencies": {

--- a/main/tests/cypress/yarn.lock
+++ b/main/tests/cypress/yarn.lock
@@ -7,10 +7,10 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@cypress/request@2.88.12":
-  version "2.88.12"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
-  integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
+"@cypress/request@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.0.tgz#7f58dfda087615ed4e6aab1b25fffe7630d6dd85"
+  integrity sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -431,12 +431,12 @@ cypress-file-upload@^5.0.8:
   resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
   integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
 
-cypress@12.17.4:
-  version "12.17.4"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-12.17.4.tgz#b4dadf41673058493fa0d2362faa3da1f6ae2e6c"
-  integrity sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==
+cypress@13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.1.0.tgz#18f268e66662cd91b1766db18bd1f63a66592205"
+  integrity sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==
   dependencies:
-    "@cypress/request" "2.88.12"
+    "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"
     "@types/node" "^16.18.39"
     "@types/sinonjs__fake-timers" "8.1.1"


### PR DESCRIPTION
Changes proposed in this pull request:
- Bump Cypress from 12.17.4 to 13.1.0.
- Bump Node from 14 to 16 for Cypress since Cypress dropped support for 14.


> Node 14 support has been removed and Node 16 support has been deprecated. Node 16 may continue to work with Cypress v13, but will not be supported moving forward to closer coincide with Node 16's end-of-life schedule. It is recommended that users update to at least Node 18.

Ref: https://docs.cypress.io/guides/references/changelog#13-0-0.
