### PR TITLE
wikibase: Better handling of the 'badtags' error

### DIFF
--- a/extensions/wikibase/module/scripts/wikibase-manager.js
+++ b/extensions/wikibase/module/scripts/wikibase-manager.js
@@ -51,7 +51,7 @@ WikibaseManager.getSelectedWikibaseMaxlag = function() {
 
 WikibaseManager.getSelectedWikibaseTagTemplate = function() {
   let tag = WikibaseManager.getSelectedWikibase().wikibase.tag;
-  return tag === undefined ? 'openrefine-${version}' : tag;
+  return tag === undefined ? 'openrefine' : tag;
 };
 
 WikibaseManager.getSelectedWikibaseMaxEditsPerMinute = function() {

--- a/extensions/wikibase/src/org/openrefine/wikibase/manifests/Manifest.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/manifests/Manifest.java
@@ -16,7 +16,7 @@ public interface Manifest {
     public static final String PROPERTY_TYPE = "property";
     public static final String MEDIAINFO_TYPE = "mediainfo";
     public static final int DEFAULT_MAX_EDITS_PER_MINUTE = 60;
-    public static final String DEFAULT_TAG_TEMPLATE = "openrefine-${version}";
+    public static final String DEFAULT_TAG_TEMPLATE = "openrefine";
 
     /**
      * The version of the manifest object, which determines its JSON format.

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/operations/PerformWikibaseEditsOperationTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/operations/PerformWikibaseEditsOperationTest.java
@@ -27,6 +27,8 @@ package org.openrefine.wikibase.operations;
 import static org.testng.Assert.assertEquals;
 
 import java.io.LineNumberReader;
+import java.util.Arrays;
+import java.util.List;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -61,6 +63,15 @@ public class PerformWikibaseEditsOperationTest extends OperationTest {
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConstructor() {
         new PerformWikibaseEditsOperation(EngineConfig.reconstruct("{}"), "", 5, "", 60, "tag");
+    }
+
+    @Test
+    public void testGetTagCandidates() {
+        PerformWikibaseEditsOperation operation = new PerformWikibaseEditsOperation(
+                EngineConfig.reconstruct("{}"), "my summary", 5, "", 60, "openrefine-${version}");
+        List<String> candidates = operation.getTagCandidates("3.4");
+
+        assertEquals(candidates, Arrays.asList("openrefine-3.4", "openrefine"));
     }
 
     @Test


### PR DESCRIPTION
This falls back on editing with a non-versioned `openrefine` tag instead of `openrefine-${version}` by default, and on editing without a tag if `openrefine` isn't available.

Closes #6551.