### PR TITLE
Handle Byte Order Mark (BOM) correctly for CSVs. Fixes #6527

### DIFF
--- a/main/src/com/google/refine/importers/FixedWidthImporter.java
+++ b/main/src/com/google/refine/importers/FixedWidthImporter.java
@@ -27,11 +27,12 @@
 
 package com.google.refine.importers;
 
+import static com.google.refine.importing.ImportingUtilities.getInputStreamReader;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
@@ -184,7 +185,7 @@ public class FixedWidthImporter extends TabularImportingParserBase {
     static public int[] guessColumnWidths(File file, String encoding) {
         try {
             InputStream is = new FileInputStream(file);
-            Reader reader = (encoding != null) ? new InputStreamReader(is, encoding) : new InputStreamReader(is);
+            Reader reader = getInputStreamReader(is, encoding);
             LineNumberReader lineNumberReader = new LineNumberReader(reader);
 
             try {

--- a/main/src/com/google/refine/importers/SeparatorBasedImporter.java
+++ b/main/src/com/google/refine/importers/SeparatorBasedImporter.java
@@ -37,7 +37,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
@@ -242,7 +241,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
 
     static public CsvFormat guessFormat(File file, String encoding) {
         try (InputStream is = new FileInputStream(file);
-                Reader reader = encoding != null ? new InputStreamReader(is, encoding) : new InputStreamReader(is);
+                Reader reader = ImportingUtilities.getInputStreamReader(is, encoding);
                 LineNumberReader lineNumberReader = new LineNumberReader(reader)) {
             CsvParserSettings settings = new CsvParserSettings();
             // We could provide a set of delimiters to consider below if we wanted to restrict this
@@ -265,7 +264,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
     static public Separator guessSeparator(File file, String encoding, boolean handleQuotes) {
         try {
             try (InputStream is = new FileInputStream(file);
-                    Reader reader = encoding != null ? new InputStreamReader(is, encoding) : new InputStreamReader(is);
+                    Reader reader = ImportingUtilities.getInputStreamReader(is, encoding);
                     LineNumberReader lineNumberReader = new LineNumberReader(reader)) {
 
                 List<Separator> separators = new ArrayList<>();
@@ -340,4 +339,5 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
         }
         return null;
     }
+
 }

--- a/main/src/com/google/refine/importers/TextFormatGuesser.java
+++ b/main/src/com/google/refine/importers/TextFormatGuesser.java
@@ -27,12 +27,13 @@
 
 package com.google.refine.importers;
 
+import static com.google.refine.importing.ImportingUtilities.getInputStreamReader;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 
 import com.google.common.base.CharMatcher;
@@ -56,8 +57,7 @@ public class TextFormatGuesser implements FormatGuesser {
             }
 
             InputStream bis = new BoundedInputStream(fis, 64 * 1024); // TODO: This seems like a lot
-            try (BufferedReader reader = new BufferedReader(
-                    encoding != null ? new InputStreamReader(bis, encoding) : new InputStreamReader(bis))) {
+            try (BufferedReader reader = new BufferedReader(getInputStreamReader(bis, encoding))) {
                 int totalChars = 0;
                 long openBraces = 0;
                 int closeBraces = 0;


### PR DESCRIPTION
DRAFT - still needs test updates

Fixes #6527

Changes proposed in this pull request:
- Create utility method to handle creating an InputStreamReader with a character encoding which is null, our special BOM encoding, or an actual Java character encoding to centralize handling of this
- Replace all conditional code with calls to the new utility
- 
