### PR TITLE
Introducing a new variable that takes only required properties of suggest options and excludes the flyout properties

### DIFF
--- a/extensions/wikibase/module/scripts/schema-alignment.js
+++ b/extensions/wikibase/module/scripts/schema-alignment.js
@@ -1237,7 +1237,7 @@ SchemaAlignment._initPropertyField = function(inputContainer, targetContainer, i
   var endpoint = WikibaseManager.getSelectedWikibaseApiForEntityType('property');
   var suggestConfig = {
     mediawiki_endpoint: endpoint,
-    entity_type: 'property',
+    //entity_type: 'property',
     language: $.i18n("core-recon/wd-recon-lang"),
     view_url: WikibaseManager.getSelectedWikibaseSiteIriForEntityType('property')+'{{id}}'
   };

--- a/extensions/wikibase/module/scripts/schema-alignment.js
+++ b/extensions/wikibase/module/scripts/schema-alignment.js
@@ -1237,7 +1237,7 @@ SchemaAlignment._initPropertyField = function(inputContainer, targetContainer, i
   var endpoint = WikibaseManager.getSelectedWikibaseApiForEntityType('property');
   var suggestConfig = {
     mediawiki_endpoint: endpoint,
-    //entity_type: 'property',
+    entity_type: 'property',
     language: $.i18n("core-recon/wd-recon-lang"),
     view_url: WikibaseManager.getSelectedWikibaseSiteIriForEntityType('property')+'{{id}}'
   };

--- a/main/webapp/modules/core/scripts/dialogs/add-column-by-reconciliation.js
+++ b/main/webapp/modules/core/scripts/dialogs/add-column-by-reconciliation.js
@@ -145,7 +145,6 @@ ExtendReconciledDataPreviewDialog.getAllProperties = function(url, typeID, onDon
     });
   }
 };
