### PR TITLE
Fix flaky Cypress test in cypress/e2e/create-project/preview_project.cy.js "Tests disabling of automatic preview" 

### DIFF
--- a/main/tests/cypress/cypress/e2e/create-project/preview_project.cy.js
+++ b/main/tests/cypress/cypress/e2e/create-project/preview_project.cy.js
@@ -181,24 +181,24 @@ describe(__filename, function () {
     // **Testing ignore feature with auto preview enabled** //
     cy.get('input[bind="ignoreInput"]').type('{backspace}1');
     cy.get('input[bind="ignoreCheckbox"]').check();
-    cy.waitForImportUpdate();
+
     // Look for automatic preview update
     cy.get('table.data-table tr').eq(1);
     cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
 
     cy.get('input[bind="ignoreCheckbox"]').uncheck();
-    cy.waitForImportUpdate();
+    cy.get('table.data-table tr').eq(1);
+    cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
 
     // **Testing ignore feature with auto preview disabled** //
     cy.get('input[bind="disableAutoPreviewCheckbox"]').check();
     // Verify no auto update
     cy.get('input[bind="ignoreCheckbox"]').check();
-    cy.wait(5000); // 5 second wait. No choice but to use this here because the dom is not rendered.
     cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
     cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
     // Verify update on button click
     cy.get('button[bind="previewButton"]').click();
-    cy.waitForImportUpdate(); // This can be flaky, happening too quickly to capture
+
     cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
     cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
     cy.get('input[bind="disableAutoPreviewCheckbox"]').uncheck();

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -276,6 +276,13 @@ Cypress.Commands.add('waitForOrOperation', () => {
 
 /**
  * Wait for OpenRefine parsing options to be updated
+ *
+ * @deprecated
+ *
+ * NOTE: This command is unreliable because if you call it after starting an operation e.g. with a click(), the loading
+ * indicator may have come and gone already by the time waitForImportUpdate() is called, causing the cypress test to
+ * wait forever on ('#or-import-updating').should('be.visible') until it fails due to timeout.
+ *
  */
 Cypress.Commands.add('waitForImportUpdate', () => {
   cy.get('#or-import-updating').should('be.visible');


### PR DESCRIPTION
Fixes #6158
      
Changes:
  - Remove call to `waitForImportUpdate()`
  - Updated command description of `waitForImportUpdate()`
 
`waitForImportUpdate()` has the same problem as `waitForOrOperation()` which I have been trying to remove.  Both of those methods are waiting for a temporary loading/in-progress element to be visible and then not visible.

The problem is that the element may have been shown and hidden again before this code executes, causing it to wait forever until it times out.

The solution is to not focus on the transient loading indicators, but to just do `cy.get()` and assertions on the expected state after the operation completes. For long running operations,  the timeout on the `cy.get()` command may need to be increased if the operation could exceed the default timeout of 4 seconds.

I added @deprecated note on `waitForImportUpdate()` similar to what I added for `waitForOrOperation()`. The rest of the calls can be removed once we have fixed all the tests using them.