### PR TITLE
delays the disappearance of preview by 250 milliseconds

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
@@ -443,25 +443,39 @@ class ReconCellRenderer {
    * Sets up a preview widget to appear when hovering the given DOM element.
    */
   previewOnHover(service, candidate, hoverElement, coreElement, showActions, rowIndex, cellIndex, cell, cellUI) {
-      var self = this;
-      var preview = null;
-      if ((service) && (service.preview)) {
-          preview = service.preview;
-      }
+    var self = this;
+    var preview = null;
+    if (service && service.preview) {
+        preview = service.preview;
+    }
 
-      if (preview) {
-          var dismissCallback = null;
-          hoverElement.on('mouseenter',function(evt) {
-          if (!evt.metaKey && !evt.ctrlKey) {
-              dismissCallback = self.previewCandidateTopic(candidate, coreElement, preview, showActions, rowIndex, cellIndex, cell, cellUI);
-              evt.preventDefault();
-          }
-          }).on('mouseleave',function(evt) {
-          if(dismissCallback !== null) {
-              dismissCallback();
-          }
-          });
-      }
-  };
+    var dismissCallback = null;
+    var previewDelay = 250; // Set the delay time in milliseconds 
+
+    hoverElement.on('mouseenter', function (evt) {
+        if (!evt.metaKey && !evt.ctrlKey) {
+          
+            if (dismissCallback !== null) {
+                clearTimeout(dismissCallback);
+            }
+
+            dismissCallback = self.previewCandidateTopic(candidate, coreElement, preview, showActions, rowIndex, cellIndex, cell, cellUI);
+            evt.preventDefault();
+        }
+    }).on('mouseleave', function (evt) {
+        if (dismissCallback !== null) {
+            setTimeout(function () {
+                self.dismissPreview(dismissCallback);
+            }, previewDelay);
+        }
+    });
+};
+
+dismissPreview(dismissCallback) {
+    if (dismissCallback !== null) {
+        dismissCallback();
+        dismissCallback = null;
+    }
+}
 
 }


### PR DESCRIPTION
Fixes #3144 

Changes proposed in this pull request:
- Now the preview does not disappear quickly and gives enough time to the user to select any option in the preview if they want.
- The preview stays on the screen for 250ms which can be changed easily as a previewDelay variable is added.
