### PR TITLE
Improve GREL operators. Fixes #6341 Closes #6340

### DIFF
--- a/main/src/com/google/refine/grel/Parser.java
+++ b/main/src/com/google/refine/grel/Parser.java
@@ -90,6 +90,8 @@ public class Parser {
 
         while (_token != null &&
                 _token.type == TokenType.Operator &&
+                // FIXME: This filters the <> operator which is returned from the Scanner. Fix one or the other
+                // so that they agree with each other on whether it's an operator or not.
                 ">=<==!=".indexOf(_token.text) >= 0) {
 
             String op = _token.text;

--- a/main/src/com/google/refine/grel/Scanner.java
+++ b/main/src/com/google/refine/grel/Scanner.java
@@ -286,6 +286,8 @@ public class Scanner {
         } else if (c == '<') {
             if (_index < _limit - 1 &&
                     (_text.charAt(_index + 1) == '=' ||
+                    // FIXME: Although this will scan <> as an operator, it will get filtered out in the
+                    // Parser without generating an error
                             _text.charAt(_index + 1) == '>')) {
 
                 _index += 2;

--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -348,7 +348,12 @@ public class RefineTest {
             throws ParsingException {
         Evaluable eval = MetaParser.parse("grel:" + test[0]);
         Object result = eval.evaluate(bindings);
-        Assert.assertEquals(result.toString(), test[1], "Wrong result for expression: " + test[0]);
+        if (test[1] != null) {
+            Assert.assertNotNull(result, "Expected " + test[1] + " for test " + test[0]);
+            Assert.assertEquals(result.toString(), test[1], "Wrong result for expression: " + test[0]);
+        } else {
+            Assert.assertNull(result, "Wrong result for expression: " + test[0]);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #6341. Closes #6340

- restrict string concatenation (+) to cases where at least one operand is a string (to avoid things like concatenating two dates as strings)
- Add support for dates and strings to comparison operators Strings use a collator for the default locale with normalized decomposition for the comparisons.
- Above implementation uses Comparable, so any future data types that implement that interface should get supported for free
- Add a bunch more tests
