### PR TITLE
Fixed Maven tests to work in different locales

### DIFF
--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -125,7 +125,8 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree(
+                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -186,7 +187,8 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree(
+                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -248,7 +250,8 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree(
+                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -322,7 +325,8 @@ public class ExcelImporterTests extends ImporterTest {
     public void readExcelDates() throws IOException {
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree(
+                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -348,11 +352,14 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree(
+                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
+                .readTree(
+                        "{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
         sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
+                .readTree(
+                        "{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -402,11 +409,14 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree(
+                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
+                .readTree(
+                        "{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
         sheets.add(ParsingUtilities.mapper
-                .readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
+                .readTree(
+                        "{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -480,7 +490,8 @@ public class ExcelImporterTests extends ImporterTest {
         for (int s = 0; s < SHEETS; s++) {
             Sheet sheet = wb.createSheet("Test Sheet " + s);
             for (int row = 0; row < ROWS; row++) {
-                createDataRow(sheet, row, date, dateTimeStyle, dateStyle, intStyle, floatStyle, zeroStyle, otherStyle, currencyStyle, 0);
+                createDataRow(sheet, row, date, dateTimeStyle, dateStyle, intStyle, floatStyle, zeroStyle, otherStyle,
+                        currencyStyle, 0);
             }
         }
 
@@ -528,7 +539,8 @@ public class ExcelImporterTests extends ImporterTest {
         for (int s = 0; s < SHEETS; s++) {
             Sheet sheet = wb.createSheet("Test Sheet " + s);
             for (int row = 0; row < ROWS; row++) {
-                createDataRow(sheet, row, NOW, dateTimeStyle, dateStyle, intStyle, floatStyle, zeroStyle, otherStyle, currencyStyle, s);
+                createDataRow(sheet, row, NOW, dateTimeStyle, dateStyle, intStyle, floatStyle, zeroStyle, otherStyle,
+                        currencyStyle, s);
             }
         }
 
@@ -547,9 +559,11 @@ public class ExcelImporterTests extends ImporterTest {
         return file;
     }
 
-    private static void createDataRow(Sheet sheet, int row, LocalDateTime date, CellStyle dateTimeStyle, CellStyle dateStyle,
+    private static void createDataRow(Sheet sheet, int row, LocalDateTime date, CellStyle dateTimeStyle,
+            CellStyle dateStyle,
             CellStyle intStyle,
-            CellStyle floatStyle, CellStyle zeroStyle, CellStyle otherStyle, CellStyle currencyStyle, int extra_columns) {
+            CellStyle floatStyle, CellStyle zeroStyle, CellStyle otherStyle, CellStyle currencyStyle,
+            int extra_columns) {
         int col = 0;
         Row r = sheet.createRow(row);
         Cell c;
@@ -599,9 +613,9 @@ public class ExcelImporterTests extends ImporterTest {
         c.setCellValue(1234.56);
         c.setCellStyle(currencyStyle); // currency should import as float
 
-//    HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
-//    hl.setLabel(cellData.text);
-//    hl.setAddress(cellData.link);
+        //    HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
+        //    hl.setLabel(cellData.text);
+        //    hl.setAddress(cellData.link);
 
         // Create extra columns to ensure sheet(i+1) has more columns than sheet(i)
         for (int i = 0; i < extra_columns; i++) {

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -613,9 +613,9 @@ public class ExcelImporterTests extends ImporterTest {
         c.setCellValue(1234.56);
         c.setCellStyle(currencyStyle); // currency should import as float
 
-        //    HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
-        //    hl.setLabel(cellData.text);
-        //    hl.setAddress(cellData.link);
+        // HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
+        // hl.setLabel(cellData.text);
+        // hl.setAddress(cellData.link);
 
         // Create extra columns to ensure sheet(i+1) has more columns than sheet(i)
         for (int i = 0; i < extra_columns; i++) {

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -480,8 +480,7 @@ public class ExcelImporterTests extends ImporterTest {
         for (int s = 0; s < SHEETS; s++) {
             Sheet sheet = wb.createSheet("Test Sheet " + s);
             for (int row = 0; row < ROWS; row++) {
-                createDataRow(sheet, row, date, dateTimeStyle, dateStyle, intStyle, floatStyle, zeroStyle, otherStyle,
-                        currencyStyle, 0);
+                createDataRow(sheet, row, date, dateTimeStyle, dateStyle, intStyle, floatStyle, zeroStyle, otherStyle, currencyStyle, 0);
             }
         }
 
@@ -529,8 +528,7 @@ public class ExcelImporterTests extends ImporterTest {
         for (int s = 0; s < SHEETS; s++) {
             Sheet sheet = wb.createSheet("Test Sheet " + s);
             for (int row = 0; row < ROWS; row++) {
-                createDataRow(sheet, row, NOW, dateTimeStyle, dateStyle, intStyle, floatStyle, zeroStyle, otherStyle,
-                        currencyStyle, s);
+                createDataRow(sheet, row, NOW, dateTimeStyle, dateStyle, intStyle, floatStyle, zeroStyle, otherStyle, currencyStyle, s);
             }
         }
 
@@ -549,11 +547,9 @@ public class ExcelImporterTests extends ImporterTest {
         return file;
     }
 
-    private static void createDataRow(Sheet sheet, int row, LocalDateTime date, CellStyle dateTimeStyle,
-            CellStyle dateStyle,
+    private static void createDataRow(Sheet sheet, int row, LocalDateTime date, CellStyle dateTimeStyle, CellStyle dateStyle,
             CellStyle intStyle,
-            CellStyle floatStyle, CellStyle zeroStyle, CellStyle otherStyle, CellStyle currencyStyle,
-            int extra_columns) {
+            CellStyle floatStyle, CellStyle zeroStyle, CellStyle otherStyle, CellStyle currencyStyle, int extra_columns) {
         int col = 0;
         Row r = sheet.createRow(row);
         Cell c;
@@ -603,9 +599,9 @@ public class ExcelImporterTests extends ImporterTest {
         c.setCellValue(1234.56);
         c.setCellStyle(currencyStyle); // currency should import as float
 
-        // HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
-        // hl.setLabel(cellData.text);
-        // hl.setAddress(cellData.link);
+//    HSSFHyperlink hl = new HSSFHyperlink(HSSFHyperlink.LINK_URL);
+//    hl.setLabel(cellData.text);
+//    hl.setAddress(cellData.link);
 
         // Create extra columns to ensure sheet(i+1) has more columns than sheet(i)
         for (int i = 0; i < extra_columns; i++) {

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -268,8 +268,8 @@ public class ExcelImporterTests extends ImporterTest {
 
         Assert.assertEquals(project.rows.size(), ROWS);
         Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
-        Assert.assertEquals(((String) project.rows.get(1).getCellValue(0)), NUMBER_FORMAT.format(1.1));
-        Assert.assertEquals(((String) project.rows.get(2).getCellValue(0)), NUMBER_FORMAT.format(2.2));
+        Assert.assertEquals((String) project.rows.get(1).getCellValue(0), "1.1");
+        Assert.assertEquals((String) project.rows.get(2).getCellValue(0), "2.2");
 
         assertEquals((String) project.rows.get(1).getCellValue(1), "FALSE");
         assertEquals((String) project.rows.get(2).getCellValue(1), "TRUE");
@@ -286,8 +286,8 @@ public class ExcelImporterTests extends ImporterTest {
         assertEquals(project.rows.get(1).getCellValue(7), "1");
         assertEquals(project.rows.get(2).getCellValue(7), "2");
 
-        assertEquals(project.rows.get(1).getCellValue(8), String.format("%.2f", 100.0) + "%");
-        assertEquals(project.rows.get(2).getCellValue(8), String.format("%.2f", 200.0) + "%");
+        assertEquals(project.rows.get(1).getCellValue(8), "100.00%");
+        assertEquals(project.rows.get(2).getCellValue(8), "200.00%");
 
         assertEquals(project.rows.get(1).getCellValue(9), "0001");
         assertEquals(project.rows.get(2).getCellValue(9), "0002");
@@ -296,7 +296,7 @@ public class ExcelImporterTests extends ImporterTest {
 
         assertEquals(project.rows.get(ROWS - 1).getCellValue(11), NOW_STRING.substring(0, 10)); // date only
 
-        assertEquals(project.rows.get(ROWS - 1).getCellValue(12), "$" + NUMBER_FORMAT.format(1234.56));
+        assertEquals(project.rows.get(ROWS - 1).getCellValue(12), "$1,234.56");
 
         verify(options, times(1)).get("ignoreLines");
         verify(options, times(1)).get("headerLines");

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -50,6 +50,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
@@ -94,7 +95,6 @@ public class ExcelImporterTests extends ImporterTest {
 
     private static final File xlsFileWithMultiSheets = createSheetsWithDifferentColumns(false);
     private static final File xlsxFileWithMultiSheets = createSheetsWithDifferentColumns(true);
-    private static final NumberFormat NUMBER_FORMAT = DecimalFormat.getInstance();
 
     @Override
     @BeforeTest
@@ -268,8 +268,10 @@ public class ExcelImporterTests extends ImporterTest {
 
         Assert.assertEquals(project.rows.size(), ROWS);
         Assert.assertEquals(project.rows.get(1).cells.size(), COLUMNS);
-        Assert.assertEquals((String) project.rows.get(1).getCellValue(0), "1.1");
-        Assert.assertEquals((String) project.rows.get(2).getCellValue(0), "2.2");
+
+        final NumberFormat numberFormat = DecimalFormat.getInstance(Locale.getDefault());
+        Assert.assertEquals((String) project.rows.get(1).getCellValue(0), numberFormat.format(1.1));
+        Assert.assertEquals((String) project.rows.get(2).getCellValue(0), numberFormat.format(2.2));
 
         assertEquals((String) project.rows.get(1).getCellValue(1), "FALSE");
         assertEquals((String) project.rows.get(2).getCellValue(1), "TRUE");
@@ -286,8 +288,10 @@ public class ExcelImporterTests extends ImporterTest {
         assertEquals(project.rows.get(1).getCellValue(7), "1");
         assertEquals(project.rows.get(2).getCellValue(7), "2");
 
-        assertEquals(project.rows.get(1).getCellValue(8), "100.00%");
-        assertEquals(project.rows.get(2).getCellValue(8), "200.00%");
+        final DecimalFormat decimalFormat = (DecimalFormat) NumberFormat.getNumberInstance(Locale.getDefault());
+        decimalFormat.applyPattern("0.00");
+        assertEquals(project.rows.get(1).getCellValue(8), decimalFormat.format(100.00) + "%");
+        assertEquals(project.rows.get(2).getCellValue(8), decimalFormat.format(200.00) + "%");
 
         assertEquals(project.rows.get(1).getCellValue(9), "0001");
         assertEquals(project.rows.get(2).getCellValue(9), "0002");
@@ -296,7 +300,7 @@ public class ExcelImporterTests extends ImporterTest {
 
         assertEquals(project.rows.get(ROWS - 1).getCellValue(11), NOW_STRING.substring(0, 10)); // date only
 
-        assertEquals(project.rows.get(ROWS - 1).getCellValue(12), "$1,234.56");
+        assertEquals(project.rows.get(ROWS - 1).getCellValue(12), "$" + numberFormat.format(1234.56));
 
         verify(options, times(1)).get("ignoreLines");
         verify(options, times(1)).get("headerLines");

--- a/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ExcelImporterTests.java
@@ -125,8 +125,7 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree(
-                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -187,8 +186,7 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree(
-                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -250,8 +248,7 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree(
-                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -325,8 +322,7 @@ public class ExcelImporterTests extends ImporterTest {
     public void readExcelDates() throws IOException {
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree(
-                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -352,14 +348,11 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree(
-                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         sheets.add(ParsingUtilities.mapper
-                .readTree(
-                        "{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
+                .readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
         sheets.add(ParsingUtilities.mapper
-                .readTree(
-                        "{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
+                .readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);
@@ -409,14 +402,11 @@ public class ExcelImporterTests extends ImporterTest {
 
         ArrayNode sheets = ParsingUtilities.mapper.createArrayNode();
         sheets.add(ParsingUtilities.mapper
-                .readTree(
-                        "{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
+                .readTree("{name: \"file-source#Test Sheet 0\", fileNameAndSheetIndex: \"file-source#0\", rows: 31, selected: true}"));
         sheets.add(ParsingUtilities.mapper
-                .readTree(
-                        "{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
+                .readTree("{name: \"file-source#Test Sheet 1\", fileNameAndSheetIndex: \"file-source#1\", rows: 31, selected: true}"));
         sheets.add(ParsingUtilities.mapper
-                .readTree(
-                        "{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
+                .readTree("{name: \"file-source#Test Sheet 2\", fileNameAndSheetIndex: \"file-source#2\", rows: 31, selected: true}"));
         whenGetArrayOption("sheets", options, sheets);
 
         whenGetIntegerOption("ignoreLines", options, 0);

--- a/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
@@ -48,6 +48,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
+import com.google.refine.messages.OpenRefineMessage;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
@@ -173,8 +174,8 @@ public class ImporterUtilitiesTests extends RefineTest {
         List<String> newColumnNames = new ArrayList<String>();
         Column c0 = ImporterUtilities.getOrAllocateColumn(project, newColumnNames, 0, false);
         Column c1 = ImporterUtilities.getOrAllocateColumn(project, newColumnNames, 1, false);
-        Assert.assertEquals(c0.getName(), "Column 1");
-        Assert.assertEquals(c1.getName(), "Column 2");
+        Assert.assertEquals(c0.getName(), OpenRefineMessage.importer_utilities_column()+" 1");
+        Assert.assertEquals(c1.getName(), OpenRefineMessage.importer_utilities_column()+" 2");
         Assert.assertEquals(newColumnNames.size(), 2);
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
@@ -174,8 +174,8 @@ public class ImporterUtilitiesTests extends RefineTest {
         List<String> newColumnNames = new ArrayList<String>();
         Column c0 = ImporterUtilities.getOrAllocateColumn(project, newColumnNames, 0, false);
         Column c1 = ImporterUtilities.getOrAllocateColumn(project, newColumnNames, 1, false);
-        Assert.assertEquals(c0.getName(), OpenRefineMessage.importer_utilities_column() + " 1");
-        Assert.assertEquals(c1.getName(), OpenRefineMessage.importer_utilities_column() + " 2");
+        Assert.assertEquals(c0.getName(), OpenRefineMessage.importer_utilities_column()+" 1");
+        Assert.assertEquals(c1.getName(), OpenRefineMessage.importer_utilities_column()+" 2");
         Assert.assertEquals(newColumnNames.size(), 2);
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterUtilitiesTests.java
@@ -174,8 +174,8 @@ public class ImporterUtilitiesTests extends RefineTest {
         List<String> newColumnNames = new ArrayList<String>();
         Column c0 = ImporterUtilities.getOrAllocateColumn(project, newColumnNames, 0, false);
         Column c1 = ImporterUtilities.getOrAllocateColumn(project, newColumnNames, 1, false);
-        Assert.assertEquals(c0.getName(), OpenRefineMessage.importer_utilities_column()+" 1");
-        Assert.assertEquals(c1.getName(), OpenRefineMessage.importer_utilities_column()+" 2");
+        Assert.assertEquals(c0.getName(), OpenRefineMessage.importer_utilities_column() + " 1");
+        Assert.assertEquals(c1.getName(), OpenRefineMessage.importer_utilities_column() + " 2");
         Assert.assertEquals(newColumnNames.size(), 2);
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -165,9 +165,12 @@ public class SeparatorBasedImporterTests extends ImporterTest {
             Assert.fail("Exception during file parse", e);
         }
         Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), OpenRefineMessage.importer_utilities_column() + " 1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), OpenRefineMessage.importer_utilities_column() + " 2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), OpenRefineMessage.importer_utilities_column() + " 3");
+        Assert.assertEquals(project.columnModel.columns.get(0).getName(),
+                OpenRefineMessage.importer_utilities_column() + " 1");
+        Assert.assertEquals(project.columnModel.columns.get(1).getName(),
+                OpenRefineMessage.importer_utilities_column() + " 2");
+        Assert.assertEquals(project.columnModel.columns.get(2).getName(),
+                OpenRefineMessage.importer_utilities_column() + " 3");
         Assert.assertEquals(project.rows.size(), 1);
         Assert.assertEquals(project.rows.get(0).cells.size(), 3);
         Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
@@ -338,9 +341,12 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
         Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
         Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.columnModel.columns.get(3).getName(), OpenRefineMessage.importer_utilities_column() + " 4");
-        Assert.assertEquals(project.columnModel.columns.get(4).getName(), OpenRefineMessage.importer_utilities_column() + " 5");
-        Assert.assertEquals(project.columnModel.columns.get(5).getName(), OpenRefineMessage.importer_utilities_column() + " 6");
+        Assert.assertEquals(project.columnModel.columns.get(3).getName(),
+                OpenRefineMessage.importer_utilities_column() + " 4");
+        Assert.assertEquals(project.columnModel.columns.get(4).getName(),
+                OpenRefineMessage.importer_utilities_column() + " 5");
+        Assert.assertEquals(project.columnModel.columns.get(5).getName(),
+                OpenRefineMessage.importer_utilities_column() + " 6");
         Assert.assertEquals(project.rows.size(), 1);
         Assert.assertEquals(project.rows.get(0).cells.size(), 6);
         Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
@@ -466,8 +472,8 @@ public class SeparatorBasedImporterTests extends ImporterTest {
                 "skip2\n" +
                 "data-row1-cell1" + inputSeparator + "data-row1-cell2" + inputSeparator + "data-row1-cell3\n" +
                 "data-row2-cell1" + inputSeparator + "data-row2-cell2" + inputSeparator + "\n" + // missing last data
-                                                                                                 // point of this row on
-                                                                                                 // purpose
+                // point of this row on
+                // purpose
                 "data-row3-cell1" + inputSeparator + "data-row3-cell2" + inputSeparator + "data-row1-cell3";
 
         try {
@@ -529,7 +535,8 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
         Assert.assertEquals(project.rows.size(), 1);
         Assert.assertEquals(project.rows.get(0).cells.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "\"To\n Be\" is often followed by \"or not To\n Be\"");
+        Assert.assertEquals(project.rows.get(0).cells.get(0).value,
+                "\"To\n Be\" is often followed by \"or not To\n Be\"");
         Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
     }
 
@@ -671,6 +678,7 @@ public class SeparatorBasedImporterTests extends ImporterTest {
     }
 
     // --helpers--
+
     /**
      * Used for parameterized testing for both SeparatorParser and TsvCsvParser.
      */
@@ -691,7 +699,8 @@ public class SeparatorBasedImporterTests extends ImporterTest {
             String sep, int limit, int skip, int ignoreLines,
             int headerLines, boolean guessValueType, boolean ignoreQuotes, String quoteCharacter) {
 
-        prepareOptions(sep, limit, skip, ignoreLines, headerLines, guessValueType, ignoreQuotes, quoteCharacter, "[]", false);
+        prepareOptions(sep, limit, skip, ignoreLines, headerLines, guessValueType, ignoreQuotes, quoteCharacter, "[]",
+                false);
     }
 
     protected void prepareOptions(

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -165,12 +165,9 @@ public class SeparatorBasedImporterTests extends ImporterTest {
             Assert.fail("Exception during file parse", e);
         }
         Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(),
-                OpenRefineMessage.importer_utilities_column() + " 1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(),
-                OpenRefineMessage.importer_utilities_column() + " 2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(),
-                OpenRefineMessage.importer_utilities_column() + " 3");
+        Assert.assertEquals(project.columnModel.columns.get(0).getName(), OpenRefineMessage.importer_utilities_column() + " 1");
+        Assert.assertEquals(project.columnModel.columns.get(1).getName(), OpenRefineMessage.importer_utilities_column() + " 2");
+        Assert.assertEquals(project.columnModel.columns.get(2).getName(), OpenRefineMessage.importer_utilities_column() + " 3");
         Assert.assertEquals(project.rows.size(), 1);
         Assert.assertEquals(project.rows.get(0).cells.size(), 3);
         Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
@@ -341,12 +338,9 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
         Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
         Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.columnModel.columns.get(3).getName(),
-                OpenRefineMessage.importer_utilities_column() + " 4");
-        Assert.assertEquals(project.columnModel.columns.get(4).getName(),
-                OpenRefineMessage.importer_utilities_column() + " 5");
-        Assert.assertEquals(project.columnModel.columns.get(5).getName(),
-                OpenRefineMessage.importer_utilities_column() + " 6");
+        Assert.assertEquals(project.columnModel.columns.get(3).getName(), OpenRefineMessage.importer_utilities_column() + " 4");
+        Assert.assertEquals(project.columnModel.columns.get(4).getName(), OpenRefineMessage.importer_utilities_column() + " 5");
+        Assert.assertEquals(project.columnModel.columns.get(5).getName(), OpenRefineMessage.importer_utilities_column() + " 6");
         Assert.assertEquals(project.rows.size(), 1);
         Assert.assertEquals(project.rows.get(0).cells.size(), 6);
         Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
@@ -472,8 +466,8 @@ public class SeparatorBasedImporterTests extends ImporterTest {
                 "skip2\n" +
                 "data-row1-cell1" + inputSeparator + "data-row1-cell2" + inputSeparator + "data-row1-cell3\n" +
                 "data-row2-cell1" + inputSeparator + "data-row2-cell2" + inputSeparator + "\n" + // missing last data
-                // point of this row on
-                // purpose
+                                                                                                 // point of this row on
+                                                                                                 // purpose
                 "data-row3-cell1" + inputSeparator + "data-row3-cell2" + inputSeparator + "data-row1-cell3";
 
         try {
@@ -535,8 +529,7 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
         Assert.assertEquals(project.rows.size(), 1);
         Assert.assertEquals(project.rows.get(0).cells.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value,
-                "\"To\n Be\" is often followed by \"or not To\n Be\"");
+        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "\"To\n Be\" is often followed by \"or not To\n Be\"");
         Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
     }
 
@@ -678,7 +671,6 @@ public class SeparatorBasedImporterTests extends ImporterTest {
     }
 
     // --helpers--
-
     /**
      * Used for parameterized testing for both SeparatorParser and TsvCsvParser.
      */
@@ -699,8 +691,7 @@ public class SeparatorBasedImporterTests extends ImporterTest {
             String sep, int limit, int skip, int ignoreLines,
             int headerLines, boolean guessValueType, boolean ignoreQuotes, String quoteCharacter) {
 
-        prepareOptions(sep, limit, skip, ignoreLines, headerLines, guessValueType, ignoreQuotes, quoteCharacter, "[]",
-                false);
+        prepareOptions(sep, limit, skip, ignoreLines, headerLines, guessValueType, ignoreQuotes, quoteCharacter, "[]", false);
     }
 
     protected void prepareOptions(

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -53,6 +53,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import com.google.refine.messages.OpenRefineMessage;
 import com.google.refine.util.ParsingUtilities;
 
 public class SeparatorBasedImporterTests extends ImporterTest {
@@ -164,9 +165,9 @@ public class SeparatorBasedImporterTests extends ImporterTest {
             Assert.fail("Exception during file parse", e);
         }
         Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "Column 1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "Column 2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "Column 3");
+        Assert.assertEquals(project.columnModel.columns.get(0).getName(), OpenRefineMessage.importer_utilities_column() + " 1");
+        Assert.assertEquals(project.columnModel.columns.get(1).getName(), OpenRefineMessage.importer_utilities_column() + " 2");
+        Assert.assertEquals(project.columnModel.columns.get(2).getName(), OpenRefineMessage.importer_utilities_column() + " 3");
         Assert.assertEquals(project.rows.size(), 1);
         Assert.assertEquals(project.rows.get(0).cells.size(), 3);
         Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
@@ -337,9 +338,9 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
         Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
         Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.columnModel.columns.get(3).getName(), "Column 4");
-        Assert.assertEquals(project.columnModel.columns.get(4).getName(), "Column 5");
-        Assert.assertEquals(project.columnModel.columns.get(5).getName(), "Column 6");
+        Assert.assertEquals(project.columnModel.columns.get(3).getName(), OpenRefineMessage.importer_utilities_column() + " 4");
+        Assert.assertEquals(project.columnModel.columns.get(4).getName(), OpenRefineMessage.importer_utilities_column() + " 5");
+        Assert.assertEquals(project.columnModel.columns.get(5).getName(), OpenRefineMessage.importer_utilities_column() + " 6");
         Assert.assertEquals(project.rows.size(), 1);
         Assert.assertEquals(project.rows.get(0).cells.size(), 6);
         Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeSuite;
@@ -83,7 +84,8 @@ public class ReconOperationTests extends RefineTest {
             "           \"columnName\" : \"researcher\",\n" +
             "           \"expression\" : \"forNonBlank(cell.recon.judgment, v, v, if(isNonBlank(value), \\\"(unreconciled)\\\", \\\"(blank)\\\"))\",\n"
             +
-            "           \"name\" : \"researcher: " + OpenRefineMessage.recon_operation_judgement_facet_name() + "\"\n" +
+            "           \"name\" : \"researcher: " +
+            StringEscapeUtils.escapeJson(OpenRefineMessage.recon_operation_judgement_facet_name()) + "\"\n" +
             "         },\n" +
             "         \"facetOptions\" : {\n" +
             "           \"scroll\" : true\n" +
@@ -95,7 +97,8 @@ public class ReconOperationTests extends RefineTest {
             "           \"columnName\" : \"researcher\",\n" +
             "           \"expression\" : \"cell.recon.best.score\",\n" +
             "           \"mode\" : \"range\",\n" +
-            "           \"name\" : \"researcher: " + OpenRefineMessage.recon_operation_score_facet_name() + "\"\n" +
+            "           \"name\" : \"researcher: " +
+            StringEscapeUtils.escapeJson(OpenRefineMessage.recon_operation_score_facet_name()) + "\"\n" +
             "         },\n" +
             "         \"facetType\" : \"range\"\n" +
             "       } ],\n" +

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * Copyright (C) 2018, OpenRefine contributors
  * All rights reserved.
- *
+ * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ * 
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
- *
+ * 
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- *
+ * 
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.EngineConfig;
+import com.google.refine.messages.OpenRefineMessage;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
@@ -82,7 +83,7 @@ public class ReconOperationTests extends RefineTest {
             "           \"columnName\" : \"researcher\",\n" +
             "           \"expression\" : \"forNonBlank(cell.recon.judgment, v, v, if(isNonBlank(value), \\\"(unreconciled)\\\", \\\"(blank)\\\"))\",\n"
             +
-            "           \"name\" : \"researcher: judgment\"\n" +
+            "           \"name\" : \"researcher: "+ OpenRefineMessage.recon_operation_judgement_facet_name() + "\"\n" +
             "         },\n" +
             "         \"facetOptions\" : {\n" +
             "           \"scroll\" : true\n" +
@@ -94,7 +95,7 @@ public class ReconOperationTests extends RefineTest {
             "           \"columnName\" : \"researcher\",\n" +
             "           \"expression\" : \"cell.recon.best.score\",\n" +
             "           \"mode\" : \"range\",\n" +
-            "           \"name\" : \"researcher: best candidate's score\"\n" +
+            "           \"name\" : \"researcher: " + OpenRefineMessage.recon_operation_score_facet_name() + "\"\n" +
             "         },\n" +
             "         \"facetType\" : \"range\"\n" +
             "       } ],\n" +

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
@@ -1,17 +1,17 @@
 /*******************************************************************************
  * Copyright (C) 2018, OpenRefine contributors
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
- * 
+ *
  * 2. Redistributions in binary form must reproduce the above copyright notice,
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -83,7 +83,7 @@ public class ReconOperationTests extends RefineTest {
             "           \"columnName\" : \"researcher\",\n" +
             "           \"expression\" : \"forNonBlank(cell.recon.judgment, v, v, if(isNonBlank(value), \\\"(unreconciled)\\\", \\\"(blank)\\\"))\",\n"
             +
-            "           \"name\" : \"researcher: "+ OpenRefineMessage.recon_operation_judgement_facet_name() + "\"\n" +
+            "           \"name\" : \"researcher: " + OpenRefineMessage.recon_operation_judgement_facet_name() + "\"\n" +
             "         },\n" +
             "         \"facetOptions\" : {\n" +
             "           \"scroll\" : true\n" +


### PR DESCRIPTION
Fixes #6171 

Changes proposed in this pull request:
- Made it so the following Maven tests do not depend on locale:
  - `readSimpleData_0Header_1Row()`
  - `readSimpleData_RowLongerThanHeader()`
  - `serializeReconProcess()`
  - `readXlsxAsText()`
