### PR TITLE
Bump max Java version to 21

### DIFF
--- a/.github/workflows/pull_request_server.yml
+++ b/.github/workflows/pull_request_server.yml
@@ -47,7 +47,7 @@ jobs:
   linux_server_tests:
     strategy:
       matrix:
-        java: [ 11, 20 ]
+        java: [ 11, 21 ]
 
     runs-on: ubuntu-latest
 
@@ -122,11 +122,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Java 20
+      - name: Set up Java 21
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 20
+          java-version: 21
           cache: 'maven'
 
       - name: Check Java linting

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
   <properties>
     <java.minversion>11</java.minversion>
-    <java.maxversion>20</java.maxversion>
+    <java.maxversion>21</java.maxversion>
     <jee.path>/</jee.path>
     <jee.port>3333</jee.port>
     <refine.data>/tmp/refine</refine.data>


### PR DESCRIPTION
Fixes #6087

Let's see if the Temurin 21 distribution is already available through GitHub Actions.