### PR TITLE
Encode strings before using them as URLs for Add Column by Fetching URLs - fixes #6140

### DIFF
--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -37,6 +37,9 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -380,14 +383,15 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
         }
 
         Serializable fetch(String urlString, Header[] headers) {
-            try { // HttpClients.createDefault()) {
-                try {
-                    return _httpClient.getAsString(urlString, headers);
-                } catch (IOException e) {
-                    return _onError == OnError.StoreError ? new EvalError(e) : null;
-                }
-            } catch (Exception e) {
-                return _onError == OnError.StoreError ? new EvalError(e.getMessage()) : null;
+            try {
+                // Do a little dance to get all the pieces of the URL correctly encoded, if possible
+                // TODO: Should we try to undo any existing percent encoding, so we don't end up double encoded?
+                URL url = new URL(urlString);
+                URI uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(),
+                        url.getQuery(), url.getRef());
+                return _httpClient.getAsString(uri.toASCIIString(), headers);
+            } catch (URISyntaxException | IOException e) {
+                return _onError == OnError.StoreError ? new EvalError(e) : null;
             }
         }
 

--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -37,9 +37,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -384,12 +382,7 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
 
         Serializable fetch(String urlString, Header[] headers) {
             try {
-                // Do a little dance to get all the pieces of the URL correctly encoded, if possible
-                // TODO: Should we try to undo any existing percent encoding, so we don't end up double encoded?
-                URL url = new URL(urlString);
-                URI uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(),
-                        url.getQuery(), url.getRef());
-                return _httpClient.getAsString(uri.toASCIIString(), headers);
+                return _httpClient.getAsString(HttpClient.getEscapedUrl(urlString), headers);
             } catch (URISyntaxException | IOException e) {
                 return _onError == OnError.StoreError ? new EvalError(e) : null;
             }

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -244,6 +244,8 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
             assertEquals(op.getColumnDependencies().get(), Set.of("fruits"));
             assertEquals(op.getColumnsDiff().get(), ColumnsDiff.builder().addColumn("rand", "fruits").build());
 
+            // TODO: Seems like this wait could be reduced significantly
+            // since we only have two distinct values at 5ms each.
             runOperation(op, project, 1500);
 
             // Inspect rows
@@ -264,18 +266,24 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
         try (MockWebServer server = new MockWebServer()) {
             server.start();
             HttpUrl url = server.url("/random");
-            server.enqueue(new MockResponse.Builder().build());
+            server.enqueue(new MockResponse.Builder().body("random string").build());
+            server.enqueue(new MockResponse.Builder().body("Ahmed").build());
 
             Row row0 = new Row(2);
             row0.setCell(0, new Cell("auinrestrsc", null)); // malformed -> error
             project.rows.add(row0);
             Row row1 = new Row(2);
-            row1.setCell(0, new Cell(url.toString(), null)); // fine
+            row1.setCell(0, new Cell(server.url("/random").toString(), null)); // fine
             project.rows.add(row1);
             Row row2 = new Row(2);
             // well-formed but not resolvable.
             row2.setCell(0, new Cell("http://domain.invalid/random", null));
             project.rows.add(row2);
+            Row row3 = new Row(2);
+            // needs encoding
+            final String ARABIC = "احمد";
+            row3.setCell(0, new Cell(server.url("/") + ARABIC, null));
+            project.rows.add(row3);
 
             EngineDependentOperation op = new ColumnAdditionByFetchingURLsOperation(engine_config,
                     "fruits",
@@ -287,13 +295,21 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
                     true,
                     null);
 
+            // TODO: Do we really need such a long time?
             runOperation(op, project, 10000);
 
             int newCol = project.columnModel.getColumnByName("junk").getCellIndex();
             // Inspect rows
-            Assert.assertTrue(project.rows.get(0).getCellValue(newCol) instanceof EvalError);
-            Assert.assertNotNull(project.rows.get(1).getCellValue(newCol));
-            Assert.assertTrue(ExpressionUtils.isError(project.rows.get(2).getCellValue(newCol)));
+            assertTrue(project.rows.get(0).getCellValue(newCol) instanceof EvalError);
+            assertEquals(project.rows.get(1).getCellValue(newCol), "random string");
+            assertTrue(ExpressionUtils.isError(project.rows.get(2).getCellValue(newCol)));
+            assertEquals(project.rows.get(3).getCellValue(newCol), "Ahmed");
+
+            RecordedRequest request1 = server.takeRequest();
+            assertEquals(request1.getUrl().encodedPath(), "/random");
+            RecordedRequest request2 = server.takeRequest();
+            // verify that path was correctly escaped before request was sent
+            assertEquals(request2.getPath().substring(1), UrlEscapers.urlPathSegmentEscaper().escape(ARABIC));
         }
     }
 
