### PR TITLE
Fix Flaky test

### DIFF
--- a/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -288,7 +288,7 @@ public class StandardReconConfigTests extends RefineTest {
             process.startPerforming(pm);
             Assert.assertTrue(process.isRunning());
             try {
-                Thread.sleep(1000);
+                Thread.sleep(2000);
             } catch (InterruptedException e) {
                 Assert.fail("Test interrupted");
             }


### PR DESCRIPTION
## Description

Fixed the flaky test `reconNonJsonTest` inside the `StandardReconConfigTests` class.


### Root Cause
**reconNonJsonTest**
The test `reconNonJsonTest` generates failure when running with the Maven test tool. However, using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool will give a pass result. The test failed because the process would not end within 1 second. 


https://github.com/OpenRefine/OpenRefine/blob/471cf09fa64884a84550c0a6059bc1b8995261db/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java#L284-L295


### Fix
**reconNonJsonTest**
Test in this class is fixed by extending the sleep time from 1 second to 2 seconds.  After rerunning the test 100 times, 2 seconds are enough for the process to finish, and `process.isRunning()` will return `false`. 


### How has this been tested?

1. Regular test - Failed
Command used -
```
 mvn -pl main test -Dtest=com.google.refine.model.recon.StandardReconConfigTests#reconNonJsonTest
```

2. NonDex test - Failed
Command used -
```
mvn -pl main edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.google.refine.model.recon.StandardReconConfigTests#reconNonJsonTest
```

The default test passed after the fix.


