### PR TITLE
Support Java 21 in refine scripts

### DIFF
--- a/refine
+++ b/refine
@@ -540,8 +540,8 @@ checkJavaMajorVersion() {
   if (( ${major} < 11 )); then
     error "OpenRefine requires Java version 11 or later. If you have multiple versions of Java installed, please set the environment variable JAVA_HOME to the correct version."
   fi
-  if (( ${major} > 17 )); then
-    echo "WARNING: OpenRefine is not tested and not recommended for use with Java versions greater than 17."
+  if (( ${major} > 21 )); then
+    echo "WARNING: OpenRefine is not tested and not recommended for use with Java versions greater than 21."
   fi
 }
 

--- a/refine.bat
+++ b/refine.bat
@@ -237,8 +237,8 @@ if %JAVA_RELEASE% LSS 11 (
     echo OpenRefine requires Java version 11 or later. If you have multiple versions of Java installed, please set the environment variable JAVA_HOME to the correct version.
     exit /B 1
 )
-if %JAVA_RELEASE% GTR 17 (
-    echo WARNING: OpenRefine is not tested and not recommended for use with Java versions greater than 17.
+if %JAVA_RELEASE% GTR 21 (
+    echo WARNING: OpenRefine is not tested and not recommended for use with Java versions greater than 21.
 )
 
 set CLASSPATH="%REFINE_CLASSES_DIR%;%REFINE_LIB_DIR%\*"


### PR DESCRIPTION
Fixes #6087

Changes proposed in this pull request:
- Updates `refine` and `refine.bat` scripts from Java 17 to Java 21 as upper bound
