### PR TITLE
Update license to mention OpenRefine contributors

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Copyright 2010, Google Inc. All rights reserved.
-Copyright 2012, OpenRefine contributors.
+Copyright 2010, OpenRefine contributors.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 Copyright 2010, Google Inc. All rights reserved.
-Copyright OpenRefine contributors. All rights reserved.
+Copyright 2012, OpenRefine contributors.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
 Copyright 2010, Google Inc. All rights reserved.
+Copyright 2024, OpenRefine contributors.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
-Copyright 2010, 2024 Google Inc. and OpenRefine contributors. All rights reserved.
+Copyright 2010, Google Inc. All rights reserved.
+Copyright OpenRefine contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,4 @@
-Copyright 2010, Google Inc. All rights reserved.
-Copyright 2024, OpenRefine contributors.
+Copyright 2010, 2024 Google Inc. and OpenRefine contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 


### PR DESCRIPTION
At the moment, the copyright notice only mentions Google Inc., which feels weird given that a lot of work has been done since, so I feel like it's worth adding a mention of "OpenRefine contributors", which has been the way we credit newer contributions in copyright headers throughout the project.

This is motivated by the license being shown in the Windows installer, to be released for the first time in 3.8.

![image](https://github.com/OpenRefine/OpenRefine/assets/309908/b0ec5618-5027-445c-98ac-8fe56c2ae594)

