### PR TITLE
Solve Excel importing from URL problem Fixes #6418

### DIFF
--- a/main/src/com/google/refine/importers/ImportingParserBase.java
+++ b/main/src/com/google/refine/importers/ImportingParserBase.java
@@ -117,6 +117,7 @@ abstract public class ImportingParserBase implements ImportingParser {
             final MultiFileReadingProgress progress) throws IOException {
         final File file = ImportingUtilities.getFile(job, fileRecord);
         final String fileSource = ImportingUtilities.getFileSource(fileRecord);
+        final String fileName = ImportingUtilities.getFileName(fileRecord);
         final String archiveFileName = ImportingUtilities.getArchiveFileName(fileRecord);
         int filenameColumnIndex = -1;
         int archiveColumnIndex = -1;
@@ -136,7 +137,7 @@ abstract public class ImportingParserBase implements ImportingParser {
                 }
 
                 if (useInputStream) {
-                    parseOneFile(project, metadata, job, fileSource, inputStream, limit, options, exceptions);
+                    parseOneFile(project, metadata, job, fileName, inputStream, limit, options, exceptions);
                 } else {
                     String commonEncoding = JSONUtilities.getString(options, "encoding", null);
                     if (commonEncoding != null && commonEncoding.isEmpty()) {
@@ -146,7 +147,7 @@ abstract public class ImportingParserBase implements ImportingParser {
                     Reader reader = ImportingUtilities.getReaderFromStream(
                             inputStream, fileRecord, commonEncoding);
 
-                    parseOneFile(project, metadata, job, fileSource, reader, limit, options, exceptions);
+                    parseOneFile(project, metadata, job, fileName, reader, limit, options, exceptions);
                 }
 
                 // Fill in filename and archive name column for all rows added from this file

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -601,8 +601,8 @@ public class ImportingUtilities {
     static public String getFileSource(ObjectNode fileRecord) {
         return JSONUtilities.getString(
                 fileRecord,
-                "fileName",
-                JSONUtilities.getString(fileRecord, "url", "unknown"));
+                "url",
+                JSONUtilities.getString(fileRecord, "fileName", "unknown"));
     }
 
     static public String getFileName(ObjectNode fileRecord) {

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -605,6 +605,14 @@ public class ImportingUtilities {
                 JSONUtilities.getString(fileRecord, "url", "unknown"));
     }
 
+    static public String getFileName(ObjectNode fileRecord) {
+        return JSONUtilities.getString(
+                fileRecord,
+                "fileName",
+                "unknown"
+        );
+    }
+
     static public String getArchiveFileName(ObjectNode fileRecord) {
         return JSONUtilities.getString(
                 fileRecord,

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -601,8 +601,8 @@ public class ImportingUtilities {
     static public String getFileSource(ObjectNode fileRecord) {
         return JSONUtilities.getString(
                 fileRecord,
-                "url",
-                JSONUtilities.getString(fileRecord, "fileName", "unknown"));
+                "fileName",
+                JSONUtilities.getString(fileRecord, "url", "unknown"));
     }
 
     static public String getArchiveFileName(ObjectNode fileRecord) {

--- a/main/src/com/google/refine/importing/ImportingUtilities.java
+++ b/main/src/com/google/refine/importing/ImportingUtilities.java
@@ -609,8 +609,7 @@ public class ImportingUtilities {
         return JSONUtilities.getString(
                 fileRecord,
                 "fileName",
-                "unknown"
-        );
+                "unknown");
     }
 
     static public String getArchiveFileName(ObjectNode fileRecord) {

--- a/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
@@ -40,7 +40,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;

--- a/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
+++ b/main/tests/server/src/com/google/refine/importing/ImportingUtilitiesTests.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -564,5 +565,15 @@ public class ImportingUtilitiesTests extends ImporterTest {
                 assertEquals(exception.getMessage(), message);
             }
         }
+    }
+
+    @Test
+    public void testGetFileName() {
+        ObjectNode fileRecord = ParsingUtilities.mapper.createObjectNode();
+        String fileName = "aFileName";
+
+        JSONUtilities.safePut(fileRecord, "fileName", fileName);
+
+        assertEquals(fileName, ImportingUtilities.getFileName(fileRecord));
     }
 }


### PR DESCRIPTION
Fixes #6418

Changes proposed in this pull request:
-  In the getFileSource method of the ImportingUtitilities file, use the fileName as the key to the getString method of the JsonUtilities instead of the url, so it returns the name of the file to be used instead of it's download url.

When the Excel importer will be invoked after downloading from the URL, the sheet selection logic will compare against the local filename rather than comparing against the original URL as it had been doing. 
