### PR TITLE
Provide slf4j-api & jackson to extension modules. Fixes #6475

### DIFF
--- a/extensions/database/pom.xml
+++ b/extensions/database/pom.xml
@@ -109,6 +109,12 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
       <scope>provided</scope>
@@ -117,6 +123,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <version>${jackson.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -128,7 +135,13 @@
       <artifactId>encoder</artifactId>
       <version>${owasp-encoder.version}</version>
     </dependency>
-  
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- test dependencies -->
 
     <dependency>

--- a/extensions/gdata/pom.xml
+++ b/extensions/gdata/pom.xml
@@ -97,7 +97,12 @@
       <version>${jackson.version}</version>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- test dependencies -->
 
     <dependency>

--- a/extensions/jython/pom.xml
+++ b/extensions/jython/pom.xml
@@ -88,7 +88,7 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j.version}</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
 
   </dependencies>

--- a/extensions/pc-axis/pom.xml
+++ b/extensions/pc-axis/pom.xml
@@ -66,7 +66,12 @@
       <version>${servlet-api.version}</version>
       <scope>provided</scope>
     </dependency>
-
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>

--- a/extensions/wikibase/pom.xml
+++ b/extensions/wikibase/pom.xml
@@ -86,6 +86,19 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.wikidata.wdtk</groupId>

--- a/server/src/com/google/util/logging/IndentingLayout.java
+++ b/server/src/com/google/util/logging/IndentingLayout.java
@@ -37,7 +37,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Node;


### PR DESCRIPTION
Fixes #6475

Changes proposed in this pull request:
- Add SLF4J & Jackson modules as "provided" to extension POMs
