### PR TITLE
Remove a few duplicate jars in distributions

### DIFF
--- a/extensions/database/pom.xml
+++ b/extensions/database/pom.xml
@@ -67,6 +67,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>${servlet-api.version}</version>
@@ -162,7 +168,6 @@
       <version>${log4j.version}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
 </project>

--- a/extensions/gdata/pom.xml
+++ b/extensions/gdata/pom.xml
@@ -71,6 +71,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>${servlet-api.version}</version>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -164,6 +164,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.jvnet.localizer</groupId>
+      <artifactId>localizer</artifactId>
+      <version>${org-jvnet-localizer.version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>${servlet-api.version}</version>
@@ -208,6 +213,7 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons-lang3.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>
@@ -223,11 +229,6 @@
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
       <version>${commons-validator.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity-engine-core</artifactId>
-      <version>${velocity.version}</version>
     </dependency>
     <dependency>
       <groupId>org.marc4j</groupId>
@@ -359,6 +360,7 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
       <version>${jetty.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Language detector api -->

--- a/pom.xml
+++ b/pom.xml
@@ -375,11 +375,6 @@
     <!-- dependencies are stored in the relevant submodules:
           see main/pom.xml, server/pom.xml and each extension.
     -->
-      <dependency>
-          <groupId>org.jvnet.localizer</groupId>
-          <artifactId>localizer</artifactId>
-          <version>${org-jvnet-localizer.version}</version>
-      </dependency>
   </dependencies>
 
   <!-- enabled to access our snapshots of Wikidata-Toolkit -->

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -190,6 +190,11 @@
       <version>${slf4j.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>${log4j.version}</version>


### PR DESCRIPTION
For #6515.

There are still a lot more duplicates that could be removed, but somehow I can't avoid to ship two copies of butterfly and its dependencies without making the app crash.

At least this helps reduce the size of our distributions somewhat:

* `openrefine-linux-3.9-SNAPSHOT.tar.gz`: from 153M to 146M
* `openrefine-mac-3.9-SNAPSHOT.dmg`: from 290M to 282M (uncompressed)
* `openrefine-win-with-java-3.9-SNAPSHOT.zip`: from 194M to 188M

(sizes are computed with #6513 applied).

The jars that are no longer duplicated are:
```
localizer-1.31.jar
listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
jetty-util-10.0.16.jar
jetty-io-10.0.16.jar
jetty-http-10.0.16.jar
guava-33.1.0-jre.jar
failureaccess-1.0.2.jar
checker-qual-3.42.0.jar (from 3 to 2 duplications)
```

The change feels fairly safe but still I wouldn't include it in 3.8.