### PR TITLE
Set IntelliJ setting for Javascript indent to 2 spaces

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -25,5 +25,12 @@
     <editorconfig>
       <option name="ENABLED" value="false" />
     </editorconfig>
+    <codeStyleSettings language="JavaScript">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="8" />
+      </indentOptions>
+    </codeStyleSettings>
   </code_scheme>
 </component>


### PR DESCRIPTION
No issue.

Changes proposed in this pull request:
- Sets IntelliJ to match the bulk of our historical Javascript files which use a 2 space indent.

This can be changed to track any new standard we choose.