@@ -370,6 +386,7 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
                     false,
                     null);
 
+            // 6 requests (4 retries @1 sec) + final response
             long elapsed = runOperation(op, project, 4500);
 
             // Make sure that our Retry-After headers were obeyed (4*1 sec vs 4*100msec)

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.net.UrlEscapers;
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -310,7 +310,7 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
             assertEquals(request1.getUrl().encodedPath(), "/random");
             RecordedRequest request2 = server.takeRequest();
             // verify that path was correctly escaped before request was sent
-            assertEquals(request2.getPath().substring(1), UrlEscapers.urlPathSegmentEscaper().escape(ARABIC));
+            assertEquals(request2.getUrl().encodedPath().substring(1), UrlEscapers.urlPathSegmentEscaper().escape(ARABIC));
         }
     }
 

--- a/modules/core/src/main/java/com/google/refine/util/HttpClient.java
+++ b/modules/core/src/main/java/com/google/refine/util/HttpClient.java
@@ -28,6 +28,10 @@
 package com.google.refine.util;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -212,6 +216,24 @@ public class HttpClient {
         return Pattern.compile(String.join("|", rHosts));
     }
 
+    /**
+     * Takes a human-readable URL and returns an encoded version of it ready for use, similar to what a web browser does
+     * when a URL is pasted into the address bar.
+     *
+     * @param urlString
+     * @return URL encoded as ASCII string, ready to use
+     * @throws MalformedURLException
+     * @throws URISyntaxException
+     */
+    public static String getEscapedUrl(String urlString) throws MalformedURLException, URISyntaxException {
+        // Do a little dance to get all the pieces of the URL correctly encoded, if possible
+        // TODO: Should we try to undo any existing percent encoding, so we don't end up double encoded?
+        URL url = new URL(urlString);
+        URI uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(), url.getPath(),
+                url.getQuery(), url.getRef());
+        return uri.toASCIIString();
+    }
+
     public String getAsString(String urlString, Header[] headers) throws IOException {
 
         final HttpClientResponseHandler<String> responseHandler = new HttpClientResponseHandler<String>() {
@@ -299,7 +321,7 @@ public class HttpClient {
         }
 
         /**
-         * Even our POST requests should be retried, they are deemed idempotent
+         * Even our POST requests should be retried, they are deemed idempotent
          */
         @Override
         public boolean handleAsIdempotent(final HttpRequest request) {

--- a/modules/core/src/test/java/com/google/refine/util/HttpClientTests.java
+++ b/modules/core/src/test/java/com/google/refine/util/HttpClientTests.java
@@ -1,8 +1,13 @@
 
 package com.google.refine.util;
 
+import static org.testng.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.util.regex.Pattern;
 
+import com.google.common.net.UrlEscapers;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -26,5 +31,13 @@ public class HttpClientTests {
         Assert.assertTrue(pattern3.matcher("host.domain.org").matches());
         Assert.assertTrue(pattern3.matcher("random.domain.any.com").matches());
         Assert.assertTrue(pattern3.matcher("myhosts.mydomain.mine").matches());
+    }
+
+    @Test
+    public void urlEscaping() throws MalformedURLException, URISyntaxException {
+        final String ARABIC_PATH = "احمد";
+        final String BASE_URL = "https://example.com/";
+        final String TEST_URL = BASE_URL + ARABIC_PATH;
+        assertEquals(HttpClient.getEscapedUrl(TEST_URL), BASE_URL + UrlEscapers.urlPathSegmentEscaper().escape(ARABIC_PATH));
     }
 }


### PR DESCRIPTION
Fixes #6140

Changes proposed in this pull request:
- Automatically encode URL before using it for fetch, using the correct encoding for each of the three different pieces of the URL which need encoding.

One question I have is whether we should be percent-decoding the string before feeding it to the URL encoder. This could potentially make it more compatible with existing recipes which uses `.encode("url")` as well as allowing the use of other sources of pre-encoded URLs, but is opening up a little bit of a can of worms.