### PR TITLE
Refactor EngineDependentCommand & Command hierarchy. Fixes #6443

### DIFF
--- a/main/src/com/google/refine/commands/Command.java
+++ b/main/src/com/google/refine/commands/Command.java
@@ -217,6 +217,18 @@ public abstract class Command {
         return def;
     }
 
+    static protected boolean getBooleanParameter(HttpServletRequest request, String name) {
+        if (request == null) {
+            throw new IllegalArgumentException("parameter 'request' should not be null");
+        }
+        try {
+            return Boolean.parseBoolean(request.getParameter(name));
+        } catch (Exception e) {
+            // ignore
+        }
+        return false;
+    }
+
     /**
      * Utility method for retrieving the CSRF token stored in the "csrf_token" parameter of the request, and checking
      * that it is valid.

--- a/main/src/com/google/refine/commands/EngineDependentCommand.java
+++ b/main/src/com/google/refine/commands/EngineDependentCommand.java
@@ -33,17 +33,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.commands;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
-import com.google.refine.process.Process;
 
 /**
  * Convenient super class for commands that perform abstract operations on only the filtered rows based on the faceted
@@ -58,29 +52,15 @@ import com.google.refine.process.Process;
  * Note that there are interactions on the client side that change only individual cells or individual rows (such as
  * starring one row or editing the text of one cell). These interactions do not depend on the faceted browsing engine's
  * configuration, and so they don't invoke commands that subclass this class. See AnnotateOneRowCommand and
- * EditOneCellCommand as examples.
+ * EditOneCellCommand as examples. Conversely, there are commands like GetRowsCommand and ExportRowsCommand which use
+ * the engine config, but don't modify the project, which don't subclass this.
  */
-abstract public class EngineDependentCommand extends Command {
+abstract public class EngineDependentCommand extends OperationCommand {
 
-    @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
-        if (!hasValidCSRFToken(request)) {
-            respondCSRFError(response);
-            return;
-        }
-
-        try {
-            Project project = getProject(request);
-
-            AbstractOperation op = createOperation(project, request, getEngineConfig(request));
-            Process process = op.createProcess(project, new Properties());
-
-            performProcessAndRespond(request, response, project, process);
-        } catch (Exception e) {
-            respondException(response, e);
-        }
-    }
+    protected AbstractOperation createOperation(
+            Project project, HttpServletRequest request) throws Exception {
+        return createOperation(project, request, getEngineConfig(request));
+    };
 
     abstract protected AbstractOperation createOperation(
             Project project, HttpServletRequest request, EngineConfig engineConfig) throws Exception;

--- a/main/src/com/google/refine/commands/OperationCommand.java
+++ b/main/src/com/google/refine/commands/OperationCommand.java
@@ -1,0 +1,40 @@
+
+package com.google.refine.commands;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.Project;
+import com.google.refine.process.Process;
+
+abstract public class OperationCommand extends Command {
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        if (!hasValidCSRFToken(request)) {
+            respondCSRFError(response);
+            return;
+        }
+
+        try {
+            Project project = getProject(request);
+
+            AbstractOperation op = createOperation(project, request);
+            Process process = op.createProcess(project, new Properties());
+
+            performProcessAndRespond(request, response, project, process);
+        } catch (Exception e) {
+            respondException(response, e);
+        }
+    }
+
+    abstract protected AbstractOperation createOperation(
+            Project project, HttpServletRequest request) throws Exception;
+
+}

--- a/main/src/com/google/refine/commands/cell/JoinMultiValueCellsCommand.java
+++ b/main/src/com/google/refine/commands/cell/JoinMultiValueCellsCommand.java
@@ -33,42 +33,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.commands.cell;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import com.google.refine.commands.Command;
+import com.google.refine.commands.OperationCommand;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.operations.cell.MultiValuedCellJoinOperation;
-import com.google.refine.process.Process;
 
