### PR TITLE
Remove Datejs and Moment.js dependencies

### DIFF
--- a/main/webapp/dependencies.json
+++ b/main/webapp/dependencies.json
@@ -8,11 +8,9 @@
   "files" : [
     {"from": "tablesorter/dist/js/jquery.tablesorter.js", "to": "tablesorter/jquery.tablesorter.js"},
     {"from": "tablesorter/dist/css/theme.blue.css", "to": "tablesorter/theme.blue.css"},
-    {"from": "moment/min/moment-with-locales.js", "to": "moment-with-locales.js"},
     {"from": "underscore/underscore.js", "to": "underscore.js"},
     {"from": "js-cookie/dist/js.cookie.js", "to": "js.cookie.js"},
     {"from": "jquery-migrate/dist/jquery-migrate.js", "to": "jquery-migrate.js"},
-    {"from": "datejs-coolite/build/date.js", "to": "date.js"},
     {"from": "jquery/dist/jquery.js", "to": "jquery.js"},
     {"from": "select2/dist/css/select2.css", "to": "select2/select2.css"},
     {"from": "select2/dist/js/select2.js", "to": "select2/select2.js"},

--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -356,9 +356,7 @@ function init() {
     "index/scripts",
     module,
     commonModules.concat([
-      "3rdparty/date.js",
       "3rdparty/tablesorter/jquery.tablesorter.js",
-      "3rdparty/moment-with-locales.js",
       "3rdparty/select2/select2.js",
 
       "scripts/util/misc.js",
@@ -436,7 +434,6 @@ function init() {
     module,
     commonModules.concat([
       "externals/suggest/suggest-4_3a.js",
-      "3rdparty/date.js",
       "scripts/util/i18n.js",
       "scripts/util/csrf.js",
       "scripts/project.js",

--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -134,6 +134,11 @@ Refine.OpenProjectUI.prototype._fetchProjects = function() {
     });
 };
 
+const dateOptions = { year: 'numeric', month: '2-digit', day: '2-digit' };
+const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: true };
+const dateFormatter = new Intl.DateTimeFormat(navigator.language, dateOptions);
+const timeFormatter =  new Intl.DateTimeFormat(navigator.language, timeOptions);
+
 Refine.OpenProjectUI.prototype._renderProjects = function(data) {
   var self = this;
   var projects = [];
@@ -149,7 +154,20 @@ Refine.OpenProjectUI.prototype._renderProjects = function(data) {
          console.log('Project '+project.id+' name is not set. skipping...');
          continue;
       }
-      project.date = moment(project.modified).format('YYYY-MM-DD HH:mm A');
+      // project.modified is ISO 8601 format
+      const date = new Date(project.modified);
+      const dateParts = dateFormatter.formatToParts(date);
+      const timeParts = timeFormatter.formatToParts(date);
+      const findPart = (parts, type) => parts.find(part => part.type === type)?.value;
+
+      const year = findPart(dateParts, 'year');
+      const month = findPart(dateParts, 'month');
+      const day = findPart(dateParts, 'day');
+      const hour = findPart(timeParts, 'hour');
+      const minute = findPart(timeParts, 'minute');
+      const dayPeriod = findPart(timeParts, 'dayPeriod'); // AM or PM
+
+      project.date = `${year}-${month}-${day} ${hour}:${minute} ${dayPeriod}`;
       
       if (typeof project.userMetadata !== "undefined")  {
           for (var m in data.customMetadataColumns) {

--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -135,7 +135,7 @@ Refine.OpenProjectUI.prototype._fetchProjects = function() {
 };
 
 const dateOptions = { year: 'numeric', month: '2-digit', day: '2-digit' };
-const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: true };
+const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
 const dateFormatter = new Intl.DateTimeFormat(navigator.language, dateOptions);
 const timeFormatter =  new Intl.DateTimeFormat(navigator.language, timeOptions);
 

--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -165,9 +165,8 @@ Refine.OpenProjectUI.prototype._renderProjects = function(data) {
       const day = findPart(dateParts, 'day');
       const hour = findPart(timeParts, 'hour');
       const minute = findPart(timeParts, 'minute');
-      const dayPeriod = findPart(timeParts, 'dayPeriod'); // AM or PM
 
-      project.date = `${year}-${month}-${day} ${hour}:${minute} ${dayPeriod}`;
+      project.date = `${year}-${month}-${day} ${hour}:${minute}`;
       
       if (typeof project.userMetadata !== "undefined")  {
           for (var m in data.customMetadataColumns) {

--- a/main/webapp/package-lock.json
+++ b/main/webapp/package-lock.json
@@ -8,11 +8,9 @@
       "hasInstallScript": true,
       "dependencies": {
         "@wikimedia/jquery.i18n": "1.0.9",
-        "datejs-coolite": "1.0.0",
         "jquery": "3.7.1",
         "jquery-migrate": "3.4.1",
         "js-cookie": "3.0.5",
-        "moment": "2.29.4",
         "select2": "4.1.0-rc.0",
         "tablesorter": "2.31.3",
         "underscore": "1.13.6"
@@ -28,11 +26,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@wikimedia/jquery.i18n/-/jquery.i18n-1.0.9.tgz",
       "integrity": "sha512-g6nlCAeYX4n9o6CyCJniNnEB0wGSo1o6sw2WPneb0wOtWiGDFUCZtlkmgvPLL+ynkYRaf5IJiq/CNGQ7p6nB+Q=="
-    },
-    "node_modules/datejs-coolite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/datejs-coolite/-/datejs-coolite-1.0.0.tgz",
-      "integrity": "sha512-kppYUwn9R2pzsoChLsDlWLtKTwjf5k9Z3fx8CNKjwvhYfpadKIFoL+16dDJvftiXKwT+ixh2PRslZsfzp+1ZVA=="
     },
     "node_modules/jquery": {
       "version": "3.7.1",
@@ -53,14 +46,6 @@
       "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/select2": {
@@ -88,11 +73,6 @@
       "resolved": "https://registry.npmjs.org/@wikimedia/jquery.i18n/-/jquery.i18n-1.0.9.tgz",
       "integrity": "sha512-g6nlCAeYX4n9o6CyCJniNnEB0wGSo1o6sw2WPneb0wOtWiGDFUCZtlkmgvPLL+ynkYRaf5IJiq/CNGQ7p6nB+Q=="
     },
-    "datejs-coolite": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/datejs-coolite/-/datejs-coolite-1.0.0.tgz",
-      "integrity": "sha512-kppYUwn9R2pzsoChLsDlWLtKTwjf5k9Z3fx8CNKjwvhYfpadKIFoL+16dDJvftiXKwT+ixh2PRslZsfzp+1ZVA=="
-    },
     "jquery": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
@@ -108,11 +88,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
       "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="
-    },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "select2": {
       "version": "4.1.0-rc.0",

--- a/main/webapp/package.json
+++ b/main/webapp/package.json
@@ -11,11 +11,9 @@
   "type": "module",
   "dependencies": {
     "@wikimedia/jquery.i18n": "1.0.9",
-    "datejs-coolite": "1.0.0",
     "jquery": "3.7.1",
     "jquery-migrate": "3.4.1",
     "js-cookie": "3.0.5",
-    "moment": "2.29.4",
     "select2": "4.1.0-rc.0",
     "tablesorter": "2.31.3",
     "underscore": "1.13.6"


### PR DESCRIPTION
Changes proposed in this pull request:
  - Change formatting of dates in Open Project table to use Intl.DateFormat instead of Moment.js.
   - Formatting the same except AM/PM is not shown because Intl.DateFormat doesn't support that when 24-hour military time is used.
  - Webapp package.json
    - Remove datejs-coolite (Unused after https://github.com/OpenRefine/OpenRefine/pull/6157).
    - Remove Moment.js (Deprecated https://momentjs.com/).
    
BEFORE (Moment.js - using 24HR time with AM/PM)
![image](https://github.com/OpenRefine/OpenRefine/assets/42903164/4d078e57-09b0-44be-8dfa-ce3551b8c086)


AFTER (Intl.DateFormat using 24HR time without AM/PM)
![image](https://github.com/OpenRefine/OpenRefine/assets/42903164/098fd0f4-8fb7-4354-9c8f-142ff660d1e4)