### PR TITLE
Use chunked uploading for files larger than a certain size

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
@@ -96,6 +96,12 @@ public class MediaFileUtils {
      */
     public MediaUploadResponse uploadLocalFile(File path, String fileName, String wikitext, String summary, List<String> tags)
             throws IOException, MediaWikiApiErrorException {
+        if (path.length() > 100000000) {
+            try (ChunkedFile chunkedFile = new ChunkedFile(path)) {
+                return uploadLocalFileChunked(chunkedFile, fileName, wikitext, summary, tags);
+            }
+        }
+
         Map<String, String> parameters = new HashMap<>();
         parameters.put("action", "upload");
         parameters.put("tags", String.join("|", tags));


### PR DESCRIPTION
The threshold is 100,000,000 bytes for now to be below the upload limit for Wikimedia Commons, see
https://commons.wikimedia.org/wiki/Commons:Maximum_file_size. This makes sure that files are chunked if they can't otherwise be uploaded. The value is hard coded for now, but will be read from the manifest in a later patch.

For #4303