### PR TITLE
Restore project expression history. Fixes #6362.

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/edit-cells/transform.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/edit-cells/transform.cy.js
@@ -67,4 +67,6 @@ describe(__filename, function () {
     cy.assertCellEquals(1, 'b', 'replace expects three strings, or one string, one regex, and one string');
     cy.assertCellEquals(2, 'b', 'replace expects three strings, or one string, one regex, and one string');
   });
+
+  // TODO: Add test for repeated transforms
 });

--- a/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
@@ -120,7 +120,7 @@ describe(__filename, function () {
     ).should('to.contain', 'Error: No matching method');
   });
 
-  it('Test switching from one langage to another', function () {
+  it('Test switching from one language to another', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
     cy.typeExpression('(.. value (toLowerCase) )');
@@ -166,7 +166,7 @@ describe(__filename, function () {
 
   it('Test the history behavior, ensure expressions are stored', function () {
     cy.loadAndVisitProject('food.mini');
-    // Because history is shared across projects, we need to use an expression that is unique
+    // Because global history is shared across projects, we need to use an expression that is unique
 
     // Use a first unique expression
     const uniqueExpression = generateUniqueExpression();
@@ -180,9 +180,15 @@ describe(__filename, function () {
     // Ensure the previously used expression is listed
     loadExpressionPanel();
     cy.get('#expression-preview-tabs li').contains('History').click();
-    cy.get('#expression-preview-tabs-history')
+    cy.get('#expression-preview-tabs-history .expression-preview-table-wrapper tr:nth-child(2) td:last-child')
       .should('be.visible')
-      .should('to.contain', uniqueExpression);
+      .should('to.have.text', uniqueExpression);
+    // Make sure it's in the local project history, not the global history
+    cy.get('#expression-preview-tabs-history .expression-preview-table-wrapper tr:nth-child(2) td:nth-child(3)')
+      .should('to.contain', "This");
+    // The next one down should be from a previous project, so should be in the global list
+    cy.get('#expression-preview-tabs-history .expression-preview-table-wrapper tr:nth-child(3) td:nth-child(3)')
+      .should('to.contain', "Other");
   });
 
   it('Test the reuse of expressions from the history', function () {

--- a/main/tests/server/src/com/google/refine/commands/expr/GetExpressionHistoryCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/expr/GetExpressionHistoryCommandTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.commands.expr;
 
+import static org.mockito.Mockito.when;
+
 import java.io.IOException;
 
 import javax.servlet.ServletException;
@@ -39,6 +41,7 @@ public class GetExpressionHistoryCommandTests extends ExpressionCommandTestBase 
     @BeforeMethod
     public void setUp() {
         command = new GetExpressionHistoryCommand();
+        when(request.getParameter("project")).thenReturn(Long.toString(PROJECT_ID));
     }
 
     @Test
@@ -50,28 +53,40 @@ public class GetExpressionHistoryCommandTests extends ExpressionCommandTestBase 
                 "        \"list\": [\n" +
                 "          \"grel:facetCount(value, 'value', 'Column 1')\",\n" +
                 "          \"grel:facetCount(value, 'value', 'Column 3')\",\n" +
-                "          \"grel:cell.recon.match.id\"" +
+                "          \"grel:cell.recon.match.id\",\n" +
+                "          \"grel:value\"\n" +
                 "]}",
                 "{\n" +
                         "        \"class\": \"com.google.refine.preference.TopList\",\n" +
                         "        \"top\": 100,\n" +
                         "        \"list\": [\n" +
                         "          \"grel:cell.recon.match.id\"\n" +
+                        "]}",
+
+                "{\n" +
+                        "        \"class\": \"com.google.refine.preference.TopList\",\n" +
+                        "        \"top\": 100,\n" +
+                        "        \"list\": [\n" +
+                        "          \"grel:value\"\n" +
                         "]}");
 
         String json = "{\n" +
                 "       \"expressions\" : [ {\n" +
                 "         \"code\" : \"grel:facetCount(value, 'value', 'Column 1')\",\n" +
-                "         \"global\" : false,\n" +
+                "         \"global\" : true,\n" +
                 "         \"starred\" : false\n" +
                 "       }, {\n" +
                 "         \"code\" : \"grel:facetCount(value, 'value', 'Column 3')\",\n" +
-                "         \"global\" : false,\n" +
+                "         \"global\" : true,\n" +
                 "         \"starred\" : false\n" +
                 "       }, {\n" +
                 "         \"code\" : \"grel:cell.recon.match.id\",\n" +
-                "         \"global\" : false,\n" +
+                "         \"global\" : true,\n" +
                 "         \"starred\" : true\n" +
+                "       }, {\n" +
+                "         \"code\" : \"grel:value\",\n" +
+                "         \"global\" : false,\n" +
+                "         \"starred\" : false\n" +
                 "       } ]\n" +
                 "     }";
         command.doGet(request, response);
@@ -81,7 +96,7 @@ public class GetExpressionHistoryCommandTests extends ExpressionCommandTestBase 
     @Test
     public void testUninitialized() throws ServletException, IOException {
 
-        initWorkspace("{}");
+        initWorkspace(null, null, null);
 
         String json = "{\n" +
                 "       \"expressions\" : []\n" +

--- a/main/tests/server/src/com/google/refine/commands/expr/GetExpressionLanguageInfoCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/expr/GetExpressionLanguageInfoCommandTests.java
@@ -48,7 +48,7 @@ public class GetExpressionLanguageInfoCommandTests extends ExpressionCommandTest
     @Test
     public void testJsonResponse() throws ServletException, IOException {
 
-        initWorkspace(null, null);
+        initWorkspace(null, null, null);
 
         command.doGet(request, response);
         String jsonResponse = writer.toString();

--- a/main/tests/server/src/com/google/refine/commands/expr/GetStarredExpressionsCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/expr/GetStarredExpressionsCommandTests.java
@@ -57,6 +57,12 @@ public class GetStarredExpressionsCommandTests extends ExpressionCommandTestBase
                         "        \"top\": 100,\n" +
                         "        \"list\": [\n" +
                         "          \"grel:cell.recon.match.id\"\n" +
+                        "]}",
+                "{\n" +
+                        "        \"class\": \"com.google.refine.preference.TopList\",\n" +
+                        "        \"top\": 100,\n" +
+                        "        \"list\": [\n" +
+                        "          \"grel:value\"\n" +
                         "]}");
 
         String json = "{\n" +

--- a/main/tests/server/src/com/google/refine/commands/expr/ToggleStarredExpressionCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/expr/ToggleStarredExpressionCommandTests.java
@@ -62,6 +62,12 @@ public class ToggleStarredExpressionCommandTests extends ExpressionCommandTestBa
                         "        \"top\": 100,\n" +
                         "        \"list\": [\n" +
                         "          \"grel:cell.recon.match.id\"\n" +
+                        "]}",
+                "{\n" +
+                        "        \"class\": \"com.google.refine.preference.TopList\",\n" +
+                        "        \"top\": 100,\n" +
+                        "        \"list\": [\n" +
+                        "          \"grel:value\"\n" +
                         "]}");
 
         String json = "{\n" +


### PR DESCRIPTION
Fixes #6362

Changes proposed in this pull request:
- restores the local (ie project specific) expression history
- adds both unit tests and Cypress e2e tests to cover functionality
