### PR TITLE
Switch to standard Coveralls action. Fixes #6493

### DIFF
--- a/.github/workflows/pull_request_server.yml
+++ b/.github/workflows/pull_request_server.yml
@@ -112,14 +112,70 @@ jobs:
       - name: Build and test with Maven
         run: mvn -B jacoco:prepare-agent test jacoco:report
 
-      - name: Coveralls
+      - name: Coveralls main
         uses: coverallsapp/github-action@v2
         with:
-          files: main/target/site/jacoco/jacoco.xml extensions/*/target/site/jacoco/jacoco.xml
+          base-path: main/src
+          files: main/target/site/jacoco/jacoco.xml
+          format: jacoco
+          flag-name: Java-${{ matrix.java }}-main
+          fail-on-error: false
+          parallel: true
+
+      - name: Coveralls database
+        uses: coverallsapp/github-action@v2
+        with:
+          base-path: extensions/database/src
+          files: extensions/database/target/site/jacoco/jacoco.xml
           github-token: ${{ env.COVERALLS_TOKEN }}
           format: jacoco
-          flag-name: Java ${{ matrix.java }}
+          flag-name: Java-${{ matrix.java }}-database
           fail-on-error: false
+          parallel: true
+
+      - name: Coveralls phonetic
+        uses: coverallsapp/github-action@v2
+        with:
+          base-path: extensions/phonetic/src
+          files: extensions/phonetic/target/site/jacoco/jacoco.xml
+          github-token: ${{ env.COVERALLS_TOKEN }}
+          format: jacoco
+          flag-name: Java-${{ matrix.java }}-phonetic
+          fail-on-error: false
+          parallel: true
+
+      - name: Coveralls gdata
+        uses: coverallsapp/github-action@v2
+        with:
+          base-path: extensions/gdata/src
+          files: extensions/gdata/target/site/jacoco/jacoco.xml
+          github-token: ${{ env.COVERALLS_TOKEN }}
+          format: jacoco
+          flag-name: Java-${{ matrix.java }}-gdata
+          fail-on-error: false
+          parallel: true
+
+      - name: Coveralls wikibase
+        uses: coverallsapp/github-action@v2
+        with:
+          base-path: extensions/wikibase/src
+          files: extensions/wikibase/target/site/jacoco/jacoco.xml
+          github-token: ${{ env.COVERALLS_TOKEN }}
+          format: jacoco
+          flag-name: Java-${{ matrix.java }}-wikibase
+          fail-on-error: false
+          parallel: true
+
+      - name: Coveralls jython
+        uses: coverallsapp/github-action@v2
+        with:
+          base-path: extensions/jython/src
+          files: extensions/jython/target/site/jacoco/jacoco.xml
+          github-token: ${{ env.COVERALLS_TOKEN }}
+          format: jacoco
+          flag-name: Java-${{ matrix.java }}-jython
+          fail-on-error: false
+          parallel: true
 
   windows_server_tests:
     runs-on: windows-latest
@@ -141,3 +197,14 @@ jobs:
 
       - name: Build and test with Maven
         run: mvn -B jacoco:prepare-agent test
+
+  finish:
+    needs: linux_server_tests
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close parallel build
+        uses: coverallsapp/github-action@v2
+        with:
+          parallel-finished: true
+

--- a/.github/workflows/pull_request_server.yml
+++ b/.github/workflows/pull_request_server.yml
@@ -47,7 +47,7 @@ jobs:
   linux_server_tests:
     strategy:
       matrix:
-        java: [ 11, 21 ]
+        java: [ 21 ]
 
     runs-on: ubuntu-latest
 
@@ -203,8 +203,8 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
+      # Only really needed if we're testing in separate jobs (e.g. multiple Java versions)
       - name: Close parallel build
         uses: coverallsapp/github-action@v2
         with:
           parallel-finished: true
-

--- a/.github/workflows/pull_request_server.yml
+++ b/.github/workflows/pull_request_server.yml
@@ -110,11 +110,16 @@ jobs:
           PGPASSWORD: postgres
 
       - name: Build and test with Maven
-        run: mvn -B jacoco:prepare-agent test
+        run: mvn -B jacoco:prepare-agent test jacoco:report
 
-      - name: Submit test coverage to Coveralls
-        run: |
-          mvn jacoco:report coveralls:report -DrepoToken=${{ env.COVERALLS_TOKEN }} -DpullRequest=${{ github.event.number }} -DfailOnServiceError=false
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          files: main/target/site/jacoco/jacoco.xml extensions/*/target/site/jacoco/jacoco.xml
+          github-token: ${{ env.COVERALLS_TOKEN }}
+          format: jacoco
+          flag-name: Java ${{ matrix.java }}
+          fail-on-error: false
 
   windows_server_tests:
     runs-on: windows-latest

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -164,11 +164,16 @@ jobs:
       run: cd main/webapp && npm install
       
     - name: Build and test with Maven
