### PR TITLE
Package Java classes into jars

### DIFF
--- a/extensions/database/pom.xml
+++ b/extensions/database/pom.xml
@@ -23,7 +23,6 @@
     </resources>
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>tests/src</testSourceDirectory>
-    <outputDirectory>module/MOD-INF/classes</outputDirectory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/extensions/gdata/pom.xml
+++ b/extensions/gdata/pom.xml
@@ -27,7 +27,6 @@
     </resources>
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>tests/src</testSourceDirectory>
-    <outputDirectory>module/MOD-INF/classes</outputDirectory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/extensions/jython/pom.xml
+++ b/extensions/jython/pom.xml
@@ -25,7 +25,6 @@
     </resources>
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>tests/src</testSourceDirectory>
-    <outputDirectory>module/MOD-INF/classes</outputDirectory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/extensions/pc-axis/pom.xml
+++ b/extensions/pc-axis/pom.xml
@@ -23,7 +23,6 @@
     </resources>
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>tests/src</testSourceDirectory>
-    <outputDirectory>module/MOD-INF/classes</outputDirectory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -48,6 +48,24 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <skipIfEmpty>true</skipIfEmpty>
+              <outputDirectory>module/MOD-INF/lib</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.11</version>

--- a/extensions/wikibase/pom.xml
+++ b/extensions/wikibase/pom.xml
@@ -32,7 +32,6 @@
         <directory>tests/data</directory>
       </testResource>
     </testResources>
-    <outputDirectory>module/MOD-INF/classes</outputDirectory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -42,7 +42,6 @@
         <directory>tests/data</directory>
       </testResource>
     </testResources>
-    <outputDirectory>webapp/WEB-INF/classes</outputDirectory>
     <plugins>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -96,6 +95,17 @@
 	<version>${maven-jar-plugin.version}</version>
         <executions>
           <execution>
+            <id>default-jar</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>webapp/WEB-INF/lib</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>test-jar</id>
             <goals>
               <goal>test-jar</goal>
             </goals>


### PR DESCRIPTION
Closes #6257.

I tested running it both from the development version (`./refine` in a git clone) and from the packaged version on Linux. Let's see if the CI agrees.

I'd be tempted to include this in 3.8 but because it is likely that this breaks some things, I'd make it another beta instead of releasing 3.8.0 already.