### PR TITLE
Remove unnecessary CSS from recon-dialog.css

### DIFF
--- a/main/webapp/modules/core/styles/reconciliation/recon-dialog.css
+++ b/main/webapp/modules/core/styles/reconciliation/recon-dialog.css
@@ -102,18 +102,7 @@ a.recon-dialog-service-selector-remove {
   background-repeat: no-repeat;
   background-position: 0px 0px;
 }
-.dialog-footer {
-  display: flex;
-}
 
-.button-left {
-  display: flex;
-}
-
-.button-right {
-  display: flex;
-  gap: 10px; 
-}
 .recon-service-entry{
   display:inline-block;
 


### PR DESCRIPTION
Following up on
https://github.com/OpenRefine/OpenRefine/issues/6353#issuecomment-2021092463.

The `button-left` and `button-right` classes are not used anywhere in the app. The `dialog-footer` class should not be styled by this file and the `display: flex` does not have any visible impact on dialogs as far as I can tell, so it looks safe to remove.