-public class JoinMultiValueCellsCommand extends Command {
+public class JoinMultiValueCellsCommand extends OperationCommand {
 
     @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
-        if (!hasValidCSRFToken(request)) {
-            respondCSRFError(response);
-            return;
-        }
+    protected AbstractOperation createOperation(Project project, HttpServletRequest request) throws Exception {
+        String columnName = request.getParameter("columnName");
+        String keyColumnName = request.getParameter("keyColumnName");
+        String separator = request.getParameter("separator");
 
-        try {
-            Project project = getProject(request);
-
-            String columnName = request.getParameter("columnName");
-            String keyColumnName = request.getParameter("keyColumnName");
-            String separator = request.getParameter("separator");
-
-            AbstractOperation op = new MultiValuedCellJoinOperation(columnName, keyColumnName, separator);
-            Process process = op.createProcess(project, new Properties());
-
-            performProcessAndRespond(request, response, project, process);
-        } catch (Exception e) {
-            respondException(response, e);
-        }
+        return new MultiValuedCellJoinOperation(columnName, keyColumnName, separator);
     }
 }

--- a/main/src/com/google/refine/commands/cell/KeyValueColumnizeCommand.java
+++ b/main/src/com/google/refine/commands/cell/KeyValueColumnizeCommand.java
@@ -33,44 +33,22 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.commands.cell;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import com.google.refine.commands.Command;
+import com.google.refine.commands.OperationCommand;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.operations.cell.KeyValueColumnizeOperation;
-import com.google.refine.process.Process;
 
-public class KeyValueColumnizeCommand extends Command {
+public class KeyValueColumnizeCommand extends OperationCommand {
 
     @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
-        if (!hasValidCSRFToken(request)) {
-            respondCSRFError(response);
-            return;
-        }
+    protected AbstractOperation createOperation(Project project, HttpServletRequest request) throws Exception {
+        String keyColumnName = request.getParameter("keyColumnName");
+        String valueColumnName = request.getParameter("valueColumnName");
+        String noteColumnName = request.getParameter("noteColumnName");
 
-        try {
-            Project project = getProject(request);
-
-            String keyColumnName = request.getParameter("keyColumnName");
-            String valueColumnName = request.getParameter("valueColumnName");
-            String noteColumnName = request.getParameter("noteColumnName");
-
-            AbstractOperation op = new KeyValueColumnizeOperation(
-                    keyColumnName, valueColumnName, noteColumnName);
-
-            Process process = op.createProcess(project, new Properties());
-
-            performProcessAndRespond(request, response, project, process);
-        } catch (Exception e) {
-            respondException(response, e);
-        }
+        return new KeyValueColumnizeOperation(
+                keyColumnName, valueColumnName, noteColumnName);
     }
 }

--- a/main/src/com/google/refine/commands/cell/TransposeRowsIntoColumnsCommand.java
+++ b/main/src/com/google/refine/commands/cell/TransposeRowsIntoColumnsCommand.java
@@ -33,43 +33,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.commands.cell;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import com.google.refine.commands.Command;
+import com.google.refine.commands.OperationCommand;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.operations.cell.TransposeRowsIntoColumnsOperation;
-import com.google.refine.process.Process;
 
-public class TransposeRowsIntoColumnsCommand extends Command {
+public class TransposeRowsIntoColumnsCommand extends OperationCommand {
 
     @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
-        if (!hasValidCSRFToken(request)) {
-            respondCSRFError(response);
-            return;
-        }
+    protected AbstractOperation createOperation(Project project, HttpServletRequest request) throws Exception {
+        String columnName = request.getParameter("columnName");
+        int rowCount = getIntegerParameter(request, "rowCount", 0);
 
-        try {
-            Project project = getProject(request);
-
-            String columnName = request.getParameter("columnName");
-            int rowCount = Integer.parseInt(request.getParameter("rowCount"));
-
-            AbstractOperation op = new TransposeRowsIntoColumnsOperation(
-                    columnName, rowCount);
-
-            Process process = op.createProcess(project, new Properties());
-
-            performProcessAndRespond(request, response, project, process);
-        } catch (Exception e) {
-            respondException(response, e);
-        }
+        return new TransposeRowsIntoColumnsOperation(columnName, rowCount);
     }
 }

--- a/main/src/com/google/refine/commands/column/MoveColumnCommand.java
+++ b/main/src/com/google/refine/commands/column/MoveColumnCommand.java
@@ -33,41 +33,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.commands.column;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import com.google.refine.commands.Command;
+import com.google.refine.commands.OperationCommand;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.operations.column.ColumnMoveOperation;
-import com.google.refine.process.Process;
 
-public class MoveColumnCommand extends Command {
+public class MoveColumnCommand extends OperationCommand {
 
     @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
-        if (!hasValidCSRFToken(request)) {
-            respondCSRFError(response);
-            return;
-        }
+    protected AbstractOperation createOperation(Project project, HttpServletRequest request) throws Exception {
+        String columnName = request.getParameter("columnName");
+        int index = getIntegerParameter(request, "index", -1);
 
-        try {
-            Project project = getProject(request);
-
-            String columnName = request.getParameter("columnName");
-            int index = Integer.parseInt(request.getParameter("index"));
-
-            AbstractOperation op = new ColumnMoveOperation(columnName, index);
-            Process process = op.createProcess(project, new Properties());
-
-            performProcessAndRespond(request, response, project, process);
-        } catch (Exception e) {
-            respondException(response, e);
-        }
+        return new ColumnMoveOperation(columnName, index);
     }
 }

--- a/main/src/com/google/refine/commands/column/RemoveColumnCommand.java
+++ b/main/src/com/google/refine/commands/column/RemoveColumnCommand.java
@@ -33,40 +33,18 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.commands.column;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import com.google.refine.commands.Command;
+import com.google.refine.commands.OperationCommand;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.operations.column.ColumnRemovalOperation;
-import com.google.refine.process.Process;
 
-public class RemoveColumnCommand extends Command {
+public class RemoveColumnCommand extends OperationCommand {
 
     @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
-        if (!hasValidCSRFToken(request)) {
-            respondCSRFError(response);
-            return;
-        }
-
-        try {
-            Project project = getProject(request);
-
-            String columnName = request.getParameter("columnName");
-
-            AbstractOperation op = new ColumnRemovalOperation(columnName);
-            Process process = op.createProcess(project, new Properties());
-
-            performProcessAndRespond(request, response, project, process);
-        } catch (Exception e) {
-            respondException(response, e);
-        }
+    protected AbstractOperation createOperation(Project project, HttpServletRequest request) throws Exception {
+        String columnName = request.getParameter("columnName");
+        return new ColumnRemovalOperation(columnName);
     }
 }

--- a/main/src/com/google/refine/commands/column/RenameColumnCommand.java
+++ b/main/src/com/google/refine/commands/column/RenameColumnCommand.java
@@ -33,41 +33,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.commands.column;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import com.google.refine.commands.Command;
+import com.google.refine.commands.OperationCommand;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.operations.column.ColumnRenameOperation;
-import com.google.refine.process.Process;
 
-public class RenameColumnCommand extends Command {
+public class RenameColumnCommand extends OperationCommand {
 
     @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
-        if (!hasValidCSRFToken(request)) {
-            respondCSRFError(response);
-            return;
-        }
+    protected AbstractOperation createOperation(Project project, HttpServletRequest request) throws Exception {
+        String oldColumnName = request.getParameter("oldColumnName");
+        String newColumnName = request.getParameter("newColumnName");
 
-        try {
-            Project project = getProject(request);
-
-            String oldColumnName = request.getParameter("oldColumnName");
-            String newColumnName = request.getParameter("newColumnName");
-
-            AbstractOperation op = new ColumnRenameOperation(oldColumnName, newColumnName);
-            Process process = op.createProcess(project, new Properties());
-
-            performProcessAndRespond(request, response, project, process);
-        } catch (Exception e) {
-            respondException(response, e);
-        }
+        return new ColumnRenameOperation(oldColumnName, newColumnName);
     }
 }

--- a/main/src/com/google/refine/commands/column/ReorderColumnsCommand.java
+++ b/main/src/com/google/refine/commands/column/ReorderColumnsCommand.java
@@ -39,18 +39,17 @@ import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 
-import com.google.refine.browsing.EngineConfig;
-import com.google.refine.commands.EngineDependentCommand;
+import com.google.refine.commands.OperationCommand;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.operations.column.ColumnReorderOperation;
 import com.google.refine.util.ParsingUtilities;
 
-public class ReorderColumnsCommand extends EngineDependentCommand {
+public class ReorderColumnsCommand extends OperationCommand {
 
     @Override
     protected AbstractOperation createOperation(Project project,
-            HttpServletRequest request, EngineConfig engineConfig) throws Exception {
+            HttpServletRequest request) throws Exception {
 
         String columnNames = request.getParameter("columnNames");
         return new ColumnReorderOperation(

--- a/main/src/com/google/refine/commands/row/AnnotateOneRowCommand.java
+++ b/main/src/com/google/refine/commands/row/AnnotateOneRowCommand.java
@@ -46,6 +46,7 @@ import com.google.refine.model.changes.RowFlagChange;
 import com.google.refine.model.changes.RowStarChange;
 import com.google.refine.process.QuickHistoryEntryProcess;
 
+// TODO: Define new super class ProcessCommand ?
 public class AnnotateOneRowCommand extends Command {
 
     @Override

--- a/main/src/com/google/refine/commands/row/DenormalizeCommand.java
+++ b/main/src/com/google/refine/commands/row/DenormalizeCommand.java
@@ -33,38 +33,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.commands.row;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import com.google.refine.commands.Command;
+import com.google.refine.commands.OperationCommand;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.operations.row.DenormalizeOperation;
-import com.google.refine.process.Process;
 
-public class DenormalizeCommand extends Command {
+public class DenormalizeCommand extends OperationCommand {
 
     @Override
-    public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
-        if (!hasValidCSRFToken(request)) {
-            respondCSRFError(response);
-            return;
-        }
-
-        try {
-            Project project = getProject(request);
-
-            AbstractOperation op = new DenormalizeOperation();
-            Process process = op.createProcess(project, new Properties());
-
-            performProcessAndRespond(request, response, project, process);
-        } catch (Exception e) {
-            respondException(response, e);
-        }
+    protected AbstractOperation createOperation(Project project, HttpServletRequest request) throws Exception {
+        return new DenormalizeOperation();
     }
 }

--- a/main/src/com/google/refine/commands/row/ReorderRowsCommand.java
+++ b/main/src/com/google/refine/commands/row/ReorderRowsCommand.java
@@ -38,18 +38,17 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 
 import com.google.refine.browsing.Engine;
-import com.google.refine.browsing.EngineConfig;
-import com.google.refine.commands.EngineDependentCommand;
+import com.google.refine.commands.OperationCommand;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.operations.row.RowReorderOperation;
 import com.google.refine.sorting.SortingConfig;
 
-public class ReorderRowsCommand extends EngineDependentCommand {
+public class ReorderRowsCommand extends OperationCommand {
 
     @Override
     protected AbstractOperation createOperation(Project project,
-            HttpServletRequest request, EngineConfig engineConfig) throws Exception {
+            HttpServletRequest request) throws Exception {
 
         String mode = request.getParameter("mode");
         SortingConfig sorting = null;


### PR DESCRIPTION
Fixes #6443

Changes proposed in this pull request:
- Introduce an OperationCommand class to hold the bulk of the EngineDependentCommand implementation and move EngineDependentCommand to be its subclass.
- refactor `Command`s which create `Operation`s to use the new class and delete all the code made redundant.
