### PR TITLE
Sandbox the reconciliation preview iframes

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
@@ -389,6 +389,7 @@ class ReconCellRenderer {
       .width(preview.width)
       .height(preview.height)
       .attr("src", url)
+      .attr("sandbox", "")
       .appendTo(fakeMenu);
     } else {
       return; // no preview service available


### PR DESCRIPTION
Fixes #3140 

On our end we have been running with this patch (all restrictions) for a few months without any problems. I have also tested the change with the common Wikidata reconciliation service.

I therefore suggest that we opt for all restrictions and hope that if there is a _valid_ use-case for loosened restrictions in use today its discovered during snapshots or pre-releases. 