### PR TITLE
fix(sec): upgrade com.google.guava:guava to 32.0.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <opencsv-multichar.version>2.4</opencsv-multichar.version>
     <swc-parser-lazy.version>3.1.9</swc-parser-lazy.version>
     <commons-io.version>2.13.0</commons-io.version>
-    <guava.version>31.1-jre</guava.version>
+    <guava.version>32.0.0-jre</guava.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <juniversalchardet.version>2.4.0</juniversalchardet.version>
     <testng.version>7.7.1</testng.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.guava:guava 31.1-jre
- [CVE-2023-2976](https://www.oscs1024.com/hd/CVE-2023-2976)


### What did I do？
Upgrade com.google.guava:guava from 31.1-jre to 32.0.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS