### PR TITLE
Avoid crashing when a cell renderer throws an exception

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -85,7 +85,11 @@ DataTableCellUI.prototype._render = function() {
 
   var renderedCell = undefined;
   for (let record of CellRendererRegistry.renderers) {
-    renderedCell = record.renderer.render(this._rowIndex, this._cellIndex, cell, this);
+    try {
+      renderedCell = record.renderer.render(this._rowIndex, this._cellIndex, cell, this);
+    } catch (e) {
+      continue;
+    }
     if (renderedCell) {
       break;
     }


### PR DESCRIPTION
This will let the next cell renderers attempt to render the cell instead of aborting the rendering of the entire grid.

For https://github.com/OpenRefine/CommonsExtension/issues/99.