### PR TITLE
Update Advisory Committee members

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -90,15 +90,16 @@ Advisory Committee members:
 * Can be part of the Admin team for the project on GitHub
 
 #### Conflict of Interest
-In the event of any conflict of interest (a Committee Member, their family member, or someone with whom the Committee Member has a close academic or employment relationship is involved in a decision), the Committee Member must immediately notify other Committee Members. The Committee Member will be asked to recuse themselves from ongoing conversations, and decision process regarding the Transaction.  
+In the event of any conflict of interest (a Committee Member, their family member, or someone with whom the Committee Member has a close academic or employment relationship is involved in a decision), the Committee Member must immediately notify other Committee Members. The Committee Members will be asked to recuse themselves from ongoing conversations and decision processes regarding the Transaction.  
 
 #### Current list of Advisory Committee members
 * Jan Ainali
 * Antonin Delpeuch
-* [Open Position]
+* Julie Faure-Lacroix
+* Esther Jackson
 
 ### Project Manager
-OpenRefine's Project Manager (paid position) works closely with OpenRefine’s advisory and steering committees, and with its communities of users and contributors.
+OpenRefine's Project Manager (paid position) works closely with OpenRefine’s advisory and steering committees and with its communities of users and contributors.
 
 The Project Manager:
 * Helps to improve OpenRefine's governance and community diversity


### PR DESCRIPTION
Update the governance document to include the two new advisory committee members. See the PR for the official announcement via the blog [openrefine.org/pull/290](https://github.com/OpenRefine/openrefine.org/pull/290)