### PR TITLE
Fix bad backport of "wikibase: remove the need for SchemaAlignment.resize()"

### DIFF
--- a/extensions/wikibase/module/styles/schema-alignment.less
+++ b/extensions/wikibase/module/styles/schema-alignment.less
@@ -60,7 +60,7 @@
   position: sticky;
   top: 0;
   padding-top: 1em;
-  background-color: var(--background-primary);
+  background-color: #fff;
   z-index: 1;
 }
 


### PR DESCRIPTION
Closes #6163.

To be released in an upcoming 3.7 patch release (3.7.7)