### PR TITLE
Add module names to About page. Fixes #5546

### DIFF
--- a/main/src/com/google/refine/RefineServlet.java
+++ b/main/src/com/google/refine/RefineServlet.java
@@ -222,6 +222,15 @@ public class RefineServlet extends Butterfly {
         return _modulesByName.get(name);
     }
 
+    /**
+     * Get a list of the names of currently loaded modules.
+     *
+     * @return an array of module names in alphabetical order
+     */
+    public String[] getModuleNames() {
+        return _modulesByName.keySet().stream().sorted().toArray(String[]::new);
+    }
+
     protected String getCommandKey(HttpServletRequest request) {
         // A command path has this format: /command/module-name/command-name/...
 

--- a/main/src/com/google/refine/commands/GetVersionCommand.java
+++ b/main/src/com/google/refine/commands/GetVersionCommand.java
@@ -62,10 +62,11 @@ public class GetVersionCommand extends Command {
         @JsonProperty("java_runtime_name")
         public String java_runtime_name = System.getProperty("java.runtime.name", "?");
         @JsonProperty("java_runtime_version")
-        // public String java_runtime_version = Runtime.getRuntime().version(); // Java 9 or later
-        public String java_runtime_version = System.getProperty("java.runtime.version", "?");
+        public String java_runtime_version = Runtime.getRuntime().version().toString();
         @JsonProperty("display_new_version_notice")
         public String display_new_version_notice = System.getProperty("refine.display.new.version.notice");
+        @JsonProperty("module_names")
+        public String[] modules = servlet.getModuleNames();
     }
 
     @Override

--- a/main/webapp/modules/core/about.html
+++ b/main/webapp/modules/core/about.html
@@ -54,7 +54,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <script type="text/javascript" src="3rdparty/jquery.i18n/languages/fi.js"></script>
     <script type="text/javascript" src="3rdparty/jquery.i18n/languages/ru.js"></script>
     <script type="text/javascript" src="scripts/util/i18n.js"></script>
+    <script type="text/javascript" src="scripts/util/csrf.js"></script>
     <script type="text/javascript" src="scripts/index.js"></script>
+    <script type="text/javascript" src="about.js"></script>
 
   </head>
   <body>
@@ -70,6 +72,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       <!-- The following two IDs must match those in index.vt/index.js -->
       <h2 id="openrefine-version"></h2>
       <h3 id="java-runtime-version"></h3>
+      <h3 id="openrefine-extensions"></h3>
       
       <p id="definition">
       </p>

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -10,6 +10,7 @@
     "core-index/version": "Version",
     "core-index/new-version": "New Version",
     "core-index/refine-version": "Version $1",
+    "core-index/refine-extensions": "Extensions: $1",
     "core-index/download-now": "Download $1 now.",
     "core-index/change-value": "Change value of preference key",
     "core-index/delete-key": "Delete preference key",

--- a/main/webapp/modules/core/scripts/index.js
+++ b/main/webapp/modules/core/scripts/index.js
@@ -90,6 +90,7 @@ $(function() {
           OpenRefineVersion = data;
 
           $("#openrefine-version").text($.i18n('core-index/refine-version', OpenRefineVersion.full_version));
+          $("#openrefine-extensions").text($.i18n('core-index/refine-extensions', OpenRefineVersion.module_names.join(", ")));
           $("#java-runtime-version").text(OpenRefineVersion.java_runtime_name + " " + OpenRefineVersion.java_runtime_version);
           if (OpenRefineVersion.display_new_version_notice === "true") {
             $.getJSON("https://api.github.com/repos/openrefine/openrefine/releases/latest",


### PR DESCRIPTION
Fixes #5546

Changes proposed in this pull request:
- add Butterfly's list of loaded modules to the info returned by the GetVersion command
- Add that information to the About page HTML & update the Javascript to populate it
- also repair broken OpenRefine & JVM version display on About page