### PR TITLE
Add double quotes to column in title of split column into several columns dialog

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -614,7 +614,7 @@
     "core-views/http-headers": "HTTP headers to be used when fetching URLs",
     "core-views/enter-col-name": "Enter new column name",
     "core-views/join-col": "Join columns…",
-    "core-views/split-col": "Split column $1 into several columns",
+    "core-views/split-col": "Split column \"$1\" into several columns",
     "core-views/how-split": "How to split column",
     "core-views/how-split-cells": "How to split multi-valued cells",
     "core-views/by-sep": "by separator",


### PR DESCRIPTION
Follow-up for #6021 

Changes proposed in this pull request:
- Add quotes around the column in the title of the split into several columns dialog:

![image](https://github.com/OpenRefine/OpenRefine/assets/42903164/caa57c1d-06c2-458e-9303-ad0992898dca)
