### PR TITLE
Use real TSV exporter/importer. Fixes #2071

### DIFF
--- a/main/src/com/google/refine/importers/ImporterUtilities.java
+++ b/main/src/com/google/refine/importers/ImporterUtilities.java
@@ -68,6 +68,7 @@ public class ImporterUtilities {
 
                 try {
                     double d = Double.parseDouble(text2);
+                    // FIXME: Why do we skip Infinities and NaNs?
                     if (!Double.isInfinite(d) && !Double.isNaN(d)) {
                         return d;
                     }

--- a/main/tests/server/src/com/google/refine/exporters/TsvExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/TsvExporterTests.java
@@ -137,7 +137,7 @@ public class TsvExporterTests extends RefineTest {
 
         assertEqualsSystemLineEnding(writer.toString(), "column0\tcolumn1\tcolumn2\n" +
                 "row0cell0\trow0cell1\trow0cell2\n" +
-                "row1cell0\t\"line\n\n\nbreak\"\trow1cell2\n" +
+                "row1cell0\tline\\n\\n\\nbreak\trow1cell2\n" +
                 "row2cell0\trow2cell1\trow2cell2\n");
     }
 
@@ -154,7 +154,7 @@ public class TsvExporterTests extends RefineTest {
 
         assertEqualsSystemLineEnding(writer.toString(), "column0\tcolumn1\tcolumn2\n" +
                 "row0cell0\trow0cell1\trow0cell2\n" +
-                "row1cell0\t\"with\t tab\"\trow1cell2\n" +
+                "row1cell0\twith\\t tab\trow1cell2\n" +
                 "row2cell0\trow2cell1\trow2cell2\n");
     }
 
@@ -171,7 +171,7 @@ public class TsvExporterTests extends RefineTest {
 
         assertEqualsSystemLineEnding(writer.toString(), "column0\tcolumn1\tcolumn2\n" +
                 "row0cell0\trow0cell1\trow0cell2\n" +
-                "row1cell0\t\"line has \"\"quote\"\"\"\trow1cell2\n" +
+                "row1cell0\tline has \"quote\"\trow1cell2\n" +
                 "row2cell0\trow2cell1\trow2cell2\n");
     }
 

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -643,6 +643,29 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         Assert.assertEquals((String) project.rows.get(0).cells.get(3).value, "data4");
     }
 
+    @Test
+    public void readTsvWithEmbeddedEscapes() {
+        // Be careful of whitespace at field boundaries which will get trimmed by trimWhitespace = true
+        // Also take care to make sure backslashes are escaped correctly for Java
+        String input = "da\\rta1\tdat\\ta2\tdata3\tdat\\na4";
+        StringReader reader = new StringReader(input);
+
+        prepareOptions("\t", -1, 0, 0, 0, false, true);
+
+        try {
+            parseOneFile(SUT, reader);
+        } catch (Exception e) {
+            Assert.fail("Exception during file parse", e);
+        }
+
+        Assert.assertEquals(project.rows.size(), 1);
+        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
+        Assert.assertEquals((String) project.rows.get(0).cells.get(0).value, "da\rta1");
+        Assert.assertEquals((String) project.rows.get(0).cells.get(1).value, "dat\ta2");
+        Assert.assertEquals((String) project.rows.get(0).cells.get(2).value, "data3");
+        Assert.assertEquals((String) project.rows.get(0).cells.get(3).value, "dat\na4");
+    }
+
     // ---------------------guess separators------------------------
 
     @Test


### PR DESCRIPTION
Fixes #2071

Changes proposed in this pull request:
- Don't escape quotes when writing TSV format
- Escape \n and \r as is common practice
- Adjust tests to match desired behavior (they were written over a decade ago to match the observed behavior of the CSV library rather than the industry practice)
- Switch to real TSV parser for case where \t is the separator and there are no "exotic" options (so users can still use the CSV importer with \t if they need fancy quote support or something similar)
- Add test for unescaping of \t, \n, \r
