### PR TITLE
Make sure all mock http server requests have timeouts. Fixes #6099

### DIFF
--- a/main/tests/server/src/com/google/refine/commands/recon/GuessTypesOfColumnCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/recon/GuessTypesOfColumnCommandTests.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.concurrent.TimeUnit;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -148,7 +149,7 @@ public class GuessTypesOfColumnCommandTests extends RefineTest {
 
             TestUtils.assertEqualsAsJson(guessedTypes, writer.toString());
 
-            RecordedRequest request = server.takeRequest();
+            RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
             Assert.assertEquals(request.getBody().readUtf8(), expectedQuery);
         }
     }

--- a/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -287,7 +288,7 @@ public class StandardReconConfigTests extends RefineTest {
             }
             Assert.assertFalse(process.isRunning());
 
-            RecordedRequest request1 = server.takeRequest();
+            RecordedRequest request1 = server.takeRequest(5, TimeUnit.SECONDS);
 
             assertNotNull(request1);
 
@@ -394,8 +395,8 @@ public class StandardReconConfigTests extends RefineTest {
             }
             Assert.assertFalse(process.isRunning());
 
-            server.takeRequest(); // ignore the first request which was a 503 error
-            RecordedRequest request1 = server.takeRequest();
+            server.takeRequest(5, TimeUnit.SECONDS); // ignore the first request which was a 503 error
+            RecordedRequest request1 = server.takeRequest(5, TimeUnit.SECONDS);
 
             assertNotNull(request1);
             String query = request1.getBody().readUtf8Line();

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -255,7 +256,7 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
 
             runAndWait(op, 3000);
 
-            RecordedRequest request = server.takeRequest();
+            RecordedRequest request = server.takeRequest(5, TimeUnit.SECONDS);
             Assert.assertEquals(request.getHeader("user-agent"), userAgentValue);
             Assert.assertEquals(request.getHeader("authorization"), authorizationValue);
             Assert.assertEquals(request.getHeader("accept"), acceptValue);


### PR DESCRIPTION
Fixes #6099

Changes proposed in this pull request:
- Make sure all mock HTTP server takeRequest calls have timeouts, so that tests don't hang until killed in failure cases
