### PR TITLE
Deal with localized numbers. Fixes OpenRefine#6351

### DIFF
--- a/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/excel-parser-ui.html
@@ -24,19 +24,19 @@
       <tr>
         <td width="1%"><input type="checkbox" bind="ignoreCheckbox" id="$ignore" /></td>
         <td><label for="$ignore" id="or-import-ignore"></label></td>
-        <td><input bind="ignoreInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="ignoreInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$ignore" id="or-import-lines"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="headerLinesCheckbox" id="$headers" /></td>
         <td><label for="$headers" id="or-import-parse"></label></td>
-        <td><input bind="headerLinesInput" spellcheck="false" type="text" class="lightweight" size="2" value="1" />
+        <td><input bind="headerLinesInput" type="number" class="lightweight" size="7" value="1" />
           <label for="$headers" id="or-import-header"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="skipCheckbox" id="$skip" /></td>
         <td><label for="$skip" id="or-import-discard"></label></td>
-        <td><input bind="skipInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="skipInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$skip" id="or-import-rows"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="limitCheckbox" id="$limit" /></td>
         <td><label for="$limit" id="or-import-load"></label></td>
-        <td><input bind="limitInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="limitInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$limit" id="or-import-rows2"></label></td></tr>
     </table></div></td>
 

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/fixed-width-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/fixed-width-parser-ui.html
@@ -28,19 +28,19 @@
     <td><div class="grid-layout layout-tightest"><table>
       <tr><td width="1%"><input type="checkbox" bind="ignoreCheckbox" id="$ignore" /></td>
         <td><label for="$ignore" id="or-import-ignore"></label></td>
-        <td><input bind="ignoreInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="ignoreInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$ignore" id="or-import-lines"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="headerLinesCheckbox" id="$headers" /></td>
         <td><label for="$headers" id="or-import-parse"></label></td>
-        <td><input bind="headerLinesInput" spellcheck="false" type="text" class="lightweight" size="2" value="1" />
+        <td><input bind="headerLinesInput" type="number" class="lightweight" size="7" value="1" />
           <label for="$headers" id="or-import-header"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="skipCheckbox" id="$skip" /></td>
         <td><label for="$skip" id="or-import-discard"></label></td>
-        <td><input bind="skipInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="skipInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$skip" id="or-import-rows"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="limitCheckbox" id="$limit" /></td>
         <td><label for="$limit" id="or-import-load"></label></td>
-        <td><input bind="limitInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="limitInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$limit" id="or-import-rows2"></label></td></tr>
     </table></div></td>
     

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/json-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/json-parser-ui.html
@@ -17,7 +17,7 @@
     <td><div class="grid-layout layout-tightest"><table>
       <tr><td width="1%"><input type="checkbox" bind="limitCheckbox" id="$limit" /></td>
         <td><label for="$limit" id="or-import-load"></label></td>
-        <td><input bind="limitInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="limitInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$limit" id="or-import-rows"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="storeEmptyStringsCheckbox" id="$store-empty-strings" value=true/></td>
         <td colspan="2"><label for="$store-empty-strings" id="or-import-preserve"></label></td></tr>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/line-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/line-based-parser-ui.html
@@ -58,15 +58,15 @@
     <td><div class="grid-layout layout-tightest"><table>
       <tr><td width="1%"><input type="checkbox" bind="ignoreCheckbox" id="$ignore" /></td>
         <td><label for="$ignore" id="or-import-ignore"></label></td>
-        <td><input bind="ignoreInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="ignoreInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$ignore" id="or-import-lines"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="skipCheckbox" id="$skip" /></td>
         <td><label for="$skip" id="or-import-discard"></label></td>
-        <td><input bind="skipInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="skipInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$skip" id="or-import-rows"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="limitCheckbox" id="$limit" /></td>
         <td><label for="$limit" id="or-import-load"></label></td>
