### PR TITLE
Fix selection of Wikibase statement merging strategy

### DIFF
--- a/extensions/wikibase/module/scripts/dialogs/statement-configuration-dialog.js
+++ b/extensions/wikibase/module/scripts/dialogs/statement-configuration-dialog.js
@@ -18,7 +18,7 @@ class PropertyStrategy {
 
 class SnakStrategy {
   id() {
-    return 'property';
+    return 'snak';
   }
 
   initialState() {

--- a/extensions/wikibase/src/org/openrefine/wikibase/schema/strategies/QualifiersStatementMerger.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/schema/strategies/QualifiersStatementMerger.java
@@ -49,11 +49,14 @@ public class QualifiersStatementMerger implements StatementMerger {
 
     @Override
     public boolean match(Statement existing, Statement added) {
+        Snak existingSnak = existing.getMainSnak();
+        Snak addedSnak = added.getMainSnak();
+
         // Select the discriminating SnakGroups
         List<SnakGroup> existingDiscriminatingSnaks = discriminatingSnaks(existing.getQualifiers());
         List<SnakGroup> addedDiscriminatingSnaks = discriminatingSnaks(added.getQualifiers());
 
-        return snakGroupsEqual(existingDiscriminatingSnaks, addedDiscriminatingSnaks);
+        return snakEquality(existingSnak, addedSnak) && snakGroupsEqual(existingDiscriminatingSnaks, addedDiscriminatingSnaks);
     }
 
     @Override

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/strategies/QualifiersStatementMergerTests.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/strategies/QualifiersStatementMergerTests.java
@@ -33,6 +33,7 @@ public class QualifiersStatementMergerTests {
     PropertyIdValue otherPid = Datamodel.makeWikidataPropertyIdValue("P898");
     PropertyIdValue otherPid2 = Datamodel.makeWikidataPropertyIdValue("P33333");
     Snak mainSnak = Datamodel.makeValueSnak(otherPid, qidA);
+    Snak otherMainSnak = Datamodel.makeValueSnak(otherPid, qidB);
     SnakGroup discriminatingQualifier1 = Datamodel.makeSnakGroup(
             Collections.singletonList(Datamodel.makeValueSnak(discrimatingQualifierPid, qidA)));
     SnakGroup discriminatingQualifier2 = Datamodel.makeSnakGroup(
@@ -53,6 +54,7 @@ public class QualifiersStatementMergerTests {
     Statement statementD = statement(Datamodel.makeClaim(qidA, mainSnak, Arrays.asList(
             nonDiscriminatingQualifier2, discriminatingQualifier1, nonDiscriminatingQualifier3)));
     Statement statementE = statement(Datamodel.makeClaim(qidA, mainSnak, Collections.emptyList()));
+    Statement statementF = statement(Datamodel.makeClaim(qidA, otherMainSnak, Collections.singletonList(discriminatingQualifier1)));
 
     @Test
     public void testMatchNoPids() {
@@ -74,6 +76,7 @@ public class QualifiersStatementMergerTests {
         assertTrue(SUTwithPids.match(statementA, statementD));
         assertFalse(SUTwithPids.match(statementA, statementE));
         assertTrue(SUTwithPids.match(statementC, statementD));
+        assertFalse(SUTwithPids.match(statementA, statementF));
     }
 
     @Test


### PR DESCRIPTION
Closes #6064.

There were two closely related but separate problems:
* the "Property and value" strategy (`SnakStrategy` internally) had a wrong identifier, meaning that it was not possible to select it manually (it would only work if used as the default strategy without editing the merging settings)
* the "Property, value and qualifiers" strategy was actually only a sort of "Property and qualifiers" strategy because it did not actually check the value of the main snak of each statement!