### PR TITLE
[#3243] Ignore JSON comments by default

### DIFF
--- a/main/src/com/google/refine/importers/JsonImporter.java
+++ b/main/src/com/google/refine/importers/JsonImporter.java
@@ -91,7 +91,8 @@ public class JsonImporter extends TreeImportingParserBase {
             try {
                 ObjectNode firstFileRecord = fileRecords.get(0);
                 File file = ImportingUtilities.getFile(job, firstFileRecord);
-                JsonFactory factory = JsonFactory.builder().enable(JsonReadFeature.ALLOW_JAVA_COMMENTS).enable(JsonReadFeature.ALLOW_YAML_COMMENTS).build();
+                JsonFactory factory = JsonFactory.builder().enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+                        .enable(JsonReadFeature.ALLOW_YAML_COMMENTS).build();
                 JsonParser parser = factory.createParser(file);
                 parser.enable(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
 

--- a/main/src/com/google/refine/importers/JsonImporter.java
+++ b/main/src/com/google/refine/importers/JsonImporter.java
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonParser.NumberType;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
@@ -90,7 +91,7 @@ public class JsonImporter extends TreeImportingParserBase {
             try {
                 ObjectNode firstFileRecord = fileRecords.get(0);
                 File file = ImportingUtilities.getFile(job, firstFileRecord);
-                JsonFactory factory = new JsonFactory();
+                JsonFactory factory = JsonFactory.builder().enable(JsonReadFeature.ALLOW_JAVA_COMMENTS).enable(JsonReadFeature.ALLOW_YAML_COMMENTS).build();
                 JsonParser parser = factory.createParser(file);
                 parser.enable(JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
 
@@ -206,8 +207,12 @@ public class JsonImporter extends TreeImportingParserBase {
             ImportingJob job, String fileSource, InputStream is,
             ImportColumnGroup rootColumnGroup, int limit, ObjectNode options, List<Exception> exceptions) {
 
+        JSONTreeReader jsonTreeReader = new JSONTreeReader(is);
+        jsonTreeReader.parser.enable(JsonParser.Feature.ALLOW_COMMENTS);
+        jsonTreeReader.parser.enable(JsonParser.Feature.ALLOW_YAML_COMMENTS);
+
         parseOneFile(project, metadata, job, fileSource,
-                new JSONTreeReader(is), rootColumnGroup, limit, options, exceptions);
+                jsonTreeReader, rootColumnGroup, limit, options, exceptions);
     }
 
     static public class JSONTreeReader implements TreeReader {

--- a/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/JsonImporterTests.java
@@ -113,6 +113,17 @@ public class JsonImporterTests extends ImporterTest {
     }
 
     @Test
+    public void canParseSampleWithComments() {
+        RunTest(getSampleWithComments());
+        assertProjectCreated(project, 4, 6);
+
+        Row row = project.rows.get(0);
+        Assert.assertNotNull(row);
+        Assert.assertNotNull(row.getCell(1));
+        Assert.assertEquals(row.getCell(1).value, "Author 1, The");
+    }
+
+    @Test
     public void canThrowError() {
         String errJSON = getSampleWithError();
         ObjectNode options = SUT.createParserUIInitializationData(
@@ -561,6 +572,23 @@ public class JsonImporterTests extends ImporterTest {
             }
         }
         sb.append("]");
+        return sb.toString();
+    }
+
+    static String getSampleWithComments() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        for (int i = 1; i < 7; i++) {
+            sb.append(getTypicalElement(i));
+            if (i < 6) {
+                sb.append(",");
+            }
+        }
+        sb.append("// zyadtaha testing c++ commments \n");
+        sb.append("/* zyadtaha testing c commments */ \n");
+        sb.append("# zyadtaha testing python commments \n");
+        sb.append("]");
+        System.out.println(sb.toString());
         return sb.toString();
     }
 


### PR DESCRIPTION
Fixes [#3243](https://github.com/OpenRefine/OpenRefine/issues/3243)

Changes proposed in this pull request:
- Ignore JSON comments by default while importing JSON files