### PR TITLE
Fix benign "bug"

### DIFF
--- a/main/src/com/google/refine/clustering/binning/Metaphone3.java
+++ b/main/src/com/google/refine/clustering/binning/Metaphone3.java
@@ -3259,7 +3259,7 @@ public class Metaphone3 {
 				if(Internal_Hard_G())
 				{
 					// don't encode KG or KK if e.g. "mcgill"
-					if(!((m_current == 2) && StringAt(0, 2, "MC", "")) 
+					if(((m_current == 2) && StringAt(0, 2, "MC", "")) 
 						   || ((m_current == 3) && StringAt(0, 3, "MAC", "")))
 					{
 						if(SlavoGermanic())


### PR DESCRIPTION
In the `Encode_Non_Initial_G_Front_Vowel` method inside  `Metaphone3.java`. The negation is redundant since if `m_current` equaled 3 and it was indeed prefixed with "MAC" the first condition would fail, and we'd land where we need to anyway.

```java
if(
  ! ((m_current == 2) && StringAt(0, 2, "MC", "")) 
  || ((m_current == 3) && StringAt(0, 3, "MAC", ""))
)
```
