### PR TITLE
Removed grey background from button tag

### DIFF
--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -186,6 +186,8 @@ table.data-table td.column-header, table.data-table th.column-header {
   background-repeat: no-repeat;
   cursor: pointer;
   border: none;
+  padding: 0;
+  background-color: transparent;
 }
 
 .column-header-menu-expand {


### PR DESCRIPTION
Fixes #6440

Changes proposed in this pull request:
- `padding: 0` - Removes unwanted padding
- `background-color: transparent` - Converts grey background into transparent color
