### PR TITLE
Update Velocity from 1.5 to 2.3. Fixes #4078 / CVE-2020-13936

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -228,8 +228,8 @@
       <version>${commons-validator.version}</version>
     </dependency>
     <dependency>
-      <groupId>velocity</groupId>
-      <artifactId>velocity</artifactId>
+      <groupId>org.apache.velocity</groupId>
+      <artifactId>velocity-engine-core</artifactId>
       <version>${velocity.version}</version>
     </dependency>
     <dependency>

--- a/main/webapp/WEB-INF/velocity.properties
+++ b/main/webapp/WEB-INF/velocity.properties
@@ -7,5 +7,11 @@ velocimacro.context.localscope=false
 velocimacro.library.autoreload=false
 velocimacro.permissions.allow.inline.local.scope=true
 
+# UTF-8 is the default encoding for 2.x, so these might be superfluous
 input.encoding=UTF-8
 output.encoding=UTF-8
+
+# Settings to maximize backward compatibility with 1.x
+runtime.conversion.handler = none
+space.gobbling = bc
+directive.if.emptycheck = false

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <!-- v1.15 of commons-codec is needed for Jena 3.14+ - copied from org.apache.jena:jena:pom -->
     <commons-codec.version>1.16.0</commons-codec.version>
     <commons-compress.version>1.25.0</commons-compress.version>
-    <velocity.version>1.5</velocity.version>
+    <velocity.version>2.3</velocity.version>
     <marc4j.version>2.9.5</marc4j.version>
     <jsoup.version>1.15.3</jsoup.version>
     <odfdom-java.version>0.9.0</odfdom-java.version> <!-- do not update to 0.10.0, see issue #4397 -->


### PR DESCRIPTION
Fixes #4078. Resolves [CVE-2020-13936](https://github.com/advisories/GHSA-59j4-wjwp-mw9m)

Changes proposed in this pull request:
- Update Apache Velocity from 1.5 to 2.3
- Set properties for maximum 1.x compatibility per version upgrade notes 
  https://velocity.apache.org/engine/2.0/upgrading.html
