### PR TITLE
formatter:format changes in database module

### DIFF
--- a/extensions/database/src/com/google/refine/extension/database/DatabaseConfiguration.java
+++ b/extensions/database/src/com/google/refine/extension/database/DatabaseConfiguration.java
@@ -133,8 +133,7 @@ public class DatabaseConfiguration {
                     databaseHost + ((databasePort == 0) ? "" : (":" + databasePort)),
                     "/" + databaseName,
                     useSSL ? "useSSL=true" : null,
-                    null
-            );
+                    null);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }

--- a/extensions/database/tests/src/com/google/refine/extension/database/DatabaseConfigurationTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/DatabaseConfigurationTest.java
@@ -1,3 +1,4 @@
+
 package com.google.refine.extension.database;
 
 import org.testng.annotations.Test;


### PR DESCRIPTION
No issue.

Changes to make the linter happy. It looks like the latest security patch made it through CI without linting?

@wetneb any idea how that happened?