### PR TITLE
Added a new feature to import files using drag and drop. Requested in issue #6250

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -105,6 +105,7 @@
     "core-index-import/warning-clipboard": "You must paste some data to import.",
     "core-index-import/uploading-pasted-data": "Uploading pasted data…",
     "core-index-import/locate-files": "Locate one or more files on your computer to upload:",
+    "core-index-import/drag-locate-files": "or drag and drop one or more files anywhere below:",
     "core-index-import/enter-url": "Enter one or more web addresses (URLs) pointing to data to download:",
     "core-index-import/remove-row": "Remove this row",
     "core-index-import/clipboard-label": "Paste data from clipboard here:",

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -105,7 +105,6 @@
     "core-index-import/warning-clipboard": "You must paste some data to import.",
     "core-index-import/uploading-pasted-data": "Uploading pasted data…",
     "core-index-import/locate-files": "Locate one or more files on your computer to upload:",
-    "core-index-import/drag-locate-files": "or drag and drop one or more files anywhere below:",
     "core-index-import/enter-url": "Enter one or more web addresses (URLs) pointing to data to download:",
     "core-index-import/remove-row": "Remove this row",
     "core-index-import/clipboard-label": "Paste data from clipboard here:",

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -105,6 +105,7 @@
     "core-index-import/warning-clipboard": "You must paste some data to import.",
     "core-index-import/uploading-pasted-data": "Uploading pasted data…",
     "core-index-import/locate-files": "Locate one or more files on your computer to upload:",
+    "core-index-import/drag-files": "Drag files here",
     "core-index-import/enter-url": "Enter one or more web addresses (URLs) pointing to data to download:",
     "core-index-import/remove-row": "Remove this row",
     "core-index-import/clipboard-label": "Paste data from clipboard here:",

--- a/main/webapp/modules/core/scripts/index/default-importing-sources/import-from-computer-form.html
+++ b/main/webapp/modules/core/scripts/index/default-importing-sources/import-from-computer-form.html
@@ -1,17 +1,15 @@
 <form bind="form"><div class="grid-layout layout-normal"><table>
   <tr><td id="or-import-locate-files"></td></tr>
-  <tr><td><input type="file" multiple bind="fileInput1" name="upload" /></td></tr>
-  <tr><td id="or-drag-locate-files"></td></tr>
-  <tr><td>
-      <div class="file-area">
-        <input type="file" multiple bind="fileInput2" name="upload" required/>
+  <tr>
+    <td>
 
-        <div class="file-dummy">
-          <span class="default">Click to select a file, or drag it here</span>
-          <span class="success">Great, your file is selected</span>
-        </div>
+      <div class="file-input-container">
+        <input type="file" multiple id="fileInput" name="upload" class="file-input" />
+        <span class="file-input-text">Drag files here</span>
       </div>
 
-    </td></tr>
+    </td>
+  </tr>
   <tr><td><button bind="nextButton" class="button button-primary" type="button"></button></td></tr>
 </table></div></form>
+

--- a/main/webapp/modules/core/scripts/index/default-importing-sources/import-from-computer-form.html
+++ b/main/webapp/modules/core/scripts/index/default-importing-sources/import-from-computer-form.html
@@ -4,7 +4,7 @@
     <td>
 
       <div class="file-input-container">
-        <input type="file" multiple id="fileInput" name="upload" class="file-input" />
+        <input type="file" multiple bind="fileInput" name="upload" class="file-input" />
         <span class="file-input-text">Drag files here</span>
       </div>
 

--- a/main/webapp/modules/core/scripts/index/default-importing-sources/import-from-computer-form.html
+++ b/main/webapp/modules/core/scripts/index/default-importing-sources/import-from-computer-form.html
@@ -1,5 +1,17 @@
 <form bind="form"><div class="grid-layout layout-normal"><table>
   <tr><td id="or-import-locate-files"></td></tr>
