### PR TITLE
Wikibase: proxy manifest requests

### DIFF
--- a/extensions/wikibase/module/MOD-INF/controller.js
+++ b/extensions/wikibase/module/MOD-INF/controller.js
@@ -48,6 +48,7 @@ function init() {
     RefineServlet.registerCommand(module, "perform-wikibase-edits", new PerformWikibaseEditsCommand());
     RefineServlet.registerCommand(module, "parse-wikibase-schema", new ParseWikibaseSchemaCommand());
     RefineServlet.registerCommand(module, "login", new LoginCommand());
+    RefineServlet.registerCommand(module, "fetch-manifest", new FetchManifestCommand());
 
     /*
      * GREL functions

--- a/extensions/wikibase/module/scripts/wikibase-manager.js
+++ b/extensions/wikibase/module/scripts/wikibase-manager.js
@@ -308,7 +308,7 @@ WikibaseManager.fetchManifestFromURL = function (manifestURL, onSuccess, onError
   };
 
   // The manifest host must support CORS.
-  $.ajax(manifestURL, {
+  $.ajax("/command/wikidata/fetch-manifest?url=" + manifestURL, {
     "dataType": "json",
     "timeout": 5000
   }).done(function (data) {

--- a/extensions/wikibase/src/org/openrefine/wikibase/commands/FetchManifestCommand.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/commands/FetchManifestCommand.java
@@ -1,18 +1,19 @@
 
 package org.openrefine.wikibase.commands;
 
+import static org.openrefine.wikibase.commands.CommandUtilities.respondError;
+
+import java.io.IOException;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import com.google.refine.commands.Command;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
-import static org.openrefine.wikibase.commands.CommandUtilities.respondError;
-
-import java.io.IOException;
+import com.google.refine.commands.Command;
 
 /**
  * Proxies Wikibase manifests to allow the client to bypass CORS restrictions.

--- a/extensions/wikibase/src/org/openrefine/wikibase/commands/FetchManifestCommand.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/commands/FetchManifestCommand.java
@@ -1,0 +1,43 @@
+package org.openrefine.wikibase.commands;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.refine.commands.Command;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+import static org.openrefine.wikibase.commands.CommandUtilities.respondError;
+
+import java.io.IOException;
+
+/**
+ * Proxies Wikibase manifests to allow the client to bypass CORS restrictions.
+ */
+public class FetchManifestCommand extends Command {
+    
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+        throws ServletException, IOException {
+        String url = request.getParameter("url");
+        try {
+            if (url == null) {
+                respondError(response, "No URL provided.");
+                return;
+            }
+
+            // fetch the contents at the url with a plain get request and return the response
+            OkHttpClient client = new OkHttpClient();
+            Request req = new Request.Builder().url(url).build();
+            Response res = client.newCall(req).execute();
+            response.getWriter().write(res.body().string());
+            response.setContentType("application/json");
+            response.setStatus(200);
+            response.setCharacterEncoding("UTF-8");
+        } catch (Exception e) {
+            respondException(response, e);
+        }
+    }
+}

--- a/extensions/wikibase/src/org/openrefine/wikibase/commands/FetchManifestCommand.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/commands/FetchManifestCommand.java
@@ -32,10 +32,10 @@ public class FetchManifestCommand extends Command {
             OkHttpClient client = new OkHttpClient();
             Request req = new Request.Builder().url(url).build();
             Response res = client.newCall(req).execute();
-            response.getWriter().write(res.body().string());
-            response.setContentType("application/json");
-            response.setStatus(200);
             response.setCharacterEncoding("UTF-8");
+            response.setContentType("application/json");
+            response.getWriter().write(res.body().string());
+            response.setStatus(200);
         } catch (Exception e) {
             respondException(response, e);
         }

--- a/extensions/wikibase/src/org/openrefine/wikibase/commands/FetchManifestCommand.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/commands/FetchManifestCommand.java
@@ -1,3 +1,4 @@
+
 package org.openrefine.wikibase.commands;
 
 import javax.servlet.ServletException;
@@ -17,10 +18,10 @@ import java.io.IOException;
  * Proxies Wikibase manifests to allow the client to bypass CORS restrictions.
  */
 public class FetchManifestCommand extends Command {
-    
+
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response)
-        throws ServletException, IOException {
+            throws ServletException, IOException {
         String url = request.getParameter("url");
         try {
             if (url == null) {


### PR DESCRIPTION
This makes the backend proxy requests for Wikibase manifests to allow them to be hosted in MediaWiki itself(removing the CORS requirement).

MediaWiki hosted manifest example(Wikidata): https://www.wikidata.org/wiki/User:Abbe98/openrefine-manifest.json?action=raw

Setting this to draft for now but I would like to hear what others think about this approach before working out the details.