### PR TITLE
Introduce test utility to compare project contents

### DIFF
--- a/main/src/com/google/refine/model/Cell.java
+++ b/main/src/com/google/refine/model/Cell.java
@@ -59,8 +59,9 @@ import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.Pool;
 import com.google.refine.util.StringUtils;
 
-public class Cell implements HasFields {
+public class Cell implements HasFields, Serializable {
 
+    private static final long serialVersionUID = 7456683757764146620L;
     @JsonIgnore
     final public Serializable value;
     @JsonIgnore

--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -86,6 +86,7 @@ import com.google.refine.util.TestUtils;
  */
 public class RefineTest {
 
+    public static final double EPSILON = 0.0000001;
     protected static Properties bindings = null;
 
     protected Logger logger;
@@ -485,7 +486,7 @@ public class RefineTest {
                     assertEquals(
                             (double) actualCell.value,
                             (double) expectedCell.value,
-                            0.0000001,
+                            EPSILON,
                             String.format("mismatching cells in row %d, column '%s'", i, actual.columnModel.columns.get(j)));
                 } else {
                     assertEquals(

--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -47,6 +47,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
@@ -70,6 +71,7 @@ import com.google.refine.importers.SeparatorBasedImporter;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingManager;
 import com.google.refine.io.FileProjectManager;
+import com.google.refine.messages.OpenRefineMessage;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
 import com.google.refine.model.ModelException;
@@ -449,4 +451,58 @@ public class RefineTest {
     public static void assertEqualsSystemLineEnding(String actual, String expected) {
         Assert.assertEquals(actual, expected.replaceAll("\n", System.lineSeparator()));
     }
+
+    /**
+     * Checks that the grid contents are equal in both projects. Differences in "cell indices" are not taken into
+     * account as this is an internal detail: the goal is to assert equality of the user-facing parts of project data.
+     * 
+     * @param actual
+     *            the actual project state
+     * @param expected
+     *            the expected project state
+     */
+    public static void assertProjectEquals(Project actual, Project expected) {
+        assertEquals(actual.columnModel.getColumnNames(), expected.columnModel.getColumnNames(), "mismatching column names");
+        int columnCount = actual.columnModel.columns.size();
+        // TODO also check that ReconConfig and ReconStats are identical?
+        assertEquals(actual.rows.size(), expected.rows.size(), "mismatching number of rows");
+
+        List<Integer> actualCellIndices = actual.columnModel.columns.stream()
+                .map(Column::getCellIndex)
+                .collect(Collectors.toList());
+        List<Integer> expectedCellIndices = expected.columnModel.columns.stream()
+                .map(Column::getCellIndex)
+                .collect(Collectors.toList());
+        for (int i = 0; i != actual.rows.size(); i++) {
+            Row actualRow = actual.rows.get(i);
+            Row expectedRow = expected.rows.get(i);
+            for (int j = 0; j != columnCount; j++) {
+                Cell actualCell = actualRow.getCell(actualCellIndices.get(j));
+                Cell expectedCell = expectedRow.getCell(expectedCellIndices.get(j));
+
+                // special case for floating-point numbers to accept rounding errors
+                if (expectedCell != null && expectedCell.value instanceof Double && actualCell != null && actualCell.value != null) {
+                    assertEquals(
+                            (double) actualCell.value,
+                            (double) expectedCell.value,
+                            0.0000001,
+                            String.format("mismatching cells in row %d, column '%s'", i, actual.columnModel.columns.get(j)));
+                } else {
+                    assertEquals(
+                            actualCell == null ? null : actualCell.value,
+                            expectedCell == null ? null : expectedCell.value,
+                            String.format("mismatching cells in row %d, column '%s'", i, actual.columnModel.columns.get(j)));
+                }
+            }
+        }
+    }
+
+    /**
+     * Utility method to return a default column name, for the purpose of generating expected grid contents in a concise
+     * way in tests.
+     */
+    public static String numberedColumn(int index) {
+        return OpenRefineMessage.importer_utilities_column() + " " + index;
+    }
+
 }

--- a/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/FixedWidthImporterTests.java
@@ -27,6 +27,7 @@
 
 package com.google.refine.importers;
 
+import java.io.Serializable;
 import java.io.StringReader;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -37,6 +38,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import com.google.refine.model.Project;
 import com.google.refine.util.JSONUtilities;
 import com.google.refine.util.ParsingUtilities;
 
@@ -97,15 +99,14 @@ public class FixedWidthImporterTests extends ImporterTest {
             Assert.fail(e.getMessage());
         }
 
-        Assert.assertEquals(project.rows.size(), 3); // Column names count as a row?
-        Assert.assertEquals(project.rows.get(1).cells.size(), 3);
-        Assert.assertEquals((String) project.rows.get(1).getCellValue(0), "NDB_No");
-        Assert.assertEquals((String) project.rows.get(1).getCellValue(1), "Shrt_Desc");
-        Assert.assertEquals((String) project.rows.get(1).getCellValue(2), "Water");
-        Assert.assertEquals(project.rows.get(2).cells.size(), 3);
-        Assert.assertEquals((String) project.rows.get(2).getCellValue(0), "TooSho");
-        Assert.assertEquals((String) project.rows.get(2).getCellValue(1), "rt");
-        Assert.assertNull(project.rows.get(2).getCellValue(2));
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { "Col 1", "Col 2", "Col 3" }, // TODO those should be column names instead
+                        { "NDB_No", "Shrt_Desc", "Water" },
+                        { "TooSho", "rt", null },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
 }

--- a/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
@@ -37,6 +37,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -59,6 +60,7 @@ import com.google.refine.importers.tree.ImportColumnGroup;
 import com.google.refine.importers.tree.TreeImportingParserBase;
 import com.google.refine.importers.tree.TreeReader.Token;
 import com.google.refine.importing.ImportingJob;
+import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.util.JSONUtilities;
 import com.google.refine.util.ParsingUtilities;
@@ -156,12 +158,13 @@ public class JsonImporterTests extends ImporterTest {
                 "    }\n" +
                 "]\n";
         RunTest(ScraperwikiOutput, true);
-        assertProjectCreated(project, 4, 1);
-        Row row = project.rows.get(0);
-        Assert.assertNotNull(row);
-        Assert.assertNotNull(row.getCell(1));
-        Assert.assertEquals(row.getCell(0).value, "University of Cambridge");
-        Assert.assertEquals(row.getCell(1).value, "Amy Zhang");
+
+        Project expectedProject = createProject(
+                new String[] { "_ - school", "_ - name", "_ - student-faculty-score", "_ - intl-student-score" },
+                new Serializable[][] {
+                        { "University of Cambridge", "Amy Zhang", "100", "95" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -175,25 +178,36 @@ public class JsonImporterTests extends ImporterTest {
                 "    }\n" +
                 "]\n";
         RunTest(ScraperwikiOutput);
-        assertProjectCreated(project, 4, 1);
-        Row row = project.rows.get(0);
-        Assert.assertNotNull(row);
-        Assert.assertNotNull(row.getCell(1));
-        Assert.assertEquals(row.getCell(0).value, "  University of Cambridge  ");
-        Assert.assertEquals(row.getCell(1).value, "          Amy Zhang                   ");
+
+        Project expectedProject = createProject(
+                new String[] { "_ - school", "_ - name", "_ - student-faculty-score", "_ - intl-student-score" },
+                new Serializable[][] {
+                        { "  University of Cambridge  ", "          Amy Zhang                   ", "100", "95" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
     public void canParseSampleWithDuplicateNestedElements() {
         RunTest(getSampleWithDuplicateNestedElements());
-        assertProjectCreated(project, 4, 12);
 
-        Row row = project.rows.get(0);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 4);
-        Assert.assertNotNull(row.getCell(1));
-        Assert.assertEquals(row.getCell(1).value, "Author 1, The");
-        Assert.assertEquals(project.rows.get(1).getCell(1).value, "Author 1, Another");
+        Project expectedProject = createProject(
+                new String[] { "_ - id", "_ - title", "_ - publish_date", "_ - authors - _ - name" },
+                new Serializable[][] {
+                        { 1L, "Book title 1", "2010-05-26", "Author 1, The" },
+                        { null, null, null, "Author 1, Another" },
+                        { 2L, "Book title 2", "2010-05-26", "Author 2, The" },
+                        { null, null, null, "Author 2, Another" },
+                        { 3L, "Book title 3", "2010-05-26", "Author 3, The" },
+                        { null, null, null, "Author 3, Another" },
+                        { 4L, "Book title 4", "2010-05-26", "Author 4, The" },
+                        { null, null, null, "Author 4, Another" },
+                        { 5L, "Book title 5", "2010-05-26", "Author 5, The" },
+                        { null, null, null, "Author 5, Another" },
+                        { 6L, "Book title 6", "2010-05-26", "Author 6, The" },
+                        { null, null, null, "Author 6, Another" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -201,11 +215,17 @@ public class JsonImporterTests extends ImporterTest {
         RunTest(getSampleWithLineBreak());
         assertProjectCreated(project, 4, 6);
 
-        Row row = project.rows.get(3);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 4);
-        Assert.assertNotNull(row.getCell(1));
-        Assert.assertEquals(row.getCell(1).value, "With line\n break");
+        Project expectedProject = createProject(
+                new String[] { "_ - id", "_ - author", "_ - title", "_ - publish_date" },
+                new Serializable[][] {
+                        { 1L, "Author 1, The", "Book title 1", "2010-05-26" },
+                        { 2L, "Author 2, The", "Book title 2", "2010-05-26" },
+                        { 3L, "Author 3, The", "Book title 3", "2010-05-26" },
+                        { 4L, "With line\n break", "Book title 4", "2010-05-26" },
+                        { 5L, "Author 5, The", "Book title 5", "2010-05-26" },
+                        { 6L, "Author 6, The", "Book title 6", "2010-05-26" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -213,28 +233,34 @@ public class JsonImporterTests extends ImporterTest {
         RunTest(getSampleWithVaryingStructure());
         assertProjectCreated(project, 5, 6);
 
-        Assert.assertEquals(project.columnModel.getColumnByCellIndex(4).getName(), JsonImporter.ANONYMOUS + " - genre");
-
-        Row row0 = project.rows.get(0);
-        Assert.assertNotNull(row0);
-        Assert.assertEquals(row0.cells.size(), 4);
-
-        Row row5 = project.rows.get(5);
-        Assert.assertNotNull(row5);
-        Assert.assertEquals(row5.cells.size(), 5);
+        Project expectedProject = createProject(
+                new String[] { "_ - id", "_ - author", "_ - title", "_ - publish_date", "_ - genre" },
+                new Serializable[][] {
+                        { 1L, "Author 1, The", "Book title 1", "2010-05-26", null },
+                        { 2L, "Author 2, The", "Book title 2", "2010-05-26", null },
+                        { 3L, "Author 3, The", "Book title 3", "2010-05-26", null },
+                        { 4L, "Author 4, The", "Book title 4", "2010-05-26", null },
+                        { 5L, "Author 5, The", "Book title 5", "2010-05-26", null },
+                        { 6L, "Author 6, The", "Book title 6", "2010-05-26", "New element not seen in other records" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
     public void testElementWithNestedTree() {
         RunTest(getSampleWithTreeStructure());
-        assertProjectCreated(project, 5, 6);
 
-        Assert.assertEquals(project.columnModel.columnGroups.size(), 1);
-        Assert.assertEquals(project.columnModel.columnGroups.get(0).keyColumnIndex, 3);
-        Assert.assertEquals(project.columnModel.columnGroups.get(0).startColumnIndex, 3);
-        Assert.assertNull(project.columnModel.columnGroups.get(0).parentGroup);
-        Assert.assertEquals(project.columnModel.columnGroups.get(0).subgroups.size(), 0);
-        Assert.assertEquals(project.columnModel.columnGroups.get(0).columnSpan, 2);
+        Project expectedProject = createProject(
+                new String[] { "_ - id", "_ - title", "_ - publish_date", "_ - author - author-name", "_ - author - author-dob" },
+                new Serializable[][] {
+                        { 1L, "Book title 1", "2010-05-26", "Author 1, The", "1950-01-15" },
+                        { 2L, "Book title 2", "2010-05-26", "Author 2, The", "1950-02-15" },
+                        { 3L, "Book title 3", "2010-05-26", "Author 3, The", "1950-03-15" },
+                        { 4L, "Book title 4", "2010-05-26", "Author 4, The", "1950-04-15" },
+                        { 5L, "Book title 5", "2010-05-26", "Author 5, The", "1950-05-15" },
+                        { 6L, "Book title 6", "2010-05-26", "Author 6, The", "1950-06-15" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -250,7 +276,28 @@ public class JsonImporterTests extends ImporterTest {
         JSONUtilities.safePut(options, "recordPath", path);
 
         RunTest(mqlOutput, options);
-        assertProjectCreated(project, 3, 16);
+
+        Project expectedProject = createProject(
+                new String[] { "_ - id", "_ - type", "_ - armed_force - id" },
+                new Serializable[][] {
+                        { "/en/afrika_korps", "/military/military_unit", "/en/wehrmacht" },
+                        { "/en/sacred_band_of_thebes", "/military/military_unit", "/m/0chtrwn" },
+                        { "/en/british_16_air_assault_brigade", "/military/military_unit", "/en/british_army" },
+                        { "/en/pathfinder_platoon", "/military/military_unit", "/en/british_army" },
+                        { "/en/sacred_band", "/military/military_unit", "/m/0ch7qgz" },
+                        { "/en/3rd_ship_flotilla", "/military/military_unit", "/en/polish_navy" },
+                        { "/m/0c0kxn9", "/military/military_unit", "/m/0chtrwn" },
+                        { "/m/0c0kxq9", "/military/military_unit", "/m/0chtrwn" },
+                        { "/m/0c0kxqh", "/military/military_unit", "/m/0chtrwn" },
+                        { "/m/0c0kxqp", "/military/military_unit", "/m/0chtrwn" },
+                        { "/m/0c0kxqw", "/military/military_unit", "/m/0chtrwn" },
+                        { "/m/0c1wxl3", "/military/military_unit", "/m/0chtrwn" },
+                        { "/m/0c1wxlp", "/military/military_unit", "/m/0chtrwn" },
+                        { "/m/0ck96kz", "/military/military_unit", "/m/0chtrwn" },
+                        { "/m/0cm3j23", "/military/military_unit", "/m/0chtrwn" },
+                        { "/m/0cw8hb4", "/military/military_unit", "/m/0chtrwn" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -282,7 +329,17 @@ public class JsonImporterTests extends ImporterTest {
                 "    }\n" +
                 "]\n";
         RunTest(ScraperwikiOutput);
-        assertProjectCreated(project, 9, 2);
+
+        Project expectedProject = createProject(
+                new String[] { "_ - school", "_ - student-faculty-score", "_ - intl-student-score", "_ - intl-faculty-score", "_ - rank",
+                        "_ - peer-review-score", "_ - emp-review-score", "_ - score", "_ - citations-score" },
+                new Serializable[][] {
+                        { "University of Cambridge\n                            United Kingdom", "100", "95", "96", "#1", "100", "100",
+                                "100.0", "93" },
+                        { "Harvard University\n                            United States", "97", "87", "71", "#2", "100", "100", "99.2",
+                                "100" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     /**
@@ -390,67 +447,33 @@ public class JsonImporterTests extends ImporterTest {
     @Test
     public void testJsonDatatypes() {
         RunTest(getSampleWithDataTypes());
-        assertProjectCreated(project, 2, 21, 4);
 
-        Assert.assertEquals(project.columnModel.getColumnByCellIndex(0).getName(), JsonImporter.ANONYMOUS + " - id");
-        Assert.assertEquals(project.columnModel.getColumnByCellIndex(1).getName(), JsonImporter.ANONYMOUS + " - cell - cell");
-
-        Row row = project.rows.get(8);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, ""); // Make sure empty strings are preserved
-
-        // null, true, false 0,1,-2.1,0.23,-0.24,3.14e100
-
-        row = project.rows.get(12);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertNull(row.cells.get(1).value);
-
-        row = project.rows.get(13);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Boolean.TRUE);
-
-        row = project.rows.get(14);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Boolean.FALSE);
-
-        row = project.rows.get(15);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Long.valueOf(0));
-
-        row = project.rows.get(16);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Long.valueOf(1));
-
-        row = project.rows.get(17);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Double.parseDouble("-2.1"));
-
-        row = project.rows.get(18);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Double.valueOf((double) 0.23));
-
-        row = project.rows.get(19);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertEquals(row.cells.get(1).value, Double.valueOf((double) -0.24));
-
-        row = project.rows.get(20);
-        Assert.assertNotNull(row);
-        Assert.assertEquals(row.cells.size(), 2);
-        Assert.assertFalse(Double.isNaN((Double) row.cells.get(1).value));
-        Assert.assertEquals(row.cells.get(1).value, Double.valueOf((double) 3.14e100));
-
-        // null, true, false 0,1,-2.1,0.23,-0.24,3.14e100
-
-        // TODO: check data types
+        Project expectedProject = createProject(
+                new String[] { "_ - id", "_ - cell - cell" },
+                new Serializable[][] {
+                        { 1L, "39766" },
+                        { null, "T1009" },
+                        { null, "foo" },
+                        { null, "DEU" },
+                        { null, "19" },
+                        { null, "01:49" },
+                        { 2L, "39766" },
+                        { null, "T1009" },
+                        { null, "" },
+                        { null, "DEU" },
+                        { null, "19" },
+                        { null, "01:49" },
+                        { null, null },
+                        { null, true },
+                        { null, false },
+                        { null, 0L },
+                        { null, 1L },
+                        { null, -2.1 },
+                        { null, 0.23 },
+                        { null, -0.24 },
+                        { null, 3.14E100 },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -462,6 +485,7 @@ public class JsonImporterTests extends ImporterTest {
                 ". \tcolumn groups number:" + project.columnModel.columnGroups.size() +
                 ".\trow number:" + project.rows.size() + ".\trecord number:" + project.recordModel.getRecordCount());
 
+        // we don't make specific assertions about project contents because the expected grid is rather big.
         assertProjectCreated(project, 63, 63, 8);
     }
 
@@ -496,8 +520,14 @@ public class JsonImporterTests extends ImporterTest {
                 -1,
                 options,
                 exceptions);
-        Assert.assertNotNull(project.columnModel.getColumnByName("File"));
-        Assert.assertEquals(project.rows.get(0).getCell(0).value, "json-sample-format-1.json");
+
+        Project expectedProject = createProject(
+                new String[] { "File", "_ - library - _ - book1 - genre", "_ - library - _ - book1 - author - author-name",
+                        "_ - library - _ - book1 - author - author-dob" },
+                new Serializable[][] {
+                        { "json-sample-format-1.json", "genre1", "author1", "date" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     // ------------helper methods---------------

--- a/main/tests/server/src/com/google/refine/importers/LineBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/LineBasedImporterTests.java
@@ -27,9 +27,9 @@
 
 package com.google.refine.importers;
 
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
+import java.io.Serializable;
 import java.io.StringReader;
 
 import org.slf4j.LoggerFactory;
@@ -38,6 +38,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import com.google.refine.model.Project;
 
 public class LineBasedImporterTests extends ImporterTest {
 
@@ -75,11 +77,12 @@ public class LineBasedImporterTests extends ImporterTest {
             fail("Exception during file parse", e);
         }
 
-        assertEquals(project.columnModel.columns.size(), 1);
-        assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        assertEquals(project.rows.size(), 1);
-        assertEquals(project.rows.get(0).cells.size(), 1);
-        assertEquals(project.rows.get(0).cells.get(0).value, "data1");
+        Project expectedProject = createProject(
+                new String[] { "col1" },
+                new Serializable[][] {
+                        { "data1" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test()
@@ -93,11 +96,14 @@ public class LineBasedImporterTests extends ImporterTest {
             fail("Exception during file parse", e);
         }
 
-        assertEquals(project.rows.size(), 3);
-        assertEquals(project.rows.get(0).cells.size(), 1);
-        assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        assertEquals(project.rows.get(1).cells.get(0).value, "data2");
-        assertEquals(project.rows.get(2).cells.get(0).value, "data3\rdata4");
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1) },
+                new Serializable[][] {
+                        { "data1" },
+                        { "data2" },
+                        { "data3\rdata4" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "LineBasedImporter-Separators")
@@ -111,12 +117,15 @@ public class LineBasedImporterTests extends ImporterTest {
             fail("Exception during file parse", e);
         }
 
-        assertEquals(project.rows.size(), 4);
-        assertEquals(project.rows.get(0).cells.size(), 1);
-        assertEquals(project.rows.get(0).cells.get(0).value, "dataa");
-        assertEquals(project.rows.get(1).cells.get(0).value, "datab");
-        assertEquals(project.rows.get(2).cells.get(0).value, "datac");
-        assertEquals(project.rows.get(3).cells.get(0).value, "datad");
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1) },
+                new Serializable[][] {
+                        { "dataa" },
+                        { "datab" },
+                        { "datac" },
+                        { "datad" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @DataProvider(name = "LineBasedImporter-Separators")

--- a/main/tests/server/src/com/google/refine/importers/MarcImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/MarcImporterTests.java
@@ -32,13 +32,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.importers;
 
-import static org.testng.Assert.assertEquals;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,7 +51,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.refine.importing.ImportingUtilities;
-import com.google.refine.model.Row;
+import com.google.refine.model.Project;
 import com.google.refine.util.JSONUtilities;
 import com.google.refine.util.ParsingUtilities;
 
@@ -104,18 +103,44 @@ public class MarcImporterTests extends XmlImporterTests {
         File xmlFile = ImportingUtilities.getFile(job, fileRecords.get(0));
         InputStream inputStream = new FileInputStream(xmlFile);
         parseOneFile(SUT, inputStream, options);
-        assertEquals(project.rows.size(), 30);
-        assertEquals(project.rows.get(1).cells.size(), 6);
 
-        Row r0 = project.rows.get(0);
-        assertEquals(r0.getCellValue(1), "001");
-        assertEquals(r0.getCellValue(3), "010");
-        assertEquals(project.rows.get(1).getCellValue(1), "003");
-        assertEquals(project.rows.get(1).getCellValue(2), "DLC");
-        Row r2 = project.rows.get(2);
-        assertEquals(r2.getCellValue(1), "005");
-        assertEquals(r2.getCellValue(5), "£4.99");
-        assertEquals(project.rows.get(29).getCellValue(3), "700");
+        Project expectedProject = createProject(
+                new String[] { "marc:record - marc:leader", "marc:record - marc:controlfield - tag", "marc:record - marc:controlfield",
+                        "marc:record - marc:datafield - tag", "marc:record - marc:datafield - ind2", "marc:record - marc:datafield - ind1",
+                        "marc:record - marc:datafield - marc:subfield - code", "marc:record - marc:datafield - marc:subfield" },
+                new Serializable[][] {
+                        { "00762cam a22002658a 4500", "001", "93032341", "010", null, null, "a", "93032341" },
+                        { null, "003", "DLC", "020", null, null, "a", "0192814591 :" },
+                        { null, "005", "20000302171755.0", null, null, null, "c", "£4.99" },
+                        { null, "008", "930830s1994    enk           000 0 eng", "040", null, null, "a", "DLC" },
+                        { null, null, null, null, null, null, "c", "DLC" },
+                        { null, null, null, null, null, null, "d", "DLC" },
+                        { null, null, null, "050", "0", "0", "a", "PR2801.A2" },
+                        { null, null, null, null, null, null, "b", "S66 1994" },
+                        { null, null, null, "082", "0", "0", "a", "822.3/3" },
+                        { null, null, null, null, null, null, "2", "20" },
+                        { null, null, null, "100", null, "1", "a", "Shakespeare, William," },
+                        { null, null, null, null, null, null, "d", "1564-1616." },
+                        { null, null, null, "245", "0", "1", "a", "All's well that ends well /" },
+                        { null, null, null, null, null, null, "c", "edited by Susan Snyder." },
+                        { null, null, null, "260", null, null, "a", "Oxford ;" },
+                        { null, null, null, null, null, null, "a", "New York :" },
+                        { null, null, null, null, null, null, "b", "Oxford University Press," },
+                        { null, null, null, null, null, null, "c", "1994." },
+                        { null, null, null, "263", null, null, "a", "9402" },
+                        { null, null, null, "300", null, null, "a", "p. cm." },
+                        { null, null, null, "440", "4", null, "a", "The World's classics" },
+                        { null, null, null, "651", "0", null, "a", "Florence (Italy)" },
+                        { null, null, null, null, null, null, "x", "Drama." },
+                        { null, null, null, "650", "0", null, "a", "Runaway husbands" },
+                        { null, null, null, null, null, null, "x", "Drama." },
+                        { null, null, null, "650", "0", null, "a", "Married women" },
+                        { null, null, null, null, null, null, "x", "Drama." },
+                        { null, null, null, "655", "7", null, "a", "Comedies." },
+                        { null, null, null, null, null, null, "2", "gsafd" },
+                        { null, null, null, "700", null, "1", "a", "Snyder, Susan." },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
 }

--- a/main/tests/server/src/com/google/refine/importers/OdsImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/OdsImporterTests.java
@@ -36,14 +36,15 @@ package com.google.refine.importers;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -54,7 +55,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.model.Row;
+import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 
 public class OdsImporterTests extends ImporterTest {
@@ -108,17 +109,23 @@ public class OdsImporterTests extends ImporterTest {
             Assert.fail(e.getMessage());
         }
 
-        assertEquals(project.rows.size(), ROWS);
-        Row row = project.rows.get(0);
-        assertEquals(row.cells.size(), COLUMNS);
-        assertEquals((String) row.getCellValue(1), "2 Days In New York");
-        assertEquals(((OffsetDateTime) row.getCellValue(3)).toString().substring(0, 10), "2012-03-28");
-        assertEquals(((Number) row.getCellValue(5)).doubleValue(), 4.5, EPSILON);
+        // TODO dates should not be interpreted in a particular time zone like this
+        DateTimeFormatter format = DateTimeFormatter.ISO_LOCAL_DATE;
+        OffsetDateTime expectedDate = LocalDate.from(format.parse("2012-03-28"))
+                .atStartOfDay()
+                .atZone(ZoneId.systemDefault())
+                .toOffsetDateTime();
 
-        assertFalse((Boolean) row.getCellValue(7));
-        assertTrue((Boolean) project.rows.get(1).getCellValue(7));
-
-        assertNull((String) project.rows.get(2).getCellValue(2));
+        Project expectedProject = createProject(
+                new String[] { "Category", "Title", "Director", "Release Date", "Gross", "Rating", "Rank", "Good?" },
+                new Serializable[][] {
+                        { "Narrative Features", "2 Days In New York", "Julie Delpy", expectedDate, 1.0E7, 4.5, 1.0, false },
+                        { "Narrative Features", "Booster", null, null, null, null, null, true },
+                        { "Narrative Features", "Dark Horse", null, null, null, null, null, null },
+                        { "Narrative Features", "Fairhaven", null, null, null, null, null, null },
+                        { null, null, null, null, null, null, null, null }, // TODO: should likely not be there?
+                });
+        assertProjectEquals(project, expectedProject);
 
         verify(options, times(1)).get("ignoreLines");
         verify(options, times(1)).get("headerLines");

--- a/main/tests/server/src/com/google/refine/importers/RdfTripleImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/RdfTripleImporterTests.java
@@ -37,6 +37,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.slf4j.LoggerFactory;

--- a/main/tests/server/src/com/google/refine/importers/RdfTripleImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/RdfTripleImporterTests.java
@@ -35,7 +35,7 @@ package com.google.refine.importers;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.StringReader;
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 
@@ -68,24 +68,19 @@ public class RdfTripleImporterTests extends ImporterTest {
         JSONUtilities.safePut(options, "base-url", "http://rdf.mybase.com");
     }
 
-    @Test(enabled = false)
-    public void canParseSingleLineTriple() {
+    @Test
+    public void canParseSingleLineTriple() throws UnsupportedEncodingException {
         String sampleRdf = "<http://rdf.mybase.com/ns/en.bob_dylan> <http://rdf.mybase.com/ns/music.artist.album> <http://rdf.mybase.com/ns/en.blood_on_the_tracks>.";
-        StringReader reader = new StringReader(sampleRdf);
+        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
 
-        try {
-            parseOneFile(SUT, reader);
-        } catch (Exception e) {
-            Assert.fail();
-        }
+        parseOneFile(SUT, input);
 
-        assertColumnNamesMatch(project, new String[] { "subject", "http://rdf.mybase.com/ns/music.artist.album" });
-
-        Assert.assertEquals(project.columnModel.columns.size(), 2);
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "http://rdf.mybase.com/ns/en.bob_dylan");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "http://rdf.mybase.com/ns/en.blood_on_the_tracks");
+        Project expectedProject = createProject(
+                new String[] { "subject", "http://rdf.mybase.com/ns/music.artist.album" },
+                new Serializable[][] {
+                        { "http://rdf.mybase.com/ns/en.bob_dylan", "http://rdf.mybase.com/ns/en.blood_on_the_tracks" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -98,31 +93,17 @@ public class RdfTripleImporterTests extends ImporterTest {
         InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
         parseOneFile(SUT, input);
 
-        String[] columns = {
-                "subject",
-                "http://rdf.mybase.com/ns/music.artist.album",
-        };
-        assertColumnNamesMatch(project, columns);
+        Project expectedProject = createProject(
+                new String[] { "subject", "http://rdf.mybase.com/ns/music.artist.album" },
+                new Serializable[][] {
+                        { "http://rdf.mybase.com/ns/en.bob_dylan", "http://rdf.mybase.com/ns/en.bringing_it_all_back_home" },
+                        { null, "http://rdf.mybase.com/ns/en.under_the_red_sky" },
+                        { null, "http://rdf.mybase.com/ns/en.blood_on_the_tracks" },
+                });
+        assertProjectEquals(project, expectedProject);
 
-        // rows
-        Assert.assertEquals(project.rows.size(), 3);
-
-        // row0
-        Assert.assertEquals(project.rows.get(0).cells.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "http://rdf.mybase.com/ns/en.bob_dylan");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "http://rdf.mybase.com/ns/en.bringing_it_all_back_home");
-
-        // row1
-        Assert.assertEquals(project.rows.get(1).cells.size(), 2);
-        Assert.assertNull(project.rows.get(1).cells.get(0));
-        Assert.assertEquals(project.rows.get(1).cells.get(1).value, "http://rdf.mybase.com/ns/en.under_the_red_sky");
         Assert.assertEquals(project.recordModel.getRowDependency(1).cellDependencies[1].rowIndex, 0);
         Assert.assertEquals(project.recordModel.getRowDependency(1).cellDependencies[1].cellIndex, 0);
-
-        // row2
-        Assert.assertEquals(project.rows.get(2).cells.size(), 2);
-        Assert.assertNull(project.rows.get(2).cells.get(0));
-        Assert.assertEquals(project.rows.get(2).cells.get(1).value, "http://rdf.mybase.com/ns/en.blood_on_the_tracks");
         Assert.assertEquals(project.recordModel.getRowDependency(2).cellDependencies[1].rowIndex, 0);
         Assert.assertEquals(project.recordModel.getRowDependency(2).cellDependencies[1].cellIndex, 0);
     }
@@ -137,26 +118,14 @@ public class RdfTripleImporterTests extends ImporterTest {
         InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
         parseOneFile(SUT, input);
 
-        String[] columns = {
-                "subject",
-                "http://rdf.mybase.com/ns/music.artist.album",
-                "http://rdf.mybase.com/ns/music.artist.genre"
-        };
-        assertColumnNamesMatch(project, columns);
-
-        // rows
-        Assert.assertEquals(project.rows.size(), 2);
-
-        // row0
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "http://rdf.mybase.com/ns/en.bob_dylan");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "http://rdf.mybase.com/ns/en.bringing_it_all_back_home");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "http://rdf.mybase.com/ns/en.folk_rock");
-
-        // row1
-        Assert.assertEquals(project.rows.get(1).cells.size(), 2);
-        Assert.assertNull(project.rows.get(1).cells.get(0));
-        Assert.assertEquals(project.rows.get(1).cells.get(1).value, "http://rdf.mybase.com/ns/en.blood_on_the_tracks");
+        Project expectedProject = createProject(
+                new String[] { "subject", "http://rdf.mybase.com/ns/music.artist.album", "http://rdf.mybase.com/ns/music.artist.genre" },
+                new Serializable[][] {
+                        { "http://rdf.mybase.com/ns/en.bob_dylan", "http://rdf.mybase.com/ns/en.bringing_it_all_back_home",
+                                "http://rdf.mybase.com/ns/en.folk_rock" },
+                        { null, "http://rdf.mybase.com/ns/en.blood_on_the_tracks", null },
+                });
+        assertProjectEquals(project, expectedProject);
         Assert.assertEquals(project.recordModel.getRowDependency(1).cellDependencies[1].rowIndex, 0);
         Assert.assertEquals(project.recordModel.getRowDependency(1).cellDependencies[1].cellIndex, 0);
     }
@@ -169,16 +138,12 @@ public class RdfTripleImporterTests extends ImporterTest {
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.N3);
         parseOneFile(SUT, input);
 
-        String[] columns = {
-                "subject",
-                "http://rdf.mybase.com/ns/common.topic.alias",
-        };
-        assertColumnNamesMatch(project, columns);
-
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "http://rdf.mybase.com/ns/en.bob_dylan");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "Robert Zimmerman@en");
+        Project expectedProject = createProject(
+                new String[] { "subject", "http://rdf.mybase.com/ns/common.topic.alias" },
+                new Serializable[][] {
+                        { "http://rdf.mybase.com/ns/en.bob_dylan", "Robert Zimmerman@en" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -236,20 +201,13 @@ public class RdfTripleImporterTests extends ImporterTest {
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.N3);
         parseOneFile(SUT, input);
 
-        String[] columns = {
-                "subject",
-                "http://www.example.org/meeting_organization#attending",
-                "http://www.example.org/personal_details#hasEmail",
-                "http://www.example.org/personal_details#GivenName",
-        };
-        assertColumnNamesMatch(project, columns);
-
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "http://www.example.org/people#fred");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "http://meetings.example.com/cal#m1");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "mailto:fred@example.com");
-        Assert.assertEquals(project.rows.get(0).cells.get(3).value, "Fred");
+        Project expectedProject = createProject(
+                new String[] { "subject", "http://www.example.org/meeting_organization#attending",
+                        "http://www.example.org/personal_details#hasEmail", "http://www.example.org/personal_details#GivenName" },
+                new Serializable[][] {
+                        { "http://www.example.org/people#fred", "http://meetings.example.com/cal#m1", "mailto:fred@example.com", "Fred" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -266,20 +224,13 @@ public class RdfTripleImporterTests extends ImporterTest {
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.TTL);
         parseOneFile(SUT, input);
 
-        String[] columns = {
-                "subject",
-                "http://www.example.org/meeting_organization#attending",
-                "http://www.example.org/personal_details#hasEmail",
-                "http://www.example.org/personal_details#GivenName",
-        };
-        assertColumnNamesMatch(project, columns);
-
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "http://www.example.org/people#fred");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "http://meetings.example.com/cal#m1");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "mailto:fred@example.com");
-        Assert.assertEquals(project.rows.get(0).cells.get(3).value, "Fred");
+        Project expectedProject = createProject(
+                new String[] { "subject", "http://www.example.org/meeting_organization#attending",
+                        "http://www.example.org/personal_details#hasEmail", "http://www.example.org/personal_details#GivenName" },
+                new Serializable[][] {
+                        { "http://www.example.org/people#fred", "http://meetings.example.com/cal#m1", "mailto:fred@example.com", "Fred" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -294,24 +245,13 @@ public class RdfTripleImporterTests extends ImporterTest {
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.NT);
         parseOneFile(SUT, input);
 
-        String[] columns = {
-                "subject",
-                "http://www.example.org/personal_details#GivenName",
-                "http://www.example.org/personal_details#hasEmail",
-                "http://www.example.org/meeting_organization#attending"
-        };
-        assertColumnNamesMatch(project, columns);
-
-        String[][] gridValues = {
-                { "http://www.example.org/people#fred", "Fred", "mailto:fred@example.com", "http://meetings.example.com/cal#m1" }
-        };
-
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "http://www.example.org/people#fred");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "Fred");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "mailto:fred@example.com");
-        Assert.assertEquals(project.rows.get(0).cells.get(3).value, "http://meetings.example.com/cal#m1");
+        Project expectedProject = createProject(
+                new String[] { "subject", "http://www.example.org/personal_details#GivenName",
+                        "http://www.example.org/personal_details#hasEmail", "http://www.example.org/meeting_organization#attending" },
+                new Serializable[][] {
+                        { "http://www.example.org/people#fred", "Fred", "mailto:fred@example.com", "http://meetings.example.com/cal#m1" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -389,19 +329,12 @@ public class RdfTripleImporterTests extends ImporterTest {
         SUT = new RdfTripleImporter(RdfTripleImporter.Mode.JSONLD);
         parseOneFile(SUT, input);
 
-        String[] columns = {
-                "subject",
-                "http://www.example.org/personal_details#hasEmail",
-                "http://www.example.org/personal_details#GivenName",
-                "http://www.example.org/meeting_organization#attending"
-        };
-        assertColumnNamesMatch(project, columns);
-
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "http://www.example.org/people#fred");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "mailto:fred@example.com");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "Fred");
-        Assert.assertEquals(project.rows.get(0).cells.get(3).value, "http://meetings.example.com/cal#m1");
+        Project expectedProject = createProject(
+                new String[] { "subject", "http://www.example.org/personal_details#hasEmail",
+                        "http://www.example.org/personal_details#GivenName", "http://www.example.org/meeting_organization#attending" },
+                new Serializable[][] {
+                        { "http://www.example.org/people#fred", "mailto:fred@example.com", "Fred", "http://meetings.example.com/cal#m1" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 }

--- a/main/tests/server/src/com/google/refine/importers/RdfTripleImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/RdfTripleImporterTests.java
@@ -69,9 +69,9 @@ public class RdfTripleImporterTests extends ImporterTest {
     }
 
     @Test
-    public void canParseSingleLineTriple() throws UnsupportedEncodingException {
+    public void canParseSingleLineTriple() {
         String sampleRdf = "<http://rdf.mybase.com/ns/en.bob_dylan> <http://rdf.mybase.com/ns/music.artist.album> <http://rdf.mybase.com/ns/en.blood_on_the_tracks>.";
-        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes("UTF-8"));
+        InputStream input = new ByteArrayInputStream(sampleRdf.getBytes(StandardCharsets.UTF_8));
 
         parseOneFile(SUT, input);
 

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -38,6 +38,7 @@ import static org.testng.AssertJUnit.assertFalse;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -53,7 +54,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.google.refine.messages.OpenRefineMessage;
+import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 
 public class SeparatorBasedImporterTests extends ImporterTest {
@@ -96,10 +97,12 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
+
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -116,15 +119,12 @@ public class SeparatorBasedImporterTests extends ImporterTest {
             Assert.fail("Exception during file parse", e);
         }
 
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                        { "data1", "data2", "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -140,16 +140,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertTrue(project.rows.get(0).cells.get(1).value instanceof Long);
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, Long.parseLong("234"));
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                        { "data1", 234L, "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -164,15 +161,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), OpenRefineMessage.importer_utilities_column() + " 1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), OpenRefineMessage.importer_utilities_column() + " 2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), OpenRefineMessage.importer_utilities_column() + " 3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { "data1", "data2", "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
@@ -187,12 +182,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, " data1 ");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, " 3.4 ");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, " data3 ");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { " data1 ", " 3.4 ", " data3 " },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -207,12 +203,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, " data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, 12L);
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, " data3");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { " data1", 12L, " data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
@@ -227,12 +224,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "3.4");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { "data1", "3.4", "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
@@ -247,12 +245,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, " data1 ");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, " 3.4 ");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, " data3 ");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { " data1 ", " 3.4 ", " data3 " },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
@@ -267,12 +266,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, Double.parseDouble("3.4"));
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { "data1", 3.4, "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -287,12 +287,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, " data1");
-        Assert.assertNull(project.rows.get(0).cells.get(1));
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, " data3");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { " data1", null, " data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -309,15 +310,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1 sub1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2 sub2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3 sub3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+
+        Project expectedProject = createProject(
+                new String[] { "col1 sub1", "col2 sub2", "col3 sub3" },
+                new Serializable[][] {
+                        { "data1", "data2", "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -334,21 +333,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 6);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.columnModel.columns.get(3).getName(), OpenRefineMessage.importer_utilities_column() + " 4");
-        Assert.assertEquals(project.columnModel.columns.get(4).getName(), OpenRefineMessage.importer_utilities_column() + " 5");
-        Assert.assertEquals(project.columnModel.columns.get(5).getName(), OpenRefineMessage.importer_utilities_column() + " 6");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 6);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
-        Assert.assertEquals(project.rows.get(0).cells.get(3).value, "data4");
-        Assert.assertEquals(project.rows.get(0).cells.get(4).value, "data5");
-        Assert.assertEquals(project.rows.get(0).cells.get(5).value, "data6");
+
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3", numberedColumn(4), numberedColumn(5), numberedColumn(6) },
+                new Serializable[][] {
+                        { "data1", "data2", "data3", "data4", "data5", "data6" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
@@ -364,14 +355,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "\"To Be\" is often followed by \"or not To Be\"");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
+
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                        { "\"To Be\" is often followed by \"or not To Be\"", "data2", null },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -388,15 +378,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                        { "data1", "data2", "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -413,15 +401,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                        { "data1", "data2", "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -442,15 +428,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1 sub1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2 sub2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3 sub3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+
+        Project expectedProject = createProject(
+                new String[] { "col1 sub1", "col2 sub2", "col3 sub3" },
+                new Serializable[][] {
+                        { "data1", "data2", "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
@@ -476,19 +460,14 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1 sub1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2 sub2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3 sub3");
-        Assert.assertEquals(project.rows.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data-row1-cell1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data-row1-cell2");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data-row1-cell3");
-        Assert.assertEquals(project.rows.get(1).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(1).cells.get(0).value, "data-row2-cell1");
-        Assert.assertEquals(project.rows.get(1).cells.get(1).value, "data-row2-cell2");
-        Assert.assertNull(project.rows.get(1).cells.get(2));
+
+        Project expectedProject = createProject(
+                new String[] { "col1 sub1", "col2 sub2", "col3 sub3" },
+                new Serializable[][] {
+                        { "data-row1-cell1", "data-row1-cell2", "data-row1-cell3" },
+                        { "data-row2-cell1", "data-row2-cell2", null },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -502,12 +481,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 4);
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2\"");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3), numberedColumn(4) },
+                new Serializable[][] {
+                        { "data1", "data2\"", "data3", "data4" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
@@ -523,14 +503,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "\"To\n Be\" is often followed by \"or not To\n Be\"");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
+
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                        { "\"To\n Be\" is often followed by \"or not To\n Be\"", "data2", null },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(groups = {}, dataProvider = "CSV-TSV-AutoDetermine")
@@ -546,14 +525,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "A line with many \n\n\n\n\n empty lines");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
+
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                        { "A line with many \n\n\n\n\n empty lines", "data2", null },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -570,15 +548,12 @@ public class SeparatorBasedImporterTests extends ImporterTest {
             Assert.fail("Exception during file parse", e);
         }
 
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                        { "data1", "data2", "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test(dataProvider = "CSV-TSV-AutoDetermine")
@@ -593,13 +568,13 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "col1");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "col2");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "col3");
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "data2");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "data3");
+
+        Project expectedProject = createProject(
+                new String[] { "col1", "col2", "col3" },
+                new Serializable[][] {
+                        { "data1", "data2", "data3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     // ---------------------read tests------------------------
@@ -615,11 +590,12 @@ public class SeparatorBasedImporterTests extends ImporterTest {
             Assert.fail("Exception during file parse", e);
         }
 
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals((String) project.rows.get(0).cells.get(0).value, "NDB_No");
-        Assert.assertEquals((String) project.rows.get(0).cells.get(1).value, "Shrt_Desc");
-        Assert.assertEquals((String) project.rows.get(0).cells.get(2).value, "Water");
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { "NDB_No", "Shrt_Desc", "Water" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -635,12 +611,12 @@ public class SeparatorBasedImporterTests extends ImporterTest {
             Assert.fail("Exception during file parse", e);
         }
 
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
-        Assert.assertEquals((String) project.rows.get(0).cells.get(0).value, "data1");
-        Assert.assertEquals((String) project.rows.get(0).cells.get(1).value, "data2\"");
-        Assert.assertEquals((String) project.rows.get(0).cells.get(2).value, "data3");
-        Assert.assertEquals((String) project.rows.get(0).cells.get(3).value, "data4");
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3), numberedColumn(4) },
+                new Serializable[][] {
+                        { "data1", "data2\"", "data3", "data4" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -658,12 +634,12 @@ public class SeparatorBasedImporterTests extends ImporterTest {
             Assert.fail("Exception during file parse", e);
         }
 
-        Assert.assertEquals(project.rows.size(), 1);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 4);
-        Assert.assertEquals((String) project.rows.get(0).cells.get(0).value, "da\rta1");
-        Assert.assertEquals((String) project.rows.get(0).cells.get(1).value, "dat\ta2");
-        Assert.assertEquals((String) project.rows.get(0).cells.get(2).value, "data3");
-        Assert.assertEquals((String) project.rows.get(0).cells.get(3).value, "dat\na4");
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3), numberedColumn(4) },
+                new Serializable[][] {
+                        { "da\rta1", "dat\ta2", "data3", "dat\na4" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     // ---------------------guess separators------------------------

--- a/main/tests/server/src/com/google/refine/importers/WikitextImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/WikitextImporterTests.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.importers;
 
+import java.io.Serializable;
 import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,6 +47,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 
 public class WikitextImporterTests extends ImporterTest {
@@ -90,12 +92,14 @@ public class WikitextImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Parsing failed", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.rows.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "a");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "b\n2");
-        Assert.assertEquals(project.rows.get(1).cells.get(2).value, "f");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { "a", "b\n2", "c" },
+                        { "d", "e", "f" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     /**
@@ -119,11 +123,14 @@ public class WikitextImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Parsing failed", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.rows.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(1).cells.get(1).value, "e");
-        Assert.assertEquals(project.rows.get(1).cells.get(2).value, "f");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { "a", "b\n2", "c" },
+                        { "d", "e", "f" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     public void readTableWithLinks() throws Exception {
@@ -201,13 +208,18 @@ public class WikitextImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Parsing failed", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 7);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "Europäisches Zentrum für die Förderung der Berufsbildung");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "Cedefop");
-        Assert.assertEquals(project.rows.get(1).cells.get(1).value, "EUROFOUND");
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "Offizieller Name");
-        Assert.assertEquals(project.columnModel.columns.get(6).getName(), "Anmerkungen");
-        Assert.assertEquals(project.rows.get(0).cells.size(), 7);
+
+        Project expectedProject = createProject(
+                new String[] { "Offizieller Name", "Abkürzung", "Website", "Standort", "Staat", "Gründung", "Anmerkungen" },
+                new Serializable[][] {
+                        { "Europäisches Zentrum für die Förderung der Berufsbildung", "Cedefop", "http://www.cedefop.europa.eu/",
+                                "Thessaloniki", "{{Griechenland}}", "1975", "" },
+                        { "Europäische Stiftung zur Verbesserung der Lebens- und Arbeitsbedingungen", "EUROFOUND",
+                                "http://www.eurofound.europa.eu/", "Dublin", "{{Irland}}", "1975", "" },
+                        { "Europäische Beobachtungsstelle für Drogen und Drogensucht", "EMCDDA", "http://www.emcdda.europa.eu/", "Lissabon",
+                                "{{Portugal}}", "1993", "" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -234,10 +246,14 @@ public class WikitextImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Parsing failed", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 6);
-        Assert.assertNull(project.rows.get(1).cells.get(2));
-        Assert.assertNull(project.rows.get(1).cells.get(3));
-        Assert.assertEquals(project.rows.get(1).cells.get(4).value, "Butter");
+
+        Project expectedProject = createProject(
+                new String[] { "Shopping List", "Column", "Column2", "Column3", "Column4", "Column5" },
+                new Serializable[][] {
+                        { "Bread & Butter", "Pie", "Buns", "Danish", "Croissant", null },
+                        { "Cheese", "Ice cream", null, null, "Butter", "Yogurt" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -260,12 +276,14 @@ public class WikitextImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Parsing failed", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 5);
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "b");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "http://gnu.org");
-        Assert.assertEquals(project.rows.get(0).cells.get(4).value, "http://microsoft.com/");
-        Assert.assertEquals(project.rows.get(1).cells.get(4).value, "http://gnu.org");
-        Assert.assertEquals(project.rows.get(1).cells.get(2).value, "http://microsoft.com/");
+
+        Project expectedProject = createProject(
+                new String[] { "price", "fruit", "Column", "merchant", "Column2" },
+                new Serializable[][] {
+                        { "a", "b", "http://gnu.org", "c", "http://microsoft.com/" },
+                        { "d", "e", "http://microsoft.com/", "f", "http://gnu.org" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -288,12 +306,14 @@ public class WikitextImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Parsing failed", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 5);
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "b");
-        Assert.assertEquals(project.rows.get(0).cells.get(2).value, "http://gnu.org");
-        Assert.assertEquals(project.rows.get(0).cells.get(4).value, "http://microsoft.com/");
-        Assert.assertEquals(project.rows.get(1).cells.get(4).value, "http://gnu.org");
-        Assert.assertEquals(project.rows.get(1).cells.get(2).value, "http://microsoft.com/");
+
+        Project expectedProject = createProject(
+                new String[] { "price", "fruit", "Column", "merchant", "Column2" },
+                new Serializable[][] {
+                        { "a", "b", "http://gnu.org", "c", "http://microsoft.com/" },
+                        { "d", "e", "http://microsoft.com/", "f", "http://gnu.org" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     /**
@@ -317,11 +337,14 @@ public class WikitextImporterTests extends ImporterTest {
         } catch (Exception e) {
             Assert.fail("Parsing failed", e);
         }
-        Assert.assertEquals(project.columnModel.columns.size(), 3);
-        Assert.assertEquals(project.rows.size(), 2);
-        Assert.assertEquals(project.rows.get(0).cells.size(), 3);
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "{{free to read}}");
-        Assert.assertEquals(project.rows.get(1).cells.get(1).value, "[[File:My logo.svg]]");
+
+        Project expectedProject = createProject(
+                new String[] { numberedColumn(1), numberedColumn(2), numberedColumn(3) },
+                new Serializable[][] {
+                        { "{{free to read}}", "b", "c" },
+                        { "d", "[[File:My logo.svg]]", "f" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     // --helpers--

--- a/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
@@ -94,10 +93,15 @@ public class BlankDownTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals("c", project.rows.get(0).cells.get(2).value);
-        Assert.assertNull(project.rows.get(1).cells.get(2));
-        Assert.assertEquals("c", project.rows.get(2).cells.get(2).value);
-        Assert.assertNull(project.rows.get(3).cells.get(2));
+        Project expectedProject = createProject(
+                new String[] { "key", "first", "second" },
+                new Serializable[][] {
+                        { "a", "b", "c" },
+                        { null, "d", null },
+                        { "e", "f", "c" },
+                        { null, null, null },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -108,10 +112,15 @@ public class BlankDownTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals("c", project.rows.get(0).cells.get(2).value);
-        Assert.assertNull(project.rows.get(1).cells.get(2));
-        Assert.assertNull(project.rows.get(2).cells.get(2));
-        Assert.assertNull(project.rows.get(3).cells.get(2));
+        Project expectedProject = createProject(
+                new String[] { "key", "first", "second" },
+                new Serializable[][] {
+                        { "a", "b", "c" },
+                        { null, "d", null },
+                        { "e", "f", null },
+                        { null, null, null },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -134,9 +143,14 @@ public class BlankDownTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals("c", project.rows.get(0).cells.get(3).value);
-        Assert.assertNull(project.rows.get(1).cells.get(3));
-        Assert.assertEquals("c", project.rows.get(2).cells.get(3).value);
-        Assert.assertNull(project.rows.get(3).cells.get(3));
+        Project expectedProject = createProject(
+                new String[] { "key", "first", "second" },
+                new Serializable[][] {
+                        { "a", "b", "c" },
+                        { null, "d", null },
+                        { "e", "f", "c" },
+                        { null, null, null },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 }

--- a/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
@@ -93,10 +92,15 @@ public class FillDownTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals("a", project.rows.get(0).cells.get(0).value);
-        Assert.assertEquals("a", project.rows.get(1).cells.get(0).value);
-        Assert.assertEquals("e", project.rows.get(2).cells.get(0).value);
-        Assert.assertEquals("e", project.rows.get(3).cells.get(0).value);
+        Project expectedProject = createProject(
+                new String[] { "key", "first", "second" },
+                new Serializable[][] {
+                        { "a", "b", "c" },
+                        { "a", "d", null },
+                        { "e", "f", null },
+                        { "e", null, "h" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     // For issue #742
@@ -109,10 +113,15 @@ public class FillDownTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals("c", project.rows.get(0).cells.get(2).value);
-        Assert.assertEquals("c", project.rows.get(1).cells.get(2).value);
-        Assert.assertNull(project.rows.get(2).cells.get(2));
-        Assert.assertEquals("h", project.rows.get(3).cells.get(2).value);
+        Project expectedProject = createProject(
+                new String[] { "key", "first", "second" },
+                new Serializable[][] {
+                        { "a", "b", "c" },
+                        { null, "d", "c" },
+                        { "e", "f", null },
+                        { null, null, "h" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     // For issue #742
@@ -125,10 +134,15 @@ public class FillDownTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals("c", project.rows.get(0).cells.get(2).value);
-        Assert.assertEquals("c", project.rows.get(1).cells.get(2).value);
-        Assert.assertEquals("c", project.rows.get(2).cells.get(2).value);
-        Assert.assertEquals("h", project.rows.get(3).cells.get(2).value);
+        Project expectedProject = createProject(
+                new String[] { "key", "first", "second" },
+                new Serializable[][] {
+                        { "a", "b", "c" },
+                        { null, "d", "c" },
+                        { "e", "f", "c" },
+                        { null, null, "h" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -151,9 +165,14 @@ public class FillDownTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals("c", project.rows.get(0).cells.get(3).value);
-        Assert.assertEquals("c", project.rows.get(1).cells.get(3).value);
-        Assert.assertNull(project.rows.get(2).cells.get(3));
-        Assert.assertEquals("h", project.rows.get(3).cells.get(3).value);
+        Project expectedProject = createProject(
+                new String[] { "key", "first", "second" },
+                new Serializable[][] {
+                        { "a", "b", "c" },
+                        { null, "d", "c" },
+                        { "e", "f", null },
+                        { null, null, "h" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 }

--- a/main/tests/server/src/com/google/refine/operations/cell/JoinMultiValuedCellsTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/JoinMultiValuedCellsTests.java
@@ -37,7 +37,6 @@ import java.io.Serializable;
 import java.util.Properties;
 
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.BeforeTest;
@@ -101,11 +100,12 @@ public class JoinMultiValuedCellsTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        int keyCol = project.columnModel.getColumnByName("Key").getCellIndex();
-        int valueCol = project.columnModel.getColumnByName("Value").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(keyCol), "Record_1");
-        Assert.assertEquals(project.rows.get(0).getCellValue(valueCol), "one,two,three,four");
+        Project expectedProject = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one,two,three,four" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -117,11 +117,12 @@ public class JoinMultiValuedCellsTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        int keyCol = project.columnModel.getColumnByName("Key").getCellIndex();
-        int valueCol = project.columnModel.getColumnByName("Value").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(keyCol), "Record_1");
-        Assert.assertEquals(project.rows.get(0).getCellValue(valueCol), "one,     ,two,     ,three,     ,four");
+        Project expectedProject = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one,     ,two,     ,three,     ,four" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
 }

--- a/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
@@ -33,16 +33,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Properties;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
@@ -53,7 +49,6 @@ import com.google.refine.ProjectMetadata;
 import com.google.refine.RefineServlet;
 import com.google.refine.RefineServletStub;
 import com.google.refine.RefineTest;
-import com.google.refine.importers.SeparatorBasedImporter;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingManager;
 import com.google.refine.io.FileProjectManager;
@@ -71,9 +66,7 @@ public class KeyValueColumnizeTests extends RefineTest {
     private RefineServlet servlet;
     private Project project;
     private ProjectMetadata pm;
-    private ObjectNode options;
     private ImportingJob job;
-    private SeparatorBasedImporter importer;
 
     @Override
     @BeforeTest
@@ -90,12 +83,9 @@ public class KeyValueColumnizeTests extends RefineTest {
         pm = new ProjectMetadata();
         pm.setName("KeyValueColumnize test");
         ProjectManager.singleton.registerProject(project, pm);
-        options = mock(ObjectNode.class);
         OperationRegistry.registerOperation(getCoreModule(), "key-value-columnize", KeyValueColumnizeOperation.class);
-
         ImportingManager.initialize(servlet);
         job = ImportingManager.createJob();
-        importer = new SeparatorBasedImporter();
     }
 
     @AfterMethod
@@ -105,7 +95,6 @@ public class KeyValueColumnizeTests extends RefineTest {
         job = null;
         project = null;
         pm = null;
-        options = null;
     }
 
     @Test
@@ -151,36 +140,14 @@ public class KeyValueColumnizeTests extends RefineTest {
 
         process.performImmediate();
 
-        // Expected output from the GUI.
-        // ID,a,b,c,d
-        // 1,1,3,,
-        // 2,,4,5,
-        // 3,2,5,,3
-        Assert.assertEquals(project.columnModel.columns.size(), 5);
-        Assert.assertEquals(project.columnModel.columns.get(0).getName(), "ID");
-        Assert.assertEquals(project.columnModel.columns.get(1).getName(), "a");
-        Assert.assertEquals(project.columnModel.columns.get(2).getName(), "b");
-        Assert.assertEquals(project.columnModel.columns.get(3).getName(), "c");
-        Assert.assertEquals(project.columnModel.columns.get(4).getName(), "d");
-        Assert.assertEquals(project.rows.size(), 3);
-
-        // The actual row data structure has to leave the columns model untouched for redo/undo purpose.
-        // So we have 2 empty columns(column 1,2) on the row level.
-        // 1,1,3,,
-        Assert.assertEquals(project.rows.get(0).cells.get(0).value, "1");
-        Assert.assertEquals(project.rows.get(0).cells.get(3).value, "1");
-        Assert.assertEquals(project.rows.get(0).cells.get(4).value, "3");
-
-        // 2,,4,5,
-        Assert.assertEquals(project.rows.get(1).cells.get(0).value, "2");
-        Assert.assertEquals(project.rows.get(1).cells.get(4).value, "4");
-        Assert.assertEquals(project.rows.get(1).cells.get(5).value, "5");
-
-        // 3,2,5,,3
-        Assert.assertEquals(project.rows.get(2).cells.get(0).value, "3");
-        Assert.assertEquals(project.rows.get(2).cells.get(3).value, "2");
-        Assert.assertEquals(project.rows.get(2).cells.get(4).value, "5");
-        Assert.assertEquals(project.rows.get(2).cells.get(6).value, "3");
+        Project expectedProject = createProject(
+                new String[] { "ID", "a", "b", "c", "d" },
+                new Serializable[][] {
+                        { "1", "1", "3", null, null },
+                        { "2", null, "4", "5", null },
+                        { "3", "2", "5", null, "3" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     /**
@@ -210,33 +177,14 @@ public class KeyValueColumnizeTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        int merchantCol = project.columnModel.getColumnByName("merchant").getCellIndex();
-        int fruitCol = project.columnModel.getColumnByName("fruit").getCellIndex();
-        int priceCol = project.columnModel.getColumnByName("price").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(merchantCol), "Katie");
-        Assert.assertEquals(project.rows.get(1).getCellValue(merchantCol), null);
-        Assert.assertEquals(project.rows.get(2).getCellValue(merchantCol), "John");
-        Assert.assertEquals(project.rows.get(0).getCellValue(fruitCol), "apple");
-        Assert.assertEquals(project.rows.get(1).getCellValue(fruitCol), "pear");
-        Assert.assertEquals(project.rows.get(2).getCellValue(fruitCol), "banana");
-        Assert.assertEquals(project.rows.get(0).getCellValue(priceCol), "1.2");
-        Assert.assertEquals(project.rows.get(1).getCellValue(priceCol), "1.5");
-        Assert.assertEquals(project.rows.get(2).getCellValue(priceCol), "3.1");
-    }
-
-    private void prepareOptions(
-            String sep, int limit, int skip, int ignoreLines,
-            int headerLines, boolean guessValueType, boolean ignoreQuotes) {
-
-        whenGetStringOption("separator", options, sep);
-        whenGetIntegerOption("limit", options, limit);
-        whenGetIntegerOption("skipDataLines", options, skip);
-        whenGetIntegerOption("ignoreLines", options, ignoreLines);
-        whenGetIntegerOption("headerLines", options, headerLines);
-        whenGetBooleanOption("guessCellValueTypes", options, guessValueType);
-        whenGetBooleanOption("processQuotes", options, !ignoreQuotes);
-        whenGetBooleanOption("storeBlankCellsAsNulls", options, true);
+        Project expectedProject = createProject(
+                new String[] { "merchant", "fruit", "price" },
+                new Serializable[][] {
+                        { "Katie", "apple", "1.2" },
+                        { null, "pear", "1.5" },
+                        { "John", "banana", "3.1" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
 }

--- a/main/tests/server/src/com/google/refine/operations/cell/SplitMultiValuedCellsTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/SplitMultiValuedCellsTests.java
@@ -37,7 +37,6 @@ import java.io.Serializable;
 import java.util.Properties;
 
 import org.slf4j.LoggerFactory;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -108,14 +107,13 @@ public class SplitMultiValuedCellsTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        int keyCol = project.columnModel.getColumnByName("Key").getCellIndex();
-        int valueCol = project.columnModel.getColumnByName("Value").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(keyCol), "Record_1");
-        Assert.assertEquals(project.rows.get(0).getCellValue(valueCol), "one");
-        Assert.assertEquals(project.rows.get(1).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(1).getCellValue(valueCol),
-                "two;three four;fiveSix SevèËight;niné91011twelve thirteen 14Àifteen");
+        Project expectedProject = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one" },
+                        { null, "two;three four;fiveSix SevèËight;niné91011twelve thirteen 14Àifteen" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -128,17 +126,20 @@ public class SplitMultiValuedCellsTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        int keyCol = project.columnModel.getColumnByName("Key").getCellIndex();
-        int valueCol = project.columnModel.getColumnByName("Value").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(keyCol), "Record_1");
-        Assert.assertEquals(project.rows.get(0).getCellValue(valueCol), "one");
-        Assert.assertEquals(project.rows.get(1).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(1).getCellValue(valueCol), "two");
-        Assert.assertEquals(project.rows.get(2).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(2).getCellValue(valueCol), "three");
-        Assert.assertEquals(project.rows.get(3).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(3).getCellValue(valueCol), "four");
+        Project expectedProject = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one" },
+                        { null, "two" },
+                        { null, "three" },
+                        { null, "four" },
+                        { null, "fiveSix" },
+                        { null, "SevèËight" },
+                        { null, "niné91011twelve" },
+                        { null, "thirteen" },
+                        { null, "14Àifteen" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -152,17 +153,15 @@ public class SplitMultiValuedCellsTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        int keyCol = project.columnModel.getColumnByName("Key").getCellIndex();
-        int valueCol = project.columnModel.getColumnByName("Value").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(keyCol), "Record_1");
-        Assert.assertEquals(project.rows.get(0).getCellValue(valueCol), "one:");
-        Assert.assertEquals(project.rows.get(1).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(1).getCellValue(valueCol), "two;");
-        Assert.assertEquals(project.rows.get(2).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(2).getCellValue(valueCol), "three ");
-        Assert.assertEquals(project.rows.get(3).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(3).getCellValue(valueCol), "four");
+        Project expectedProject = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one:" },
+                        { null, "two;" },
+                        { null, "three " },
+                        { null, "four" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -175,17 +174,15 @@ public class SplitMultiValuedCellsTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        int keyCol = project.columnModel.getColumnByName("Key").getCellIndex();
-        int valueCol = project.columnModel.getColumnByName("Value").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(keyCol), "Record_1");
-        Assert.assertEquals(project.rows.get(0).getCellValue(valueCol), "one:two;three four;five");
-        Assert.assertEquals(project.rows.get(1).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(1).getCellValue(valueCol), "Six ");
-        Assert.assertEquals(project.rows.get(2).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(2).getCellValue(valueCol), "Sevè");
-        Assert.assertEquals(project.rows.get(3).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(3).getCellValue(valueCol), "Ëight;niné91011twelve thirteen 14Àifteen");
+        Project expectedProject = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one:two;three four;five" },
+                        { null, "Six " },
+                        { null, "Sevè" },
+                        { null, "Ëight;niné91011twelve thirteen 14Àifteen" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -198,19 +195,16 @@ public class SplitMultiValuedCellsTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        int keyCol = project.columnModel.getColumnByName("Key").getCellIndex();
-        int valueCol = project.columnModel.getColumnByName("Value").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(keyCol), "Record_1");
-        Assert.assertEquals(project.rows.get(0).getCellValue(valueCol), "one:two;three four;fiveS");
-        Assert.assertEquals(project.rows.get(1).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(1).getCellValue(valueCol), "ix S");
-        Assert.assertEquals(project.rows.get(2).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(2).getCellValue(valueCol), "evèË");
-        Assert.assertEquals(project.rows.get(3).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(3).getCellValue(valueCol), "ight;niné91011twelve thirteen 14À");
-        Assert.assertEquals(project.rows.get(4).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(4).getCellValue(valueCol), "ifteen");
+        Project expectedProject = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one:two;three four;fiveS" },
+                        { null, "ix S" },
+                        { null, "evèË" },
+                        { null, "ight;niné91011twelve thirteen 14À" },
+                        { null, "ifteen" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -223,15 +217,14 @@ public class SplitMultiValuedCellsTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        int keyCol = project.columnModel.getColumnByName("Key").getCellIndex();
-        int valueCol = project.columnModel.getColumnByName("Value").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(keyCol), "Record_1");
-        Assert.assertEquals(project.rows.get(0).getCellValue(valueCol), "one:two;three four;fiveSix SevèËight;niné91011");
-        Assert.assertEquals(project.rows.get(1).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(1).getCellValue(valueCol), "twelve thirteen 14");
-        Assert.assertEquals(project.rows.get(2).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(2).getCellValue(valueCol), "Àifteen");
+        Project expectedProject = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one:two;three four;fiveSix SevèËight;niné91011" },
+                        { null, "twelve thirteen 14" },
+                        { null, "Àifteen" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -244,14 +237,13 @@ public class SplitMultiValuedCellsTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        int keyCol = project.columnModel.getColumnByName("Key").getCellIndex();
-        int valueCol = project.columnModel.getColumnByName("Value").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(keyCol), "Record_1");
-        Assert.assertEquals(project.rows.get(0).getCellValue(valueCol), "one:two;three four;fiveSix SevèËight;niné");
-        Assert.assertEquals(project.rows.get(1).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(1).getCellValue(valueCol), "91011twelve thirteen ");
-        Assert.assertEquals(project.rows.get(2).getCellValue(keyCol), null);
-        Assert.assertEquals(project.rows.get(2).getCellValue(valueCol), "14Àifteen");
+        Project expectedProject = createProject(
+                new String[] { "Key", "Value" },
+                new Serializable[][] {
+                        { "Record_1", "one:two;three four;fiveSix SevèËight;niné" },
+                        { null, "91011twelve thirteen " },
+                        { null, "14Àifteen" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 }

--- a/main/tests/server/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperationTest.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperationTest.java
@@ -4,7 +4,6 @@ package com.google.refine.operations.cell;
 import java.io.Serializable;
 import java.util.Properties;
 
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
@@ -48,10 +47,15 @@ public class TransposeColumnsIntoRowsOperationTest extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals("num1:2", project.rows.get(0).cells.get(0).value);
-        Assert.assertEquals("num2:3", project.rows.get(1).cells.get(0).value);
-        Assert.assertEquals("num1:6", project.rows.get(2).cells.get(0).value);
-        Assert.assertEquals("num1:5", project.rows.get(3).cells.get(0).value);
-        Assert.assertEquals("num2:9", project.rows.get(4).cells.get(0).value);
+        Project expectedProject = createProject(
+                new String[] { "a" },
+                new Serializable[][] {
+                        { "num1:2" },
+                        { "num2:3" },
+                        { "num1:6" },
+                        { "num1:5" },
+                        { "num2:9" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 }

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnReorderOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnReorderOperationTests.java
@@ -73,25 +73,24 @@ public class ColumnReorderOperationTests extends RefineTest {
     @Test
     public void testEraseCellsOnRemovedColumns() throws Exception {
 
-        int aCol = project.columnModel.getColumnByName("a").getCellIndex();
         int bCol = project.columnModel.getColumnByName("b").getCellIndex();
         int cCol = project.columnModel.getColumnByName("c").getCellIndex();
-
-        Assert.assertEquals(project.rows.get(0).getCellValue(aCol), "1|2");
-        Assert.assertEquals(project.rows.get(0).getCellValue(bCol), "d");
-        Assert.assertEquals(project.rows.get(0).getCellValue(cCol), "e");
-        Assert.assertEquals(project.rows.get(1).getCellValue(aCol), "3");
-        Assert.assertEquals(project.rows.get(1).getCellValue(bCol), "f");
-        Assert.assertEquals(project.rows.get(1).getCellValue(cCol), "g");
 
         AbstractOperation op = new ColumnReorderOperation(Arrays.asList("a"));
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals(project.rows.get(0).getCellValue(aCol), "1|2");
+        Project expectedProject = createProject(
+                new String[] { "a" },
+                new Serializable[][] {
+                        { "1|2" },
+                        { "3" },
+                });
+        assertProjectEquals(project, expectedProject);
+
+        // deleted cell indices are nulled out
         Assert.assertEquals(project.rows.get(0).getCellValue(bCol), null);
         Assert.assertEquals(project.rows.get(0).getCellValue(cCol), null);
-        Assert.assertEquals(project.rows.get(1).getCellValue(aCol), "3");
         Assert.assertEquals(project.rows.get(1).getCellValue(bCol), null);
         Assert.assertEquals(project.rows.get(1).getCellValue(cCol), null);
 

--- a/main/tests/server/src/com/google/refine/operations/recon/ExtendDataOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ExtendDataOperationTests.java
@@ -36,6 +36,7 @@ package com.google.refine.operations.recon;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -144,6 +145,7 @@ public class ExtendDataOperationTests extends RefineTest {
 
     // dependencies
     Project project;
+    Cell reconCell1, reconCell2, reconCell3, reconCell4;
     Properties options;
     EngineConfig engine_config;
     Engine engine;
@@ -166,16 +168,20 @@ public class ExtendDataOperationTests extends RefineTest {
         engine.setMode(Engine.Mode.RowBased);
 
         Row row = new Row(2);
-        row.setCell(0, reconciledCell("Iran", "Q794"));
+        reconCell1 = reconciledCell("Iran", "Q794");
+        row.setCell(0, reconCell1);
         project.rows.add(row);
         row = new Row(2);
-        row.setCell(0, reconciledCell("Japan", "Q17"));
+        reconCell2 = reconciledCell("Japan", "Q17");
+        row.setCell(0, reconCell2);
         project.rows.add(row);
         row = new Row(2);
-        row.setCell(0, reconciledCell("Tajikistan", "Q863"));
+        reconCell3 = reconciledCell("Tajikistan", "Q863");
+        row.setCell(0, reconCell3);
         project.rows.add(row);
         row = new Row(2);
-        row.setCell(0, reconciledCell("United States of America", "Q30"));
+        reconCell4 = reconciledCell("United States of America", "Q30");
+        row.setCell(0, reconCell4);
         project.rows.add(row);
 
         dispatcher = new Dispatcher() {
@@ -280,11 +286,15 @@ public class ExtendDataOperationTests extends RefineTest {
             LongRunningProcessStub process = new LongRunningProcessStub(op.createProcess(project, options));
             process.run();
 
-            // Inspect rows
-            Assert.assertTrue("IR".equals(project.rows.get(0).getCellValue(1)), "Bad country code for Iran.");
-            Assert.assertTrue("JP".equals(project.rows.get(1).getCellValue(1)), "Bad country code for Japan.");
-            Assert.assertNull(project.rows.get(2).getCell(1), "Expected a null country code.");
-            Assert.assertTrue("US".equals(project.rows.get(3).getCellValue(1)), "Bad country code for United States.");
+            Project expectedProject = createProject(
+                    new String[] { "country", "ISO 3166-1 alpha-2 code" },
+                    new Serializable[][] {
+                            { reconCell1, "IR" },
+                            { reconCell2, "JP" },
+                            { reconCell3, null },
+                            { reconCell4, "US" },
+                    });
+            assertProjectEquals(project, expectedProject);
 
             // Make sure we did not create any recon stats for that column (no reconciled value)
             Assert.assertTrue(project.columnModel.getColumnByName("ISO 3166-1 alpha-2 code").getReconStats() == null);
@@ -331,11 +341,15 @@ public class ExtendDataOperationTests extends RefineTest {
             LongRunningProcessStub process = new LongRunningProcessStub(op.createProcess(project, options));
             process.run();
 
-            // Test to be updated as countries change currencies!
-            Assert.assertTrue(Math.round((double) project.rows.get(2).getCellValue(1)) == 2,
-                    "Incorrect number of currencies returned for Tajikistan.");
-            Assert.assertTrue(Math.round((double) project.rows.get(3).getCellValue(1)) == 1,
-                    "Incorrect number of currencies returned for United States.");
+            Project expectedProject = createProject(
+                    new String[] { "country", "currency" },
+                    new Serializable[][] {
+                            { reconCell1, 1.0 },
+                            { reconCell2, 1.0 },
+                            { reconCell3, 2.0 },
+                            { reconCell4, 1.0 },
+                    });
+            assertProjectEquals(project, expectedProject);
 
             // Make sure we did not create any recon stats for that column (no reconciled value)
             Assert.assertTrue(project.columnModel.getColumnByName("currency").getReconStats() == null);

--- a/main/tests/server/src/com/google/refine/operations/row/RowReorderOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowReorderOperationTests.java
@@ -86,12 +86,17 @@ public class RowReorderOperationTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "h");
-        Assert.assertEquals(project.rows.get(1).cells.get(1).value, "f");
-        Assert.assertEquals(project.rows.get(2).cells.get(1).value, "b");
-        Assert.assertEquals(project.rows.get(3).cells.get(1).value, "F");
-        Assert.assertEquals(project.rows.get(4).cells.get(1).value, "f");
-        Assert.assertEquals(project.rows.get(5).cells.get(1).value, "d");
+        Project expectedProject = createProject(
+                new String[] { "key", "first" },
+                new Serializable[][] {
+                        { "1", "h" },
+                        { "2", "f" },
+                        { "8", "b" },
+                        { "9", "F" },
+                        { "10", "f" },
+                        { "", "d" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test
@@ -104,12 +109,17 @@ public class RowReorderOperationTests extends RefineTest {
         Process process = op.createProcess(project, new Properties());
         process.performImmediate();
 
-        Assert.assertEquals(project.rows.get(5).cells.get(1).value, "h");
-        Assert.assertEquals(project.rows.get(4).cells.get(1).value, "f");
-        Assert.assertEquals(project.rows.get(3).cells.get(1).value, "b");
-        Assert.assertEquals(project.rows.get(2).cells.get(1).value, "F");
-        Assert.assertEquals(project.rows.get(1).cells.get(1).value, "f");
-        Assert.assertEquals(project.rows.get(0).cells.get(1).value, "d"); // controlled by blankPosition, not reverse
+        Project expectedProject = createProject(
+                new String[] { "key", "first" },
+                new Serializable[][] {
+                        { "", "d" },
+                        { "10", "f" },
+                        { "9", "F" },
+                        { "8", "b" },
+                        { "2", "f" },
+                        { "1", "h" },
+                });
+        assertProjectEquals(project, expectedProject);
     }
 
     @Test


### PR DESCRIPTION
Closes #6372. Follow-up to #6371.

This is a preparation before backporting more tests from the 4.0 branch.

There are a couple of places which I didn't migrate because checking for equality on reconciliation objects is currently inconvenient (as `equals(Object)` is not overridden on the `Recon` class). I'll follow-up with a fix for that.

The only change in non-test classes is making `Cell` serializable.