### PR TITLE
Bump cypress from 13.2.0 to 13.3.0

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
@@ -314,7 +314,7 @@ describe(__filename, function () {
       .contains('Shrt_Desc');
   });
 
-  it.only('Test the mass edit from a Facet', function () {
+  it('Test the mass edit from a Facet', function () {
     cy.loadAndVisitProject('food.small');
     cy.columnActionClick('Water', ['Facet', 'Text facet']);
 

--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
@@ -325,10 +325,12 @@ describe(__filename, function () {
           const elem = cy.contains('edit');
           elem.invoke('css', 'visibility', 'visible');
           elem.click();
+          elem.invoke('css', 'visibility', 'hidden');
         });
 
+
     // mass edit all cells that have Water = 15.87
-    cy.get('.data-table-cell-editor textarea').type(50);
+    cy.get('.data-table-cell-editor textarea').should('exist').type(50);
     cy.get('.data-table-cell-editor button').contains('Apply').click();
 
     // ensure rows has been modified

--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
@@ -314,7 +314,7 @@ describe(__filename, function () {
       .contains('Shrt_Desc');
   });
 
-  it('Test the mass edit from a Facet', function () {
+  it.only('Test the mass edit from a Facet', function () {
     cy.loadAndVisitProject('food.small');
     cy.columnActionClick('Water', ['Facet', 'Text facet']);
 
@@ -325,7 +325,6 @@ describe(__filename, function () {
           const elem = cy.contains('edit');
           elem.invoke('css', 'visibility', 'visible');
           elem.click();
-          elem.invoke('css', 'visibility', 'hidden');
         });
 
     // mass edit all cells that have Water = 15.87

--- a/main/tests/cypress/package.json
+++ b/main/tests/cypress/package.json
@@ -16,7 +16,7 @@
         "lint": "prettier --check . && eslint ."
     },
     "dependencies": {
-        "cypress": "13.2.0",
+        "cypress": "13.3.0",
         "cypress-file-upload": "^5.0.8"
     },
     "devDependencies": {

--- a/main/tests/cypress/yarn.lock
+++ b/main/tests/cypress/yarn.lock
@@ -431,10 +431,10 @@ cypress-file-upload@^5.0.8:
   resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
   integrity sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==
 
-cypress@13.2.0:
-  version "13.2.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.2.0.tgz#10f73d06a0764764ffbb903a31e96e2118dcfc1d"
-  integrity sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==
+cypress@13.3.0:
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.3.0.tgz#d00104661b337d662c5a4280a051ee59f8aa1e31"
+  integrity sha512-mpI8qcTwLGiA4zEQvTC/U1xGUezVV4V8HQCOYjlEOrVmU1etVvxOjkCXHGwrlYdZU/EPmUiWfsO3yt1o+Q2bgw==
   dependencies:
     "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
Changes proposed in this pull request:
-  Bump cypress from 13.2.0 to 13.3.0.
- Fixes the 'Test the mass edit from a Facet' test in facets.cy.
