### PR TITLE
Added 10s timeout for Jython tests to fix flakiness

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/add_columns_based_on_this_column.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/add_columns_based_on_this_column.cy.js
@@ -29,9 +29,9 @@ describe(__filename, function () {
 
     cy.get('input[bind="columnNameInput"]').type('Test_Python_toLower');
     cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
-    cy.typeExpression('return value.lower()');
+    cy.typeExpression('return value.lower()',{timeout: 10000});
     cy.get(
-      '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'
+      '.expression-preview-table-wrapper tr:nth-child(2) td:last-child',{timeout: 10000}
     ).should('to.contain', 'butter,with salt');
     cy.confirmDialogPanel();
 

--- a/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
@@ -47,10 +47,10 @@ describe(__filename, function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
     cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
-    cy.typeExpression('return value.lower()');
+    cy.typeExpression('return value.lower()',{timeout: 10000});
     cy.get('.expression-preview-parsing-status').contains('No syntax error.');
     cy.get(
-      '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'
+      '.expression-preview-table-wrapper tr:nth-child(2) td:last-child',{timeout: 10000}
     ).should('to.contain', 'butter,with salt');
   });
 
@@ -76,7 +76,7 @@ describe(__filename, function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
     cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
-    cy.typeExpression('(;)');
+    cy.typeExpression('(;)',{timeout: 10000});
     cy.get('.expression-preview-parsing-status').contains('Internal error');
   });
 
@@ -103,7 +103,7 @@ describe(__filename, function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
     cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
-    cy.typeExpression('return value.thisPythonFunctionDoesNotExists()');
+    cy.typeExpression('return value.thisPythonFunctionDoesNotExists()',{timeout: 10000});
 
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -294,15 +294,10 @@ Cypress.Commands.add('waitForImportUpdate', () => {
  * Utility method to fill something into the expression input
  * Need to wait for OpenRefine to preview the result, hence the cy.wait
  */
-Cypress.Commands.add('typeExpression', (expression) => {
-  if (expression.length <= 30) {
-    cy.get('textarea.expression-preview-code').type(expression);
-    cy.get('tbody > tr:nth-child(1) > td:nth-child(3)').should('contain',expression);
-  } else {
-    cy.get('textarea.expression-preview-code').type(expression);
-    cy.get('tbody > tr:nth-child(1) > td:nth-child(3)').should('contain',expression.substring(0,30) + ' ...');
-  }
-
+Cypress.Commands.add('typeExpression', (expression, options = {}) => {
+    cy.get('textarea.expression-preview-code', options).type(expression);
+    const expectedText = expression.length <= 30 ? expression : `${expression.substring(0, 30)} ...`;
+    cy.get('tbody > tr:nth-child(1) > td:nth-child(3)', options).should('contain', expectedText);
 });
 
 /**


### PR DESCRIPTION
The Cypress tests related to Jython have become flaky due to the recent change to [using lazy initialization for the Jython interpreter](#6175), resulting in the first server request related to Jython sometimes exceeding the default 4 second timeout.

![image](https://github.com/OpenRefine/OpenRefine/assets/42903164/496e5263-6400-4d47-9d53-242ab7d6d9cd)
Ref: https://cloud.cypress.io/projects/s5du3k/analytics/flaky-tests

Changes:
- Added 10 second timeout for Jython related tests, so that the `cy.get()` calls will wait up to 10 seconds.