### PR TITLE
Fix for workflows running on forks

### DIFF
--- a/.github/workflows/codeql_java.yml
+++ b/.github/workflows/codeql_java.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   analyze:
+    if: github.repository == 'OpenRefine/OpenRefine'
     name: Analyze Java
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/codeql_javascript.yml
+++ b/.github/workflows/codeql_javascript.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   analyze:
+    if: github.repository == 'OpenRefine/OpenRefine'
     name: Analyze JavaScript
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   prepare_e2e_test_matrix:
+    if: github.repository == 'OpenRefine/OpenRefine'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -29,6 +30,7 @@ jobs:
         env:
           browsers: chrome
   e2e_test:
+    if: github.repository == 'OpenRefine/OpenRefine'
     name: e2e_test ${{ matrix.specs.group }}
     needs: prepare_e2e_test_matrix
     runs-on: ubuntu-latest
@@ -93,7 +95,7 @@ jobs:
 
 
   build:
-
+    if: github.repository == 'OpenRefine/OpenRefine'
     services:
       postgres:
         image: postgres
@@ -175,6 +177,7 @@ jobs:
       run: mvn -B package -DskipTests=true
 
   mac_test_and_deploy:
+    if: github.repository == 'OpenRefine/OpenRefine'
     runs-on: macos-12
 
     outputs: 
@@ -331,6 +334,7 @@ jobs:
         name: openrefine-mac-${{ steps.version_string_variable.outputs.output_value }}
 
   windows_installer:
+    if: github.repository == 'OpenRefine/OpenRefine'
     runs-on: windows-2022
     needs: mac_test_and_deploy
 

--- a/.github/workflows/unassign_issues.yml
+++ b/.github/workflows/unassign_issues.yml
@@ -8,6 +8,7 @@ jobs:
   # Best used in combination with actions/stale to assign a Stale label
   
   unassign-good-first-issues-after-90-days-of-inactivity:
+    if: github.repository == 'OpenRefine/OpenRefine'
     name: Unassign issues labeled "good first issue" after 45 days of inactivity.
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I am seeing the snapshot release GitHub action workflow being triggered for each cloned repo when a user syncs their master branch with OpenRefine's master branch. The snapshot build fails on these runs and the e2e tests are published to Cypress Dashboard as duplicate runs.

Changes:
- Don't run the following workflows on forks:
  - snapshot_release.yml - (Should not be run on forks).
  - codeql_java.yml - (Shouldn't be run on forks as these already run on OR's master branch when you commit).
  - codeql_javascript.yml - (Shouldn't be run on forks as these already run on OR's master branch when you commit).
  - unassign_issues.yml - (Should not be run on forks as well).
  
The following screenshot shows 4 workflow runs on Cypress Dashboard that have the same commit from when developers sync their master with the latest OR master branch:

![image](https://github.com/OpenRefine/OpenRefine/assets/42903164/dee3f3f5-a379-461b-936d-44cb7d4bf65b)

The solution is to check `github.repository == 'OpenRefine/OpenRefine'` for each job in any workflows that should only be run in the main repo.

Example from Microsoft's TypeScript repo:
![image](https://github.com/OpenRefine/OpenRefine/assets/42903164/967d46fa-8920-4cb3-9307-bb41078e8ca8)


