### PR TITLE
Remove use of Properties for URL query parsing, fixes #6403

### DIFF
--- a/extensions/database/src/com/google/refine/extension/database/DatabaseImportController.java
+++ b/extensions/database/src/com/google/refine/extension/database/DatabaseImportController.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -83,9 +83,9 @@ public class DatabaseImportController implements ImportingController {
             logger.debug("doPost Query String::{}", request.getQueryString());
         }
         response.setCharacterEncoding("UTF-8");
-        Properties parameters = ParsingUtilities.parseUrlParameters(request);
+        Map<String, String> parameters = ParsingUtilities.parseParameters(request);
 
-        String subCommand = parameters.getProperty("subCommand");
+        String subCommand = parameters.get("subCommand");
 
         if (logger.isDebugEnabled()) {
             logger.info("doPost::subCommand::{}", subCommand);
@@ -131,7 +131,8 @@ public class DatabaseImportController implements ImportingController {
      * @throws ServletException
      * @throws IOException
      */
-    private void doInitializeParserUI(HttpServletRequest request, HttpServletResponse response, Properties parameters)
+    private void doInitializeParserUI(HttpServletRequest request, HttpServletResponse response,
+            Map<String, String> parameters)
             throws ServletException, IOException {
         if (logger.isDebugEnabled()) {
             logger.debug("::doInitializeParserUI::");
@@ -164,13 +165,13 @@ public class DatabaseImportController implements ImportingController {
      * @throws DatabaseServiceException
      */
     private void doParsePreview(
-            HttpServletRequest request, HttpServletResponse response, Properties parameters)
+            HttpServletRequest request, HttpServletResponse response, Map<String, String> parameters)
             throws ServletException, IOException, DatabaseServiceException {
         if (logger.isDebugEnabled()) {
-            logger.debug("JobID::{}", parameters.getProperty("jobID"));
+            logger.debug("JobID::{}", parameters.get("jobID"));
         }
 
-        long jobID = Long.parseLong(parameters.getProperty("jobID"));
+        long jobID = Long.parseLong(parameters.get("jobID"));
         ImportingJob job = ImportingManager.getJob(jobID);
         if (job == null) {
             HttpUtilities.respond(response, "error", "No such import job");
@@ -289,13 +290,14 @@ public class DatabaseImportController implements ImportingController {
      * @param response
      * @param parameters
      */
-    private void doCreateProject(HttpServletRequest request, HttpServletResponse response, Properties parameters)
+    private void doCreateProject(HttpServletRequest request, HttpServletResponse response,
+            Map<String, String> parameters)
             throws ServletException, IOException {
         if (logger.isDebugEnabled()) {
-            logger.debug("DatabaseImportController::doCreateProject:::{}", parameters.getProperty("jobID"));
+            logger.debug("DatabaseImportController::doCreateProject:::{}", parameters.get("jobID"));
         }
 
-        long jobID = Long.parseLong(parameters.getProperty("jobID"));
+        long jobID = Long.parseLong(parameters.get("jobID"));
         final ImportingJob job = ImportingManager.getJob(jobID);
         if (job == null) {
             HttpUtilities.respond(response, "error", "No such import job");

--- a/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
@@ -7,6 +7,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -141,9 +143,14 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
 
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("controller", new String[] { "database/database-import-controller" });
+        parameters.put("subCommand", new String[] { "initialize-parser-ui" });
+
         when(request.getQueryString()).thenReturn(
                 "http://127.0.0.1:3333/command/core/importing-controller?controller=database/database-import-controller&subCommand=initialize-parser-ui");
         when(response.getWriter()).thenReturn(pw);
+        when(request.getParameterMap()).thenReturn(parameters);
 
         SUT.doPost(request, response);
 
@@ -163,6 +170,11 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
 
         long jobId = job.id;
 
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("controller", new String[] { "database/database-import-controller" });
+        parameters.put("jobID", new String[] { String.valueOf(jobId) });
+        parameters.put("subCommand", new String[] { "parse-preview" });
+
         when(request.getQueryString()).thenReturn(
                 "http://127.0.0.1:3333/command/core/importing-controller?controller=database%2Fdatabase-import-controller&jobID="
                         + jobId + "&subCommand=parse-preview");
@@ -176,6 +188,7 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
         when(request.getParameter("initialDatabase")).thenReturn(testDbConfig.getDatabaseName());
         when(request.getParameter("query")).thenReturn(query);
         when(request.getParameter("options")).thenReturn(JSON_OPTION);
+        when(request.getParameterMap()).thenReturn(parameters);
 
         SUT.doPost(request, response);
 
@@ -195,6 +208,11 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
 
         long jobId = job.id;
 
+        Map<String, String[]> parameters = new HashMap<>();
+        parameters.put("controller", new String[] { "database/database-import-controller" });
+        parameters.put("jobID", new String[] { String.valueOf(jobId) });
+        parameters.put("subCommand", new String[] { "create-project" });
+
         when(request.getQueryString()).thenReturn(
                 "http://127.0.0.1:3333/command/core/importing-controller?controller=database%2Fdatabase-import-controller&jobID="
                         + jobId + "&subCommand=create-project");
@@ -208,6 +226,7 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
         when(request.getParameter("initialDatabase")).thenReturn(testDbConfig.getDatabaseName());
         when(request.getParameter("query")).thenReturn(query);
         when(request.getParameter("options")).thenReturn(JSON_OPTION);
+        when(request.getParameterMap()).thenReturn(parameters);
 
         SUT.doPost(request, response);
 

--- a/extensions/gdata/src/com/google/refine/extension/gdata/GDataImportingController.java
+++ b/extensions/gdata/src/com/google/refine/extension/gdata/GDataImportingController.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -91,8 +91,8 @@ public class GDataImportingController implements ImportingController {
             throws ServletException, IOException {
 
         response.setCharacterEncoding("UTF-8");
-        Properties parameters = ParsingUtilities.parseUrlParameters(request);
-        String subCommand = parameters.getProperty("subCommand");
+        Map<String, String> parameters = ParsingUtilities.parseParameters(request);
+        String subCommand = parameters.get("subCommand");
         if ("list-documents".equals(subCommand)) {
             doListDocuments(request, response, parameters);
         } else if ("initialize-parser-ui".equals(subCommand)) {
@@ -106,7 +106,7 @@ public class GDataImportingController implements ImportingController {
         }
     }
 
-    private void doListDocuments(HttpServletRequest request, HttpServletResponse response, Properties parameters)
+    private void doListDocuments(HttpServletRequest request, HttpServletResponse response, Map<String, String> parameters)
             throws ServletException, IOException {
 
         String token = TokenCookie.getToken(request);
@@ -171,11 +171,11 @@ public class GDataImportingController implements ImportingController {
     }
 
     private void doInitializeParserUI(
-            HttpServletRequest request, HttpServletResponse response, Properties parameters)
+            HttpServletRequest request, HttpServletResponse response, Map<String, String> parameters)
             throws ServletException, IOException {
         String token = TokenCookie.getToken(request);
-        String type = parameters.getProperty("docType");
-        String urlString = parameters.getProperty("docUrl");
+        String type = parameters.get("docType");
+        String urlString = parameters.get("docUrl");
         ObjectNode result = ParsingUtilities.mapper.createObjectNode();
         ObjectNode options = ParsingUtilities.mapper.createObjectNode();
 
@@ -227,12 +227,12 @@ public class GDataImportingController implements ImportingController {
     }
 
     private void doParsePreview(
-            HttpServletRequest request, HttpServletResponse response, Properties parameters)
+            HttpServletRequest request, HttpServletResponse response, Map<String, String> parameters)
             throws ServletException, IOException {
 
         String token = TokenCookie.getToken(request);
 
-        long jobID = Long.parseLong(parameters.getProperty("jobID"));
+        long jobID = Long.parseLong(parameters.get("jobID"));
         ImportingJob job = ImportingManager.getJob(jobID);
         if (job == null) {
             HttpUtilities.respond(response, "error", "No such import job");
@@ -285,12 +285,12 @@ public class GDataImportingController implements ImportingController {
         job.updating = false;
     }
 
-    private void doCreateProject(HttpServletRequest request, HttpServletResponse response, Properties parameters)
+    private void doCreateProject(HttpServletRequest request, HttpServletResponse response, Map<String, String> parameters)
             throws ServletException, IOException {
 
         final String token = TokenCookie.getToken(request);
 
-        long jobID = Long.parseLong(parameters.getProperty("jobID"));
+        long jobID = Long.parseLong(parameters.get("jobID"));
         final ImportingJob job = ImportingManager.getJob(jobID);
         if (job == null) {
             HttpUtilities.respond(response, "error", "No such import job");

--- a/main/src/com/google/refine/commands/Command.java
+++ b/main/src/com/google/refine/commands/Command.java
@@ -246,8 +246,8 @@ public abstract class Command {
         if (request == null) {
             throw new IllegalArgumentException("parameter 'request' should not be null");
         }
-        Properties options = ParsingUtilities.parseUrlParameters(request);
-        String token = options.getProperty("csrf_token");
+        Map<String, String> options = ParsingUtilities.parseParameters(request);
+        String token = options.get("csrf_token");
         return token != null && csrfFactory.validToken(token);
     }
 

--- a/main/src/com/google/refine/commands/importing/ImportingControllerCommand.java
+++ b/main/src/com/google/refine/commands/importing/ImportingControllerCommand.java
@@ -34,7 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands.importing;
 
 import java.io.IOException;
-import java.util.Properties;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -95,8 +95,8 @@ public class ImportingControllerCommand extends Command {
          * will get read and we won't have a chance to parse the body ourselves. This is why we have to parse the URL
          * for parameters ourselves. Don't call request.getParameter() before calling internalImport().
          */
-        Properties options = ParsingUtilities.parseUrlParameters(request);
-        String name = options.getProperty("controller");
+        Map<String, String> options = ParsingUtilities.parseParameters(request);
+        String name = options.get("controller");
         if (name != null) {
             return ImportingManager.controllers.get(name);
         }

--- a/main/src/com/google/refine/commands/project/ImportProjectCommand.java
+++ b/main/src/com/google/refine/commands/project/ImportProjectCommand.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.Properties;
+import java.util.Map;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -70,7 +70,7 @@ public class ImportProjectCommand extends Command {
 
         ProjectManager.singleton.setBusy(true);
         try {
-            Properties options = ParsingUtilities.parseUrlParameters(request);
+            Map<String, String> options = ParsingUtilities.parseParameters(request);
 
             long projectID = Project.generateID();
             logger.info("Importing existing project using new ID {}", projectID);
@@ -82,7 +82,7 @@ public class ImportProjectCommand extends Command {
             ProjectMetadata pm = ProjectManager.singleton.getProjectMetadata(projectID);
             if (pm != null) {
                 if (options.containsKey("project-name")) {
-                    String projectName = options.getProperty("project-name");
+                    String projectName = options.get("project-name");
                     if (projectName != null && projectName.length() > 0) {
                         pm.setName(projectName);
                     }
@@ -101,7 +101,7 @@ public class ImportProjectCommand extends Command {
 
     protected void internalImport(
             HttpServletRequest request,
-            Properties options,
+            Map<String, String> options,
             long projectID) throws Exception {
 
         String url = null;

--- a/main/src/com/google/refine/importing/DefaultImportingController.java
+++ b/main/src/com/google/refine/importing/DefaultImportingController.java
@@ -39,7 +39,6 @@ import java.io.StringWriter;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -80,8 +79,8 @@ public class DefaultImportingController extends Command implements ImportingCont
          * will get read and we won't have a chance to parse the body ourselves. This is why we have to parse the URL
          * for parameters ourselves.
          */
-        Properties parameters = ParsingUtilities.parseUrlParameters(request);
-        String subCommand = parameters.getProperty("subCommand");
+        Map<String, String> parameters = ParsingUtilities.parseParameters(request);
+        String subCommand = parameters.get("subCommand");
         if ("load-raw-data".equals(subCommand)) {
             doLoadRawData(request, response, parameters);
         } else if ("update-file-selection".equals(subCommand)) {
@@ -97,10 +96,10 @@ public class DefaultImportingController extends Command implements ImportingCont
         }
     }
 
-    private void doLoadRawData(HttpServletRequest request, HttpServletResponse response, Properties parameters)
+    private void doLoadRawData(HttpServletRequest request, HttpServletResponse response, Map<String, String> parameters)
             throws ServletException, IOException {
 
-        long jobID = Long.parseLong(parameters.getProperty("jobID"));
+        long jobID = Long.parseLong(parameters.get("jobID"));
         ImportingJob job = ImportingManager.getJob(jobID);
         if (job == null) {
             respondStatusError(response, "No such import job");
@@ -120,10 +119,10 @@ public class DefaultImportingController extends Command implements ImportingCont
         job.updating = false;
     }
 
-    private void doUpdateFileSelection(HttpServletRequest request, HttpServletResponse response, Properties parameters)
+    private void doUpdateFileSelection(HttpServletRequest request, HttpServletResponse response, Map<String, String> parameters)
             throws ServletException, IOException {
 
-        long jobID = Long.parseLong(parameters.getProperty("jobID"));
+        long jobID = Long.parseLong(parameters.get("jobID"));
         ImportingJob job = ImportingManager.getJob(jobID);
         if (job == null) {
             respondStatusError(response, "No such import job");
@@ -147,10 +146,10 @@ public class DefaultImportingController extends Command implements ImportingCont
         job.updating = false;
     }
 
-    private void doUpdateFormatAndOptions(HttpServletRequest request, HttpServletResponse response, Properties parameters)
+    private void doUpdateFormatAndOptions(HttpServletRequest request, HttpServletResponse response, Map<String, String> parameters)
             throws ServletException, IOException {
 
-        long jobID = Long.parseLong(parameters.getProperty("jobID"));
+        long jobID = Long.parseLong(parameters.get("jobID"));
         ImportingJob job = ImportingManager.getJob(jobID);
         if (job == null) {
             respondStatusError(response, "No such import job");
@@ -187,10 +186,10 @@ public class DefaultImportingController extends Command implements ImportingCont
         job.updating = false;
     }
 
-    private void doInitializeParserUI(HttpServletRequest request, HttpServletResponse response, Properties parameters)
+    private void doInitializeParserUI(HttpServletRequest request, HttpServletResponse response, Map<String, String> parameters)
             throws ServletException, IOException {
 
-        long jobID = Long.parseLong(parameters.getProperty("jobID"));
+        long jobID = Long.parseLong(parameters.get("jobID"));
         ImportingJob job = ImportingManager.getJob(jobID);
         if (job == null) {
             respondStatusError(response, "No such import job");
@@ -216,10 +215,10 @@ public class DefaultImportingController extends Command implements ImportingCont
         }
     }
 
-    private void doCreateProject(HttpServletRequest request, HttpServletResponse response, Properties parameters)
+    private void doCreateProject(HttpServletRequest request, HttpServletResponse response, Map<String, String> parameters)
             throws ServletException, IOException {
 
-        long jobID = Long.parseLong(parameters.getProperty("jobID"));
+        long jobID = Long.parseLong(parameters.get("jobID"));
         ImportingJob job = ImportingManager.getJob(jobID);
         if (job == null) {
             respondStatusError(response, "No such import job");

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -114,10 +114,32 @@ public class ImportingUtilities {
         public boolean isCanceled();
     }
 
+    /**
+     * @deprecated Use
+     *             {@link #loadDataAndPrepareJob(HttpServletRequest, HttpServletResponse, Map, ImportingJob, ObjectNode)}
+     *             instead.
+     */
+    @Deprecated
     static public void loadDataAndPrepareJob(
             HttpServletRequest request,
             HttpServletResponse response,
             Properties parameters,
+            final ImportingJob job,
+            ObjectNode config) throws IOException, ServletException {
+
+        Map<String, String> parametersMap = propsToMap(parameters);
+        loadDataAndPrepareJob(request, response, parametersMap, job, config);
+    }
+
+    private static Map<String, String> propsToMap(Properties properties) {
+        return properties.entrySet().stream()
+                .collect(Collectors.toMap(e -> (String) e.getKey(), e -> (String) e.getValue()));
+    }
+
+    static public void loadDataAndPrepareJob(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Map<String, String> parameters,
             final ImportingJob job,
             ObjectNode config) throws IOException, ServletException {
 
@@ -183,12 +205,29 @@ public class ImportingUtilities {
         job.setRankedFormats(rankedFormats);
     }
 
+    /**
+     * @deprecated Use {@link #retrieveContentFromPostRequest(HttpServletRequest, Map, File, ObjectNode, Progress)}
+     *             instead.
+     */
+    @Deprecated
     static public void retrieveContentFromPostRequest(
             HttpServletRequest request,
             Properties parameters,
             File rawDataDir,
             ObjectNode retrievalRecord,
             final Progress progress) throws IOException, FileUploadException {
+
+        Map<String, String> parametersMap = propsToMap(parameters);
+        retrieveContentFromPostRequest(request, parametersMap, rawDataDir, retrievalRecord, progress);
+    }
+
+    static public void retrieveContentFromPostRequest(
+            HttpServletRequest request,
+            Map<String, String> parameters,
+            File rawDataDir,
+            ObjectNode retrievalRecord,
+            final Progress progress) throws IOException, FileUploadException {
+
         ArrayNode fileRecords = ParsingUtilities.mapper.createArrayNode();
         JSONUtilities.safePut(retrievalRecord, "files", fileRecords);
 

--- a/main/src/com/google/refine/util/ParsingUtilities.java
+++ b/main/src/com/google/refine/util/ParsingUtilities.java
@@ -46,8 +46,10 @@ import java.time.format.DateTimeParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.Map;
 import java.util.Properties;
 import java.util.TimeZone;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import javax.servlet.http.HttpServletRequest;
@@ -103,6 +105,22 @@ public class ParsingUtilities {
     public static final DateTimeFormatter ISO8601 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'");
     private static final ZoneId defaultZone = ZoneId.systemDefault();
 
+    /**
+     * Parses parameters from the given HttpServletRequest and returns them as a Map.
+     *
+     * @param request
+     *            HttpServletRequest containing parameters.
+     * @return Map containing parameter names and their first values.
+     */
+    public static Map<String, String> parseParameters(HttpServletRequest request) {
+        return request.getParameterMap().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue()[0]));
+    }
+
+    /**
+     * @deprecated Use {@link #parseParameters(HttpServletRequest request)} instead.
+     */
+    @Deprecated
     static public Properties parseUrlParameters(HttpServletRequest request) {
         Properties options = new Properties();
 
@@ -116,6 +134,10 @@ public class ParsingUtilities {
         return options;
     }
 
+    /**
+     * @deprecated Use {@link #parseParameters(HttpServletRequest request)} instead.
+     */
+    @Deprecated
     static public Properties parseParameters(Properties p, String str) {
         if (str != null) {
             String[] pairs = str.split("&");
@@ -129,6 +151,10 @@ public class ParsingUtilities {
         return p;
     }
 
+    /**
+     * @deprecated Use {@link #parseParameters(HttpServletRequest request)} instead.
+     */
+    @Deprecated
     static public Properties parseParameters(String str) {
         return (str == null) ? null : parseParameters(new Properties(), str);
     }

--- a/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
@@ -47,6 +47,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.StreamSupport;
 
@@ -221,7 +222,7 @@ public class ImportingUtilitiesTests extends ImporterTest {
         when(req.getInputStream()).thenReturn(new MockServletInputStream(is));
 
         ImportingJob job = ImportingManager.createJob();
-        Properties parameters = ParsingUtilities.parseUrlParameters(req);
+        Map<String, String> parameters = ParsingUtilities.parseParameters(req);
         ObjectNode retrievalRecord = ParsingUtilities.mapper.createObjectNode();
         ObjectNode progress = ParsingUtilities.mapper.createObjectNode();
         try {
@@ -272,7 +273,7 @@ public class ImportingUtilitiesTests extends ImporterTest {
         when(req.getInputStream()).thenReturn(new MockServletInputStream(is));
 
         ImportingJob job = ImportingManager.createJob();
-        Properties parameters = ParsingUtilities.parseUrlParameters(req);
+        Map<String, String> parameters = ParsingUtilities.parseParameters(req);
         ObjectNode retrievalRecord = ParsingUtilities.mapper.createObjectNode();
         ObjectNode progress = ParsingUtilities.mapper.createObjectNode();
         try {
@@ -537,7 +538,7 @@ public class ImportingUtilitiesTests extends ImporterTest {
         when(req.getInputStream()).thenReturn(new MockServletInputStream(is));
 
         ImportingJob job = ImportingManager.createJob();
-        Properties parameters = ParsingUtilities.parseUrlParameters(req);
+        Map<String, String> parameters = ParsingUtilities.parseParameters(req);
         ObjectNode retrievalRecord = ParsingUtilities.mapper.createObjectNode();
         Progress dummyProgress = new Progress() {
 

--- a/main/tests/server/src/com/google/refine/util/ParsingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/util/ParsingUtilitiesTests.java
@@ -40,9 +40,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.zip.GZIPOutputStream;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
@@ -139,5 +144,22 @@ public class ParsingUtilitiesTests extends RefineTest {
         } catch (Exception e) {
             Assert.fail();
         }
+    }
+
+    @Test
+    public void testParseParameters() {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+        Mockito.when(request.getParameterMap()).thenReturn(
+                Map.of("param1", new String[] { "value1" },
+                        "param2", new String[] { "value2", "value3" }));
+
+        Map<String, String> result = ParsingUtilities.parseParameters(request);
+
+        Map<String, String> expectedResult = new HashMap<>();
+        expectedResult.put("param1", "value1");
+        expectedResult.put("param2", "value2");
+
+        Assert.assertEquals(expectedResult, result);
     }
 }


### PR DESCRIPTION
Fixes #6403

Changes proposed in this pull request: 
- Deprecate all methods in `ParsingUtilities` that return `java.util.Properties`.
- Introduce a new method, `static public Map<String, String> parseParameters(HttpServletRequest request)`, as a replacement for `parseUrlParameters`. This new method utilizes the `request.getParameterMap()` functionality for its implementation.
- Modify all uses of `parseUrlParameters` to use the new method.
- Adjust all necessary code to accommodate the new return type `(Map<String, String>)`.
- Deprecate all public methods `ImportingUtilities` that use `java.util.Properties` and make new versions of them using `Map<String, String>` instead.