### PR TITLE
Check for invalid Zip file & report to user. Fixes #6253

### DIFF
--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
 import javax.servlet.ServletException;
@@ -150,8 +151,8 @@ public class ImportingUtilities {
         } catch (Exception e) {
             JSONUtilities.safePut(config, "state", "error");
             JSONUtilities.safePut(config, "error", "Error uploading data");
-            JSONUtilities.safePut(config, "errorDetails", e.getLocalizedMessage());
-            throw new IOException(e.getMessage());
+            JSONUtilities.safePut(config, "errorDetails", String.valueOf(e.getCause()));
+            throw new IOException(e);
         }
 
         ArrayNode fileSelectionIndexes = ParsingUtilities.mapper.createArrayNode();
@@ -667,37 +668,45 @@ public class ImportingUtilities {
         }
     }
 
-    static public InputStream tryOpenAsArchive(File file, String mimeType) {
+    static public InputStream tryOpenAsArchive(File file, String mimeType) throws IOException {
         return tryOpenAsArchive(file, mimeType, null);
     }
 
-    static public InputStream tryOpenAsArchive(File file, String mimeType, String contentType) {
+    static public InputStream tryOpenAsArchive(File file, String mimeType, String contentType) throws IOException {
         String fileName = file.getName();
-        try {
-            if (fileName.endsWith(".tar.gz") || fileName.endsWith(".tgz") || isFileGZipped(file)) {
-                TarArchiveInputStream archiveInputStream = new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(file)));
-                if (archiveInputStream.getNextTarEntry() != null) {
-                    // It's a tar archive
-                    return archiveInputStream;
-                }
-                // It's not a tar archive, so it must be gzip compressed (or something else)
-                return null;
-            } else if (fileName.endsWith(".tar.bz2")) {
-                return new TarArchiveInputStream(new BZip2CompressorInputStream(new FileInputStream(file)));
-            } else if (fileName.endsWith(".tar") || "application/x-tar".equals(contentType)) {
-                return new TarArchiveInputStream(new FileInputStream(file));
-            } else if (fileName.endsWith(".zip")
-                    || "application/x-zip-compressed".equals(contentType)
-                    || "application/zip".equals(contentType)
-                    || "application/x-compressed".equals(contentType)
-                    || "multipart/x-zip".equals(contentType)) {
-                return new ZipInputStream(new FileInputStream(file));
-            } else if (fileName.endsWith(".kmz")) {
-                return new ZipInputStream(new FileInputStream(file));
+        if (fileName.endsWith(".tar.gz") || fileName.endsWith(".tgz") || isFileGZipped(file)) {
+            TarArchiveInputStream archiveInputStream = new TarArchiveInputStream(new GZIPInputStream(new FileInputStream(file)));
+            // TODO: Check whether the below is consuming the first entry (effectively throwing it away)
+            if (archiveInputStream.getNextTarEntry() != null) {
+                // It's a tar archive
+                return archiveInputStream;
             }
-        } catch (IOException ignored) {
+            // It's not a tar archive, so it must be gzip compressed (or something else)
+            return null;
+        } else if (fileName.endsWith(".tar.bz2")) {
+            return new TarArchiveInputStream(new BZip2CompressorInputStream(new FileInputStream(file)));
+        } else if (fileName.endsWith(".tar") || "application/x-tar".equals(contentType)) {
+            return new TarArchiveInputStream(new FileInputStream(file));
+        } else if (fileName.endsWith(".zip")
+                || "application/x-zip-compressed".equals(contentType)
+                || "application/zip".equals(contentType)
+                || "application/x-compressed".equals(contentType)
+                || "multipart/x-zip".equals(contentType)) {
+            return new ZipInputStream(new FileInputStream(checkValidZip(file)));
+        } else if (fileName.endsWith(".kmz")) {
+            return new ZipInputStream(new FileInputStream(checkValidZip(file)));
         }
         return null;
+    }
+
+    private static File checkValidZip(File file) throws IOException {
+        try (ZipFile zf = new ZipFile(file)) {
+            if (!zf.entries().hasMoreElements()) {
+                // Needs to have at least one entry to be useful
+                throw new IOException("Empty Zip file");
+            }
+        }
+        return file;
     }
 
     private static boolean isFileGZipped(File file) {

--- a/main/tests/data/notazip.zip
+++ b/main/tests/data/notazip.zip
@@ -1,0 +1,1 @@
+This is a text file masquerading as a zip file.

--- a/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
@@ -416,10 +416,16 @@ public class ImportingUtilitiesTests extends ImporterTest {
 
     @Test
     public void importUnsupportedZipFile() throws IOException {
-        String filename = "unsupportedPPMD.zip";
+        for (String basename : new String[] { "unsupportedPPMD", "notazip" }) {
+            testInvalidZipFile(basename);
+        }
+    }
+
+    private void testInvalidZipFile(String basename) throws IOException {
+        String filename = basename + ".zip";
         String filepath = ClassLoader.getSystemResource(filename).getPath();
         // Make a copy in our data directory where it's expected
-        File tmp = File.createTempFile("openrefine-test-unsupportedPPMD", ".zip", job.getRawDataDir());
+        File tmp = File.createTempFile("openrefine-test-" + basename, ".zip", job.getRawDataDir());
         tmp.deleteOnExit();
         FileUtils.copyFile(new File(filepath), tmp);
 
@@ -446,13 +452,13 @@ public class ImportingUtilitiesTests extends ImporterTest {
         HttpServletRequest request = mock(HttpServletRequest.class);
         HttpServletResponse response = mock(HttpServletResponse.class);
 
-        assertThrows(IOException.class,
+        assertThrows("Failed to throw for " + filename, IOException.class,
                 () -> ImportingUtilities.postProcessRetrievedFile(job.getRawDataDir(), tmp, fileRecord, fileRecords, dummyProgress));
-        assertThrows(FileUploadBase.InvalidContentTypeException.class, () -> ImportingUtilities.retrieveContentFromPostRequest(request,
-                new Properties(), job.getRawDataDir(), fileRecord, dummyProgress));
-        assertThrows(IOException.class,
+        assertThrows("Failed to throw for " + filename, FileUploadBase.InvalidContentTypeException.class,
+                () -> ImportingUtilities.retrieveContentFromPostRequest(request,
+                        new Properties(), job.getRawDataDir(), fileRecord, dummyProgress));
+        assertThrows("Failed to throw for " + filename, IOException.class,
                 () -> ImportingUtilities.loadDataAndPrepareJob(request, response, new Properties(), job, fileRecord));
-
     }
 
     @Test


### PR DESCRIPTION
Fixes #6253

Changes proposed in this pull request:
- Use ZipFile class to pre-check for errors since it does a better job than ZipInputStream.
- Add test for non-zip format files with .zip extension
