### PR TITLE
Make UI update when matching cell

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
@@ -360,7 +360,7 @@ class ReconCellRenderer {
       command,
       params,
       bodyParams,
-      { columnStatsChanged: columnStatsChanged },
+      { cellsChanged: true, columnStatsChanged: columnStatsChanged },
       {
         onDone: function(o) {
           if (o.cell.r) {


### PR DESCRIPTION
Fixes #6236

I was able to reproduce the issue by clicking the 'Match this cell' button in the preview overlay. Before the change, refreshing the page after clicking 'Match this cell' updates that cell's contents.

The UI just needed to update when clicking the 'Match this cell' button.

After:
![match this cell ui fix](https://github.com/OpenRefine/OpenRefine/assets/42903164/7479fb24-1741-4e36-a761-98242596b51d)



Changes proposed in this pull request:
- Make UI update when clicking the 'Match this cell' button. 