### PR TITLE
Remove 'Access service API' link from reconciliation dialog

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -425,7 +425,6 @@
     "core-project/continue-remaining": "Continue with the remaining operations?",
     "core-project/undo": "Undo",
     "core-recon/add-std-srv": "Add standard service",
-    "core-recon/access-service": "Access service API",
     "core-recon/service-documentation":"Service documentation",
     "core-recon/cell-type": "Reconcile each cell to an entity of one of these types:",
     "core-recon/col-detail": "Also use relevant details from other columns:",

--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.html
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.html
@@ -2,8 +2,6 @@
   <div class="grid-layout layout-normal layout-full grid-layout-for-ui"><table>
     <tr>
       <td colspan="2" style="text-align: right;">
-        <a href="" target="_blank" bind="rawServiceLink"><span bind="or_proc_access"></span>
-          <span class="ui-icon ui-icon-link" style="display: inline-block"></span></a>
         <a href="" target="_blank" bind="documentationLink"><span bind="or_proc_accessDocumentation"></span>
           <span class="ui-icon ui-icon-link" style="display: inline-block"></span></a>
       </td>

--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -89,7 +89,6 @@ ReconStandardServicePanel.prototype._constructUI = function() {
   this._elmts = DOM.bind(this._panel);
   this._elmts.or_proc_accessDocumentation.html($.i18n('core-recon/service-documentation'));
   this._elmts.automatchCheck[0].checked=JSON.parse(Refine.getPreference("ui.reconciliation.automatch", true));
-  this._elmts.or_proc_access.html($.i18n('core-recon/access-service'));
   this._elmts.or_proc_cellType.html($.i18n('core-recon/cell-type'));
   this._elmts.or_proc_colDetail.html($.i18n('core-recon/col-detail'));
   this._elmts.or_proc_againstType.html($.i18n('core-recon/against-type'));
@@ -98,7 +97,6 @@ ReconStandardServicePanel.prototype._constructUI = function() {
   this._elmts.or_proc_max_candidates.html($.i18n('core-recon/max-candidates'));
   this._elmts.typeInput.attr('aria-label',$.i18n('core-recon/type'))
 
-  this._elmts.rawServiceLink.attr("href", this._service.url);
   this._elmts.documentationLink.css("display", "none");
   if(this._service.documentation) {
     this._elmts.documentationLink.attr("href", this._service.documentation);


### PR DESCRIPTION
Follow-up to #6118 suggested by #6184.

Because the accessing the API directly with the browser is rarely useful for users, I think we don't need to show this link in this dialog. The full URL is visible in the previous step (service selection), which enables users to copy the link (for instance to share it with someone else who would like to install the same service).

@Abbe98 note that the problem you want to solve in #6184 (the dialog being pushed down by the documentation link when it is present) is still here - it might make sense to put this documentation link in a totally different place so that this does not happen. But then the solution will be different from the one you proposed in #6184.

## For a service with a documentation link

### Before
![image](https://github.com/OpenRefine/OpenRefine/assets/309908/6f9cde9d-8ecf-43c4-8555-9ad4df40e46f)

### After
![image](https://github.com/OpenRefine/OpenRefine/assets/309908/3f5895d3-508f-4f70-a8b9-d94c7f145709)

## For a service without a documentation link

### Before
![image](https://github.com/OpenRefine/OpenRefine/assets/309908/c168c994-79ef-473d-93cf-72a59a3b92a9)

### After
![image](https://github.com/OpenRefine/OpenRefine/assets/309908/df987441-aa24-42df-9894-215b6cd69ae0)
