### PR TITLE
Log the java version during server startup

### DIFF
--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -173,6 +173,7 @@ class RefineServer extends Server {
     private ThreadPoolExecutor threadPool;
 
     public void init(String iface, int port, String host) throws Exception {
+        logger.info("Using Java version: " + System.getProperty("java.runtime.version"));
         logger.info("Starting Server bound to '" + iface + ":" + port + "'");
 
         String memory = Configurations.get("refine.memory");


### PR DESCRIPTION
Fixes #6404 

Changes proposed in this pull request:
- Adds logger info line for the Java Runtime version to the Server init

