### PR TITLE
Display of logo of the Reconciliation service a which column is reconciled against

### DIFF
--- a/extensions/wikibase/module/scripts/schema-alignment.js
+++ b/extensions/wikibase/module/scripts/schema-alignment.js
@@ -246,7 +246,7 @@ SchemaAlignment.updateColumns = function() {
      // TODO we could potentially ignore any reconciliation to a siteIRI not
      // mentioned in the manifest…
      var cell = SchemaAlignment._createDraggableColumn(column.name,
-        reconConfig && column.reconStats ? reconConfig.identifierSpace : null);
+        reconConfig && column.reconStats ? reconConfig.identifierSpace : null, reconConfig);
      this._columnArea.append(cell);
   }
 
@@ -433,8 +433,31 @@ SchemaAlignment._changesCleared = function() {
         .addClass('disabled');
 };
 
-SchemaAlignment._createDraggableColumn = function(name, reconciledSiteIRI) {
+SchemaAlignment._createDraggableColumn = function(name, reconciledSiteIRI, reconConfig) {
+  var serviceUrl = null;
+  var service = null;
+  var serviceLogo=null;
+  var reconConfig = reconConfig;
+  if (reconConfig) {
+     serviceUrl =reconConfig.service;
+  }
+  if (serviceUrl) {
+    service = ReconciliationManager.getServiceFromUrl(serviceUrl);
+  }    
+  if(service){
+    serviceLogo=service.logo;
+  }
+
+  var img = $("<img>");
+ 
+  if(serviceLogo ){
+  var imageUrl = serviceLogo; 
+  img.attr("src", imageUrl); 
+  img.attr("title", service.name); 
+  img.addClass("serviceLogo-for-schema")    
+  }
   var cell = $("<div></div>").addClass('wbs-draggable-column').text(name);
+  cell.append(img);
   cell.data({
         'columnName': name,
         'reconciledSiteIRI': reconciledSiteIRI
@@ -1544,7 +1567,7 @@ SchemaAlignment._initField = function(inputContainer, mode, initialValue, change
         input.val(initialValue.label);
         input.addClass("wbs-validated-input");
      } else if (initialValue.type == "wbentityvariable") {
-        var cell = SchemaAlignment._createDraggableColumn(initialValue.columnName, true);
+        var cell = SchemaAlignment._createDraggableColumn(initialValue.columnName, true, null);
         acceptDraggableColumn(cell);
      } else if (initialValue.type === "wbstringconstant" ||
                 initialValue.type === "wbdateconstant" ||
@@ -1557,7 +1580,7 @@ SchemaAlignment._initField = function(inputContainer, mode, initialValue, change
                 initialValue.type === "wbdatevariable" ||
                 initialValue.type === "wblocationvariable" ||
                 initialValue.type === "wblanguagevariable") {
-        var cell = SchemaAlignment._createDraggableColumn(initialValue.columnName, false);
+        var cell = SchemaAlignment._createDraggableColumn(initialValue.columnName, false, null);
         acceptDraggableColumn(cell);
      }
      inputContainer.data("jsonValue", initialValue);

--- a/extensions/wikibase/module/styles/schema-alignment.css
+++ b/extensions/wikibase/module/styles/schema-alignment.css
@@ -20,7 +20,11 @@
 .schema-alignment-tab-content {
   max-width: 70em;
 }
-
+.serviceLogo-for-schema{
+  float: left!important;
+  width: 19px;
+  height: 21px; 
+};
 .main-view-panel-tab-header {
   margin-top: 9px;
   margin-left: 7px;

--- a/extensions/wikibase/module/styles/schema-alignment.css
+++ b/extensions/wikibase/module/styles/schema-alignment.css
@@ -20,11 +20,7 @@
 .schema-alignment-tab-content {
   max-width: 70em;
 }
-.serviceLogo-for-schema{
-  float: left!important;
-  width: 19px;
-  height: 21px; 
-};
+
 .main-view-panel-tab-header {
   margin-top: 9px;
   margin-left: 7px;

--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -70,6 +70,30 @@ DataTableColumnHeaderUI.prototype._render = function() {
     self._createMenuForColumnHeader(this);
   });
 
+  var serviceUrl = null;
+  var service = null;
+  var serviceLogo=null;
+  if (this._column.reconConfig) {
+    serviceUrl =this._column.reconConfig.service;
+  }
+  if (serviceUrl) {
+    service = ReconciliationManager.getServiceFromUrl(serviceUrl);
+  }
+  if(service){
+    serviceLogo=service.logo;
+  }
+
+  var img =$("<img>");
+  if(serviceLogo ){
+    var imageUrl = serviceLogo; 
+    img.attr("src", imageUrl); 
+    img.attr("title", service.name); 
+    img.addClass("serviceLogo")
+    img.appendTo(elmts.serviceLogoContainer.show());
+
+  }
+      
+      
   if ("reconStats" in this._column) {
     var stats = this._column.reconStats;
     if (stats.nonBlanks > 0) {

--- a/main/webapp/modules/core/scripts/views/data-table/column-header.html
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header.html
@@ -1,2 +1,5 @@
 <div class="column-header-title"><button class="column-header-menu" bind="dropdownMenu"></button><span class="column-header-name" bind="nameContainer"></span></div>
-<div style="display:none;" bind="reconStatsContainer"></div>
+<div class="container">
+  <div style="display: none; grid-column:1" bind="serviceLogoContainer" ></div>
+  <div style="display: none; grid-column:2" bind="reconStatsContainer"></div>
+</div>

--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -192,13 +192,23 @@ table.data-table td.column-header, table.data-table th.column-header {
   background-position: -17px 0px;
 }
 
+.container {
+  display: grid;
+  grid-template-columns: max-content auto;
+  width:100%;
+}
 .column-header-recon-stats-bar {
-  margin-top: 10px;
-  height: 4px;
+  margin-top:4px;
+  height: 6px;
   background: #ddd;
   border: 1px solid #ccc;
   position: relative;
   width: 100%;
+}
+
+.serviceLogo {
+    width: 19px;
+    height: 21px; 
 }
 
 .column-header-recon-stats-matched {


### PR DESCRIPTION


Fixes #4824 

Changes proposed in this pull request:
- We have a logo of the service against which the column is reconciled beside the recon stats bar
- We also have the logo beside the column name during schema building(if the column is reconciled against a service which has a logo ) 

