### PR TITLE
Fix e2e_tests (Cypress). Fixes #6271

### DIFF
--- a/refine
+++ b/refine
@@ -381,6 +381,15 @@ e2e_tests() {
     add_option "-Drefine.autoreload=false"
     add_option "-Dbutterfly.autoreload=false"
 
+    check_running
+
+    if [ "$RUNNING" ] ; then
+        echo "An OpenRefine server is already running. Please shut it down so that we can start a test server."
+        exit
+    fi
+
+    echo "Starting OpenRefine server"
+
     run fork > /dev/null
 
     echo "Waiting for OpenRefine to load..."

--- a/refine
+++ b/refine
@@ -364,6 +364,10 @@ e2e_tests() {
         CYPRESS_BROWSER="electron"
     fi
 
+    if [ -z "$CYPRESS_SPECS" ] ; then
+        CYPRESS_SPECS="cypress/e2e/**/*.cy.js"
+    fi
+
     if [ ! -z "$CYPRESS_PROJECT_ID" ] && [ ! -z "$CYPRESS_RECORD_KEY" ] ; then
         CYPRESS_RECORD=1
         echo "Tests will be recorded in Cypress Dashboard"
@@ -392,11 +396,11 @@ e2e_tests() {
     # Cypress needs a unique group id
     # We're hashing the list of files to generate such Group Id
     CYPRESS_GROUP=$(echo $CYPRESS_BROWSER$CYPRESS_SPECS | shasum)
-    CYPRESS_RUN_CMD="yarn --cwd ./main/tests/cypress run cypress run --spec "$CYPRESS_SPECS" --browser $CYPRESS_BROWSER --group "$CYPRESS_GROUP" --headless --quiet --reporter list --env DISABLE_PROJECT_CLEANUP=1,OPENREFINE_URL=http://$REFINE_HOST_INTERNAL:$REFINE_PORT"
+    CYPRESS_RUN_CMD="yarn --cwd ./main/tests/cypress run cypress run --spec "$CYPRESS_SPECS" --browser $CYPRESS_BROWSER  --headless --quiet --reporter list --env DISABLE_PROJECT_CLEANUP=1,OPENREFINE_URL=http://$REFINE_HOST_INTERNAL:$REFINE_PORT"
     if [ "$CYPRESS_RECORD" = "1" ] ; then
         # if tests are recorded, project id is added to env vars, and --record flag is added to the cmd-line
         export CYPRESS_PROJECT_ID=$CYPRESS_PROJECT_ID
-        CYPRESS_RUN_CMD="$CYPRESS_RUN_CMD --record --key $CYPRESS_RECORD_KEY --ci-build-id=$CYPRESS_CI_BUILD_ID --tag $CYPRESS_BROWSER"
+        CYPRESS_RUN_CMD="$CYPRESS_RUN_CMD --record --key $CYPRESS_RECORD_KEY --ci-build-id=$CYPRESS_CI_BUILD_ID --tag $CYPRESS_BROWSER --group "$CYPRESS_GROUP""
     fi
     export MOZ_FORCE_DISABLE_E10S=1
     echo $CYPRESS_RUN_CMD


### PR DESCRIPTION
Fixes #6271 

Changes proposed in this pull request:
- provide default specs definition of all specs if one is not provided
- don't set group unless recording
- don't silently fail if an OpenRefine server is already running 
