### PR TITLE
Switch generic test to use SQLite instead of MySQL

### DIFF
--- a/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
@@ -219,22 +219,20 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
     }
 
     @BeforeTest
-    @Parameters({ "sqliteDbName", "sqliteDbHost", "sqliteDbPort", "sqliteDbUser", "sqliteDbPassword", "sqliteTestTable" })
+    @Parameters({ "sqliteDbName", "sqliteTestTable" })
     public void beforeTest(
-            @Optional(DEFAULT_MYSQL_DB_NAME) String sqliteDbName, @Optional(DEFAULT_MYSQL_HOST) String sqliteDbHost,
-            @Optional(DEFAULT_MYSQL_PORT) String sqliteDbPort, @Optional(DEFAULT_MYSQL_USER) String sqliteDbUser,
-            @Optional(DEFAULT_MYSQL_PASSWORD) String sqliteDbPassword, @Optional(DEFAULT_TEST_TABLE) String sqliteTestTable) {
+            @Optional(DEFAULT_SQLITE_DB_NAME) String sqliteDbName, @Optional(DEFAULT_TEST_TABLE) String sqliteTestTable) {
 
         MockitoAnnotations.initMocks(this);
 
+        // Much of the below is ignored, but required by validation
+        // in {@link DatabaseImportController#getQueryInfo}
         testDbConfig = new DatabaseConfiguration();
-        testDbConfig.setDatabaseHost(sqliteDbHost);
+        testDbConfig.setDatabaseHost(""); // This is ignored, but not allowed to be null
         testDbConfig.setDatabaseName(sqliteDbName);
-        testDbConfig.setDatabasePassword(sqliteDbPassword);
-        testDbConfig.setDatabasePort(0); // unused for SQLite
+        testDbConfig.setDatabasePassword(""); // This is ignored, but not allowed to be null
         testDbConfig.setDatabaseType(SQLiteDatabaseService.DB_NAME);
-        testDbConfig.setDatabaseUser(sqliteDbUser);
-        testDbConfig.setUseSSL(false);
+        testDbConfig.setDatabaseUser(""); // This is ignored, but not allowed to be null
         query = "SELECT count(*) FROM " + sqliteTestTable;
 
         DatabaseService.DBType.registerDatabase(SQLiteDatabaseService.DB_NAME, SQLiteDatabaseService.getInstance());

--- a/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 import com.google.refine.ProjectManager;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.RefineServlet;
-import com.google.refine.extension.database.mysql.MySQLDatabaseService;
+import com.google.refine.extension.database.sqlite.SQLiteDatabaseService;
 import com.google.refine.extension.database.stub.RefineDbServletStub;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingManager;
@@ -34,7 +34,6 @@ import com.google.refine.io.FileProjectManager;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 
-@Test(groups = { "requiresMySQL" })
 public class DatabaseImportControllerTest extends DBExtensionTests {
 
     @Mock
@@ -220,27 +219,25 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
     }
 
     @BeforeTest
-    @Parameters({ "mySqlDbName", "mySqlDbHost", "mySqlDbPort", "mySqlDbUser", "mySqlDbPassword", "mySqlTestTable" })
+    @Parameters({ "sqliteDbName", "sqliteDbHost", "sqliteDbPort", "sqliteDbUser", "sqliteDbPassword", "sqliteTestTable" })
     public void beforeTest(
-            @Optional(DEFAULT_MYSQL_DB_NAME) String mySqlDbName, @Optional(DEFAULT_MYSQL_HOST) String mySqlDbHost,
-            @Optional(DEFAULT_MYSQL_PORT) String mySqlDbPort, @Optional(DEFAULT_MYSQL_USER) String mySqlDbUser,
-            @Optional(DEFAULT_MYSQL_PASSWORD) String mySqlDbPassword, @Optional(DEFAULT_TEST_TABLE) String mySqlTestTable) {
+            @Optional(DEFAULT_MYSQL_DB_NAME) String sqliteDbName, @Optional(DEFAULT_MYSQL_HOST) String sqliteDbHost,
+            @Optional(DEFAULT_MYSQL_PORT) String sqliteDbPort, @Optional(DEFAULT_MYSQL_USER) String sqliteDbUser,
+            @Optional(DEFAULT_MYSQL_PASSWORD) String sqliteDbPassword, @Optional(DEFAULT_TEST_TABLE) String sqliteTestTable) {
 
         MockitoAnnotations.initMocks(this);
 
         testDbConfig = new DatabaseConfiguration();
-        testDbConfig.setDatabaseHost(mySqlDbHost);
-        testDbConfig.setDatabaseName(mySqlDbName);
-        testDbConfig.setDatabasePassword(mySqlDbPassword);
-        testDbConfig.setDatabasePort(Integer.parseInt(mySqlDbPort));
-        testDbConfig.setDatabaseType(MySQLDatabaseService.DB_NAME);
-        testDbConfig.setDatabaseUser(mySqlDbUser);
+        testDbConfig.setDatabaseHost(sqliteDbHost);
+        testDbConfig.setDatabaseName(sqliteDbName);
+        testDbConfig.setDatabasePassword(sqliteDbPassword);
+        testDbConfig.setDatabasePort(0); // unused for SQLite
+        testDbConfig.setDatabaseType(SQLiteDatabaseService.DB_NAME);
+        testDbConfig.setDatabaseUser(sqliteDbUser);
         testDbConfig.setUseSSL(false);
-        query = "SELECT count(*) FROM " + mySqlTestTable;
+        query = "SELECT count(*) FROM " + sqliteTestTable;
 
-        // testTable = mySqlTestTable;
-
-        DatabaseService.DBType.registerDatabase(MySQLDatabaseService.DB_NAME, MySQLDatabaseService.getInstance());
+        DatabaseService.DBType.registerDatabase(SQLiteDatabaseService.DB_NAME, SQLiteDatabaseService.getInstance());
 
     }
 


### PR DESCRIPTION
Addresses the issue found in PR #6407 

Changes proposed in this pull request:
- Switch generic test to use SQLite instead of MySQL so no separate database installs are required (and test isn't skipped by default)
