### PR TITLE
Improved type selection in recon dialog

### DIFF
--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.html
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.html
@@ -17,11 +17,18 @@
       <td width="50%"><div class="detail-container" bind="detailContainer"></div></td>
     </tr>
     <tr>
-      <td colspan="2"><input type="radio" name="type-choice" id="againstTypeId" bind="againstType" value="">
-        <label for="againstTypeId"><span bind="or_proc_againstType"></span></label> <input aria-label="" size="20" bind="typeInput" /></td>
+      <td colspan="2" style="display:flex;align-items:center;">
+        <input type="radio" name="type-choice" id="againstTypeId" bind="againstType" value="">
+        <label for="againstTypeId"><span bind="or_proc_againstType"></span></label>
+        <div class='against-type-control'>
+          <span class="mapped-value"><a></a><span class="type-id">()</span><a bind='editMappedType' class="edit-mapped-value">edit</a></span>
+          <input aria-label="" size="25" bind="typeInput" spellcheck="false"/>
+        </div>
+      </td>
     </tr>
     <tr>
-      <td colspan="2"><input type="radio" name="type-choice" id="noTypeId" bind="noType" value="-">
+      <td colspan="2" style="display:flex;align-items:center;">
+        <input type="radio" name="type-choice" id="noTypeId" bind="noType" value="-">
         <label for="noTypeId"><span bind="or_proc_noType"></span></label></td>
     </tr>
     <tr>

--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -124,7 +124,7 @@ ReconStandardServicePanel.prototype._constructUI = function() {
           $label = $mappedValue.parent().find('.mapped-value > a:not(.edit-mapped-value)');
           $input.val($label.text()).prop('disabled',false);
           $mappedValue.toggle();
-          $input.focus();
+          $input.trigger('focus');
         })
   });
 };
@@ -237,7 +237,7 @@ ReconStandardServicePanel.prototype._populatePanel = function() {
               $label = $(this).parent().parent().find('.mapped-value > a:not(.edit-mapped-value)');
               $input.val($label.text()).prop('disabled',false);
               mappedColumn.toggle();
-              $input.focus();
+              $input.trigger('focus');
             }));
 
     $(td1).append(mappedColumn)

--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -110,13 +110,22 @@ ReconStandardServicePanel.prototype._constructUI = function() {
     self._elmts.typeInput.trigger('focus').trigger('select');
   });
 
