### PR TITLE
#5452 Removing missing unit warning

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/QuantityScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/QuantityScrutinizer.java
@@ -19,7 +19,7 @@ import org.openrefine.wikibase.qa.QAWarning;
 
 /**
  * Scrutinizer checking for units and bounds in quantities.
- * 
+ *
  * @author Antonin Delpeuch
  *
  */
@@ -95,7 +95,7 @@ public class QuantityScrutinizer extends SnakScrutinizer {
             if (value.getUnitItemId() != null) {
                 currentUnit = value.getUnitItemId();
             }
-            if (allowedUnits != null &&
+            if (allowedUnits != null && (currentUnit != null || !allowedUnits.isEmpty()) &&
                     !allowedUnits.contains(currentUnit)) {
                 String issueType = currentUnit == null ? noUnitProvidedType : invalidUnitType;
                 QAWarning issue = new QAWarning(issueType, pid.getId(), QAWarning.Severity.IMPORTANT, 1);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QuantityScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QuantityScrutinizerTest.java
@@ -280,7 +280,11 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
                 .addStatement(add(statement))
                 .build();
 
-        List<Statement> constraintDefinitions = constraintParameterStatementList(allowedUnitEntity, new ArrayList<>());
+        Snak qualifierSnak = Datamodel.makeNoValueSnak(itemParameterPID);
+        List<Snak> qualifierSnakList = Collections.singletonList(qualifierSnak);
+        SnakGroup qualifierSnakGroup = Datamodel.makeSnakGroup(qualifierSnakList);
+        List<SnakGroup> constraintQualifiers = Collections.singletonList(qualifierSnakGroup);
+        List<Statement> constraintDefinitions = constraintParameterStatementList(allowedUnitEntity, constraintQualifiers);
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
         when(fetcher.getConstraintsByType(propertyIdValue, ALLOWED_UNITS_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
         setFetcher(fetcher);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QuantityScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QuantityScrutinizerTest.java
@@ -270,4 +270,22 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         scrutinize(update);
         assertNoWarningRaised();
     }
+
+    @Test
+    public void testNoUnitRequired() {
+        ItemIdValue idA = TestingData.existingId;
+        Snak mainSnak = Datamodel.makeValueSnak(propertyIdValue, integerValue);
+        Statement statement = new StatementImpl("P1083", mainSnak, idA);
+        TermedStatementEntityEdit update = new ItemEditBuilder(idA)
+                .addStatement(add(statement))
+                .build();
+
+        List<Statement> constraintDefinitions = constraintParameterStatementList(allowedUnitEntity, new ArrayList<>());
+        ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
+        when(fetcher.getConstraintsByType(propertyIdValue, ALLOWED_UNITS_CONSTRAINT_QID)).thenReturn(constraintDefinitions);
+        setFetcher(fetcher);
+
+        scrutinize(update);
+        assertNoWarningRaised();
+    }
 }


### PR DESCRIPTION
Fixes #5452 

Changes proposed in this pull request:
Fix for removing the warning for Statements which do not have any unit like student count
Added the logic for not showing warning in case Statement does not have any unit

- 
-
- 