-  <tr><td><input type="file" multiple bind="fileInput" name="upload" /></td></tr>
+  <tr><td><input type="file" multiple bind="fileInput1" name="upload" /></td></tr>
+  <tr><td id="or-drag-locate-files"></td></tr>
+  <tr><td>
+      <div class="file-area">
+        <input type="file" multiple bind="fileInput2" name="upload" required/>
+
+        <div class="file-dummy">
+          <span class="default">Click to select a file, or drag it here</span>
+          <span class="success">Great, your file is selected</span>
+        </div>
+      </div>
+
+    </td></tr>
   <tr><td><button bind="nextButton" class="button button-primary" type="button"></button></td></tr>
 </table></div></form>

--- a/main/webapp/modules/core/scripts/index/default-importing-sources/import-from-computer-form.html
+++ b/main/webapp/modules/core/scripts/index/default-importing-sources/import-from-computer-form.html
@@ -5,7 +5,7 @@
 
       <div class="file-input-container">
         <input type="file" multiple bind="fileInput" name="upload" class="file-input" />
-        <span class="file-input-text">Drag files here</span>
+        <span class="file-input-text" id="drag-files"></span>
       </div>
 
     </td>

--- a/main/webapp/modules/core/scripts/index/default-importing-sources/sources.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-sources/sources.js
@@ -55,11 +55,10 @@ ThisComputerImportingSourceUI.prototype.attachUI = function(bodyDiv) {
   this._elmts = DOM.bind(bodyDiv);
   
   $('#or-import-locate-files').text($.i18n('core-index-import/locate-files'));
-  $('#or-drag-locate-files').text($.i18n('core-index-import/drag-locate-files'));
   this._elmts.nextButton.html($.i18n('core-buttons/next'));
   
   this._elmts.nextButton.on('click',function(evt) {
-    if (self._elmts.fileInput1[0].files.length === 0 && self._elmts.fileInput2[0].files.length === 0) {
+    if (self._elmts.fileInput[0].files.length === 0) {
       window.alert($.i18n('core-index-import/warning-data-file'));
     } else {
       self._controller.startImportJob(self._elmts.form, $.i18n('core-index-import/uploading-data'));

--- a/main/webapp/modules/core/scripts/index/default-importing-sources/sources.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-sources/sources.js
@@ -55,6 +55,7 @@ ThisComputerImportingSourceUI.prototype.attachUI = function(bodyDiv) {
   this._elmts = DOM.bind(bodyDiv);
   
   $('#or-import-locate-files').text($.i18n('core-index-import/locate-files'));
+  $('#drag-files').text($.i18n('core-index-import/drag-files'));
   this._elmts.nextButton.html($.i18n('core-buttons/next'));
   
   this._elmts.nextButton.on('click',function(evt) {

--- a/main/webapp/modules/core/scripts/index/default-importing-sources/sources.js
+++ b/main/webapp/modules/core/scripts/index/default-importing-sources/sources.js
@@ -55,10 +55,11 @@ ThisComputerImportingSourceUI.prototype.attachUI = function(bodyDiv) {
   this._elmts = DOM.bind(bodyDiv);
   
   $('#or-import-locate-files').text($.i18n('core-index-import/locate-files'));
+  $('#or-drag-locate-files').text($.i18n('core-index-import/drag-locate-files'));
   this._elmts.nextButton.html($.i18n('core-buttons/next'));
   
   this._elmts.nextButton.on('click',function(evt) {
-    if (self._elmts.fileInput[0].files.length === 0) {
+    if (self._elmts.fileInput1[0].files.length === 0 && self._elmts.fileInput2[0].files.length === 0) {
       window.alert($.i18n('core-index-import/warning-data-file'));
     } else {
       self._controller.startImportJob(self._elmts.form, $.i18n('core-index-import/uploading-data'));

--- a/main/webapp/modules/core/styles/index/default-importing-sources.css
+++ b/main/webapp/modules/core/styles/index/default-importing-sources.css
@@ -40,3 +40,51 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   max-width: 50em;
   height: 30em;
 }
+
+
+.file-area {
+        width: 100%;
+        position: relative;
+        font-size: 18px;
+}
+
+.file-area input[type=file] {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+.file-area .file-dummy {
+    width: 100%;
+    padding: 50px 30px;
+    border: 2px dashed #ccc;
+    background-color: #fff;
+    text-align: center;
+    transition: background 0.3s ease-in-out;
+}
+
+.file-area .file-dummy .success {
+       display: none;
+}
+
+.file-area:hover .file-dummy {
+    border: 2px dashed #1abc9c;
+}
+
+.file-area input[type=file]:valid + .file-dummy {
+    border-color: #1abc9c;
+}
+
+.file-area input[type=file]:valid + .file-dummy .success {
+    display: inline-block;
+}
+
+.file-area input[type=file]:valid + .file-dummy .default {
+    display: none;
+}

--- a/main/webapp/modules/core/styles/index/default-importing-sources.css
+++ b/main/webapp/modules/core/styles/index/default-importing-sources.css
@@ -41,50 +41,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   height: 30em;
 }
 
-
-.file-area {
-        width: 100%;
-        position: relative;
-        font-size: 18px;
+.file-input {
+    width: 200px;
+    height: 100px;
+    border: 2px solid #ccc;
+    border-radius: 5px;
+    padding: 5px;
+    box-sizing: border-box;
 }
 
-.file-area input[type=file] {
+.file-input-container {
+    position: relative;
+}
+
+.file-input-text {
     position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    opacity: 0;
-    cursor: pointer;
-}
-
-.file-area .file-dummy {
-    width: 100%;
-    padding: 50px 30px;
-    border: 2px dashed #ccc;
-    background-color: #fff;
+    top: 50%;
+    left: 50%;
+    transform: translate(-110%, -30%);
+    pointer-events: none;
     text-align: center;
-    transition: background 0.3s ease-in-out;
-}
-
-.file-area .file-dummy .success {
-       display: none;
-}
-
-.file-area:hover .file-dummy {
-    border: 2px dashed #1abc9c;
-}
-
-.file-area input[type=file]:valid + .file-dummy {
-    border-color: #1abc9c;
-}
-
-.file-area input[type=file]:valid + .file-dummy .success {
-    display: inline-block;
-}
-
-.file-area input[type=file]:valid + .file-dummy .default {
-    display: none;
+    color: #555;
 }

--- a/main/webapp/modules/core/styles/index/default-importing-sources.css
+++ b/main/webapp/modules/core/styles/index/default-importing-sources.css
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 }
 
 .file-input {
-    width: 200px;
+    min-width: 200px;
     height: 100px;
     border: 2px solid #ccc;
     border-radius: 5px;
@@ -58,7 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     position: absolute;
     top: 50%;
     left: 50%;
-    transform: translate(-110%, -30%);
+    transform: translate(-65%, 0%);
     pointer-events: none;
     text-align: center;
     color: #555;


### PR DESCRIPTION
Added a new way to import files using drag and drop

Fixes #6250

Here is how the UI will look like after adding the drag and drop feature

Before dragging any file:

<img width="1194" alt="Screenshot 2024-03-11 at 8 38 46 PM" src="https://github.com/OpenRefine/OpenRefine/assets/116679740/1d679ed6-0bda-45d9-a23d-e08ca6988c00">


After dragging and dropping the files you need:

<img width="1110" alt="Screenshot 2024-03-11 at 8 39 45 PM" src="https://github.com/OpenRefine/OpenRefine/assets/116679740/fe78fefd-b25f-474a-93fe-445d438eeec8">

Changes proposed in this pull request:
- Added new text below the choose files button
- Added a box to indicate the area to which the files will be dragged to
- Added some css to polish the look of this feature
- Modified some javascript to take the new file input feature into consideration 