### PR TITLE
Fixes #6367: replace doesn't work

### DIFF
--- a/main/src/com/google/refine/grel/Scanner.java
+++ b/main/src/com/google/refine/grel/Scanner.java
@@ -174,13 +174,15 @@ public class Scanner {
             while (_index < _limit) {
                 c = _text.charAt(_index);
                 if (c == delimiter) {
-                    _index++; // skip closing delimiter
-
-                    return new Token(
-                            start,
-                            _index,
-                            TokenType.String,
-                            sb.toString());
+                    if ((_index < _limit - 1 && _text.charAt(_index + 1) != delimiter) || (_index == _limit - 1)) {
+                        _index++; // skip closing delimiter
+                        return new Token(
+                                start,
+                                _index,
+                                TokenType.String,
+                                sb.toString());
+                    }
+                    sb.append(c);
                 } else if (c == '\\') {
                     _index++; // skip escaping marker
                     if (_index < _limit) {

--- a/main/src/com/google/refine/grel/Scanner.java
+++ b/main/src/com/google/refine/grel/Scanner.java
@@ -174,12 +174,13 @@ public class Scanner {
             while (_index < _limit) {
                 c = _text.charAt(_index);
                 if (c == delimiter) {
-                        _index++; // skip closing delimiter
-                        return new Token(
-                                start,
-                                _index,
-                                TokenType.String,
-                                sb.toString());
+                    _index++; // skip closing delimiter
+
+                    return new Token(
+                            start,
+                            _index,
+                            TokenType.String,
+                            sb.toString());
                 } else if (c == '\\') {
                     _index++; // skip escaping marker
                     if (_index < _limit) {

--- a/main/src/com/google/refine/grel/Scanner.java
+++ b/main/src/com/google/refine/grel/Scanner.java
@@ -174,15 +174,12 @@ public class Scanner {
             while (_index < _limit) {
                 c = _text.charAt(_index);
                 if (c == delimiter) {
-                    if ((_index < _limit - 1 && _text.charAt(_index + 1) != delimiter) || (_index == _limit - 1)) {
                         _index++; // skip closing delimiter
                         return new Token(
                                 start,
                                 _index,
                                 TokenType.String,
                                 sb.toString());
-                    }
-                    sb.append(c);
                 } else if (c == '\\') {
                     _index++; // skip escaping marker
                     if (_index < _limit) {

--- a/main/tests/cypress/cypress/e2e/project/grid/column/edit-cells/replace.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/edit-cells/replace.cy.js
@@ -143,4 +143,24 @@ describe(__filename, function () {
     cy.assertCellEquals(2, 'b', 'first_name');
 
   });
+  it('Ensure cells are replaced with \"', function () {
+    const fixture = [
+      ['a', 'b', 'c'],
+      ['d', 'e', ' f']
+    ];
+
+    cy.loadAndVisitProject(fixture);
+
+    cy.columnActionClick('b', ['Edit cells', 'Replace']);
+
+    cy.get('.dialog-container input[bind="text_to_findInput"]').type("e");
+    cy.get('.dialog-container input[bind="replacement_textInput"]').type("\"");
+    cy.get('label[bind="or_views_replace_dont_escape"]').click();
+    cy.confirmDialogPanel();
+
+    cy.assertNotificationContainingText('Text transform on 1 cells in column b');
+
+    cy.assertCellEquals(0, 'b', '\"');
+
+  });
 });

--- a/main/tests/server/src/com/google/refine/grel/GrelTests.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTests.java
@@ -244,15 +244,4 @@ public class GrelTests extends RefineTest {
             Assert.fail("Unexpected parse failure for cross function: " + test);
         }
     }
-
-    @Test
-    public void testNextDelimiterIsNotNext() {
-        String test = "value.replace(\"”\",\"\"\")";
-        try {
-            MetaParser.parse("grel:" + test);
-        } catch (ParsingException e) {
-            Assert.fail("Unexpected parse failure for nextDelimiter function: " + test);
-        }
-    }
-
 }

--- a/main/tests/server/src/com/google/refine/grel/GrelTests.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTests.java
@@ -245,4 +245,14 @@ public class GrelTests extends RefineTest {
         }
     }
 
+    @Test
+    public void testNextDelimiterIsNotNext() {
+        String test = "value.replace(\"”\",\"\"\")";
+        try {
+            MetaParser.parse("grel:" + test);
+        } catch (ParsingException e) {
+            Assert.fail("Unexpected parse failure for nextDelimiter function: " + test);
+        }
+    }
+
 }

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
@@ -229,6 +229,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       // replace "\newline" with "\n" and "\tab" with "\t"
       temp = temp.replace(/\\\n/g, '\\n').replace(/\\\t/g, '\\t');
     }
+    // replace """" with "\""
+    temp = temp.replace(/"/g, '\\"');
     // replace newline with "\n" and tab with "\t"
     return temp.replace(/\n/g, '\\n').replace(/\t/g, '\\t').replace(/[\x00-\x1F\x80-\x9F]/g,'');
   }


### PR DESCRIPTION
Fixes #6367 

Changes proposed in this pull request:

While using replace from "”" to """, value.replace("”",""") grel expression.

Added code to escape double quotes(") when using replace.

<img width="1728" alt="image" src="https://github.com/OpenRefine/OpenRefine/assets/51887332/8725860e-993f-4bae-8762-57d039102abc">