-        <td><input bind="limitInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="limitInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$limit" id="or-import-rows2"></label></td></tr>
     </table></div></td>
   </tr>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
@@ -89,7 +89,7 @@
                 <label for="$ignore" id="or-import-ignore"></label>
               </td>
               <td>
-                <input bind="ignoreInput" spellcheck="false" type="number" class="lightweight" size="2" value="0" />
+                <input bind="ignoreInput" spellcheck="false" type="number" class="lightweight" size="7" value="0" />
                 <label for="$ignore" id="or-import-lines"></label>
               </td>
             </tr>
@@ -104,7 +104,7 @@
                 <label for="$headers" id="or-import-parse"></label>
               </td>
               <td>
-                <input bind="headerLinesInput" spellcheck="false" type="number" class="lightweight" size="2" value="1" />
+                <input bind="headerLinesInput" spellcheck="false" type="number" class="lightweight" size="7" value="1" />
                 <label for="$headers" id="or-import-header"></label>
               </td>
             </tr>
@@ -126,7 +126,7 @@
               </td>
               <td width="100px"><label for="$skip" id="or-import-discard"></label></td>
               <td>
-                <input bind="skipInput" spellcheck="false" type="number" class="lightweight" size="2" value="0" />
+                <input bind="skipInput" spellcheck="false" type="number" class="lightweight" size="7" value="0" />
                 <label for="$skip" id="or-import-rows"></label>
               </td>
             </tr>
@@ -136,7 +136,7 @@
               </td>
               <td><label for="$limit" id="or-import-load"></label></td>
               <td>
-                <input bind="limitInput" spellcheck="false" type="number" class="lightweight" size="2" value="0" />
+                <input bind="limitInput" spellcheck="false" type="number" class="lightweight" size="7" value="0" />
                 <label for="$limit" id="or-import-rows2"></label>
               </td>
             </tr>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
@@ -89,7 +89,7 @@
                 <label for="$ignore" id="or-import-ignore"></label>
               </td>
               <td>
-                <input bind="ignoreInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+                <input bind="ignoreInput" spellcheck="false" type="number" class="lightweight" size="2" value="0" />
                 <label for="$ignore" id="or-import-lines"></label>
               </td>
             </tr>
@@ -104,7 +104,7 @@
                 <label for="$headers" id="or-import-parse"></label>
               </td>
               <td>
-                <input bind="headerLinesInput" spellcheck="false" type="text" class="lightweight" size="2" value="1" />
+                <input bind="headerLinesInput" spellcheck="false" type="number" class="lightweight" size="2" value="1" />
                 <label for="$headers" id="or-import-header"></label>
               </td>
             </tr>
@@ -126,7 +126,7 @@
               </td>
               <td width="100px"><label for="$skip" id="or-import-discard"></label></td>
               <td>
-                <input bind="skipInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+                <input bind="skipInput" spellcheck="false" type="number" class="lightweight" size="2" value="0" />
                 <label for="$skip" id="or-import-rows"></label>
               </td>
             </tr>
@@ -136,7 +136,7 @@
               </td>
               <td><label for="$limit" id="or-import-load"></label></td>
               <td>
-                <input bind="limitInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+                <input bind="limitInput" spellcheck="false" type="number" class="lightweight" size="2" value="0" />
                 <label for="$limit" id="or-import-rows2"></label>
               </td>
             </tr>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.html
@@ -89,7 +89,7 @@
                 <label for="$ignore" id="or-import-ignore"></label>
               </td>
               <td>
-                <input bind="ignoreInput" spellcheck="false" type="number" class="lightweight" size="7" value="0" />
+                <input bind="ignoreInput" type="number" class="lightweight" size="7" value="0" />
                 <label for="$ignore" id="or-import-lines"></label>
               </td>
             </tr>
@@ -104,7 +104,7 @@
                 <label for="$headers" id="or-import-parse"></label>
               </td>
               <td>
