### PR TITLE
Remove dependency to POI in FileProjectManager

### DIFF
--- a/main/src/com/google/refine/io/FileProjectManager.java
+++ b/main/src/com/google/refine/io/FileProjectManager.java
@@ -53,7 +53,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-import org.apache.poi.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -190,7 +189,7 @@ public class FileProjectManager extends ProjectManager {
             } else {
                 FileOutputStream fout = new FileOutputStream(destEntry);
                 try {
-                    IOUtils.copy(tin, fout);
+                    tin.transferTo(fout);
                 } finally {
                     fout.close();
                 }

--- a/main/src/com/google/refine/util/IOUtils.java
+++ b/main/src/com/google/refine/util/IOUtils.java
@@ -60,7 +60,7 @@ public class IOUtils {
     }
 
     /**
-     * @deprecated use {@link InputStream#transferTo(OutputStream) in combination with {@link FileOutputStream}}
+     * @deprecated use {@link InputStream#transferTo(OutputStream)} in combination with {@link FileOutputStream}
      */
     @Deprecated(since = "3.9")
     public static long copy(InputStream input, File file) throws IOException {

--- a/main/src/com/google/refine/util/IOUtils.java
+++ b/main/src/com/google/refine/util/IOUtils.java
@@ -39,10 +39,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+@Deprecated(since = "3.9")
 public class IOUtils {
 
     private static final int DEFAULT_BUFFER_SIZE = 4 * 1024;
 
+    /**
+     * @deprecated use {@link InputStream#transferTo(OutputStream)}
+     */
+    @Deprecated(since = "3.9")
     public static long copy(InputStream input, OutputStream output) throws IOException {
         byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
         long count = 0;
@@ -54,6 +59,10 @@ public class IOUtils {
         return count;
     }
 
+    /**
+     * @deprecated use {@link InputStream#transferTo(OutputStream) in combination with {@link FileOutputStream}}
+     */
+    @Deprecated(since = "3.9")
     public static long copy(InputStream input, File file) throws IOException {
         FileOutputStream output = new FileOutputStream(file);
         byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];


### PR DESCRIPTION
This avoids an unnecessary dependency from one of our core classes to the Apache POI library, which should only be relied on to support XLS(X) in importers/exporters.

Also deprecates some old utility functions which can be replaced by functionality from the JDK (since we require Java >= 11).