### PR TITLE
Fix flaky Cypress test: Copy reconciliation data from species to species_copy

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/reconcile/copy_reconciliation_data.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/reconcile/copy_reconciliation_data.cy.js
@@ -3,7 +3,7 @@ describe('Copy reconciliation data', () => {
     cy.addProjectForDeletion();
   });
   
-  it('Copy reconciliation data from species to species_copy', () => {
+  it.only('Copy reconciliation data from species to species_copy', () => {
     cy.visitOpenRefine();
     cy.navigateTo('Import project');
     cy.get('#or-import-locate').should('to.contain', 'Locate an existing Refine project file');
@@ -42,9 +42,10 @@ describe('Copy reconciliation data', () => {
       'Copy 4 recon judgments from column species to duplicated_column'
     );
 
-    // ensure 4 are matched on the duplicate column
-    cy.get(
-      'table.data-table td .data-table-cell-content:contains("Choose new match")'
-    ).should('have.length', 4);
+    cy.get('table.data-table th').contains('duplicated_column').should('exist').then(() => {
+      cy.get('table.data-table tbody tr')
+              .find('td:last .data-table-cell-content:contains("Choose new match")')
+              .should('have.length', 4);
+    });
   });
 });

--- a/main/tests/cypress/cypress/e2e/project/grid/column/reconcile/copy_reconciliation_data.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/reconcile/copy_reconciliation_data.cy.js
@@ -3,7 +3,7 @@ describe('Copy reconciliation data', () => {
     cy.addProjectForDeletion();
   });
   
-  it.only('Copy reconciliation data from species to species_copy', () => {
+  it('Copy reconciliation data from species to species_copy', () => {
     cy.visitOpenRefine();
     cy.navigateTo('Import project');
     cy.get('#or-import-locate').should('to.contain', 'Locate an existing Refine project file');


### PR DESCRIPTION
The copy reconciliation data test copies a column, then counts 'Choose new match' in all TDs, including the original column.  On slower computers the count is 4.  On faster computers the count is 8.

Changes proposed in this pull request:

- Fix flaky Cypress test that fails on faster computers.

- Change to first wait for 'duplicated_column' to show up, then count 'Choose new match' occurrences only in the last column.