-  this._elmts.noType.on('click', function() {
+  this._elmts.noType.on('click', function () {
     self._rewirePropertySuggests(null) // Clear any selected type
   });
-    self._populateProperties();
-  this._guessTypes(function() {
+  self._populateProperties();
+  this._guessTypes(function () {
     self._populatePanel();
     self._wireEvents();
+    self._elmts.editMappedType.on('click', function() {
+          $input = self._elmts.typeInput;
+          $mappedValue = $(this).parent();
+          $input.removeData('data.suggest');
+          $label = $mappedValue.parent().find('.mapped-value > a:not(.edit-mapped-value)');
+          $input.val($label.text()).prop('disabled',false);
+          $mappedValue.toggle();
+          $input.focus();
+        })
   });
 };
 
@@ -217,15 +226,15 @@ ReconStandardServicePanel.prototype._populatePanel = function() {
     $(td0).attr("columnName", column.name).html(column.name);
     $(td1).data('id','property').css('position','relative');
 
-    let mappedColumn = $("<span>").addClass("mapped-column");
+    let mappedColumn = $("<span>").addClass("mapped-value");
 
     mappedColumn.append($("<a>").text(""))
         .append($("<span>").addClass("type-id").text("()"))
-        .append($("<a>").addClass("edit-mapped-column").text("edit")
+        .append($("<a>").addClass("edit-mapped-value").text("edit")
             .on('click', function() {
               $input = $(this).parent().siblings('input[name="property"]');
               $input.removeData('data.suggest');
-              $label = $(this).parent().parent().find('.mapped-column > a:not(.edit-mapped-column)');
+              $label = $(this).parent().parent().find('.mapped-value > a:not(.edit-mapped-value)');
               $input.val($label.text()).prop('disabled',false);
               mappedColumn.toggle();
               $input.focus();
@@ -262,7 +271,15 @@ ReconStandardServicePanel.prototype._wireEvents = function() {
     if (this._service.ui && this._service.ui.access) {
       suggestOptions.access = this._service.ui.access;
     }
-    input.suggestT(sanitizeSuggestOptions(suggestOptions));
+    input.suggestT(sanitizeSuggestOptions(suggestOptions)).on("fb-select", function(e, data) {
+      let $input = $(e.currentTarget);
+      let $td = $input.parent();
+      let mapping = $input.data('data.suggest');
+      $td.children('.mapped-value').css('display', 'inline-flex');
+      $input.val('').prop('disabled', true);
+      $td.find('.mapped-value > a:not(.edit-mapped-value)').text(mapping.name);
+      $td.find('.mapped-value > .type-id').text("(" + mapping.id + ")");
+    });
   }
 
   input.on("bind fb-select", function(e, data) {
@@ -296,26 +313,30 @@ ReconStandardServicePanel.prototype._rewirePropertySuggests = function(type) {
       let $input = $(e.currentTarget);
       let $td = $input.parent();
       let mapping = $input.data('data.suggest');
-      $td.children('.mapped-column').css('display', 'inline');
+      $td.children('.mapped-value').css('display', 'inline-flex');
       $td.children('input[name="property"]').val('').prop('disabled', true);
-      $td.find('.mapped-column > a:not(.edit-mapped-column)').text(mapping.name);
-      $td.find('.mapped-column > .type-id').text("(" + mapping.id + ")");
+      $td.find('.mapped-value > a:not(.edit-mapped-value)').text(mapping.name);
+      $td.find('.mapped-value > .type-id').text("(" + mapping.id + ")");
     });
     }
 };
 
 ReconStandardServicePanel.prototype.start = function() {
-  var self = this;
+  let self = this;
+  let invalidState = false;
 
-  var type = this._elmts.typeInput.data("data.suggest");
-  if (!(type)) {
-    type = {
-        id: this._elmts.typeInput[0].value,
-        name: this._elmts.typeInput[0].value
-    };
+  let type = this._elmts.typeInput.data("data.suggest");
+  let hasSuggest = type && type.id && type.name;
+  if (!hasSuggest) {
+    let value = jQueryTrim(this._elmts.typeInput.val());
+    let hasValue = value && value.length > 0;
+    if (hasValue) {
+      alert('Reconcile against type "'+value+'" is not mapped.');
+      invalidState = true;
+    }
   }
 
-  var choices = this._panel.find('input[name="type-choice"]:checked');
+  let choices = this._panel.find('input[name="type-choice"]:checked');
   if (choices !== null && choices.length > 0) {
     if (choices[0].value == '-') { // TODO: This is the signal value for "no type", but don't think it's used anymore
       type = null;
@@ -327,8 +348,8 @@ ReconStandardServicePanel.prototype.start = function() {
     }
   }
 
-  var columnDetails = [];
-  var invalidState = false;
+  let columnDetails = [];
+
   $.each(
     this._panel.find('input[name="property"]'),
     function(index) {

--- a/main/webapp/modules/core/styles/reconciliation/standard-service-panel.css
+++ b/main/webapp/modules/core/styles/reconciliation/standard-service-panel.css
@@ -31,7 +31,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 */
 
-.edit-mapped-column {
+.against-type-control {
+  position: relative;
+  width: fit-content;
+}
+
+.edit-mapped-value {
   margin-right: 0.5em;
   float: right;
   text-decoration: none;
@@ -44,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   cursor: pointer;
 }
 
-.mapped-column {
+.mapped-value {
   display: none;
   width: 100%;
   padding: 2px;
@@ -54,19 +59,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   background: transparent;
 }
 
-.mapped-column a {
+.mapped-value a {
   margin-left: 0.2em;
   margin-right: 0.25em;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 15ch;
+  max-width: 13ch;
   display: inline-block;
   vertical-align: middle;
 }
 
 .type-id {
   vertical-align: middle;
+  margin-left: 0;
+  margin-right: auto;
 }
 
 .recon-dialog-standard-service-panel-message {


### PR DESCRIPTION
Follow-up to https://github.com/OpenRefine/OpenRefine/pull/6060

Changes proposed in this pull request:

* Reconcile Against Type Mapping
   * After selecting a type mapping from the suggest dropdown, the mapping is displayed as "`type` `(Q-id)` edit" (See screenshot below).
   * Clicking edit will revert the field back to an editable textbox.

* Start Reconciling... button
   * If 'Reconcile against type' was selected reconciling will only begin if the type was successfully mapped  (name, id).  
   * If the type mapping contains plaintext, it is invalid so an alert window is popped up 'Reconcile against type xxxx is unmapped.' and the reconciliation is aborted.
   
   
![image](https://github.com/OpenRefine/OpenRefine/assets/42903164/577bbf39-bc73-41b3-b342-49645d6d81fc)