-
 ExtendReconciledDataPreviewDialog.prototype._show = function(properties) {
   this._level = DialogSystem.showDialog(this._dialog);
 
@@ -181,13 +180,7 @@ ExtendReconciledDataPreviewDialog.prototype._show = function(properties) {
   if (this._serviceMetadata.ui && this._serviceMetadata.ui.access) {
     suggestConfig.access = this._serviceMetadata.ui.access;
   }
-  var sanitizedSuggestConfig = {
-    query_param_name: suggestConfig.query_param_name,
-    access: suggestConfig.access,
-
-};
-
-  this._elmts.addPropertyInput.suggestP(sanitizedSuggestConfig).on("fb-select", function(evt, data) {
+  this._elmts.addPropertyInput.suggestP(sanitizeSuggestOptions(suggestConfig)).on("fb-select", function(evt, data) {
     self._addProperty({
       id : data.id,
       name: data.name,

--- a/main/webapp/modules/core/scripts/dialogs/add-column-by-reconciliation.js
+++ b/main/webapp/modules/core/scripts/dialogs/add-column-by-reconciliation.js
@@ -181,9 +181,13 @@ ExtendReconciledDataPreviewDialog.prototype._show = function(properties) {
   if (this._serviceMetadata.ui && this._serviceMetadata.ui.access) {
     suggestConfig.access = this._serviceMetadata.ui.access;
   }
-    
+  var sanitizedSuggestConfig = {
+    query_param_name: suggestConfig.query_param_name,
+    access: suggestConfig.access,
 
-  this._elmts.addPropertyInput.suggestP(suggestConfig).on("fb-select", function(evt, data) {
+};
+
+  this._elmts.addPropertyInput.suggestP(sanitizedSuggestConfig).on("fb-select", function(evt, data) {
     self._addProperty({
       id : data.id,
       name: data.name,

--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -246,7 +246,11 @@ ReconStandardServicePanel.prototype._wireEvents = function() {
     if (this._service.ui && this._service.ui.access) {
       suggestOptions.access = this._service.ui.access;
     }
-    input.suggestT(suggestOptions);
+    var sanitizedSuggestOptions = {
+      query_param_name: suggestOptions.query_param_name,
+      access: suggestOptions.access,
+    }
+    input.suggestT(sanitizedSuggestOptions);
   }
 
   input.on("bind fb-select", function(e, data) {

--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -246,11 +246,7 @@ ReconStandardServicePanel.prototype._wireEvents = function() {
     if (this._service.ui && this._service.ui.access) {
       suggestOptions.access = this._service.ui.access;
     }
-    var sanitizedSuggestOptions = {
-      query_param_name: suggestOptions.query_param_name,
-      access: suggestOptions.access,
-    }
-    input.suggestT(sanitizedSuggestOptions);
+    input.suggestT(sanitizeSuggestOptions(suggestOptions));
   }
 
   input.on("bind fb-select", function(e, data) {
@@ -281,7 +277,7 @@ ReconStandardServicePanel.prototype._rewirePropertySuggests = function(type) {
     if (type) {
       suggestOptions.type = typeof type == "string" ? type : type.id;
     }
-    inputs.suggestP(suggestOptions);
+    inputs.suggestP(sanitizeSuggestOptions(suggestOptions));
   }
 };
 

--- a/main/webapp/modules/core/scripts/util/custom-suggest.js
+++ b/main/webapp/modules/core/scripts/util/custom-suggest.js
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 var CustomSuggest = {};
+
 function sanitizeSuggestOptions(options) {
   return {
     query_param_name: options.query_param_name,
@@ -41,6 +42,7 @@ function sanitizeSuggestOptions(options) {
     service_path:options.service_path,
   };
 }
+
 (function() {
 
   /*

--- a/main/webapp/modules/core/scripts/util/custom-suggest.js
+++ b/main/webapp/modules/core/scripts/util/custom-suggest.js
@@ -32,7 +32,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 var CustomSuggest = {};
-
+function sanitizeSuggestOptions(options) {
+  return {
+    query_param_name: options.query_param_name,
+    access: options.access,
+    formatter_url: options.formatter_url,
+    service_url:options.service_url,
+    service_path:options.service_path,
+  };
+}
 (function() {
 
   /*

--- a/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
@@ -320,7 +320,7 @@ class ReconCellRenderer {
     }
     var suggest = elmts.input
     .val(cell.v)
-    .suggest(suggestOptions2);
+    .suggest(sanitizeSuggestOptions(suggestOptions2));
 
     suggest.on("fb-pane-show", function(e, data) {
       DialogSystem.pauseEscapeKeyHandling();

--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -131,6 +131,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     
     input.suggest(sanitizeSuggestOptions(suggestOptions)).on("fb-select", function(e, data) {
         var types = data.notable ? data.notable : [];
+      
         Refine.postCoreProcess(
         "recon-match-specific-topic-to-cells",
         {

--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -128,9 +128,9 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     $('<p></p>').text($.i18n('core-views/search-fb-topic')).appendTo(body);
 
     var input = $('<input />').appendTo($('<p></p>').appendTo(body));
+    
     input.suggest(sanitizeSuggestOptions(suggestOptions)).on("fb-select", function(e, data) {
         var types = data.notable ? data.notable : [];
-
         Refine.postCoreProcess(
         "recon-match-specific-topic-to-cells",
         {

--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -93,7 +93,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       createReconServiceSelectionDialog(headerText, explanationText, onSelect);
     }
   };
-
+  
   var doSearchToMatch = function() {
     var serviceUrl = null;
     var service = null;
@@ -117,13 +117,6 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           suggestOptions.formatter_url = service.view.url;
        }
     }
-    
-    var sanitizedSuggestOptions = {
-      query_param_name: suggestOptions.query_param_name,
-      access: suggestOptions.access,
-      formatter_url: suggestOptions.formatter_url,
-  };
-
     var frame = DialogSystem.createDialog();
     frame.width("400px");
 
@@ -134,8 +127,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     $('<p></p>').text($.i18n('core-views/search-fb-topic')).appendTo(body);
 
     var input = $('<input />').appendTo($('<p></p>').appendTo(body));
-
-    input.suggest(sanitizedSuggestOptions).on("fb-select", function(e, data) {
+    input.suggest(sanitizeSuggestOptions(suggestOptions)).on("fb-select", function(e, data) {
         var types = data.notable ? data.notable : [];
 
         Refine.postCoreProcess(

--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -117,6 +117,12 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           suggestOptions.formatter_url = service.view.url;
        }
     }
+    
+    var sanitizedSuggestOptions = {
+      query_param_name: suggestOptions.query_param_name,
+      access: suggestOptions.access,
+      formatter_url: suggestOptions.formatter_url,
+  };
 
     var frame = DialogSystem.createDialog();
     frame.width("400px");
@@ -129,7 +135,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
 
     var input = $('<input />').appendTo($('<p></p>').appendTo(body));
 
-    input.suggest(suggestOptions).on("fb-select", function(e, data) {
+    input.suggest(sanitizedSuggestOptions).on("fb-select", function(e, data) {
         var types = data.notable ? data.notable : [];
 
         Refine.postCoreProcess(

--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -117,6 +117,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           suggestOptions.formatter_url = service.view.url;
        }
     }
+    
     var frame = DialogSystem.createDialog();
     frame.width("400px");
 


### PR DESCRIPTION


Fixes #3141 

Changes proposed in this pull request:
an object variable sanitizedSuggestOptions which only takes some properties used by the suggestOptions object and then I pass this new var sanitizedSuggestOptions for initializing the suggest library.

I am trying to take this approach for all the places where we have suggestOptions or suggestConfig variables. 
