### PR TITLE
fix: reconciliation documentation link display type

### DIFF
--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -103,7 +103,7 @@ ReconStandardServicePanel.prototype._constructUI = function() {
   if(this._service.documentation) {
     this._elmts.documentationLink.attr("href", this._service.documentation);
     // Show the documentation link if documentation is available
-    this._elmts.documentationLink.css("display", "block");
+    this._elmts.documentationLink.css("display", "inline");
   } 
   
   this._elmts.againstType.on('change', function() {


### PR DESCRIPTION
`inline` is the default type for <a> elements and `block` causes the links to be stacked vertically.
