### PR TITLE
project client: get the project-id from the URL rather than from Velocity injection

### DIFF
--- a/main/webapp/modules/core/project.vt
+++ b/main/webapp/modules/core/project.vt
@@ -38,7 +38,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <title>OpenRefine</title>
     <link rel="icon" type="image/png" href="images/favicon.png">
     $styleInjection
-    <script type="text/javascript">var theProject = { id : $projectID };</script>
+    <script type="text/javascript">
+      const urlParams = new URLSearchParams(window.location.search);
+      var theProject = { id : urlParams.get("project") };
+    </script>
     <script type="text/javascript" src="wirings.js"></script>
     $scriptInjection
     <script>Refine.encodings = $encodingJson; Refine.defaultEncoding = $defaultEncoding;</script>


### PR DESCRIPTION
Part of a downstream attempt to nuke Velocity usage.