### PR TITLE
Fix project name lookup with missing metadata. Fixes #6453

### DIFF
--- a/main/src/com/google/refine/ProjectManager.java
+++ b/main/src/com/google/refine/ProjectManager.java
@@ -376,25 +376,29 @@ public abstract class ProjectManager {
      *             If no unique project is found with the given name
      */
     public long getProjectID(String name) throws GetProjectIDException {
-        Integer c = 0;
-        Long id = 0L;
+        if (name == null) {
+            throw new GetProjectIDException("Can't lookup a project with a null name");
+        }
+        Integer count = 0;
+        Long id = -1L;
+        // TODO: Linear search assumes small number of projects
         for (Entry<Long, ProjectMetadata> entry : _projectsMetadata.entrySet()) {
-            if (entry.getValue().getName().equals(name)) {
+            ProjectMetadata metadata = entry.getValue();
+            if (metadata != null && name.equals(metadata.getName())) {
                 id = entry.getKey();
-                c += 1;
+                count += 1;
             }
         }
-        if (c == 1) {
+        if (count == 1) {
             return id;
-        } else if (c == 0) {
+        } else if (count == 0) {
             throw new GetProjectIDException("Unable to find project with name: " + name);
-        } else {
-            throw new GetProjectIDException(c + " projects found with name: " + name);
         }
+        throw new GetProjectIDException("Multiple (" + count + ") projects found with name: " + name);
     }
 
     /**
-     * A valid user meta data definition should have name and display property
+     * A valid user metadata definition should have name and display property
      * 
      * @param placeHolderJsonObj
      * @return
@@ -454,7 +458,7 @@ public abstract class ProjectManager {
     }
 
     /**
-     * honor the meta data preference
+     * honor the metadata preference
      * 
      * @param jsonObjArray
      */
@@ -533,7 +537,7 @@ public abstract class ProjectManager {
      *
      * @deprecated Deprecated for v3.8. Use {@link #getAllProjectsTags()}
      */
-    @Deprecated
+    @Deprecated(since = "3.8")
     @JsonIgnore
     public Map<String, Integer> getAllProjectTags() {
         return _projectsTags;

--- a/main/src/com/google/refine/history/History.java
+++ b/main/src/com/google/refine/history/History.java
@@ -291,7 +291,7 @@ public class History {
         writer.write("/e/\n");
     }
 
-    synchronized public void load(Project project, LineNumberReader reader) throws Exception {
+    synchronized public void load(Project project, LineNumberReader reader) throws IOException {
         String line;
         while ((line = reader.readLine()) != null && !"/e/".equals(line)) {
             int equal = line.indexOf('=');

--- a/main/src/com/google/refine/io/FileHistoryEntryManager.java
+++ b/main/src/com/google/refine/io/FileHistoryEntryManager.java
@@ -52,6 +52,8 @@ import com.google.refine.util.Pool;
 
 public class FileHistoryEntryManager implements HistoryEntryManager {
 
+    public static final String HISTORY_DIR = "history";
+
     @Override
     public void delete(HistoryEntry historyEntry) {
         File file = getChangeFile(historyEntry);
@@ -141,7 +143,7 @@ public class FileHistoryEntryManager implements HistoryEntryManager {
     protected File getHistoryDir(HistoryEntry historyEntry) {
         File dir = new File(((FileProjectManager) ProjectManager.singleton)
                 .getProjectDir(historyEntry.projectID),
-                "history");
+                HISTORY_DIR);
         dir.mkdirs();
 
         return dir;

--- a/main/src/com/google/refine/io/FileProjectManager.java
+++ b/main/src/com/google/refine/io/FileProjectManager.java
@@ -39,6 +39,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -67,6 +69,9 @@ import com.google.refine.util.ParsingUtilities;
 public class FileProjectManager extends ProjectManager {
 
     final static protected String PROJECT_DIR_SUFFIX = ".project";
+    public static final String WORKSPACE_JSON = "workspace.json";
+    public static final String WORKSPACE_OLD_JSON = "workspace.old.json";
+    public static final String WORKSPACE_TEMP_JSON = "workspace.temp.json";
 
     protected File _workspaceDir;
 
@@ -101,16 +106,31 @@ public class FileProjectManager extends ProjectManager {
     }
 
     static public File getProjectDir(File workspaceDir, long projectID) {
+        return getProjectDir(workspaceDir, projectID, true);
+    }
+
+    static public File getProjectDir(File workspaceDir, long projectID, boolean createIfMissing) {
         File dir = new File(workspaceDir, projectID + PROJECT_DIR_SUFFIX);
         if (!dir.exists()) {
-            dir.mkdir();
+            if (createIfMissing) {
+                logger.warn("(Re)creating missing project directory - {}", dir.getAbsolutePath());
+                dir.mkdir();
+            } else {
+                logger.error("Missing project directory {}", dir.getAbsolutePath());
+                return null;
+            }
         }
         return dir;
     }
 
     @JsonIgnore
     public File getProjectDir(long projectID) {
-        return getProjectDir(_workspaceDir, projectID);
+        return getProjectDir(projectID, true);
+    }
+
+    @JsonIgnore
+    public File getProjectDir(long projectID, boolean createIfMissing) {
+        return getProjectDir(_workspaceDir, projectID, createIfMissing);
     }
 
     /**
@@ -205,6 +225,7 @@ public class FileProjectManager extends ProjectManager {
 
                     tos.putArchiveEntry(entry);
 
+                    // TODO: replace with Files.copy(file.toPath(), tos);
                     copyFile(file, tos);
 
                     tos.closeArchiveEntry();
@@ -213,6 +234,10 @@ public class FileProjectManager extends ProjectManager {
         }
     }
 
+    /**
+     * @deprecated use {@link Files#copy(Path, OutputStream)}
+     */
+    @Deprecated(since = "3.9")
     protected void copyFile(File file, OutputStream os) throws IOException {
         final int buffersize = 4096;
 
@@ -260,23 +285,23 @@ public class FileProjectManager extends ProjectManager {
             }
             File tempFile = saveWorkspaceToTempFile();
             if (tempFile == null) return;
-            File file = new File(_workspaceDir, "workspace.json");
-            File oldFile = new File(_workspaceDir, "workspace.old.json");
+            File file = new File(_workspaceDir, WORKSPACE_JSON);
+            File oldFile = new File(_workspaceDir, WORKSPACE_OLD_JSON);
 
             if (oldFile.exists()) {
                 if (!oldFile.delete()) {
-                    logger.warn("Failed to delete previous backup workspace.old.json");
+                    logger.warn("Failed to delete previous backup {}", oldFile.getAbsolutePath());
                 }
             }
 
             if (file.exists()) {
                 if (!file.renameTo(oldFile)) {
-                    logger.error("Failed to rename workspace.json to workspace.old.json");
+                    logger.error("Failed to rename {} to {}", file.getAbsolutePath(), oldFile.getAbsolutePath());
                 }
             }
 
             if (!tempFile.renameTo(file)) {
-                logger.error("Failed to rename new temp workspace file to workspace.json");
+                logger.error("Failed to rename new temp workspace file to {}", file.getAbsolutePath());
             }
             projectRemoved = false;
             logger.info("Saved workspace");
@@ -284,12 +309,11 @@ public class FileProjectManager extends ProjectManager {
     }
 
     private File saveWorkspaceToTempFile() {
-        File tempFile = new File(_workspaceDir, "workspace.temp.json");
+        File tempFile = new File(_workspaceDir, WORKSPACE_TEMP_JSON);
         try {
             saveToFile(tempFile);
-        } catch (Exception e) {
-            e.printStackTrace();
-            logger.warn("Failed to save workspace");
+        } catch (IOException e) {
+            logger.warn("Failed to save workspace", e);
             return null;
         }
         // set the workspace to owner-only readable, because it can contain credentials
@@ -302,7 +326,10 @@ public class FileProjectManager extends ProjectManager {
         List<Long> modified = _projectsMetadata.entrySet().stream()
                 .filter(e -> {
                     ProjectMetadata metadata = e.getValue();
-                    if (metadata == null) return false;
+                    if (metadata == null) {
+                        logger.error("Missing metadata for project ID {}", e.getKey());
+                        return false;
+                    }
                     return metadata.isDirty();
                 }).map(Entry::getKey).collect(Collectors.toList());
         return modified;
@@ -313,6 +340,8 @@ public class FileProjectManager extends ProjectManager {
             ProjectMetadata metadata = _projectsMetadata.get(id);
             if (metadata != null) {
                 ProjectMetadataUtilities.save(metadata, getProjectDir(id));
+            } else {
+                logger.error("Missing metadata on save for project ID {}", id);
             }
         }
     }
@@ -364,14 +393,10 @@ public class FileProjectManager extends ProjectManager {
     }
 
     protected void load() {
-        if (loadFromFile(new File(_workspaceDir, "workspace.json"))) {
-            return;
-        }
-        if (loadFromFile(new File(_workspaceDir, "workspace.temp.json"))) {
-            return;
-        }
-        if (loadFromFile(new File(_workspaceDir, "workspace.old.json"))) {
-            return;
+        for (String filename : new String[] { WORKSPACE_JSON, WORKSPACE_TEMP_JSON, WORKSPACE_OLD_JSON }) {
+            if (loadFromFile(new File(_workspaceDir, filename))) {
+                return;
+            }
         }
         logger.error("Failed to load workspace from any attempted alternatives.");
     }
@@ -381,21 +406,19 @@ public class FileProjectManager extends ProjectManager {
 
         _projectsMetadata.clear();
 
-        boolean found = false;
-
         if (file.exists() || file.canRead()) {
             try {
                 ParsingUtilities.mapper.readerForUpdating(this).readValue(file);
 
+                // TODO: This seems odd. Why is this here?
                 LocaleUtils.setLocale((String) this.getPreferenceStore().get("userLang"));
 
-                found = true;
+                return true;
             } catch (IOException e) {
-                logger.warn(e.toString());
+                logger.warn("Failed to load workspace", e);
             }
         }
-
-        return found;
+        return false;
     }
 
     protected void recover() {
@@ -403,8 +426,7 @@ public class FileProjectManager extends ProjectManager {
         File[] files = _workspaceDir.listFiles();
         if (files == null) return;
         for (File file : files) {
-            if (file == null) continue;
-            if (file.isDirectory() && !file.isHidden()) {
+            if (file != null && file.isDirectory() && !file.isHidden()) {
                 String dirName = file.getName();
                 if (file.getName().endsWith(PROJECT_DIR_SUFFIX)) {
                     String idString = dirName.substring(0, dirName.length() - PROJECT_DIR_SUFFIX.length());
@@ -417,12 +439,10 @@ public class FileProjectManager extends ProjectManager {
 
                     if (id > 0 && !_projectsMetadata.containsKey(id)) {
                         if (loadProjectMetadata(id)) {
-                            logger.info("Recovered project named "
-                                    + getProjectMetadata(id).getName()
-                                    + " in directory " + dirName);
+                            logger.info("Recovered project named {} in directory {}", getProjectMetadata(id).getName(), dirName);
                             recovered = true;
                         } else {
-                            logger.warn("Failed to recover project in directory " + dirName);
+                            logger.warn("Failed to recover project in directory {}", dirName);
 
                             file.renameTo(new File(file.getParentFile(), dirName + ".corrupted"));
                         }
@@ -460,7 +480,11 @@ public class FileProjectManager extends ProjectManager {
     protected void loadProjects(List<Long> projectIDs) {
         for (Long id : projectIDs) {
 
-            File projectDir = getProjectDir(id);
+            File projectDir = getProjectDir(id, false);
+            if (projectDir == null) {
+                logger.error("Missing project directory for project {}", id);
+                continue;
+            }
             ProjectMetadata metadata = ProjectMetadataUtilities.load(projectDir);
 
             mergeEmptyUserMetadata(metadata);

--- a/main/src/com/google/refine/io/ProjectUtilities.java
+++ b/main/src/com/google/refine/io/ProjectUtilities.java
@@ -120,7 +120,7 @@ public class ProjectUtilities {
                 if (file.exists()) {
                     return loadFromFile(file, id);
                 }
-            } catch (Exception e) {
+            } catch (IOException e) {
                 logger.warn("Failed to load from data file {} / {}", dir, filename, e);
             }
         }
@@ -130,7 +130,7 @@ public class ProjectUtilities {
 
     static protected Project loadFromFile(
             File file,
-            long id) throws Exception {
+            long id) throws IOException {
         ZipFile zipFile = new ZipFile(file);
         try {
             Pool pool = new Pool();

--- a/main/src/com/google/refine/io/ProjectUtilities.java
+++ b/main/src/com/google/refine/io/ProjectUtilities.java
@@ -50,18 +50,20 @@ import com.google.refine.util.Pool;
 public class ProjectUtilities {
 
     final static Logger logger = LoggerFactory.getLogger("project_utilities");
+    public static final String DATA_ZIP = "data.zip";
+    public static final String DATA_TEMP_ZIP = "data.temp.zip";
+    public static final String DATA_OLD_ZIP = "data.old.zip";
 
     synchronized public static void save(Project project) throws IOException {
         synchronized (project) {
             long id = project.id;
             File dir = ((FileProjectManager) ProjectManager.singleton).getProjectDir(id);
 
-            File tempFile = new File(dir, "data.temp.zip");
+            File tempFile = new File(dir, DATA_TEMP_ZIP);
             try {
                 saveToFile(project, tempFile);
             } catch (IOException e) {
-                e.printStackTrace();
-                logger.warn("Failed to save project {}", id);
+                logger.warn("Failed to save project {}", id, e);
                 try {
                     tempFile.delete();
                 } catch (Exception e2) {
@@ -70,8 +72,8 @@ public class ProjectUtilities {
                 throw e;
             }
 
-            File file = new File(dir, "data.zip");
-            File oldFile = new File(dir, "data.old.zip");
+            File file = new File(dir, DATA_ZIP);
+            File oldFile = new File(dir, DATA_OLD_ZIP);
 
             if (file.exists()) {
                 file.renameTo(oldFile);
@@ -112,33 +114,17 @@ public class ProjectUtilities {
     }
 
     static public Project load(File dir, long id) {
-        try {
-            File file = new File(dir, "data.zip");
-            if (file.exists()) {
-                return loadFromFile(file, id);
+        for (String filename : new String[] { DATA_ZIP, DATA_TEMP_ZIP, DATA_OLD_ZIP }) {
+            try {
+                File file = new File(dir, filename);
+                if (file.exists()) {
+                    return loadFromFile(file, id);
+                }
+            } catch (Exception e) {
+                logger.warn("Failed to load from data file {} / {}", dir, filename, e);
             }
-        } catch (Exception e) {
-            e.printStackTrace();
         }
-
-        try {
-            File file = new File(dir, "data.temp.zip");
-            if (file.exists()) {
-                return loadFromFile(file, id);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        try {
-            File file = new File(dir, "data.old.zip");
-            if (file.exists()) {
-                return loadFromFile(file, id);
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
+        logger.error("All data files and backup data files failed to load");
         return null;
     }
 

--- a/main/src/com/google/refine/model/Column.java
+++ b/main/src/com/google/refine/model/Column.java
@@ -153,7 +153,7 @@ public class Column {
         }
     }
 
-    static public Column load(String s) throws Exception {
+    static public Column load(String s) throws IOException {
         return ParsingUtilities.mapper.readValue(s, Column.class);
     }
 

--- a/main/src/com/google/refine/model/ColumnModel.java
+++ b/main/src/com/google/refine/model/ColumnModel.java
@@ -222,7 +222,7 @@ public class ColumnModel {
         writer.write("/e/\n");
     }
 
-    synchronized public void load(LineNumberReader reader) throws Exception {
+    synchronized public void load(LineNumberReader reader) throws IOException {
         String line;
         while ((line = reader.readLine()) != null && !"/e/".equals(line)) {
             int equal = line.indexOf('=');

--- a/main/src/com/google/refine/model/Project.java
+++ b/main/src/com/google/refine/model/Project.java
@@ -40,6 +40,7 @@ import java.io.LineNumberReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -188,14 +189,14 @@ public class Project {
         }
     }
 
-    static public Project loadFromInputStream(InputStream is, long id, Pool pool) throws Exception {
-        return loadFromReader(new LineNumberReader(new InputStreamReader(is, "UTF-8")), id, pool);
+    static public Project loadFromInputStream(InputStream is, long id, Pool pool) throws IOException {
+        return loadFromReader(new LineNumberReader(new InputStreamReader(is, StandardCharsets.UTF_8)), id, pool);
     }
 
     static private Project loadFromReader(
             LineNumberReader reader,
             long id,
-            Pool pool) throws Exception {
+            Pool pool) throws IOException {
         long start = System.currentTimeMillis();
 
         // version of Refine which wrote the file

--- a/main/src/com/google/refine/model/Recon.java
+++ b/main/src/com/google/refine/model/Recon.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.model;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -388,7 +389,7 @@ public class Recon implements HasFields {
         return null;
     }
 
-    static public Recon loadStreaming(String s) throws Exception {
+    static public Recon loadStreaming(String s) throws IOException {
         return ParsingUtilities.mapper.readValue(s, Recon.class);
     }
 

--- a/main/src/com/google/refine/model/ReconCandidate.java
+++ b/main/src/com/google/refine/model/ReconCandidate.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.model;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -89,12 +90,12 @@ public class ReconCandidate implements HasFields {
         return false;
     }
 
-    static public ReconCandidate loadStreaming(String s) throws Exception {
+    static public ReconCandidate loadStreaming(String s) throws IOException {
         return ParsingUtilities.mapper.readValue(s, ReconCandidate.class);
     }
 
     @Deprecated
-    static public ReconCandidate loadStreaming(JsonParser jp) throws Exception {
+    static public ReconCandidate loadStreaming(JsonParser jp) throws IOException {
         JsonToken t = jp.getCurrentToken();
         if (t == JsonToken.VALUE_NULL || t != JsonToken.START_OBJECT) {
             return null;

--- a/main/src/com/google/refine/model/Row.java
+++ b/main/src/com/google/refine/model/Row.java
@@ -203,7 +203,7 @@ public class Row implements HasFields {
         }
     }
 
-    static public Row load(String s, Pool pool) throws Exception {
+    static public Row load(String s, Pool pool) throws IOException {
         return s.length() == 0 ? null : loadStreaming(s, pool);
     }
 
@@ -218,7 +218,7 @@ public class Row implements HasFields {
         return new Row(cells, flagged, starred);
     }
 
-    static public Row loadStreaming(String s, Pool pool) throws Exception {
+    static public Row loadStreaming(String s, Pool pool) throws IOException {
         InjectableValues injectableValues = new InjectableValues.Std()
                 .addValue("pool", pool);
         return ParsingUtilities.mapper.setInjectableValues(injectableValues)

--- a/main/src/com/google/refine/util/Pool.java
+++ b/main/src/com/google/refine/util/Pool.java
@@ -41,6 +41,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -114,11 +115,11 @@ public class Pool {
         }
     }
 
-    public void load(InputStream is) throws Exception {
-        load(new InputStreamReader(is, "UTF-8"));
+    public void load(InputStream is) throws IOException {
+        load(new InputStreamReader(is, StandardCharsets.UTF_8));
     }
 
-    public void load(Reader reader) throws Exception {
+    public void load(Reader reader) throws IOException {
         LineNumberReader reader2 = new LineNumberReader(reader);
 
         /* String version = */ reader2.readLine();

--- a/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
@@ -127,7 +127,7 @@ public class CrossTests extends RefineTest {
     public void crossFunctionMultipleProjects() throws Exception {
         String duplicateProjectName = "Duplicate";
         assertEquals(((EvalError) invoke("cross", "Anne", duplicateProjectName, "friend")).message,
-                "2 projects found with name: " + duplicateProjectName);
+                "Multiple (2) projects found with name: " + duplicateProjectName);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/io/FileProjectManagerTests.java
+++ b/main/tests/server/src/com/google/refine/io/FileProjectManagerTests.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -40,6 +41,7 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.jena.atlas.json.JSON;
 import org.apache.jena.atlas.json.JsonObject;
 import org.testng.annotations.BeforeMethod;
@@ -154,6 +156,15 @@ public class FileProjectManagerTests {
         long timeAfterB = metaBFile.lastModified();
         assertEquals(timeBeforeB, timeAfterB, "Unmodified project written when it didn't need to be");
         assertNotEquals(timeBeforeA, timeAfterA, "Modified project not written");
+        // Test handling of corrupted workspace with missing metadata file
+        try {
+            FileUtils.deleteDirectory(metaAFile.getParentFile());
+        } catch (IOException e) {
+            fail("Failed to delete metadata directory for " + metaAFile);
+        }
+        // Reload our intentionally corrupted workspace.
+        manager = new FileProjectManager(workspaceDir);
+        assertEquals(manager.getProjectID("B"), idB);
     }
 
     @Test


### PR DESCRIPTION
Fixes #6453
Changes proposed in this pull request:
- improve error messages for various types of corruption
- don't automatically recreate missing directories at startup
- don't attempt to process null metadata entries
- extract magic strings into constants
- narrow Exception to IOException in error handling

The second commit and some of the cleanup in the first commit can be moved to a separate refactoring task if there's a need for a minimalist fix for 3.7.x or something else.