### PR TITLE
Make sure encoding is set before fetching writer. Fixes #6063

### DIFF
--- a/main/src/com/google/refine/commands/Command.java
+++ b/main/src/com/google/refine/commands/Command.java
@@ -276,9 +276,9 @@ public abstract class Command {
 
         HistoryEntry historyEntry = project.processManager.queueProcess(process);
         if (historyEntry != null) {
-            Writer w = response.getWriter();
             response.setCharacterEncoding("UTF-8");
             response.setHeader("Content-Type", "application/json");
+            Writer w = response.getWriter();
             ParsingUtilities.defaultWriter.writeValue(w, new HistoryEntryResponse(historyEntry));
 
             w.flush();
@@ -307,7 +307,7 @@ public abstract class Command {
 
     static protected void respond(HttpServletResponse response, String status, String message)
             throws IOException {
-
+        response.setCharacterEncoding("UTF-8");
         Writer w = response.getWriter();
         JsonGenerator writer = ParsingUtilities.mapper.getFactory().createGenerator(w);
         writer.writeStartObject();


### PR DESCRIPTION
The response encoding was being set after the writer was already created, so it was using the wrong (default) encoding.

Also fix another place where UTF-8 encoding is not being set for a response.

Fixes #6063

I've got a more general refactoring and cleanup of the JSON responses in progress, but this fixes the immediate issue which was reported.