-      run: mvn -B jacoco:prepare-agent test
+      run: mvn -B jacoco:prepare-agent test jacoco:report
 
-    - name: Submit test coverage to Coveralls
-      run: |
-        mvn jacoco:report coveralls:report -DrepoToken=${{ env.COVERALLS_TOKEN }} -DpullRequest=${{ github.event.number }} -DserviceName="GitHub Actions" -DserviceBuildNumber=${{ env.GITHUB_RUN_ID }} -Dbranch=${GITHUB_REF#refs/heads/} -DfailOnServiceError=false
+    - name: Coveralls
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ env.COVERALLS_TOKEN }}
+        format: jacoco
+        flag-name: Java ${{ matrix.java }}
+        pull-request: ${{ github.event.number }}
+        fail-on-error: false
 
     - name: Install webapp dependencies
       run: cd main/webapp && npm install

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,6 @@
     <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
     <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-    <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
     <surefire.version>3.2.5</surefire.version>
     <maven-jar-plugin.version>3.4.1</maven-jar-plugin.version>
     <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
@@ -182,85 +181,62 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-	<version>${jacoco-maven-plugin.version}</version>
+        <version>${jacoco-maven-plugin.version}</version>
         <configuration>
           <excludes>
             <exclude>org/openrefine/messages/**/*</exclude>
           </excludes>
         </configuration>
         <executions>
-            <execution>
-                <id>prepare-agent</id>
-                <goals>
-                    <goal>prepare-agent</goal>
-                </goals>
-                <phase>process-test-resources</phase>
-                <configuration>
-                    <destFile>${project.build.directory}/report/${project.name}.exec</destFile>
-                    <propertyName>surefireArgs</propertyName>
-                </configuration>
-            </execution>
-            <execution>
-                <phase>test</phase>
-                <goals>
-                    <goal>report</goal>
-                </goals>
-                <configuration>
-                    <dataFile>${project.build.directory}/report/${project.name}.exec</dataFile>
-                    <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
-                </configuration>
-            </execution>
-            <execution>
-                <id>merge</id>
-                <goals>
-                     <goal>merge</goal>
-                </goals>
-                <phase>test</phase>
-               <configuration>
-                     <destFile>${project.build.directory}/report/jacoco-merged.exec</destFile>
-                     <fileSets>
-                        <fileSet>
-                            <directory>main/target/report</directory>
-                            <includes>
-                                <include>*.exec</include>
-                            </includes>
-                        </fileSet>
-                        <fileSet>
-                            <directory>extensions/target/report</directory>
-                            <includes>
-                                <include>*.exec</include>
-                            </includes>
-                        </fileSet>
-                     </fileSets>
-                </configuration>
-             </execution>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+            <phase>process-test-resources</phase>
+            <configuration>
+              <destFile>${project.build.directory}/report/${project.name}.exec</destFile>
+              <propertyName>surefireArgs</propertyName>
+            </configuration>
+          </execution>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <configuration>
+              <dataFile>${project.build.directory}/report/${project.name}.exec</dataFile>
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>merge</id>
+            <goals>
+              <goal>merge</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <destFile>${project.build.directory}/report/jacoco-merged.exec</destFile>
+              <fileSets>
+                <fileSet>
+                  <directory>main/target/report</directory>
+                  <includes>
+                    <include>*.exec</include>
+                  </includes>
+                </fileSet>
+                <fileSet>
+                  <directory>extensions/target/report</directory>
+                  <includes>
+                    <include>*.exec</include>
+                  </includes>
+                </fileSet>
+              </fileSets>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eluder.coveralls</groupId>
-        <artifactId>coveralls-maven-plugin</artifactId>
-	<version>${coveralls-maven-plugin.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-          </dependency>
-        </dependencies>
-        <configuration>
-          <sourceDirectories>
-             <sourceDirectory>main/src</sourceDirectory>
-             <sourceDirectory>main/target/generated-sources</sourceDirectory>
-             <sourceDirectory>extensions/jython/src</sourceDirectory>
-             <sourceDirectory>extensions/wikidata/src</sourceDirectory>
-             <sourceDirectory>extensions/database/src</sourceDirectory>
-             <sourceDirectory>extensions/phonetic/src</sourceDirectory>
-             <sourceDirectory>extensions/gdata/src</sourceDirectory>
-          </sourceDirectories>
-        </configuration>
-      </plugin>
-      <plugin>
-        <!-- Pluging to generate release source -->
+        <!-- Plugin to generate release source -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <version>3.3.1</version>


### PR DESCRIPTION
Fixes #6493

Changes proposed in this pull request:
- Switch to standard Coveralls GitHub action
- Add Java version as job flag
- Remove old Maven plugin integration for Coveralls

Draft until I see if it works...