### PR TITLE
Made text selectable in alert dialog

### DIFF
--- a/extensions/gdata/module/authorized.vt
+++ b/extensions/gdata/module/authorized.vt
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       try {
         callback();
       } catch (e) {
-        alert(e.message);
+        DialogSystem.alert(e.message);
       }
     } else {
       w.close();

--- a/extensions/gdata/module/langs/translation-en.json
+++ b/extensions/gdata/module/langs/translation-en.json
@@ -10,6 +10,8 @@
     "gdata-import/sign-out": "Sign out",
     "gdata-import/retrieving": "Retrieving Google Docs documents …",
     "gdata-import/re-sign-in-another": "Sign in with different account",
+    "gdata-import/please-name-project": "Please name the project.",
+    "gdata-import/errors": "Errors:\n $1",
     "gdata-parsing/start-over": "&laquo; Start Over",
     "gdata-parsing/conf-pars": "Configure Parsing Options",
     "gdata-parsing/proj-name": "Project&nbsp;name",

--- a/extensions/gdata/module/scripts/index/gdata-source-ui.js
+++ b/extensions/gdata/module/scripts/index/gdata-source-ui.js
@@ -73,7 +73,7 @@ Refine.GDataSourceUI.prototype.attachUI = function(body) {
   this._elmts.urlNextButton.on('click',function(evt) {
     var url = jQueryTrim(self._elmts.urlInput[0].value);
     if (url.length === 0) {
-      window.alert($.i18n('gdata-source/alert-url'));
+      DialogSystem.alert($.i18n('gdata-source/alert-url'));
     } else {
       var doc = {};
       doc.docSelfLink = url;

--- a/extensions/gdata/module/scripts/index/importing-controller.js
+++ b/extensions/gdata/module/scripts/index/importing-controller.js
@@ -77,7 +77,7 @@ Refine.GDataImportingController.prototype.startImportingDocument = function(doc)
 
                 self._showParsingPanel();
             } else {
-                alert(data2.message);
+                DialogSystem.alert(data2.message);
             }
             },
             "json"
@@ -329,7 +329,7 @@ Refine.GDataImportingController.prototype._updatePreview = function() {
             });
         } else {
             self._parsingPanelElmts.progressPanel.hide();
-            alert('Errors:\n' +
+            DialogSystem.alert('Errors:\n' +
             (result.message) ? result.message : Refine.CreateProjectUI.composeErrorMessage(job));
         }
         },
@@ -373,7 +373,7 @@ Refine.GDataImportingController.prototype._getPreviewData = function(callback, n
 Refine.GDataImportingController.prototype._createProject = function() {
   var projectName = jQueryTrim(this._parsingPanelElmts.projectNameInput[0].value);
   if (projectName.length == 0) {
-    window.alert("Please name the project.");
+    DialogSystem.alert("Please name the project.");
     this._parsingPanelElmts.projectNameInput.focus();
     return;
   }
@@ -394,7 +394,7 @@ Refine.GDataImportingController.prototype._createProject = function() {
         },
         function(o) {
         if (o.status == 'error') {
-            alert(o.message);
+            DialogSystem.alert(o.message);
         } else {
             var start = new Date();
             var timerID = window.setInterval(
@@ -412,7 +412,7 @@ Refine.GDataImportingController.prototype._createProject = function() {
                     document.location = "project?project=" + job.config.projectID;
                     },
                     function(job) {
-                    alert(Refine.CreateProjectUI.composeErrorMessage(job));
+                      DialogSystem.alert(Refine.CreateProjectUI.composeErrorMessage(job));
                     }
                 );
             },

--- a/extensions/gdata/module/scripts/index/importing-controller.js
+++ b/extensions/gdata/module/scripts/index/importing-controller.js
@@ -329,8 +329,8 @@ Refine.GDataImportingController.prototype._updatePreview = function() {
             });
         } else {
             self._parsingPanelElmts.progressPanel.hide();
-            DialogSystem.alert('Errors:\n' +
-            (result.message) ? result.message : Refine.CreateProjectUI.composeErrorMessage(job));
+            DialogSystem.alert($.i18n('gdata-import/errors',
+            (result.message) ? result.message : Refine.CreateProjectUI.composeErrorMessage(job)));
         }
         },
         "json"
@@ -373,7 +373,7 @@ Refine.GDataImportingController.prototype._getPreviewData = function(callback, n
 Refine.GDataImportingController.prototype._createProject = function() {
   var projectName = jQueryTrim(this._parsingPanelElmts.projectNameInput[0].value);
   if (projectName.length == 0) {
-    DialogSystem.alert("Please name the project.");
+    DialogSystem.alert($.i18n('gdata-import/please-name-project'));
     this._parsingPanelElmts.projectNameInput.focus();
     return;
   }

--- a/extensions/gdata/module/scripts/project/exporters.js
+++ b/extensions/gdata/module/scripts/project/exporters.js
@@ -68,7 +68,7 @@ ExporterManager.MenuItems.push(
             if (o.url) {
               window.open(o.url, '_blank');
             } else {
-                alert($.i18n('gdata-exporter/upload-error') + o.message)
+              DialogSystem.alert($.i18n('gdata-exporter/upload-error') + o.message)
             }
             if (onDone) {
               onDone();
@@ -111,9 +111,9 @@ ExporterManager.handlers.exportProjectToGoogleDrive = function () {
           dismiss();
 
           if (o.url) {
-            alert($.i18n('gdata-exporter/upload-google-drive-success'));
+            DialogSystem.alert($.i18n('gdata-exporter/upload-google-drive-success'));
           } else {
-            alert($.i18n('gdata-exporter/upload-error') + o.message)
+            DialogSystem.alert($.i18n('gdata-exporter/upload-error') + o.message)
           }
         },
         "json"
@@ -144,9 +144,9 @@ ExporterManager.handlers.exportProjectToGoogleSheets = function () {
           dismiss();
 
           if (o.url) {
-            alert($.i18n('gdata-exporter/upload-google-sheets-success'));
+            DialogSystem.alert($.i18n('gdata-exporter/upload-google-sheets-success'));
           } else {
-            alert($.i18n('gdata-exporter/upload-error') + o.message)
+            DialogSystem.alert($.i18n('gdata-exporter/upload-error') + o.message)
           }
         },
         "json"

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -334,6 +334,7 @@
     "core-dialogs/choose-export-destination": "Please choose the destination for project export",
     "core-dialogs/export-to-local": "OpenRefine project archive to file",
     "core-dialogs/missing-bad-template": "Missing or bad template",
+    "core-dialogs/could-not-stringify": "Error: Could not stringify JSON error object.",
     "core-facets/remove-facet": "Remove this facet",
     "core-facets/minimize-facet": "Toggle between the minimization and maximization of this facet",
     "core-facets/reset": "reset",

--- a/main/webapp/modules/core/scripts/util/dialog.js
+++ b/main/webapp/modules/core/scripts/util/dialog.js
@@ -148,3 +148,54 @@ DialogSystem.showBusy = function(message) {
   };
 };
 
+DialogSystem.alert = function (error) {
+
+    let errorMessage = '';
+    if (typeof error === 'object') {
+        try {
+            errorMessage = JSON.stringify(error, null, 4); // Indent with 4 spaces for readability
+        } catch (e) {
+            errorMessage = 'Error: Could not stringify error object.';
+        }
+    } else {
+        errorMessage = error;
+    }
+    errorMessage = errorMessage.replace(/\r\n/g, "\n");
+
+    let frame = DialogSystem.createDialog();
+    frame.css("max-width", "50em")
+    let header = $('<div></div>')
+            .addClass("dialog-header")
+            .append($('<span>', {
+                'class': 'ui-icon ui-icon-alert',
+                'style': 'float:left; margin:0 7px 5px 0;'
+            }))
+            .append(document.createTextNode($.i18n('core-dialogs/error')))
+            .appendTo(frame);
+    let body = $('<div></div>').addClass("dialog-body").appendTo(frame);
+    let footer = $('<div></div>').addClass("dialog-footer").appendTo(frame);
+
+    let errorContent;
+    if (typeof errorMessage === 'string' && !errorMessage.includes('\n')) {
+        errorContent = $('<div>').text(errorMessage);
+    } else {
+        errorContent = $('<pre>').css({
+            'white-space': 'pre-wrap',
+            'word-break': 'break-all'
+        }).text(errorMessage);
+    }
+    body.append($('<p>')).append(errorContent);
+
+    let okButton = $('<button></button>').html($.i18n('core-buttons/ok')).on({
+        'click': () => {
+            DialogSystem.dismissUntil(this._level - 1);
+        }
+    }).css({
+        'float': 'right',
+        'margin': '5px'
+    });
+    footer.append(okButton);
+
+    this._level = DialogSystem.showDialog(frame);
+}
+

--- a/main/webapp/modules/core/scripts/util/dialog.js
+++ b/main/webapp/modules/core/scripts/util/dialog.js
@@ -155,7 +155,7 @@ DialogSystem.alert = function (error) {
         try {
             errorMessage = JSON.stringify(error, null, 4); // Indent with 4 spaces for readability
         } catch (e) {
-            errorMessage = 'Error: Could not stringify error object.';
+            errorMessage = $.i18n('core-dialogs/could-not-stringify');
         }
     } else {
         errorMessage = error;


### PR DESCRIPTION
Fixes #6187

Changes:
* Add `DialogSystem.alert()` to use in place of `alert()`.
* Change all uses of `alert()` and `window.alert()` in gdata extension to use `DialogSystem.alert()`.

Notes:
* The text displayed in `alert()` in Chromium browsers is not selectable if the text contains a newline character.

Before:
![image](https://github.com/OpenRefine/OpenRefine/assets/42903164/a8af1068-0559-4bc6-9ff4-32a272ed8602)

After:
![image](https://github.com/OpenRefine/OpenRefine/assets/42903164/5b1c0ece-c388-4c9a-8b7a-361c7ab8d3e4)