-                <input bind="headerLinesInput" spellcheck="false" type="number" class="lightweight" size="7" value="1" />
+                <input bind="headerLinesInput" type="number" class="lightweight" size="7" value="1" />
                 <label for="$headers" id="or-import-header"></label>
               </td>
             </tr>
@@ -126,7 +126,7 @@
               </td>
               <td width="100px"><label for="$skip" id="or-import-discard"></label></td>
               <td>
-                <input bind="skipInput" spellcheck="false" type="number" class="lightweight" size="7" value="0" />
+                <input bind="skipInput" type="number" class="lightweight" size="7" value="0" />
                 <label for="$skip" id="or-import-rows"></label>
               </td>
             </tr>
@@ -136,7 +136,7 @@
               </td>
               <td><label for="$limit" id="or-import-load"></label></td>
               <td>
-                <input bind="limitInput" spellcheck="false" type="number" class="lightweight" size="7" value="0" />
+                <input bind="limitInput" type="number" class="lightweight" size="7" value="0" />
                 <label for="$limit" id="or-import-rows2"></label>
               </td>
             </tr>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
@@ -78,7 +78,7 @@ Refine.SeparatorBasedParserUI.prototype.getOptions = function() {
 
   var parseIntDefault = function(s, def) {
     try {
-      var n = parseInt(s.split(".")[0].match(/\d+/g).join(""),10);
+      var n = parseInt(s);
       if (!isNaN(n)) {
         return n;
       }

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/separator-based-parser-ui.js
@@ -78,7 +78,7 @@ Refine.SeparatorBasedParserUI.prototype.getOptions = function() {
 
   var parseIntDefault = function(s, def) {
     try {
-      var n = parseInt(s,10);
+      var n = parseInt(s.split(".")[0].match(/\d+/g).join(""),10);
       if (!isNaN(n)) {
         return n;
       }

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.html
@@ -6,11 +6,11 @@
 
       <tr><td width="1%"><input type="checkbox" bind="headerLinesCheckbox" id="$headers" /></td>
         <td><label for="$headers" id="or-import-parse"></label>
-          <input bind="headerLinesInput" spellcheck="false" type="text" class="lightweight" size="2" value="1" />
+          <input bind="headerLinesInput" type="number" class="lightweight" size="7" value="1" />
           <label for="$headers" id="or-import-header"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="limitCheckbox" id="$limit" /></td>
         <td><label for="$limit" id="or-import-load"></label>
-          <input bind="limitInput" spellcheck="false" type="text" class="lightweight" size="2" value="0" />
+          <input bind="limitInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$limit" id="or-import-rows2"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="guessCellValueTypesCheckbox" id="$guess" /></td>
         <td><label for="$guess" id="or-import-parseCell"></label></td></tr>

--- a/main/webapp/modules/core/scripts/index/parser-interfaces/xml-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/xml-parser-ui.html
@@ -17,9 +17,8 @@
     <td><div class="grid-layout layout-tightest"><table>
       <tr><td width="1%"><input type="checkbox" bind="limitCheckbox" id="$limit" /></td>
         <td><label for="$limit" id="or-import-load"></label></td>
-        <td><input bind="limitInput" type="text" class="lightweight" size="2" value="0" />
+        <td><input bind="limitInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$limit" id="or-import-rows"></label></td></tr>
-          
       <tr><td width="1%"><input type="checkbox" bind="storeEmptyStringsCheckbox" id="$store-empty-strings" /></td>
         <td colspan="2"><label for="$store-empty-strings" id="or-import-preserve"></label></td></tr>
       <tr><td width="1%"><input type="checkbox" bind="trimStringsCheckbox" id="$trim" /></td>


### PR DESCRIPTION
Fixes #6351 

Changes proposed in this pull request:
This change helps all input fields under the parsing options to accept any kind of number input format, such as "1,000" or "1 000".
- Adapt the "parseIntDefault" function to different localized numbers.
  1. Remove the numbers after the decimal point
  2. Extract all the numbers remained
  3. Join them together


