### PR TITLE
Avoid specifying test projects in CSV format

### DIFF
--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/commands/CommandTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/commands/CommandTest.java
@@ -54,7 +54,8 @@ public abstract class CommandTest extends WikidataRefineTest {
 
     @BeforeMethod(alwaysRun = true)
     public void setUpProject() {
-        project = createCSVProject(TestingData.inceptionWithNewCsv);
+        project = createProject(TestingData.inceptionColumns,
+                TestingData.inceptionProjectGridWithNewItem);
         TestingData.reconcileInceptionCells(project);
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/NewEntityLibraryTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/NewEntityLibraryTest.java
@@ -59,7 +59,8 @@ public class NewEntityLibraryTest extends WikidataRefineTest {
 
     @Test
     public void testUpdateReconciledCells() {
-        Project project = createCSVProject(TestingData.inceptionWithNewCsv);
+        Project project = createProject(TestingData.inceptionColumns,
+                TestingData.inceptionProjectGridWithNewItem);
         StandardReconConfig config = new StandardReconConfig("http://my.endpoint",
                 "http://my.schema", "http://my.schema", "Q5", "human", true, 10, Collections.emptyList());
         project.columnModel.columns.get(0).setReconConfig(config);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/QuickStatementsExporterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/QuickStatementsExporterTest.java
@@ -27,6 +27,7 @@ package org.openrefine.wikibase.exporters;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collections;
@@ -72,7 +73,8 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
 
     @Test
     public void testSimpleProject() throws IOException {
-        Project project = this.createCSVProject(TestingData.inceptionWithNewCsv);
+        Project project = createProject(TestingData.inceptionColumns,
+                TestingData.inceptionProjectGridWithNewItem);
         TestingData.reconcileInceptionCells(project);
         String serialized = TestingData.jsonFromFile("schema/inception.json");
         WikibaseSchema schema = WikibaseSchema.reconstruct(serialized);
@@ -209,7 +211,11 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
 
     @Test
     public void testNoSchema() throws IOException {
-        Project project = this.createCSVProject("a,b\nc,d");
+        Project project = this.createProject(
+                new String[] { "a", "b" },
+                new Serializable[][] {
+                        { "c", "d" }
+                });
         Engine engine = new Engine(project);
         StringWriter writer = new StringWriter();
         Properties properties = new Properties();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/SchemaExporterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/SchemaExporterTest.java
@@ -2,6 +2,7 @@
 package org.openrefine.wikibase.exporters;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.Properties;
 
@@ -21,7 +22,11 @@ public class SchemaExporterTest extends WikidataRefineTest {
     public void testNoSchema()
             throws IOException {
         // TODO instead of returning an empty (and invalid) schema, we should just return an error
-        Project project = this.createCSVProject("a,b\nc,d");
+        Project project = this.createProject(
+                new String[] { "a", "b" },
+                new Serializable[][] {
+                        { "c", "d" }
+                });
         Engine engine = new Engine(project);
         StringWriter writer = new StringWriter();
         Properties properties = new Properties();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/functions/WikibaseIssuesFunctionTests.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/functions/WikibaseIssuesFunctionTests.java
@@ -4,6 +4,7 @@ package org.openrefine.wikibase.functions;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -59,8 +60,12 @@ public class WikibaseIssuesFunctionTests extends RefineTest {
 
         schema = WikibaseSchema.reconstruct(schemaJson);
         manifest = ManifestParser.parse(manifestJson);
-        project = createCSVProject("my project",
-                "a,b\nc,d\ne,f");
+        project = createProject("my project",
+                new String[] { "a", "b" },
+                new Serializable[][] {
+                        { "c", "d" },
+                        { "e", "f" }
+                });
         project.overlayModels.put("wikibaseSchema", schema);
         ProjectManager.singleton.getPreferenceStore().put("wikibase.manifests", ParsingUtilities.mapper.readTree("[" + manifestJson + "]"));
         row = project.rows.get(0);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/operations/OperationTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/operations/OperationTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.LineNumberReader;
+import java.io.Serializable;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.Properties;
@@ -55,7 +56,11 @@ public abstract class OperationTest extends WikidataRefineTest {
 
     @BeforeMethod
     public void setUp() {
-        project = createCSVProject("a,b\nc,d");
+        project = createProject(
+                new String[] { "a", "b" },
+                new Serializable[][] {
+                        { "c", "d" }
+                });
         module = mock(ButterflyModule.class);
         when(module.getName()).thenReturn("wikidata");
         pool = new Pool();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/ExpressionContextTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/ExpressionContextTest.java
@@ -27,6 +27,8 @@ package org.openrefine.wikibase.schema;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+import java.io.Serializable;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -40,7 +42,12 @@ public class ExpressionContextTest extends WikidataRefineTest {
 
     @BeforeMethod
     public void setUp() {
-        project = createCSVProject("a,b\nc\nd,e");
+        project = createProject(
+                new String[] { "a", "b" },
+                new Serializable[][] {
+                        { "c", null },
+                        { "d", "e" }
+                });
     }
 
     @Test

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbExpressionTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbExpressionTest.java
@@ -88,8 +88,11 @@ public class WbExpressionTest<T> extends WikidataRefineTest {
     @BeforeMethod
     public void createProject()
             throws IOException, ModelException {
-        project = createCSVProject("Wikidata variable test project",
-                "column A,column B,column C,column D,column E\n" + "value A,value B,value C,value D,value E");
+        project = createProject("Wikidata variable test project",
+                new String[] { "column A", "column B", "column C", "column D", "column E" },
+                new Serializable[][] {
+                        { "value A", "value B", "value C", "value D", "value E" }
+                });
         warningStore = new QAWarningStore();
         row = project.rows.get(0);
         ctxt = new ExpressionContext("http://www.wikidata.org/entity/", Collections.emptyMap(), server.url("/w/api.php").toString(), 0, row,

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WikibaseSchemaTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WikibaseSchemaTest.java
@@ -108,7 +108,8 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
 
     @BeforeMethod
     public void setUpProject() {
-        project = this.createCSVProject(TestingData.inceptionCsv);
+        project = this.createProject(TestingData.inceptionColumns,
+                TestingData.inceptionProjectGrid);
         project.rows.get(0).cells.set(0, TestingData.makeMatchedCell("Q1377", "University of Ljubljana"));
         project.rows.get(1).cells.set(0, TestingData.makeMatchedCell("Q865528", "University of Warwick"));
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/testing/TestingData.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/testing/TestingData.java
@@ -26,6 +26,7 @@ package org.openrefine.wikibase.testing;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.Collections;
 
 import org.apache.commons.io.IOUtils;
@@ -56,11 +57,16 @@ import org.openrefine.wikibase.updates.StatementEdit;
 
 public class TestingData {
 
-    public static final String inceptionCsv = "subject,inception,reference\n"
-            + "Q1377,1919,http://www.ljubljana-slovenia.com/university-ljubljana\n" + "Q865528,1965,";
-    public static final String inceptionWithNewCsv = "subject,inception,reference\n"
-            + "Q1377,1919,http://www.ljubljana-slovenia.com/university-ljubljana\n" + "Q865528,1965,\n"
-            + "new uni,2016,http://new-uni.com/";
+    public static final String[] inceptionColumns = { "subject", "inception", "reference" };
+    public static final Serializable[][] inceptionProjectGrid = {
+            { "Q1377", "1919", "http://www.ljubljana-slovenia.com/university-ljubljana" },
+            { "Q865528", "1965", null }
+    };
+    public static final Serializable[][] inceptionProjectGridWithNewItem = {
+            { "Q1377", "1919", "http://www.ljubljana-slovenia.com/university-ljubljana" },
+            { "Q865528", "1965", null },
+            { "new uni", "2016", "http://new-uni.com/" }
+    };
     public static final String inceptionWithNewQS = "Q1377\tP571\t+1919-00-00T00:00:00Z/9"
             + "\tS854\t\"http://www.ljubljana-slovenia.com/university-ljubljana\""
             + "\tS813\t+2018-02-28T00:00:00Z/11\n" + "Q865528\tP571\t+1965-00-00T00:00:00Z/9"

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/testing/WikidataRefineTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/testing/WikidataRefineTest.java
@@ -2,8 +2,11 @@
 package org.openrefine.wikibase.testing;
 
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import java.io.File;
+import java.io.Serializable;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +23,11 @@ import com.google.refine.RefineTest;
 import com.google.refine.importers.SeparatorBasedImporter;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingManager;
+import com.google.refine.model.Cell;
+import com.google.refine.model.Column;
+import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
+import com.google.refine.model.Row;
 
 public class WikidataRefineTest {
 
@@ -29,10 +36,18 @@ public class WikidataRefineTest {
     private List<Project> projects = new ArrayList<Project>();
     private List<ImportingJob> importingJobs = new ArrayList<ImportingJob>();
 
+    /**
+     * @deprecated use {@link #createProject(String[], Serializable[][])}
+     */
+    @Deprecated
     public Project createCSVProject(String input) {
         return createCSVProject("test project", input);
     }
 
+    /**
+     * @deprecated use {@link #createProject(String, String[], Serializable[][])}
+     */
+    @Deprecated
     protected Project createCSVProject(String projectName, String input) {
         Project project = new Project();
 
@@ -53,6 +68,65 @@ public class WikidataRefineTest {
 
         projects.add(project);
         importingJobs.add(job);
+        return project;
+    }
+
+    /**
+     * Utility method to create a project with pre-defined contents.
+     * 
+     * @param columnNames
+     *            names of the columns
+     * @param grid
+     *            contents of the project grid, which can be either {@link Cell} instances or just the cell values (for
+     *            convenience)
+     * @return a test project with the given contents
+     */
+    public Project createProject(String[] columnNames, Serializable[][] grid) {
+        return createProject("test project", columnNames, grid);
+    }
+
+    /**
+     * Utility method to create a project with pre-defined contents.
+     * 
+     * @param name
+     *            project name
+     * @param columnNames
+     *            names of the columns
+     * @param grid
+     *            contents of the project grid, which can be either {@link Cell} instances or just the cell values (for
+     *            convenience)
+     * @return a test project with the given contents
+     */
+    public Project createProject(String name, String[] columnNames, Serializable[][] grid) {
+        Project project = new Project();
+        ProjectMetadata pm = new ProjectMetadata();
+        pm.setName(name);
+        ProjectManager.singleton.registerProject(project, pm);
+
+        try {
+            for (String columnName : columnNames) {
+                int index = project.columnModel.allocateNewCellIndex();
+                Column column = new Column(index, columnName);
+                project.columnModel.addColumn(index, column, true);
+            }
+        } catch (ModelException e) {
+            fail("The column names provided to create a test project contain duplicates");
+        }
+        for (Serializable[] rawRow : grid) {
+            assertEquals(columnNames.length, rawRow.length, "Unexpected row length in test project");
+            Row row = new Row(columnNames.length);
+            for (int i = 0; i != columnNames.length; i++) {
+                Serializable rawCell = rawRow[i];
+                if (rawCell == null || rawCell instanceof Cell) {
+                    row.setCell(i, (Cell) rawCell);
+                } else {
+                    row.setCell(i, new Cell(rawCell, null));
+                }
+            }
+            project.rows.add(row);
+        }
+        project.update();
+        projects.add(project);
         return project;
     }
 

--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -37,9 +37,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -136,31 +139,19 @@ public class RefineTest {
     }
 
     /**
-     * Helper to create a project from a CSV encoded as a file. Not much control is given on the import options, because
-     * this method is intended to be a quick way to create a project for a test. For more control over the import, just
-     * call the importer directly.
-     * 
-     * @param input
-     *            contents of the CSV file to create the project from
-     * @return
+     * @deprecated use {@link #createProject(String[], Serializable[][])} instead, so that the project's contents are
+     *             more readable in the test
      */
+    @Deprecated
     protected Project createCSVProject(String input) {
         return createCSVProject("test project", input);
     }
 
     /**
-     * Helper to create a project from a CSV encoded as a file. Not much control is given on the import options, because
-     * this method is intended to be a quick way to create a project for a test. For more control over the import, just
-     * call the importer directly.
-     * 
-     * The projects created via this method and their importing jobs will be disposed of at the end of each test.
-     * 
-     * @param projectName
-     *            the name of the project to create
-     * @param input
-     *            the content of the file, encoded as a CSV (with "," as a separator)
-     * @return
+     * @deprecated use {@link #createProject(String, String[], Serializable[][])} instead, so that the project's
+     *             contents are more readable in the test
      */
+    @Deprecated
     protected Project createCSVProject(String projectName, String input) {
 
         Project project = new Project();
@@ -183,6 +174,65 @@ public class RefineTest {
         projects.add(project);
         importingJobs.add(job);
         return project;
+    }
+
+    /**
+     * Utility method to create a project with pre-defined contents.
+     * 
+     * @param name
+     *            project name
+     * @param columnNames
+     *            names of the columns
+     * @param grid
+     *            contents of the project grid, which can be either {@link Cell} instances or just the cell values (for
+     *            convenience)
+     * @return a test project with the given contents
+     */
+    public Project createProject(String name, String[] columnNames, Serializable[][] grid) {
+        Project project = new Project();
+        ProjectMetadata pm = new ProjectMetadata();
+        pm.setName(name);
+        ProjectManager.singleton.registerProject(project, pm);
+
+        try {
+            for (String columnName : columnNames) {
+                int index = project.columnModel.allocateNewCellIndex();
+                Column column = new Column(index, columnName);
+                project.columnModel.addColumn(index, column, true);
+            }
+        } catch (ModelException e) {
+            fail("The column names provided to create a test project contain duplicates");
+        }
+        for (Serializable[] rawRow : grid) {
+            assertEquals(columnNames.length, rawRow.length, "Unexpected row length in test project");
+            Row row = new Row(columnNames.length);
+            for (int i = 0; i != columnNames.length; i++) {
+                Serializable rawCell = rawRow[i];
+                if (rawCell == null || rawCell instanceof Cell) {
+                    row.setCell(i, (Cell) rawCell);
+                } else {
+                    row.setCell(i, new Cell(rawCell, null));
+                }
+            }
+            project.rows.add(row);
+        }
+        project.update();
+        projects.add(project);
+        return project;
+    }
+
+    /**
+     * Utility method to create a project with pre-defined contents.
+     * 
+     * @param columnNames
+     *            names of the columns
+     * @param grid
+     *            contents of the project grid, which can be either {@link Cell} instances or just the cell values (for
+     *            convenience)
+     * @return a test project with the given contents
+     */
+    public Project createProject(String[] columnNames, Serializable[][] grid) {
+        return createProject("test project", columnNames, grid);
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -204,7 +204,7 @@ public class RefineTest {
             fail("The column names provided to create a test project contain duplicates");
         }
         for (Serializable[] rawRow : grid) {
-            assertEquals(columnNames.length, rawRow.length, "Unexpected row length in test project");
+            assertEquals(columnNames.length, rawRow.length, "Unexpected row length in test grid data");
             Row row = new Row(columnNames.length);
             for (int i = 0; i != columnNames.length; i++) {
                 Serializable rawCell = rawRow[i];

--- a/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java
@@ -28,6 +28,7 @@
 package com.google.refine.browsing.facets;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -98,9 +99,12 @@ public class ListFacetTests extends RefineTest {
 
     @Test
     public void serializeListFacet() throws JsonParseException, JsonMappingException, IOException {
-        Project project = createCSVProject("Column A\n" +
-                "foo\n" +
-                "bar\n");
+        Project project = createProject(
+                new String[] { "Column A" },
+                new Serializable[][] {
+                        { "foo" },
+                        { "bar" }
+                });
         Engine engine = new Engine(project);
 
         ListFacetConfig facetConfig = ParsingUtilities.mapper.readValue(jsonConfig, ListFacetConfig.class);
@@ -120,9 +124,12 @@ public class ListFacetTests extends RefineTest {
 
     @Test
     public void serializeListFacetWithError() throws JsonParseException, JsonMappingException, IOException {
-        Project project = createCSVProject("other column\n" +
-                "foo\n" +
-                "bar\n");
+        Project project = createProject(
+                new String[] { "other column" },
+                new Serializable[][] {
+                        { "foo" },
+                        { "bar" }
+                });
 
         ListFacetConfig facetConfig = ParsingUtilities.mapper.readValue(jsonConfig, ListFacetConfig.class);
         Facet facet = facetConfig.apply(project);
@@ -131,10 +138,13 @@ public class ListFacetTests extends RefineTest {
 
     @Test
     public void testSelectedEmptyChoice() throws IOException {
-        Project project = createCSVProject("Column A\n" +
-                "a\n" +
-                "c\n" +
-                "e");
+        Project project = createProject(
+                new String[] { "Column A" },
+                new Serializable[][] {
+                        { "a" },
+                        { "c" },
+                        { "e" },
+                });
         Engine engine = new Engine(project);
 
         ListFacetConfig facetConfig = ParsingUtilities.mapper.readValue(jsonConfig, ListFacetConfig.class);

--- a/main/tests/server/src/com/google/refine/browsing/facets/RangeFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/RangeFacetTests.java
@@ -28,6 +28,7 @@
 package com.google.refine.browsing.facets;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -36,7 +37,6 @@ import org.testng.annotations.Test;
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.facets.RangeFacet.RangeFacetConfig;
-import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.TestUtils;
@@ -84,14 +84,14 @@ public class RangeFacetTests extends RefineTest {
 
     @Test
     public void serializeRangeFacet() throws JsonParseException, JsonMappingException, IOException {
-        Project project = createCSVProject("my column\n"
-                + "89.2\n"
-                + "-45.9\n"
-                + "blah\n"
-                + "0.4\n");
-        project.rows.get(0).cells.set(0, new Cell(89.2, null));
-        project.rows.get(1).cells.set(0, new Cell(-45.9, null));
-        project.rows.get(3).cells.set(0, new Cell(0.4, null));
+        Project project = createProject(
+                new String[] { "my column" },
+                new Serializable[][] {
+                        { 89.2 },
+                        { -45.9 },
+                        { "blah" },
+                        { 0.4 }
+                });
         Engine engine = new Engine(project);
         RangeFacetConfig config = ParsingUtilities.mapper.readValue(configJson, RangeFacetConfig.class);
         RangeFacet facet = config.apply(project);

--- a/main/tests/server/src/com/google/refine/browsing/facets/ScatterplotFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/ScatterplotFacetTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -40,7 +41,6 @@ import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.RowFilter;
 import com.google.refine.browsing.facets.ScatterplotFacet.ScatterplotFacetConfig;
-import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.TestUtils;
@@ -90,18 +90,15 @@ public class ScatterplotFacetTests extends RefineTest {
 
     @Test
     public void serializeScatterplotFacet() throws JsonParseException, JsonMappingException, IOException {
-        Project project = createCSVProject("my column,e\n"
-                + "89.2,89.2\n" +
-                "-45.9,-45.9\n" +
-                "blah,blah\n" +
-                "0.4,0.4\n");
+        Project project = createProject(
+                new String[] { "my column", "e" },
+                new Serializable[][] {
+                        { 89.2, 89.2 },
+                        { -45.9, -45.9 },
+                        { "blah", "blah" },
+                        { 0.4, 0.4 }
+                });
         Engine engine = new Engine(project);
-        project.rows.get(0).cells.set(0, new Cell(89.2, null));
-        project.rows.get(0).cells.set(1, new Cell(89.2, null));
-        project.rows.get(1).cells.set(0, new Cell(-45.9, null));
-        project.rows.get(1).cells.set(1, new Cell(-45.9, null));
-        project.rows.get(3).cells.set(0, new Cell(0.4, null));
-        project.rows.get(3).cells.set(1, new Cell(0.4, null));
 
         ScatterplotFacetConfig config = ParsingUtilities.mapper.readValue(configJson, ScatterplotFacetConfig.class);
 

--- a/main/tests/server/src/com/google/refine/browsing/facets/TextSearchFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/TextSearchFacetTests.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.browsing.facets;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -81,12 +82,14 @@ public class TextSearchFacetTests extends RefineTest {
 
     @BeforeMethod
     public void setUp() throws IOException, ModelException {
-        project = createCSVProject("TextSearchFacet",
-                "Value\n"
-                        + "a\n"
-                        + "b\n"
-                        + "ab\n"
-                        + "Abc\n");
+        project = createProject("TextSearchFacet",
+                new String[] { "Value" },
+                new Serializable[][] {
+                        { "a" },
+                        { "b" },
+                        { "ab" },
+                        { "Abc" }
+                });
     }
 
     private void configureFilter(String filter) throws JsonParseException, JsonMappingException, IOException {

--- a/main/tests/server/src/com/google/refine/browsing/facets/TimeRangeFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/TimeRangeFacetTests.java
@@ -28,6 +28,7 @@
 package com.google.refine.browsing.facets;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.time.OffsetDateTime;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -37,7 +38,6 @@ import org.testng.annotations.Test;
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.facets.TimeRangeFacet.TimeRangeFacetConfig;
-import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.TestUtils;
@@ -85,14 +85,14 @@ public class TimeRangeFacetTests extends RefineTest {
 
     @Test
     public void serializeTimeRangeFacet() throws JsonParseException, JsonMappingException, IOException {
-        Project project = createCSVProject("my column\n"
-                + "placeholder\n"
-                + "nontime\n"
-                + "placeholder\n"
-                + "placeholder\n");
-        project.rows.get(0).cells.set(0, new Cell(OffsetDateTime.parse("2018-01-03T08:09:10Z"), null));
-        project.rows.get(2).cells.set(0, new Cell(OffsetDateTime.parse("2008-01-03T03:04:05Z"), null));
-        project.rows.get(3).cells.set(0, new Cell(OffsetDateTime.parse("2012-04-05T02:00:01Z"), null));
+        Project project = createProject(
+                new String[] { "my column" },
+                new Serializable[][] {
+                        { OffsetDateTime.parse("2018-01-03T08:09:10Z") },
+                        { "nontime" },
+                        { OffsetDateTime.parse("2008-01-03T03:04:05Z") },
+                        { OffsetDateTime.parse("2012-04-05T02:00:01Z") }
+                });
 
         Engine engine = new Engine(project);
         TimeRangeFacetConfig config = ParsingUtilities.mapper.readValue(configJson, TimeRangeFacetConfig.class);

--- a/main/tests/server/src/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
@@ -31,6 +31,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.browsing.util;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Properties;
@@ -175,14 +176,15 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
 
     @Test
     public void expressionNominalValueGrouperRecords() throws Exception {
-        String completeProjectJson = "col1,col2,col3\n"
-                + "record1,1,a\n"
-                + ",,a\n"
-                + ",,a\n"
-                + "record2,,a\n"
-                + ",1,a\n";
-
-        project = createCSVProject(completeProjectJson);
+        project = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                        { "record1", "1", "a" },
+                        { null, null, "a" },
+                        { null, null, "a" },
+                        { "record2", null, "a" },
+                        { null, "1", "a" }
+                });
         bindings = new Properties();
         bindings.put("project", project);
 

--- a/main/tests/server/src/com/google/refine/clustering/binning/BinningClustererTests.java
+++ b/main/tests/server/src/com/google/refine/clustering/binning/BinningClustererTests.java
@@ -30,6 +30,7 @@ package com.google.refine.clustering.binning;
 import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -75,11 +76,14 @@ public class BinningClustererTests extends RefineTest {
 
     @Test
     public void testSerializeBinningClusterer() throws JsonParseException, JsonMappingException, IOException {
-        Project project = createCSVProject("column\n"
-                + "a\n"
-                + "à\n"
-                + "c\n"
-                + "ĉ\n");
+        Project project = createProject(
+                new String[] { "column" },
+                new Serializable[][] {
+                        { "a" },
+                        { "à" },
+                        { "c" },
+                        { "ĉ" }
+                });
         BinningClustererConfig config = ParsingUtilities.mapper.readValue(configJson, BinningClustererConfig.class);
         BinningClusterer clusterer = config.apply(project);
         clusterer.computeClusters(new Engine(project));
@@ -88,10 +92,13 @@ public class BinningClustererTests extends RefineTest {
 
     @Test
     public void testNoLonelyClusters() throws JsonParseException, JsonMappingException, IOException {
-        Project project = createCSVProject("column\n"
-                + "c\n"
-                + "ĉ\n"
-                + "d\n");
+        Project project = createProject(
+                new String[] { "column" },
+                new Serializable[][] {
+                        { "c" },
+                        { "ĉ" },
+                        { "d" }
+                });
         BinningClustererConfig config = ParsingUtilities.mapper.readValue(configJson, BinningClustererConfig.class);
         BinningClusterer clusterer = config.apply(project);
         clusterer.computeClusters(new Engine(project));

--- a/main/tests/server/src/com/google/refine/clustering/knn/kNNClustererTests.java
+++ b/main/tests/server/src/com/google/refine/clustering/knn/kNNClustererTests.java
@@ -30,6 +30,7 @@ package com.google.refine.clustering.knn;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -62,11 +63,14 @@ public class kNNClustererTests extends RefineTest {
 
     @Test
     public void serializekNNClusterer() throws JsonParseException, JsonMappingException, IOException {
-        Project project = createCSVProject("column\n"
-                + "ab\n"
-                + "abc\n"
-                + "c\n"
-                + "ĉ\n");
+        Project project = createProject(
+                new String[] { "column" },
+                new Serializable[][] {
+                        { "ab" },
+                        { "abc" },
+                        { "c" },
+                        { "ĉ" }
+                });
 
         kNNClustererConfig config = ParsingUtilities.mapper.readValue(configJson, kNNClustererConfig.class);
         kNNClusterer clusterer = config.apply(project);
@@ -77,9 +81,12 @@ public class kNNClustererTests extends RefineTest {
 
     @Test
     public void testNoLonelyclusters() throws JsonParseException, JsonMappingException, IOException {
-        Project project = createCSVProject("column\n"
-                + "foo\n"
-                + "bar\n");
+        Project project = createProject(
+                new String[] { "column" },
+                new Serializable[][] {
+                        { "foo" },
+                        { "bar" }
+                });
         kNNClustererConfig config = ParsingUtilities.mapper.readValue(configJson, kNNClustererConfig.class);
         kNNClusterer clusterer = config.apply(project);
         clusterer.computeClusters(new Engine(project));

--- a/main/tests/server/src/com/google/refine/commands/cell/EditOneCellCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/cell/EditOneCellCommandTests.java
@@ -8,6 +8,7 @@ import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.io.StringWriter;
 
 import javax.servlet.ServletException;
@@ -34,10 +35,12 @@ public class EditOneCellCommandTests extends RefineTest {
 
     @BeforeMethod
     public void setUpProject() {
-        project = createCSVProject(
-                "first_column,second_column\n"
-                        + "a,b\n"
-                        + "c,d\n");
+        project = createProject(
+                new String[] { "first_column", "second_column" },
+                new Serializable[][] {
+                        { "a", "b" },
+                        { "c", "d" }
+                });
         command = new EditOneCellCommand();
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);

--- a/main/tests/server/src/com/google/refine/commands/expr/PreviewExpressionCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/expr/PreviewExpressionCommandTests.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.io.StringWriter;
 
 import javax.servlet.ServletException;
@@ -65,7 +66,13 @@ public class PreviewExpressionCommandTests extends RefineTest {
             e.printStackTrace();
         }
         command = new PreviewExpressionCommand();
-        project = createCSVProject("a,b\nc,d\ne,f\ng,h");
+        project = createProject(
+                new String[] { "a", "b" },
+                new Serializable[][] {
+                        { "c", "d" },
+                        { "e", "f" },
+                        { "g", "h" }
+                });
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/commands/recon/GuessTypesOfColumnCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/recon/GuessTypesOfColumnCommandTests.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.concurrent.TimeUnit;
 
@@ -45,11 +46,13 @@ public class GuessTypesOfColumnCommandTests extends RefineTest {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        project = createCSVProject(
-                "foo,bar\n"
-                        + "France,b\n"
-                        + "Japan,d\n"
-                        + "Paraguay,x");
+        project = createProject(
+                new String[] { "foo", "bar" },
+                new Serializable[][] {
+                        { "France", "b" },
+                        { "Japan", "d" },
+                        { "Paraguay", "x" }
+                });
 
     }
 

--- a/main/tests/server/src/com/google/refine/commands/recon/ReconJudgeOneCellCommandTest.java
+++ b/main/tests/server/src/com/google/refine/commands/recon/ReconJudgeOneCellCommandTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.util.Collections;
 
 import javax.servlet.http.HttpServletRequest;
@@ -62,10 +63,12 @@ public class ReconJudgeOneCellCommandTest extends RefineTest {
 
     @BeforeMethod
     public void setUp() {
-        project = createCSVProject(
-                "reconciled column,unreconciled column\n" +
-                        "a,b\n" +
-                        "c,d\n");
+        project = createProject(
+                new String[] { "reconciled column", "unreconciled column" },
+                new Serializable[][] {
+                        { "a", "b" },
+                        { "c", "d" }
+                });
         Column reconciled = project.columnModel.columns.get(0);
         ReconConfig config = new StandardReconConfig(
                 "http://my.recon.service/api",

--- a/main/tests/server/src/com/google/refine/commands/row/GetRowsCommandTest.java
+++ b/main/tests/server/src/com/google/refine/commands/row/GetRowsCommandTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.Serializable;
 import java.io.StringWriter;
 
 import javax.servlet.ServletException;
@@ -58,7 +59,11 @@ public class GetRowsCommandTest extends RefineTest {
     public void setUp() {
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);
-        project = createCSVProject("a,b\nc,d\n,f");
+        project = createProject(new String[] { "a", "b" },
+                new Serializable[][] {
+                        { "c", "d" },
+                        { null, "f" }
+                });
         command = new GetRowsCommand();
         writer = new StringWriter();
         when(request.getParameter("project")).thenReturn(String.valueOf(project.id));

--- a/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
@@ -29,6 +29,7 @@ package com.google.refine.expr.functions;
 
 import static org.testng.Assert.assertEquals;
 
+import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -78,46 +79,39 @@ public class CrossTests extends RefineTest {
         bindings = new Properties();
         emptyList = new HasFieldsListImpl();
 
-        String projectName = "My Address Book";
-        String input = "friend,address\n"
-                + "john,120 Main St.\n"
-                + "mary,50 Broadway Ave.\n"
-                + "john,999 XXXXXX St.\n" // john's 2nd address
-                + "anne,17 Morning Crescent\n"
-                + "2017-05-12T05:45:00Z,dateTime\n"
-                + "1600,integer\n"
-                + "123456789123456789,long\n"
-                + "true,boolean\n"
-                + "3.14,double\n";
-        projectAddress = createCSVProject(projectName, input);
+        projectAddress = createProject("My Address Book",
+                new String[] { "friend", "address" },
+                new Serializable[][] {
+                        { "john", "120 Main St." },
+                        { "mary", "50 Broadway Ave." },
+                        { "john", "999 XXXXXX St." },
+                        { "anne", "17 Morning Crescent" },
+                        { dateTimeValue, "dateTime" },
+                        { 1600, "integer" },
+                        { 123456789123456789L, "long" },
+                        { true, "boolean" },
+                        { 3.14, "double" },
+                });
 
-        projectName = "Christmas Gifts";
-        input = "gift,recipient\n"
-                + "lamp,mary\n"
-                + "clock,john\n"
-                + "dateTime,2017-05-12T05:45:00Z\n"
-                + "integer,1600\n"
-                + "123456789123456789,long\n"
-                + "boolean,true\n";
-        projectGift = createCSVProject(projectName, input);
-        projectName = "Duplicate";
-        input = "Col1,Col2";
-        projectDuplicate1 = createCSVProject(projectName, input);
-        projectDuplicate2 = createCSVProject(projectName, input);
+        projectGift = createProject("Christmas Gifts",
+                new String[] { "gift", "recipient" },
+                new Serializable[][] {
+                        { "lamp", "mary" },
+                        { "clock", "john" },
+                        { "dateTime", dateTimeValue },
+                        { "integer", 1600 },
+                        { "123456789123456789", 123456789123456789L },
+                        { "boolean", true }
+                });
+
+        projectDuplicate1 = createProject("Duplicate",
+                new String[] { "Col1", "Col2" },
+                new Serializable[][] {});
+        projectDuplicate2 = createProject("Duplicate",
+                new String[] { "Col1", "Col2" },
+                new Serializable[][] {});
 
         bindings.put("project", projectGift);
-
-        // Add some non-string value cells to each project
-        projectAddress.rows.get(4).cells.set(0, new Cell(dateTimeValue, null));
-        projectAddress.rows.get(5).cells.set(0, new Cell(1600, null));
-        projectAddress.rows.get(6).cells.set(0, new Cell(123456789123456789L, null));
-        projectAddress.rows.get(7).cells.set(0, new Cell(true, null));
-        projectAddress.rows.get(8).cells.set(0, new Cell(3.14, null));
-        projectGift.rows.get(2).cells.set(1, new Cell(dateTimeValue, null));
-        projectGift.rows.get(3).cells.set(1, new Cell(1600, null));
-        projectGift.rows.get(4).cells.set(1, new Cell(123456789123456789L, null));
-        projectGift.rows.get(5).cells.set(1, new Cell(true, null));
-
         // add a column address based on column recipient
         bindings.put("columnName", "recipient");
     }

--- a/main/tests/server/src/com/google/refine/model/ColumnModelTests.java
+++ b/main/tests/server/src/com/google/refine/model/ColumnModelTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.model;
 
+import java.io.Serializable;
+
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
@@ -36,8 +38,11 @@ public class ColumnModelTests extends RefineTest {
 
     @Test
     public void serializeColumnModel() {
-        Project project = createCSVProject("a,b\n" +
-                "e,e");
+        Project project = createProject(
+                new String[] { "a", "b" },
+                new Serializable[][] {
+                        { "e", "e" }
+                });
         String json = "{\n" +
                 "       \"columnGroups\" : [ ],\n" +
                 "       \"columns\" : [ {\n" +

--- a/main/tests/server/src/com/google/refine/model/RecordModelTests.java
+++ b/main/tests/server/src/com/google/refine/model/RecordModelTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.model;
 
+import java.io.Serializable;
+
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
@@ -36,9 +38,12 @@ public class RecordModelTests extends RefineTest {
 
     @Test
     public void serializeRecordModel() {
-        Project proj = createCSVProject("key,val\n"
-                + "34,first\n"
-                + ",second");
+        Project proj = createProject(
+                new String[] { "key", "val" },
+                new Serializable[][] {
+                        { "34", "first" },
+                        { null, "second" }
+                });
         TestUtils.isSerializedTo(proj.recordModel, "{\"hasRecords\":true}");
     }
 }

--- a/main/tests/server/src/com/google/refine/model/changes/DataExtensionChangeTest.java
+++ b/main/tests/server/src/com/google/refine/model/changes/DataExtensionChangeTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
+import java.io.Serializable;
 
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
@@ -58,9 +59,9 @@ public class DataExtensionChangeTest extends RefineTest {
     @BeforeMethod
     public void SetUp()
             throws IOException, ModelException {
-        project = createCSVProject(
-                "reconciled\n" +
-                        "some item");
+        project = createProject(
+                new String[] { "reconciled" },
+                new Serializable[][] { { "some item" } });
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
@@ -204,8 +205,11 @@ public class StandardReconConfigTests extends RefineTest {
 
     @Test
     public void formulateQueryTest() throws IOException {
-        Project project = createCSVProject("title,director\n"
-                + "mulholland drive,david lynch");
+        Project project = createProject(
+                new String[] { "title", "director" },
+                new Serializable[][] {
+                        { "mulholland drive", "david lynch" }
+                });
 
         String config = " {\n" +
                 "        \"mode\": \"standard-service\",\n" +
@@ -238,8 +242,11 @@ public class StandardReconConfigTests extends RefineTest {
 
     @Test
     public void reconNonJsonTest() throws Exception {
-        Project project = createCSVProject("title,director\n"
-                + "mulholland drive,david lynch");
+        Project project = createProject(
+                new String[] { "title", "director" },
+                new Serializable[][] {
+                        { "mulholland drive", "david lynch" }
+                });
 
         String nonJsonResponse = "<!DOCTYPE html>\n" +
                 "<html lang=\"en\">\n" +
@@ -305,8 +312,11 @@ public class StandardReconConfigTests extends RefineTest {
 
     @Test
     public void reconTest() throws Exception {
-        Project project = createCSVProject("title,director\n"
-                + "mulholland drive,david lynch");
+        Project project = createProject(
+                new String[] { "title", "director" },
+                new Serializable[][] {
+                        { "mulholland drive", "david lynch" }
+                });
 
         String reconResponse = "{\n" +
                 "q0: {\n" +

--- a/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
@@ -27,6 +27,7 @@
 
 package com.google.refine.operations.cell;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -60,12 +61,14 @@ public class BlankDownTests extends RefineTest {
 
     @BeforeMethod
     public void setUp() {
-        project = createCSVProject(
-                "key,first,second\n" +
-                        "a,b,c\n" +
-                        ",d,c\n" +
-                        "e,f,c\n" +
-                        ",,c\n");
+        project = createProject(
+                new String[] { "key", "first", "second" },
+                new Serializable[][] {
+                        { "a", "b", "c" },
+                        { null, "d", "c" },
+                        { "e", "f", "c" },
+                        { null, null, "c" }
+                });
     }
 
     @AfterMethod

--- a/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
@@ -27,6 +27,7 @@
 
 package com.google.refine.operations.cell;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -60,12 +61,14 @@ public class FillDownTests extends RefineTest {
 
     @BeforeMethod
     public void setUp() {
-        project = createCSVProject(
-                "key,first,second\n" +
-                        "a,b,c\n" +
-                        ",d,\n" +
-                        "e,f,\n" +
-                        ",,h\n");
+        project = createProject(
+                new String[] { "key", "first", "second" },
+                new Serializable[][] {
+                        { "a", "b", "c" },
+                        { null, "d", null },
+                        { "e", "f", null },
+                        { null, null, "h" }
+                });
     }
 
     @AfterMethod

--- a/main/tests/server/src/com/google/refine/operations/cell/JoinMultiValuedCellsTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/JoinMultiValuedCellsTests.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
+import java.io.Serializable;
 import java.util.Properties;
 
 import org.slf4j.LoggerFactory;
@@ -67,12 +68,14 @@ public class JoinMultiValuedCellsTests extends RefineTest {
 
     @BeforeMethod
     public void createProject() {
-        project = createCSVProject(
-                "Key,Value\n"
-                        + "Record_1,one\n"
-                        + ",two\n"
-                        + ",three\n"
-                        + ",four\n");
+        project = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one" },
+                        { null, "two" },
+                        { null, "three" },
+                        { null, "four" }
+                });
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -134,15 +135,17 @@ public class KeyValueColumnizeTests extends RefineTest {
      */
     @Test
     public void testKeyValueColumnizeWithID() throws Exception {
-        Project project = createCSVProject(
-                "ID,Cat,Val\n"
-                        + "1,a,1\n"
-                        + "1,b,3\n"
-                        + "2,b,4\n"
-                        + "2,c,5\n"
-                        + "3,a,2\n"
-                        + "3,b,5\n"
-                        + "3,d,3\n");
+        Project project = createProject(
+                new String[] { "ID", "Cat", "Val" },
+                new Serializable[][] {
+                        { "1", "a", "1" },
+                        { "1", "b", "3" },
+                        { "2", "b", "4" },
+                        { "2", "c", "5" },
+                        { "3", "a", "2" },
+                        { "3", "b", "5" },
+                        { "3", "d", "3" }
+                });
 
         AbstractOperation op = new KeyValueColumnizeOperation(
                 "Cat", "Val", null);

--- a/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
@@ -38,9 +38,6 @@ import static org.mockito.Mockito.mock;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Properties;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -193,20 +190,18 @@ public class KeyValueColumnizeTests extends RefineTest {
 
     @Test
     public void testKeyValueColumnize() throws Exception {
-        String csv = "Key,Value\n"
-                + "merchant,Katie\n"
-                + "fruit,apple\n"
-                + "price,1.2\n"
-                + "fruit,pear\n"
-                + "price,1.5\n"
-                + "merchant,John\n"
-                + "fruit,banana\n"
-                + "price,3.1\n";
-        prepareOptions(",", 20, 0, 0, 1, false, false);
-        List<Exception> exceptions = new ArrayList<Exception>();
-        importer.parseOneFile(project, pm, job, "filesource", new StringReader(csv), -1, options, exceptions);
-        project.update();
-        ProjectManager.singleton.registerProject(project, pm);
+        Project project = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "merchant", "Katie" },
+                        { "fruit", "apple" },
+                        { "price", "1.2" },
+                        { "fruit", "pear" },
+                        { "price", "1.5" },
+                        { "merchant", "John" },
+                        { "fruit", "banana" },
+                        { "price", "3.1" }
+                });
 
         AbstractOperation op = new KeyValueColumnizeOperation(
                 "Key",

--- a/main/tests/server/src/com/google/refine/operations/cell/SplitMultiValuedCellsTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/SplitMultiValuedCellsTests.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
+import java.io.Serializable;
 import java.util.Properties;
 
 import org.slf4j.LoggerFactory;
@@ -62,9 +63,11 @@ public class SplitMultiValuedCellsTests extends RefineTest {
 
     @BeforeMethod
     public void createProject() {
-        project = createCSVProject(
-                "Key,Value\n"
-                        + "Record_1,one:two;three four;fiveSix SevèËight;niné91011twelve thirteen 14Àifteen\n");
+        project = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one:two;three four;fiveSix SevèËight;niné91011twelve thirteen 14Àifteen" }
+                });
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperationTest.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperationTest.java
@@ -1,6 +1,7 @@
 
 package com.google.refine.operations.cell;
 
+import java.io.Serializable;
 import java.util.Properties;
 
 import org.testng.Assert;
@@ -27,11 +28,13 @@ public class TransposeColumnsIntoRowsOperationTest extends RefineTest {
 
     @BeforeMethod
     public void setUp() {
-        project = createCSVProject(
-                "num1,num2\n" +
-                        "2,3\n" +
-                        "6,\n" +
-                        "5,9");
+        project = createProject(
+                new String[] { "num1", "num2" },
+                new Serializable[][] {
+                        { "2", "3" },
+                        { "6", null },
+                        { "5", "9" }
+                });
     }
 
     @AfterMethod

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnReorderOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnReorderOperationTests.java
@@ -27,6 +27,7 @@
 
 package com.google.refine.operations.column;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -53,10 +54,12 @@ public class ColumnReorderOperationTests extends RefineTest {
 
     @BeforeMethod
     public void createProject() {
-        project = createCSVProject(
-                "a,b,c\n" +
-                        "1|2,d,e\n" +
-                        "3,f,g\n");
+        project = createProject(
+                new String[] { "a", "b", "c" },
+                new Serializable[][] {
+                        { "1|2", "d", "e" },
+                        { "3", "f", "g" },
+                });
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -91,10 +92,12 @@ public class ReconJudgeSimilarCellsTests extends RefineTest {
 
     @Test
     public void testMarkNewTopics() throws Exception {
-        Project project = createCSVProject(
-                "A,B\n"
-                        + "foo,bar\n"
-                        + "alpha,beta\n");
+        Project project = createProject(
+                new String[] { "A", "B" },
+                new Serializable[][] {
+                        { "foo", "bar" },
+                        { "alpha", "beta" }
+                });
 
         Column column = project.columnModel.columns.get(0);
         ReconConfig config = new StandardReconConfig(

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconMarkNewTopicsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconMarkNewTopicsOperationTests.java
@@ -29,6 +29,7 @@ package com.google.refine.operations.recon;
 
 import static org.testng.Assert.assertEquals;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.Properties;
 
@@ -82,9 +83,12 @@ public class ReconMarkNewTopicsOperationTests extends RefineTest {
 
     @Test
     public void testNotPreviouslyReconciled() throws Exception {
-        Project project = createCSVProject("my column\n"
-                + "hello\n"
-                + "world");
+        Project project = createProject(
+                new String[] { "my column" },
+                new Serializable[][] {
+                        { "hello" },
+                        { "world" }
+                });
         ReconMarkNewTopicsOperation op = ParsingUtilities.mapper.readValue(jsonWithService, ReconMarkNewTopicsOperation.class);
         op.createProcess(project, new Properties()).performImmediate();
 
@@ -98,9 +102,12 @@ public class ReconMarkNewTopicsOperationTests extends RefineTest {
 
     @Test
     public void testPreviouslyReconciled() throws Exception {
-        Project project = createCSVProject("my column\n"
-                + "hello\n"
-                + "world");
+        Project project = createProject(
+                new String[] { "my column" },
+                new Serializable[][] {
+                        { "hello" },
+                        { "world" }
+                });
         StandardReconConfig reconConfig = new StandardReconConfig(
                 "http://foo.com/api",
                 "http://foo.com/identifierSpace",

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
@@ -30,6 +30,7 @@ package com.google.refine.operations.recon;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -127,11 +128,13 @@ public class ReconOperationTests extends RefineTest {
 
     @Test
     public void testFailingRecon() throws Exception {
-        Project project = createCSVProject("my recon test project",
-                "column\n"
-                        + "valueA\n"
-                        + "valueB\n"
-                        + "valueC");
+        Project project = createProject("my recon test project",
+                new String[] { "column" },
+                new Serializable[][] {
+                        { "valueA" },
+                        { "valueB" },
+                        { "valueC" }
+                });
         StandardReconConfig reconConfig = mock(StandardReconConfig.class);
         List<Recon> reconList = Arrays.asList((Recon) null, (Recon) null, (Recon) null);
         ReconJob reconJob = mock(ReconJob.class);

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconUseValuesAsIdsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconUseValuesAsIdsOperationTests.java
@@ -30,6 +30,7 @@ package com.google.refine.operations.recon;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+import java.io.Serializable;
 import java.util.Properties;
 
 import org.testng.annotations.BeforeSuite;
@@ -66,10 +67,13 @@ public class ReconUseValuesAsIdsOperationTests extends RefineTest {
 
     @Test
     public void testUseValuesAsIds() throws Exception {
-        Project project = createCSVProject("ids,v\n"
-                + "Q343,hello\n"
-                + ",world\n"
-                + "http://test.org/entities/Q31,test");
+        Project project = createProject(
+                new String[] { "ids", "v" },
+                new Serializable[][] {
+                        { "Q343", "hello" },
+                        { null, "world" },
+                        { "http://test.org/entities/Q31", "test" }
+                });
         ReconUseValuesAsIdentifiersOperation op = ParsingUtilities.mapper.readValue(json, ReconUseValuesAsIdentifiersOperation.class);
         op.createProcess(project, new Properties()).performImmediate();
 

--- a/main/tests/server/src/com/google/refine/operations/row/RowReorderOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowReorderOperationTests.java
@@ -27,6 +27,7 @@
 
 package com.google.refine.operations.row;
 
+import java.io.Serializable;
 import java.util.Properties;
 
 import org.testng.Assert;
@@ -58,14 +59,16 @@ public class RowReorderOperationTests extends RefineTest {
 
     @BeforeMethod
     public void setUp() {
-        project = createCSVProject(
-                "key,first\n" +
-                        "8,b\n" +
-                        ",d\n" +
-                        "2,f\n" +
-                        "1,h\n" +
-                        "9,F\n" +
-                        "10,f\n");
+        project = createProject(
+                new String[] { "key", "first" },
+                new Serializable[][] {
+                        { "8", "b" },
+                        { null, "d" },
+                        { "2", "f" },
+                        { "1", "h" },
+                        { "9", "F" },
+                        { "10", "f" }
+                });
     }
 
     @AfterMethod


### PR DESCRIPTION
By specifying their columns and rows as arrays, we:
- avoid the dependency on the CSV parser
- make it easier to specify cell values of various datatypes
- improve readability

This is a preparation move towards backporting more of my testing improvements from 4.0
