### PR TITLE
API: Add HTTP HEAD support to commands

### DIFF
--- a/main/src/com/google/refine/RefineServlet.java
+++ b/main/src/com/google/refine/RefineServlet.java
@@ -202,6 +202,13 @@ public class RefineServlet extends Butterfly {
                     logger.trace("> DELETE {}", commandKey);
                     command.doDelete(request, response);
                     logger.trace("< DELETE {}", commandKey);
+                } else if (request.getMethod().equals("HEAD")) {
+                    if (!logger.isTraceEnabled() && command.logRequests()) {
+                        logger.info("HEAD {}", request.getPathInfo());
+                    }
+                    logger.trace("> HEAD {}", commandKey);
+                    command.doHead(request, response);
+                    logger.trace("< HEAD {}", commandKey);
                 } else {
                     response.sendError(HttpStatus.SC_METHOD_NOT_ALLOWED);
                 }

--- a/main/src/com/google/refine/commands/Command.java
+++ b/main/src/com/google/refine/commands/Command.java
@@ -88,6 +88,12 @@ public abstract class Command {
         throw new UnsupportedOperationException();
     };
 
+    public void doHead(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+
+        throw new UnsupportedOperationException();
+    };
+
     public void doPut(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
 


### PR DESCRIPTION
Allow extensions to register commands which can respond to HTTP HEAD requests.