### PR TITLE
Fix setting the log level from the command line

### DIFF
--- a/refine.bat
+++ b/refine.bat
@@ -171,7 +171,6 @@ set REFINE_LIB_DIR=server\target\lib
 :gotLibDir
 
 if not "%REFINE_VERBOSITY%" == "" goto gotVerbosity
-set REFINE_VERBOSITY=info
 :gotVerbosity
 set OPTS=%OPTS% -Drefine.verbosity=%REFINE_VERBOSITY%
 

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -131,9 +131,7 @@ public class Refine {
         }
     }
 
-
-
-        public void init(String[] args) throws Exception {
+    public void init(String[] args) throws Exception {
 
         RefineServer server = new RefineServer();
         server.init(iface, port, host);

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -100,7 +100,7 @@ public class Refine {
         // set the log verbosity level
         String logLevelArg = Configurations.get("refine.verbosity");
         if (logLevelArg != null && !logLevelArg.isEmpty()) {
-            Configurator.setAllLevels(LogManager.getRootLogger().getName(),Level.toLevel(Configurations.get("refine.verbosity", "info")));
+            Configurator.setAllLevels(LogManager.getRootLogger().getName(),Level.toLevel(logLevelArg));
         }
 
         port = Configurations.getInteger("refine.port", DEFAULT_PORT);

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -100,7 +100,7 @@ public class Refine {
         // set the log verbosity level
         String logLevelArg = Configurations.get("refine.verbosity");
         if (logLevelArg != null && !logLevelArg.isEmpty()) {
-            Configurator.setAllLevels(LogManager.getRootLogger().getName(),Level.toLevel(logLevelArg));
+            Configurator.setAllLevels(LogManager.getRootLogger().getName(), Level.toLevel(logLevelArg));
         }
 
         port = Configurations.getInteger("refine.port", DEFAULT_PORT);

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -55,8 +55,7 @@ import com.google.util.threads.ThreadPoolExecutorAdapter;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
@@ -99,7 +98,10 @@ public class Refine {
         // System.setProperty("debug","true");
 
         // set the log verbosity level
-        setRootLoggerLevel(Configurations.get("refine.verbosity"));
+        String logLevelArg = Configurations.get("refine.verbosity");
+        if (logLevelArg != null && !logLevelArg.isEmpty()) {
+            Configurator.setAllLevels(LogManager.getRootLogger().getName(),Level.toLevel(Configurations.get("refine.verbosity", "info")));
+        }
 
         port = Configurations.getInteger("refine.port", DEFAULT_PORT);
         iface = Configurations.get("refine.interface", DEFAULT_IFACE);
@@ -112,23 +114,6 @@ public class Refine {
         Refine refine = new Refine();
 
         refine.init(args);
-    }
-
-    private static void setRootLoggerLevel(String logLevelArg) {
-        Level rootLogLevel = Level.toLevel(logLevelArg);
-
-        if (logLevelArg != null && !logLevelArg.isEmpty()) {
-            // Set root logger level
-            LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
-            loggerContext.getRootLogger().setLevel(rootLogLevel);
-
-            // Set level for all loggers
-            Configuration configuration = loggerContext.getConfiguration();
-            configuration.getLoggers().forEach((name, loggerConfig) -> {
-                org.apache.logging.log4j.Logger logger = LogManager.getLogger(name);
-                ((org.apache.logging.log4j.core.Logger) logger).setLevel(rootLogLevel);
-            });
-        }
     }
 
     public void init(String[] args) throws Exception {

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -54,6 +54,7 @@ import javax.swing.JFrame;
 import com.google.util.threads.ThreadPoolExecutorAdapter;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
@@ -79,7 +80,7 @@ public class Refine {
     static private String host;
     static private String iface;
 
-    final static Logger logger = LoggerFactory.getLogger("refine");
+    final static org.apache.log4j.Logger logger = LogManager.getLogger("refine");
 
     public static void main(String[] args) throws Exception {
 
@@ -96,7 +97,11 @@ public class Refine {
         // System.setProperty("debug","true");
 
         // set the log verbosity level
-        org.apache.log4j.Logger.getRootLogger().setLevel(Level.toLevel(Configurations.get("refine.verbosity", "info")));
+        logger.setLevel(Level.toLevel(Configurations.get("refine.verbosity", "info")));
+
+        logger.info("This is info");
+        logger.warn("This is warning");
+        logger.debug("This is debug");
 
         port = Configurations.getInteger("refine.port", DEFAULT_PORT);
         iface = Configurations.get("refine.interface", DEFAULT_IFACE);

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -54,6 +54,7 @@ import javax.swing.JFrame;
 import com.google.util.threads.ThreadPoolExecutorAdapter;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
@@ -79,7 +80,7 @@ public class Refine {
     static private String host;
     static private String iface;
 
-    final static Logger logger = LoggerFactory.getLogger("refine");
+    final static org.apache.log4j.Logger logger = LogManager.getLogger("refine");
 
     public static void main(String[] args) throws Exception {
 

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -54,7 +54,6 @@ import javax.swing.JFrame;
 import com.google.util.threads.ThreadPoolExecutorAdapter;
 import org.apache.commons.lang.SystemUtils;
 import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.Server;
@@ -80,7 +79,7 @@ public class Refine {
     static private String host;
     static private String iface;
 
-    final static org.apache.log4j.Logger logger = LogManager.getLogger("refine");
+    final static Logger logger = LoggerFactory.getLogger("refine");
 
     public static void main(String[] args) throws Exception {
 
@@ -98,10 +97,6 @@ public class Refine {
 
         // set the log verbosity level
         logger.setLevel(Level.toLevel(Configurations.get("refine.verbosity", "info")));
-
-        logger.info("This is info");
-        logger.warn("This is warning");
-        logger.debug("This is debug");
 
         port = Configurations.getInteger("refine.port", DEFAULT_PORT);
         iface = Configurations.get("refine.interface", DEFAULT_IFACE);


### PR DESCRIPTION
Fixes #6286

Changes proposed in this pull request:
-  In the existing code, we are using slf4j as below

         Logger logger = LoggerFactory.getLogger("refine");
         logger.warn("No refine.host specified while binding to interface 0.0.0.0, guessing localhost.");

   Whereas for setting the logging level, we were setting it for log4j rootLogger as below
```
   org.apache.log4j.Logger.getRootLogger().setLevel(Level.toLevel(Configurations.get("refine.verbosity", "info")));
```
   Hence the refine logger was defaulting to the value mentioned in the log4j2.properties.

```
   logger.refine.name = refine
   logger.refine.level = info
```

- I have used the log4j logger
```
  final static org.apache.log4j.Logger logger = LogManager.getLogger("refine");
```
  and set the logging level for it. This resolves the issue.

To test this change, i had added 3 loggers for simplicity (not checked in).
I tried giving values as info, warn and debug to 
`.\refine /v`
The logging level was reflected correctly each time. Please find attached screenshots for testing evidence.



![warn](https://github.com/OpenRefine/OpenRefine/assets/37299522/00e50c3f-898c-4f3c-baae-1624605c8789)


![debug](https://github.com/OpenRefine/OpenRefine/assets/37299522/43bc19a1-7696-489e-95ed-04e94d90ae61)


![info](https://github.com/OpenRefine/OpenRefine/assets/37299522/3811484d-1f22-4409-8a2b-79c385ac8bcc)
