### PR TITLE
wikibase: report editing results in the grid

### DIFF
--- a/extensions/wikibase/module/langs/translation-en.json
+++ b/extensions/wikibase/module/langs/translation-en.json
@@ -150,6 +150,7 @@
     "perform-wikibase-edits/perform-edits": "Upload edits",
     "perform-wikibase-edits/cancel": "Cancel",
     "perform-wikibase-edits/analyzing-edits": "Analyzing your edits…",
+    "perform-wikibase-edits/wikibase-editing-results": "Wikibase editing results",
     "import-wikibase-schema/dialog-header": "Import Wikibase schema",
     "import-wikibase-schema/file-label": "From JSON file: ",
     "import-wikibase-schema/schema-label": "Or from JSON text:",

--- a/extensions/wikibase/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikibase/module/scripts/dialogs/perform-edits-dialog.js
@@ -58,9 +58,10 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
         maxlag: elmts.maxlag.val(),
         editGroupsUrlSchema: WikibaseManager.getSelectedWikibaseEditGroupsURLSchema(),
         tag: WikibaseManager.getSelectedWikibaseTagTemplate(),
-        maxEditsPerMinute: WikibaseManager.getSelectedWikibaseMaxEditsPerMinute()
+        maxEditsPerMinute: WikibaseManager.getSelectedWikibaseMaxEditsPerMinute(),
+        resultsColumnName: $.i18n('perform-wikibase-edits/wikibase-editing-results')
       },
-      { includeEngine: true, cellsChanged: true, columnStatsChanged: true },
+      { includeEngine: true, modelsChanged: true, cellsChanged: true, columnStatsChanged: true },
       { onDone: function() { dismiss(); } }
     );
   };

--- a/extensions/wikibase/src/org/openrefine/wikibase/commands/PerformWikibaseEditsCommand.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/commands/PerformWikibaseEditsCommand.java
@@ -45,7 +45,9 @@ public class PerformWikibaseEditsCommand extends EngineDependentCommand {
         Integer maxEditsPerMinute = maxEditsPerMinuteStr == null ? null : Integer.parseInt(maxEditsPerMinuteStr);
         String tag = request.getParameter("tag");
         String editGroupsUrlSchema = request.getParameter("editGroupsUrlSchema");
-        return new PerformWikibaseEditsOperation(engineConfig, summary, maxlag, editGroupsUrlSchema, maxEditsPerMinute, tag);
+        String resultsColumnName = request.getParameter("resultsColumnName");
+        return new PerformWikibaseEditsOperation(engineConfig, summary, maxlag, editGroupsUrlSchema, maxEditsPerMinute, tag,
+                resultsColumnName);
     }
 
 }

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
@@ -217,6 +217,7 @@ public class EditBatchProcessor {
                 currentTag = null;
                 return performEdit();
             } else {
+                batchCursor++;
                 return new EditResult(update.getContributingRowIds(), e.getErrorCode(), e.getErrorMessage());
             }
         } catch (IOException e) {

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
@@ -229,18 +229,18 @@ public class EditBatchProcessor {
 
     public static class EditResult {
 
-        private final Set<Long> correspondingRowIds;
+        private final Set<Integer> correspondingRowIds;
         private final String errorCode;
         private final String errorMessage;
 
-        public EditResult(Set<Long> correspondingRowIds,
+        public EditResult(Set<Integer> correspondingRowIds,
                 String errorCode, String errorMessage) {
             this.correspondingRowIds = correspondingRowIds;
             this.errorCode = errorCode;
             this.errorMessage = errorMessage;
         }
 
-        public Set<Long> getCorrespondingRowIds() {
+        public Set<Integer> getCorrespondingRowIds() {
             return correspondingRowIds;
         }
 

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
@@ -161,7 +161,7 @@ public class EditBatchProcessor {
             return new EditResult(update.getContributingRowIds(),
                     "rewrite-failed",
                     "Failed to rewrite update on entity " + update.getEntityId() + ". Missing entity: " + e.getMissingEntity(),
-                    0L, OptionalLong.empty());
+                    0L, OptionalLong.empty(), null);
         }
 
         // Pick a tag to apply to the edits
@@ -172,6 +172,7 @@ public class EditBatchProcessor {
 
         long oldRevisionId = 0L;
         OptionalLong lastRevisionId = OptionalLong.empty();
+        String newEntityUrl = null;
         try {
             if (update.isNew()) {
                 // New entities
@@ -184,6 +185,7 @@ public class EditBatchProcessor {
                     createdDocId = editor.createEntityDocument(update.toNewEntity(), summary, tags).getEntityId();
                 }
                 library.setId(newCell.getReconInternalId(), createdDocId.getId());
+                newEntityUrl = createdDocId.getSiteIri() + createdDocId.getId();
             } else {
                 // Existing entities
                 EntityUpdate entityUpdate;
@@ -230,14 +232,14 @@ public class EditBatchProcessor {
             } else {
                 batchCursor++;
                 return new EditResult(update.getContributingRowIds(), e.getErrorCode(), e.getErrorMessage(), oldRevisionId,
-                        OptionalLong.empty());
+                        OptionalLong.empty(), null);
             }
         } catch (IOException e) {
             logger.warn("IO error while editing: " + e.getMessage());
         }
 
         batchCursor++;
-        return new EditResult(update.getContributingRowIds(), null, null, oldRevisionId, lastRevisionId);
+        return new EditResult(update.getContributingRowIds(), null, null, oldRevisionId, lastRevisionId, newEntityUrl);
     }
 
     public static class EditResult {
@@ -247,16 +249,19 @@ public class EditBatchProcessor {
         private final String errorMessage;
         private final long baseRevisionId;
         private final OptionalLong lastRevisionId;
+        private final String newEntityUrl;
 
         public EditResult(Set<Integer> correspondingRowIds,
                 String errorCode, String errorMessage,
                 long baseRevisionId,
-                OptionalLong lastRevisionId) {
+                OptionalLong lastRevisionId,
+                String newEntityUrl) {
             this.correspondingRowIds = correspondingRowIds;
             this.errorCode = errorCode;
             this.errorMessage = errorMessage;
             this.baseRevisionId = baseRevisionId;
             this.lastRevisionId = lastRevisionId;
+            this.newEntityUrl = newEntityUrl;
         }
 
         public Set<Integer> getCorrespondingRowIds() {
@@ -277,6 +282,10 @@ public class EditBatchProcessor {
 
         public OptionalLong getLastRevisionId() {
             return lastRevisionId;
+        }
+
+        public String getNewEntityUrl() {
+            return newEntityUrl;
         }
     }
 

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
@@ -139,10 +140,10 @@ public class EditBatchProcessor {
      * 
      * @throws InterruptedException
      */
-    public void performEdit()
+    public EditResult performEdit()
             throws InterruptedException {
         if (remainingEdits() == 0) {
-            return;
+            throw new IllegalStateException("No edit to perform");
         }
         if (batchCursor == currentBatch.size()) {
             prepareNewBatch();
@@ -154,10 +155,10 @@ public class EditBatchProcessor {
         try {
             update = rewriter.rewrite(update);
         } catch (NewEntityNotCreatedYetException e) {
-            logger.warn("Failed to rewrite update on entity " + update.getEntityId() + ". Missing entity: " + e.getMissingEntity()
-                    + ". Skipping update.");
             batchCursor++;
-            return;
+            return new EditResult(update.getContributingRowIds(),
+                    "rewrite-failed",
+                    "Failed to rewrite update on entity " + update.getEntityId() + ". Missing entity: " + e.getMissingEntity());
         }
 
         // Pick a tag to apply to the edits
@@ -214,18 +215,42 @@ public class EditBatchProcessor {
             if ("badtags".equals(e.getErrorCode()) && currentTag != null) {
                 // if we tried editing with a tag that does not exist, clear the tag and try again
                 currentTag = null;
-                performEdit();
-                return;
+                return performEdit();
             } else {
-                // TODO find a way to report these errors to the user in a nice way
-                logger.warn("MediaWiki error while editing [" + e.getErrorCode()
-                        + "]: " + e.getErrorMessage());
+                return new EditResult(update.getContributingRowIds(), e.getErrorCode(), e.getErrorMessage());
             }
         } catch (IOException e) {
             logger.warn("IO error while editing: " + e.getMessage());
         }
 
         batchCursor++;
+        return new EditResult(update.getContributingRowIds(), null, null);
+    }
+
+    public static class EditResult {
+
+        private final Set<Long> correspondingRowIds;
+        private final String errorCode;
+        private final String errorMessage;
+
+        public EditResult(Set<Long> correspondingRowIds,
+                String errorCode, String errorMessage) {
+            this.correspondingRowIds = correspondingRowIds;
+            this.errorCode = errorCode;
+            this.errorMessage = errorMessage;
+        }
+
+        public Set<Long> getCorrespondingRowIds() {
+            return correspondingRowIds;
+        }
+
+        public String getErrorCode() {
+            return errorCode;
+        }
+
+        public String getErrorMessage() {
+            return errorMessage;
+        }
     }
 
     /**

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditResultsFormatter.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditResultsFormatter.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import com.google.refine.expr.EvalError;
 import com.google.refine.model.Cell;
@@ -47,8 +48,8 @@ public class EditResultsFormatter {
                 } else {
                     rowIdToError.put(firstRowId, existingError + "; " + error);
                 }
-            } else if (result.getLastRevisionId().isPresent() && result.getBaseRevisionId() != result.getLastRevisionId().getAsLong()) {
-                String revisionLink = baseUrl + "w/index.php?diff=prev&oldid=" + result.getLastRevisionId().getAsLong();
+            } else if (getEditUrl(result).isPresent()) {
+                String revisionLink = getEditUrl(result).get();
                 String existingLinks = rowIdToEditLink.get(firstRowId);
                 if (existingLinks == null) {
                     rowIdToEditLink.put(firstRowId, revisionLink);
@@ -57,6 +58,15 @@ public class EditResultsFormatter {
                 }
             }
         }
+    }
+
+    private Optional<String> getEditUrl(EditResult result) {
+        if (result.getLastRevisionId().isPresent() && result.getBaseRevisionId() != result.getLastRevisionId().getAsLong()) {
+            return Optional.of(baseUrl + "w/index.php?diff=prev&oldid=" + result.getLastRevisionId().getAsLong());
+        } else if (result.getNewEntityUrl() != null) {
+            return Optional.of(result.getNewEntityUrl());
+        }
+        return Optional.empty();
     }
 
     /**

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditResultsFormatter.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditResultsFormatter.java
@@ -1,0 +1,78 @@
+
+package org.openrefine.wikibase.editing;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.google.refine.expr.EvalError;
+import com.google.refine.model.Cell;
+import com.google.refine.model.changes.CellAtRow;
+
+import org.openrefine.wikibase.editing.EditBatchProcessor.EditResult;
+
+/**
+ * Formats the results of Wikibase edits into cells to be included in the project's grid.
+ */
+public class EditResultsFormatter {
+
+    private final String baseUrl;
+    private final Map<Integer, String> rowIdToError = new HashMap<>();
+    private final Map<Integer, String> rowIdToEditLink = new HashMap<>();
+
+    /**
+     * Constructor.
+     * 
+     * @param mediaWikiApiEndpoint
+     *            full API endpoint, ending with .../w/api.php
+     */
+    public EditResultsFormatter(String mediaWikiApiEndpoint) {
+        this.baseUrl = mediaWikiApiEndpoint.substring(0, mediaWikiApiEndpoint.length() - "w/api.php".length());
+    }
+
+    /**
+     * Log another edit result for further formatting.
+     */
+    public void add(EditResult result) {
+        if (!result.getCorrespondingRowIds().isEmpty()) {
+            int firstRowId = result.getCorrespondingRowIds().stream().min(Comparator.naturalOrder()).get();
+            if (result.getErrorMessage() != null && result.getErrorCode() != null) {
+                String error = String.format("[%s] %s", result.getErrorCode(), result.getErrorMessage());
+                String existingError = rowIdToError.get(firstRowId);
+                if (existingError == null) {
+                    rowIdToError.put(firstRowId, error);
+                } else {
+                    rowIdToError.put(firstRowId, existingError + "; " + error);
+                }
+            } else if (result.getLastRevisionId().isPresent()) {
+                String revisionLink = baseUrl + "w/index.php?diff=prev&oldid=" + result.getLastRevisionId().getAsLong();
+                String existingLinks = rowIdToEditLink.get(firstRowId);
+                if (existingLinks == null) {
+                    rowIdToEditLink.put(firstRowId, revisionLink);
+                } else {
+                    rowIdToEditLink.put(firstRowId, existingLinks + " " + revisionLink);
+                }
+            }
+        }
+    }
+
+    /**
+     * Generate a list of cells on specific rows representing the editing results
+     */
+    public List<CellAtRow> toCells() {
+        List<CellAtRow> cells = new ArrayList<>();
+        for (Entry<Integer, String> errorCell : rowIdToError.entrySet()) {
+            cells.add(new CellAtRow(errorCell.getKey(), new Cell(new EvalError(errorCell.getValue()), null)));
+        }
+        for (Entry<Integer, String> editLinkCell : rowIdToEditLink.entrySet()) {
+            int rowId = editLinkCell.getKey();
+            if (rowIdToError.get(rowId) == null) {
+                cells.add(new CellAtRow(rowId, new Cell(editLinkCell.getValue(), null)));
+            }
+        }
+        return cells;
+    }
+}

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditResultsFormatter.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditResultsFormatter.java
@@ -47,7 +47,7 @@ public class EditResultsFormatter {
                 } else {
                     rowIdToError.put(firstRowId, existingError + "; " + error);
                 }
-            } else if (result.getLastRevisionId().isPresent()) {
+            } else if (result.getLastRevisionId().isPresent() && result.getBaseRevisionId() != result.getLastRevisionId().getAsLong()) {
                 String revisionLink = baseUrl + "w/index.php?diff=prev&oldid=" + result.getLastRevisionId().getAsLong();
                 String existingLinks = rowIdToEditLink.get(firstRowId);
                 if (existingLinks == null) {

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/ReconEntityRewriter.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/ReconEntityRewriter.java
@@ -187,7 +187,8 @@ public class ReconEntityRewriter extends DatamodelConverter {
                 Set<MonolingualTextValue> aliases = update.getAliases().stream().map(l -> copy(l)).collect(Collectors.toSet());
                 List<StatementEdit> statements = update.getStatementEdits().stream().map(l -> copy(l))
                         .collect(Collectors.toList());
-                return new ItemEdit(subject, statements, labels, labelsIfNew, descriptions, descriptionsIfNew, aliases);
+                return new ItemEdit(subject, statements, labels, labelsIfNew, descriptions, descriptionsIfNew, aliases,
+                        edit.getContributingRowIds());
             } else if (edit instanceof MediaInfoEdit) {
                 MediaInfoEdit update = (MediaInfoEdit) edit;
                 Set<MonolingualTextValue> labels = update.getLabels().stream().map(l -> copy(l)).collect(Collectors.toSet());
@@ -195,7 +196,7 @@ public class ReconEntityRewriter extends DatamodelConverter {
                 List<StatementEdit> statements = update.getStatementEdits().stream().map(l -> copy(l))
                         .collect(Collectors.toList());
                 return new MediaInfoEdit(subject, statements, labels, labelsIfNew, update.getFilePath(),
-                        update.getFileName(), update.getWikitext(), update.isOverridingWikitext());
+                        update.getFileName(), update.getWikitext(), update.isOverridingWikitext(), edit.getContributingRowIds());
             } else {
                 throw new IllegalStateException(
                         "Rewriting of entities of this type (for subject id " + edit.getEntityId() + ") not supported yet");

--- a/extensions/wikibase/src/org/openrefine/wikibase/schema/WbItemEditExpr.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/schema/WbItemEditExpr.java
@@ -132,7 +132,7 @@ public class WbItemEditExpr implements WbExpression<ItemEdit> {
         for (WbNameDescExpr expr : getNameDescs()) {
             expr.contributeTo(update, ctxt);
         }
-        return update.build();
+        return update.addContributingRowId(ctxt.getRowId()).build();
     }
 
     @JsonProperty("subject")

--- a/extensions/wikibase/src/org/openrefine/wikibase/schema/WbMediaInfoEditExpr.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/schema/WbMediaInfoEditExpr.java
@@ -121,7 +121,8 @@ public class WbMediaInfoEditExpr implements WbExpression<MediaInfoEdit> {
             warning.setProperty("example", subjectId.getId());
             throw new QAWarningException(warning);
         }
-        MediaInfoEditBuilder update = new MediaInfoEditBuilder(subjectId);
+        MediaInfoEditBuilder update = new MediaInfoEditBuilder(subjectId)
+                .addContributingRowId(ctxt.getRowId());
         for (WbStatementGroupExpr expr : getStatementGroups()) {
             try {
                 StatementGroupEdit statementGroupUpdate = expr.evaluate(ctxt, subjectId);

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/EntityEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/EntityEdit.java
@@ -4,6 +4,7 @@ package org.openrefine.wikibase.updates;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,6 +32,11 @@ public interface EntityEdit {
      */
     @JsonProperty("subject")
     EntityIdValue getEntityId();
+
+    /**
+     * The set of row ids which contributed to generate this entity edit.
+     */
+    Set<Long> getContributingRowIds();
 
     /**
      * In case the subject id is not new, returns the corresponding update given the current state of the entity. Throws

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/EntityEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/EntityEdit.java
@@ -36,7 +36,7 @@ public interface EntityEdit {
     /**
      * The set of row ids which contributed to generate this entity edit.
      */
-    Set<Long> getContributingRowIds();
+    Set<Integer> getContributingRowIds();
 
     /**
      * In case the subject id is not new, returns the corresponding update given the current state of the entity. Throws

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/ItemEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/ItemEdit.java
@@ -59,8 +59,9 @@ public class ItemEdit extends TermedStatementEntityEdit {
             Set<MonolingualTextValue> labelsIfNew,
             Set<MonolingualTextValue> descriptions,
             Set<MonolingualTextValue> descriptionsIfNew,
-            Set<MonolingualTextValue> aliases) {
-        super(id, statements, labels, labelsIfNew, descriptions, descriptionsIfNew, aliases);
+            Set<MonolingualTextValue> aliases,
+            Set<Long> contributingRowIds) {
+        super(id, statements, labels, labelsIfNew, descriptions, descriptionsIfNew, aliases, contributingRowIds);
         Validate.isTrue(id instanceof ItemIdValue, "the entity id must be an ItemIdValue");
     }
 
@@ -86,8 +87,9 @@ public class ItemEdit extends TermedStatementEntityEdit {
      */
     protected ItemEdit(EntityIdValue id, List<StatementEdit> statements, Map<String, MonolingualTextValue> labels,
             Map<String, MonolingualTextValue> labelsIfNew, Map<String, MonolingualTextValue> descriptions,
-            Map<String, MonolingualTextValue> descriptionsIfNew, Map<String, List<MonolingualTextValue>> aliases) {
-        super(id, statements, labels, labelsIfNew, descriptions, descriptionsIfNew, aliases);
+            Map<String, MonolingualTextValue> descriptionsIfNew, Map<String, List<MonolingualTextValue>> aliases,
+            Set<Long> contributingRowIds) {
+        super(id, statements, labels, labelsIfNew, descriptions, descriptionsIfNew, aliases, contributingRowIds);
     }
 
     /**
@@ -126,7 +128,10 @@ public class ItemEdit extends TermedStatementEntityEdit {
                 aliases.add(alias);
             }
         }
-        return new ItemEdit(id, newStatements, newLabels, newLabelsIfNew, newDescriptions, newDescriptionsIfNew, newAliases);
+        Set<Long> contributingIds = new HashSet<>(contributingRowIds);
+        contributingIds.addAll(other.getContributingRowIds());
+        return new ItemEdit(id, newStatements, newLabels, newLabelsIfNew, newDescriptions, newDescriptionsIfNew, newAliases,
+                contributingIds);
     }
 
     /**

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/ItemEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/ItemEdit.java
@@ -60,7 +60,7 @@ public class ItemEdit extends TermedStatementEntityEdit {
             Set<MonolingualTextValue> descriptions,
             Set<MonolingualTextValue> descriptionsIfNew,
             Set<MonolingualTextValue> aliases,
-            Set<Long> contributingRowIds) {
+            Set<Integer> contributingRowIds) {
         super(id, statements, labels, labelsIfNew, descriptions, descriptionsIfNew, aliases, contributingRowIds);
         Validate.isTrue(id instanceof ItemIdValue, "the entity id must be an ItemIdValue");
     }
@@ -88,7 +88,7 @@ public class ItemEdit extends TermedStatementEntityEdit {
     protected ItemEdit(EntityIdValue id, List<StatementEdit> statements, Map<String, MonolingualTextValue> labels,
             Map<String, MonolingualTextValue> labelsIfNew, Map<String, MonolingualTextValue> descriptions,
             Map<String, MonolingualTextValue> descriptionsIfNew, Map<String, List<MonolingualTextValue>> aliases,
-            Set<Long> contributingRowIds) {
+            Set<Integer> contributingRowIds) {
         super(id, statements, labels, labelsIfNew, descriptions, descriptionsIfNew, aliases, contributingRowIds);
     }
 
@@ -128,7 +128,7 @@ public class ItemEdit extends TermedStatementEntityEdit {
                 aliases.add(alias);
             }
         }
-        Set<Long> contributingIds = new HashSet<>(contributingRowIds);
+        Set<Integer> contributingIds = new HashSet<>(contributingRowIds);
         contributingIds.addAll(other.getContributingRowIds());
         return new ItemEdit(id, newStatements, newLabels, newLabelsIfNew, newDescriptions, newDescriptionsIfNew, newAliases,
                 contributingIds);

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/ItemEditBuilder.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/ItemEditBuilder.java
@@ -24,10 +24,7 @@
 
 package org.openrefine.wikibase.updates;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.jsoup.helper.Validate;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
@@ -48,6 +45,7 @@ public class ItemEditBuilder {
     private Set<MonolingualTextValue> descriptions;
     private Set<MonolingualTextValue> descriptionsIfNew;
     private Set<MonolingualTextValue> aliases;
+    private Set<Long> contributingRowIds;
     private boolean built;
 
     /**
@@ -65,6 +63,7 @@ public class ItemEditBuilder {
         this.descriptions = new HashSet<MonolingualTextValue>();
         this.descriptionsIfNew = new HashSet<MonolingualTextValue>();
         this.aliases = new HashSet<MonolingualTextValue>();
+        this.contributingRowIds = new HashSet<>();
         this.built = false;
     }
 
@@ -189,13 +188,29 @@ public class ItemEditBuilder {
     }
 
     /**
+     * Adds a row id which contributed to this update.
+     */
+    public ItemEditBuilder addContributingRowId(long rowId) {
+        this.contributingRowIds.add(rowId);
+        return this;
+    }
+
+    /**
+     * Adds a collection of row ids which contributed to this update.
+     */
+    public ItemEditBuilder addContributingRowIds(Collection<Long> rowIds) {
+        this.contributingRowIds.addAll(rowIds);
+        return this;
+    }
+
+    /**
      * Constructs the {@link ItemEdit}.
      * 
      * @return
      */
     public ItemEdit build() {
         built = true;
-        return new ItemEdit(id, statements, labels, labelsIfNew, descriptions, descriptionsIfNew, aliases);
+        return new ItemEdit(id, statements, labels, labelsIfNew, descriptions, descriptionsIfNew, aliases, contributingRowIds);
     }
 
 }

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/ItemEditBuilder.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/ItemEditBuilder.java
@@ -45,7 +45,7 @@ public class ItemEditBuilder {
     private Set<MonolingualTextValue> descriptions;
     private Set<MonolingualTextValue> descriptionsIfNew;
     private Set<MonolingualTextValue> aliases;
-    private Set<Long> contributingRowIds;
+    private Set<Integer> contributingRowIds;
     private boolean built;
 
     /**
@@ -190,7 +190,7 @@ public class ItemEditBuilder {
     /**
      * Adds a row id which contributed to this update.
      */
-    public ItemEditBuilder addContributingRowId(long rowId) {
+    public ItemEditBuilder addContributingRowId(int rowId) {
         this.contributingRowIds.add(rowId);
         return this;
     }
@@ -198,7 +198,7 @@ public class ItemEditBuilder {
     /**
      * Adds a collection of row ids which contributed to this update.
      */
-    public ItemEditBuilder addContributingRowIds(Collection<Long> rowIds) {
+    public ItemEditBuilder addContributingRowIds(Collection<Integer> rowIds) {
         this.contributingRowIds.addAll(rowIds);
         return this;
     }

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/LabeledStatementEntityEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/LabeledStatementEntityEdit.java
@@ -27,7 +27,7 @@ import org.openrefine.wikibase.schema.strategies.StatementEditingMode;
 public abstract class LabeledStatementEntityEdit implements StatementEntityEdit {
 
     protected final EntityIdValue id;
-    protected final Set<Long> contributingRowIds;
+    protected final Set<Integer> contributingRowIds;
     protected final List<StatementEdit> statements;
     protected final Map<String, MonolingualTextValue> labels;
     protected final Map<String, MonolingualTextValue> labelsIfNew;
@@ -47,7 +47,7 @@ public abstract class LabeledStatementEntityEdit implements StatementEntityEdit 
     public LabeledStatementEntityEdit(
             EntityIdValue id, List<StatementEdit> statements,
             Set<MonolingualTextValue> labels, Set<MonolingualTextValue> labelsIfNew,
-            Set<Long> contributingRowIds) {
+            Set<Integer> contributingRowIds) {
         super();
         Validate.notNull(id);
         this.id = id;
@@ -81,7 +81,7 @@ public abstract class LabeledStatementEntityEdit implements StatementEntityEdit 
             List<StatementEdit> statements,
             Map<String, MonolingualTextValue> labels,
             Map<String, MonolingualTextValue> labelsIfNew,
-            Set<Long> contributingRowIds) {
+            Set<Integer> contributingRowIds) {
         super();
         this.id = id;
         this.statements = statements;
@@ -100,7 +100,7 @@ public abstract class LabeledStatementEntityEdit implements StatementEntityEdit 
     }
 
     @Override
-    public Set<Long> getContributingRowIds() {
+    public Set<Integer> getContributingRowIds() {
         return contributingRowIds;
     }
 

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/LabeledStatementEntityEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/LabeledStatementEntityEdit.java
@@ -27,13 +27,14 @@ import org.openrefine.wikibase.schema.strategies.StatementEditingMode;
 public abstract class LabeledStatementEntityEdit implements StatementEntityEdit {
 
     protected final EntityIdValue id;
+    protected final Set<Long> contributingRowIds;
     protected final List<StatementEdit> statements;
     protected final Map<String, MonolingualTextValue> labels;
     protected final Map<String, MonolingualTextValue> labelsIfNew;
 
     /**
      * Constructor.
-     * 
+     *
      * @param id
      *            the subject of the document. It can be a reconciled entity value for new entities.
      * @param statements
@@ -43,8 +44,10 @@ public abstract class LabeledStatementEntityEdit implements StatementEntityEdit 
      * @param labelsIfNew
      *            the labels to add on the entity, only if no label for that language exists
      */
-    public LabeledStatementEntityEdit(EntityIdValue id, List<StatementEdit> statements,
-            Set<MonolingualTextValue> labels, Set<MonolingualTextValue> labelsIfNew) {
+    public LabeledStatementEntityEdit(
+            EntityIdValue id, List<StatementEdit> statements,
+            Set<MonolingualTextValue> labels, Set<MonolingualTextValue> labelsIfNew,
+            Set<Long> contributingRowIds) {
         super();
         Validate.notNull(id);
         this.id = id;
@@ -55,13 +58,15 @@ public abstract class LabeledStatementEntityEdit implements StatementEntityEdit 
         this.labelsIfNew = new HashMap<>();
         mergeSingleTermMaps(this.labels, this.labelsIfNew, labels, labelsIfNew);
         this.statements = statements;
+        this.contributingRowIds = contributingRowIds;
+        Validate.isFalse(contributingRowIds.isEmpty(), "no contributing row id provided");
     }
 
     /**
      * Protected constructor to avoid re-constructing term maps when merging two entity updates.
-     * 
+     *
      * No validation is done on the arguments, they all have to be non-null.
-     * 
+     *
      * @param id
      *            the subject of the update
      * @param statements
@@ -75,12 +80,15 @@ public abstract class LabeledStatementEntityEdit implements StatementEntityEdit 
             EntityIdValue id,
             List<StatementEdit> statements,
             Map<String, MonolingualTextValue> labels,
-            Map<String, MonolingualTextValue> labelsIfNew) {
+            Map<String, MonolingualTextValue> labelsIfNew,
+            Set<Long> contributingRowIds) {
         super();
         this.id = id;
         this.statements = statements;
         this.labels = labels;
         this.labelsIfNew = labelsIfNew;
+        this.contributingRowIds = contributingRowIds;
+        Validate.isFalse(contributingRowIds.isEmpty(), "no contributing row id provided");
     }
 
     /**
@@ -89,6 +97,11 @@ public abstract class LabeledStatementEntityEdit implements StatementEntityEdit 
     @Override
     public EntityIdValue getEntityId() {
         return id;
+    }
+
+    @Override
+    public Set<Long> getContributingRowIds() {
+        return contributingRowIds;
     }
 
     /**

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
@@ -73,7 +73,7 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
             String fileName,
             String wikitext,
             boolean overrideWikitext,
-            Set<Long> contributingRowIds) {
+            Set<Integer> contributingRowIds) {
         super(id, statements, labels, labelsIfNew, contributingRowIds);
         this.filePath = filePath;
         this.fileName = fileName;
@@ -112,7 +112,7 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
             String fileName,
             String wikitext,
             boolean overrideWikitext,
-            Set<Long> contributingRowIds) {
+            Set<Integer> contributingRowIds) {
         super(id, statements, labels, labelsIfNew, contributingRowIds);
         this.filePath = filePath;
         this.fileName = fileName;
@@ -199,7 +199,7 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
             newWikitext = wikitext;
         }
         boolean newOverrideWikitext = other.isOverridingWikitext() || overrideWikitext;
-        Set<Long> contributingIds = new HashSet<>(contributingRowIds);
+        Set<Integer> contributingIds = new HashSet<>(contributingRowIds);
         contributingIds.addAll(other.getContributingRowIds());
         return new MediaInfoEdit(id, newStatements, newLabels, newLabelsIfNew, newFilePath, newFileName, newWikitext, newOverrideWikitext,
                 contributingIds);

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
@@ -4,13 +4,7 @@ package org.openrefine.wikibase.updates;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -78,8 +72,9 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
             String filePath,
             String fileName,
             String wikitext,
-            boolean overrideWikitext) {
-        super(id, statements, labels, labelsIfNew);
+            boolean overrideWikitext,
+            Set<Long> contributingRowIds) {
+        super(id, statements, labels, labelsIfNew, contributingRowIds);
         this.filePath = filePath;
         this.fileName = fileName;
         this.wikitext = wikitext;
@@ -116,8 +111,9 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
             String filePath,
             String fileName,
             String wikitext,
-            boolean overrideWikitext) {
-        super(id, statements, labels, labelsIfNew);
+            boolean overrideWikitext,
+            Set<Long> contributingRowIds) {
+        super(id, statements, labels, labelsIfNew, contributingRowIds);
         this.filePath = filePath;
         this.fileName = fileName;
         this.wikitext = wikitext;
@@ -203,7 +199,10 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
             newWikitext = wikitext;
         }
         boolean newOverrideWikitext = other.isOverridingWikitext() || overrideWikitext;
-        return new MediaInfoEdit(id, newStatements, newLabels, newLabelsIfNew, newFilePath, newFileName, newWikitext, newOverrideWikitext);
+        Set<Long> contributingIds = new HashSet<>(contributingRowIds);
+        contributingIds.addAll(other.getContributingRowIds());
+        return new MediaInfoEdit(id, newStatements, newLabels, newLabelsIfNew, newFilePath, newFileName, newWikitext, newOverrideWikitext,
+                contributingIds);
     }
 
     @Override

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEditBuilder.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEditBuilder.java
@@ -146,7 +146,7 @@ public class MediaInfoEditBuilder {
         this.contributingRowIds.add(rowId);
         return this;
     }
-    
+
     /**
      * Adds a collection of row ids which contributed to this update.
      */

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEditBuilder.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEditBuilder.java
@@ -27,7 +27,7 @@ public class MediaInfoEditBuilder {
     private String fileName;
     private String wikitext;
     private boolean overrideWikitext;
-    private Set<Long> contributingRowIds;
+    private Set<Integer> contributingRowIds;
     private boolean built;
 
     /**
@@ -142,7 +142,7 @@ public class MediaInfoEditBuilder {
         return this;
     }
 
-    public MediaInfoEditBuilder addContributingRowId(long rowId) {
+    public MediaInfoEditBuilder addContributingRowId(int rowId) {
         this.contributingRowIds.add(rowId);
         return this;
     }

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEditBuilder.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEditBuilder.java
@@ -2,6 +2,7 @@
 package org.openrefine.wikibase.updates;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -26,6 +27,7 @@ public class MediaInfoEditBuilder {
     private String fileName;
     private String wikitext;
     private boolean overrideWikitext;
+    private Set<Long> contributingRowIds;
     private boolean built;
 
     /**
@@ -44,6 +46,7 @@ public class MediaInfoEditBuilder {
         this.fileName = null;
         this.wikitext = null;
         this.overrideWikitext = false;
+        this.contributingRowIds = new HashSet<>();
         this.built = false;
     }
 
@@ -139,6 +142,19 @@ public class MediaInfoEditBuilder {
         return this;
     }
 
+    public MediaInfoEditBuilder addContributingRowId(long rowId) {
+        this.contributingRowIds.add(rowId);
+        return this;
+    }
+    
+    /**
+     * Adds a collection of row ids which contributed to this update.
+     */
+    public MediaInfoEditBuilder addContributingRowIds(Collection<Integer> rowIds) {
+        this.contributingRowIds.addAll(rowIds);
+        return this;
+    }
+
     /**
      * Constructs the {@link MediaInfoEdit}.
      * 
@@ -146,6 +162,6 @@ public class MediaInfoEditBuilder {
      */
     public MediaInfoEdit build() {
         built = true;
-        return new MediaInfoEdit(id, statements, labels, labelsIfNew, filePath, fileName, wikitext, overrideWikitext);
+        return new MediaInfoEdit(id, statements, labels, labelsIfNew, filePath, fileName, wikitext, overrideWikitext, contributingRowIds);
     }
 }

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/TermedStatementEntityEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/TermedStatementEntityEdit.java
@@ -68,6 +68,8 @@ public abstract class TermedStatementEntityEdit extends LabeledStatementEntityEd
      * @param aliases
      *            the aliases to add on the item. In theory their order should matter but in practice people rarely rely
      *            on the order of aliases so this is just kept as a set for simplicity.
+     * @param contributingRowIds
+     *            the set of row ids which generated this edit
      */
     public TermedStatementEntityEdit(
             EntityIdValue id,
@@ -76,8 +78,9 @@ public abstract class TermedStatementEntityEdit extends LabeledStatementEntityEd
             Set<MonolingualTextValue> labelsIfNew,
             Set<MonolingualTextValue> descriptions,
             Set<MonolingualTextValue> descriptionsIfNew,
-            Set<MonolingualTextValue> aliases) {
-        super(id, statements, new HashMap<>(), new HashMap<>());
+            Set<MonolingualTextValue> aliases,
+            Set<Long> contributingRowIds) {
+        super(id, statements, new HashMap<>(), new HashMap<>(), contributingRowIds);
         Validate.notNull(id);
         if (statements == null) {
             statements = Collections.emptyList();
@@ -116,8 +119,9 @@ public abstract class TermedStatementEntityEdit extends LabeledStatementEntityEd
             Map<String, MonolingualTextValue> labelsIfNew,
             Map<String, MonolingualTextValue> descriptions,
             Map<String, MonolingualTextValue> descriptionsIfNew,
-            Map<String, List<MonolingualTextValue>> aliases) {
-        super(id, statements, labels, labelsIfNew);
+            Map<String, List<MonolingualTextValue>> aliases,
+            Set<Long> contributingRowIds) {
+        super(id, statements, labels, labelsIfNew, contributingRowIds);
         this.descriptions = descriptions;
         this.descriptionsIfNew = descriptionsIfNew;
         this.aliases = aliases;

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/TermedStatementEntityEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/TermedStatementEntityEdit.java
@@ -79,7 +79,7 @@ public abstract class TermedStatementEntityEdit extends LabeledStatementEntityEd
             Set<MonolingualTextValue> descriptions,
             Set<MonolingualTextValue> descriptionsIfNew,
             Set<MonolingualTextValue> aliases,
-            Set<Long> contributingRowIds) {
+            Set<Integer> contributingRowIds) {
         super(id, statements, new HashMap<>(), new HashMap<>(), contributingRowIds);
         Validate.notNull(id);
         if (statements == null) {
@@ -120,7 +120,7 @@ public abstract class TermedStatementEntityEdit extends LabeledStatementEntityEd
             Map<String, MonolingualTextValue> descriptions,
             Map<String, MonolingualTextValue> descriptionsIfNew,
             Map<String, List<MonolingualTextValue>> aliases,
-            Set<Long> contributingRowIds) {
+            Set<Integer> contributingRowIds) {
         super(id, statements, labels, labelsIfNew, contributingRowIds);
         this.descriptions = descriptions;
         this.descriptionsIfNew = descriptionsIfNew;

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/scheduler/QuickStatementsUpdateScheduler.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/scheduler/QuickStatementsUpdateScheduler.java
@@ -174,7 +174,7 @@ public class QuickStatementsUpdateScheduler implements UpdateScheduler {
 
         // Reconstruct
         List<EntityEdit> fullSchedule = new ArrayList<>();
-        Map<EntityIdValue, Set<Long>> mentionedNewEntities = pointerUpdates.entrySet()
+        Map<EntityIdValue, Set<Integer>> mentionedNewEntities = pointerUpdates.entrySet()
                 .stream()
                 .collect(Collectors.toMap(update -> update.getKey(),
                         update -> update.getValue().getUpdates().get(0).getContributingRowIds()));// new
@@ -191,7 +191,7 @@ public class QuickStatementsUpdateScheduler implements UpdateScheduler {
         // Create any entity that was referred to but untouched
         // (this is just for the sake of correctness, it would be bad to do that
         // as the entities would remain blank in this batch).
-        for (Entry<EntityIdValue, Set<Long>> entry : mentionedNewEntities.entrySet()) {
+        for (Entry<EntityIdValue, Set<Integer>> entry : mentionedNewEntities.entrySet()) {
             EntityIdValue missingId = entry.getKey();
             fullSchedule.add(new ItemEditBuilder(missingId).addContributingRowIds(entry.getValue()).build());
             fullSchedule.addAll(pointerUpdates.get(missingId).getUpdates());

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/scheduler/QuickStatementsUpdateScheduler.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/scheduler/QuickStatementsUpdateScheduler.java
@@ -26,11 +26,11 @@ package org.openrefine.wikibase.updates.scheduler;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 
@@ -73,6 +73,7 @@ public class QuickStatementsUpdateScheduler implements UpdateScheduler {
         if (edit instanceof ItemEdit) {
             ItemEdit update = (ItemEdit) edit;
             ItemEditBuilder remainingUpdateBuilder = new ItemEditBuilder(update.getEntityId())
+                    .addContributingRowIds(update.getContributingRowIds())
                     .addLabels(update.getLabels(), true)
                     .addLabels(update.getLabelsIfNew(), false)
                     .addDescriptions(update.getDescriptions(), true)
@@ -88,7 +89,8 @@ public class QuickStatementsUpdateScheduler implements UpdateScheduler {
                     EntityIdValue pointer = pointers.stream().findFirst().get();
                     ItemEditBuilder referencingBuilder = referencingUpdates.get(pointer);
                     if (referencingBuilder == null) {
-                        referencingBuilder = new ItemEditBuilder(update.getEntityId());
+                        referencingBuilder = new ItemEditBuilder(update.getEntityId())
+                                .addContributingRowIds(update.getContributingRowIds());
                     }
                     referencingBuilder.addStatement(statement);
                     referencingUpdates.put(pointer, referencingBuilder);
@@ -172,7 +174,11 @@ public class QuickStatementsUpdateScheduler implements UpdateScheduler {
 
         // Reconstruct
         List<EntityEdit> fullSchedule = new ArrayList<>();
-        Set<EntityIdValue> mentionedNewEntities = new HashSet<>(pointerUpdates.keySet());
+        Map<EntityIdValue, Set<Long>> mentionedNewEntities = pointerUpdates.entrySet()
+                .stream()
+                .collect(Collectors.toMap(update -> update.getKey(),
+                        update -> update.getValue().getUpdates().get(0).getContributingRowIds()));// new
+                                                                                                  // HashMap<>(pointerUpdates.keySet());
         for (EntityEdit update : pointerFreeUpdates.getUpdates()) {
             fullSchedule.add(update);
             UpdateSequence backPointers = pointerUpdates.get(update.getEntityId());
@@ -185,8 +191,9 @@ public class QuickStatementsUpdateScheduler implements UpdateScheduler {
         // Create any entity that was referred to but untouched
         // (this is just for the sake of correctness, it would be bad to do that
         // as the entities would remain blank in this batch).
-        for (EntityIdValue missingId : mentionedNewEntities) {
-            fullSchedule.add(new ItemEditBuilder(missingId).build());
+        for (Entry<EntityIdValue, Set<Long>> entry : mentionedNewEntities.entrySet()) {
+            EntityIdValue missingId = entry.getKey();
+            fullSchedule.add(new ItemEditBuilder(missingId).addContributingRowIds(entry.getValue()).build());
             fullSchedule.addAll(pointerUpdates.get(missingId).getUpdates());
         }
         return fullSchedule;

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/scheduler/WikibaseAPIUpdateScheduler.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/scheduler/WikibaseAPIUpdateScheduler.java
@@ -24,11 +24,7 @@
 
 package org.openrefine.wikibase.updates.scheduler;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
@@ -66,9 +62,9 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
      */
     private UpdateSequence pointerFullUpdates;
     /**
-     * The set of all new entities referred to in the whole batch.
+     * The set of all new entities referred to in the whole batch, mapping to a row id where they are referred to
      */
-    private Set<EntityIdValue> allPointers;
+    private Map<EntityIdValue, Long> allPointers;
 
     private PointerExtractor extractor = new PointerExtractor();
 
@@ -77,7 +73,7 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
         List<EntityEdit> result = new ArrayList<>();
         pointerFreeUpdates = new UpdateSequence();
         pointerFullUpdates = new UpdateSequence();
-        allPointers = new HashSet<>();
+        allPointers = new HashMap<>();
 
         for (EntityEdit update : updates) {
             splitUpdate(update);
@@ -87,18 +83,27 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
         result.addAll(pointerFreeUpdates.getUpdates());
 
         // Part 1': add the remaining new entities that have not been touched
-        Set<EntityIdValue> unseenPointers = new HashSet<>(allPointers);
-        unseenPointers.removeAll(pointerFreeUpdates.getSubjects());
-        // Only items can be created explicitly: other entity types need at least some non-blank field.
-        // Therefore we check that all entities are items.
-        Optional<EntityIdValue> uncreatableEntity = unseenPointers.stream().filter(t -> !(t instanceof ItemIdValue)).findAny();
-        if (uncreatableEntity.isPresent()) {
-            throw new ImpossibleSchedulingException("The batch contains a reference to a new entity (" +
-                    uncreatableEntity.toString() + ") which is never explicitly created in the batch. " +
-                    "It cannot be created implicitly as creating a blank entity of this type is impossible.");
+        Map<EntityIdValue, Long> unseenPointers = new HashMap<>(allPointers);
+        for (EntityIdValue id : pointerFreeUpdates.getSubjects()) {
+            unseenPointers.remove(id);
         }
-        // TODO For now, we know that they are all item updates because items are the only things we can create
-        result.addAll(unseenPointers.stream().map(t -> new ItemEditBuilder(t).build()).collect(Collectors.toList()));
+        // Only items can be created explicitly: other entity types need at least some non-blank field.
+        // Therefore, we check that all entities are items.
+        Optional<Map.Entry<EntityIdValue, Long>> uncreatableEntity = unseenPointers
+                .entrySet()
+                .stream()
+                .filter(t -> !(t.getKey() instanceof ItemIdValue))
+                .findAny();
+        if (uncreatableEntity.isPresent()) {
+            throw new ImpossibleSchedulingException(
+                    "The batch contains on row " + uncreatableEntity.get().getValue() + " a reference to a new entity (" +
+                            uncreatableEntity.get().getKey().toString() + ") which is never explicitly created in the batch. " +
+                            "It cannot be created implicitly as creating a blank entity of this type is impossible.");
+        }
+        // At this stage, we know that all entities are items, thanks to the check above
+        result.addAll(unseenPointers.entrySet().stream().map(entry -> new ItemEditBuilder(entry.getKey())
+                .addContributingRowId(entry.getValue())
+                .build()).collect(Collectors.toList()));
 
         // Part 2: add all the pointer full updates
         result.addAll(pointerFullUpdates.getUpdates());
@@ -114,6 +119,7 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
     protected void splitUpdate(EntityEdit edit) {
         // TODO (antonin, 2022-05-08): there is a lot of duplication in the two cases below (Item / MediaInfo),
         // could we refactor that?
+        long rowId = edit.getContributingRowIds().stream().findAny().get();
         if (edit instanceof ItemEdit) {
             ItemEdit update = (ItemEdit) edit;
             ItemEditBuilder pointerFreeBuilder = new ItemEditBuilder(update.getEntityId())
@@ -121,8 +127,10 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
                     .addLabels(update.getLabelsIfNew(), false)
                     .addDescriptions(update.getDescriptions(), true)
                     .addDescriptions(update.getDescriptionsIfNew(), false)
-                    .addAliases(update.getAliases());
-            ItemEditBuilder pointerFullBuilder = new ItemEditBuilder(update.getEntityId());
+                    .addAliases(update.getAliases())
+                    .addContributingRowIds(update.getContributingRowIds());
+            ItemEditBuilder pointerFullBuilder = new ItemEditBuilder(update.getEntityId())
+                    .addContributingRowIds(update.getContributingRowIds());
 
             for (StatementEdit statement : update.getStatementEdits()) {
                 Set<ReconEntityIdValue> pointers = extractor.extractPointers(statement.getStatement());
@@ -131,7 +139,7 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
                 } else {
                     pointerFullBuilder.addStatement(statement);
                 }
-                allPointers.addAll(pointers);
+                pointers.stream().forEach(pointer -> allPointers.put(pointer, rowId));
             }
 
             if (update.isNew()) {
@@ -158,8 +166,10 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
                     .addWikitext(update.getWikitext())
                     .setOverrideWikitext(update.isOverridingWikitext())
                     .addLabels(update.getLabels(), true)
-                    .addLabels(update.getLabelsIfNew(), false);
-            MediaInfoEditBuilder pointerFullBuilder = new MediaInfoEditBuilder(update.getEntityId());
+                    .addLabels(update.getLabelsIfNew(), false)
+                    .addContributingRowIds(update.getContributingRowIds());
+            MediaInfoEditBuilder pointerFullBuilder = new MediaInfoEditBuilder(update.getEntityId())
+                    .addContributingRowIds(update.getContributingRowIds());
 
             for (StatementEdit statement : update.getStatementEdits()) {
                 Set<ReconEntityIdValue> pointers = extractor.extractPointers(statement.getStatement());
@@ -168,7 +178,7 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
                 } else {
                     pointerFullBuilder.addStatement(statement);
                 }
-                allPointers.addAll(pointers);
+                pointers.stream().forEach(pointer -> allPointers.put(pointer, rowId));
             }
 
             if (update.isNew()) {

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/scheduler/WikibaseAPIUpdateScheduler.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/scheduler/WikibaseAPIUpdateScheduler.java
@@ -64,7 +64,7 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
     /**
      * The set of all new entities referred to in the whole batch, mapping to a row id where they are referred to
      */
-    private Map<EntityIdValue, Long> allPointers;
+    private Map<EntityIdValue, Integer> allPointers;
 
     private PointerExtractor extractor = new PointerExtractor();
 
@@ -83,13 +83,13 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
         result.addAll(pointerFreeUpdates.getUpdates());
 
         // Part 1': add the remaining new entities that have not been touched
-        Map<EntityIdValue, Long> unseenPointers = new HashMap<>(allPointers);
+        Map<EntityIdValue, Integer> unseenPointers = new HashMap<>(allPointers);
         for (EntityIdValue id : pointerFreeUpdates.getSubjects()) {
             unseenPointers.remove(id);
         }
         // Only items can be created explicitly: other entity types need at least some non-blank field.
         // Therefore, we check that all entities are items.
-        Optional<Map.Entry<EntityIdValue, Long>> uncreatableEntity = unseenPointers
+        Optional<Map.Entry<EntityIdValue, Integer>> uncreatableEntity = unseenPointers
                 .entrySet()
                 .stream()
                 .filter(t -> !(t.getKey() instanceof ItemIdValue))
@@ -119,7 +119,7 @@ public class WikibaseAPIUpdateScheduler implements UpdateScheduler {
     protected void splitUpdate(EntityEdit edit) {
         // TODO (antonin, 2022-05-08): there is a lot of duplication in the two cases below (Item / MediaInfo),
         // could we refactor that?
-        long rowId = edit.getContributingRowIds().stream().findAny().get();
+        int rowId = edit.getContributingRowIds().stream().findAny().get();
         if (edit instanceof ItemEdit) {
             ItemEdit update = (ItemEdit) edit;
             ItemEditBuilder pointerFreeBuilder = new ItemEditBuilder(update.getEntityId())

--- a/extensions/wikibase/tests/data/operations/perform-edits.json
+++ b/extensions/wikibase/tests/data/operations/perform-edits.json
@@ -9,5 +9,6 @@
     "facets": []
   },
   "tag" : "openrefine-${version}",
-  "maxEditsPerMinute": 60
+  "maxEditsPerMinute": 60,
+  "resultsColumnName": "Wikibase editing results"
 }

--- a/extensions/wikibase/tests/data/updates/entity_update.json
+++ b/extensions/wikibase/tests/data/updates/entity_update.json
@@ -1,5 +1,6 @@
 {
   "type": "item",
+  "contributingRowIds": [ 123 ],
   "addedAliases": [],
   "descriptions": [],
   "descriptionsIfNew": [],

--- a/extensions/wikibase/tests/data/updates/mediainfo_update.json
+++ b/extensions/wikibase/tests/data/updates/mediainfo_update.json
@@ -1,5 +1,6 @@
 {
   "type": "mediainfo",
+  "contributingRowIds" : [ 123 ],
   "fileName": null,
   "filePath": null,
   "wikitext": null,

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
@@ -95,9 +95,9 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         batch.add(new ItemEditBuilder(TestingData.existingId)
                 .addAlias(Datamodel.makeMonolingualTextValue("my new alias", "en"))
                 .addStatement(TestingData.generateStatementAddition(TestingData.existingId, TestingData.newIdA))
-                .addContributingRowId(123L).build());
+                .addContributingRowId(123).build());
         MonolingualTextValue label = Datamodel.makeMonolingualTextValue("better label", "en");
-        batch.add(new ItemEditBuilder(TestingData.newIdA).addAlias(label).addContributingRowId(123L).build());
+        batch.add(new ItemEditBuilder(TestingData.newIdA).addAlias(label).addContributingRowId(123).build());
 
         // Plan expected edits
         ItemDocument existingItem = ItemDocumentBuilder.forItemId(TestingData.existingId)
@@ -132,7 +132,8 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         List<EntityEdit> batch = new ArrayList<>();
         batch.add(new ItemEditBuilder(TestingData.existingId)
                 .addAlias(Datamodel.makeMonolingualTextValue("my new alias", "en"))
-                .addContributingRowId(123L).build());
+                .addContributingRowId(123)
+                .build());
         ItemDocument existingItem = ItemDocumentBuilder.forItemId(TestingData.existingId)
                 .withLabel(Datamodel.makeMonolingualTextValue("pomme", "fr"))
                 .withDescription(Datamodel.makeMonolingualTextValue("fruit délicieux", "fr")).build();
@@ -159,7 +160,8 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         List<EntityEdit> batch = new ArrayList<>();
         batch.add(new ItemEditBuilder(TestingData.existingId)
                 .addAlias(Datamodel.makeMonolingualTextValue("my new alias", "en"))
-                .addContributingRowId(123L).build());
+                .addContributingRowId(123)
+                .build());
         ItemDocument existingItem = ItemDocumentBuilder.forItemId(TestingData.existingId)
                 .withLabel(Datamodel.makeMonolingualTextValue("pomme", "fr"))
                 .withDescription(Datamodel.makeMonolingualTextValue("fruit délicieux", "fr")).build();
@@ -188,7 +190,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         MonolingualTextValue description = Datamodel.makeMonolingualTextValue("village in Nepal", "en");
         EntityEdit edit = new ItemEditBuilder(qid)
                 .addDescription(description, true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         List<EntityEdit> batch = Collections.singletonList(edit);
         when(fetcher.getEntityDocuments(Collections.singletonList(id))).thenReturn(Collections.emptyMap());
@@ -213,7 +215,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         List<ItemIdValue> qids = ids.stream().map(e -> Datamodel.makeWikidataItemIdValue(e))
                 .collect(Collectors.toList());
         List<EntityEdit> batch = qids.stream()
-                .map(qid -> new ItemEditBuilder(qid).addDescription(description, true).addContributingRowId(123L).build())
+                .map(qid -> new ItemEditBuilder(qid).addDescription(description, true).addContributingRowId(123).build())
                 .collect(Collectors.toList());
 
         int batchSize = 50;
@@ -266,7 +268,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         List<MediaInfoIdValue> mids = ids.stream().map(e -> Datamodel.makeWikimediaCommonsMediaInfoIdValue(e))
                 .collect(Collectors.toList());
         List<EntityEdit> batch = mids.stream()
-                .map(mid -> new MediaInfoEditBuilder(mid).addLabel(label, false).addContributingRowId(123L).build())
+                .map(mid -> new MediaInfoEditBuilder(mid).addLabel(label, false).addContributingRowId(123).build())
                 .collect(Collectors.toList());
 
         int batchSize = 50;
@@ -305,7 +307,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
     public void testEditWikitext() throws MediaWikiApiErrorException, IOException, InterruptedException {
         MediaInfoIdValue mid = Datamodel.makeWikimediaCommonsMediaInfoIdValue("M12345");
         MediaInfoEdit edit = new MediaInfoEditBuilder(mid).addWikitext("my new wikitext").setOverrideWikitext(true)
-                .addContributingRowId(123L).build();
+                .addContributingRowId(123).build();
         List<EntityEdit> batch = Collections.singletonList(edit);
         List<MediaInfoDocument> existingDocuments = Collections.singletonList(Datamodel.makeMediaInfoDocument(mid));
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
@@ -24,9 +24,9 @@
 
 package org.openrefine.wikibase.editing;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyBoolean;
-import static org.mockito.Mockito.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -68,6 +68,7 @@ import org.openrefine.wikibase.updates.EntityEdit;
 import org.openrefine.wikibase.updates.ItemEditBuilder;
 import org.openrefine.wikibase.updates.MediaInfoEdit;
 import org.openrefine.wikibase.updates.MediaInfoEditBuilder;
+import org.openrefine.wikibase.updates.StatementEdit;
 
 public class EditBatchProcessorTest extends WikidataRefineTest {
 
@@ -78,6 +79,18 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
     private String summary = "my fantastic edits";
     private int maxlag = 5;
     private List<String> tags = null;
+
+    private static final String successfulEditResponse = "{\n"
+            + "    \"edit\": {\n"
+            + "        \"result\": \"Success\",\n"
+            + "        \"pageid\": 94542,\n"
+            + "        \"title\": \"File:My_test_file.png\",\n"
+            + "        \"contentmodel\": \"wikitext\",\n"
+            + "        \"oldrevid\": 371705,\n"
+            + "        \"newrevid\": 371707,\n"
+            + "        \"newtimestamp\": \"2018-12-18T16:59:42Z\"\n"
+            + "    }\n"
+            + "}";
 
     @BeforeMethod
     public void setUp() {
@@ -92,9 +105,11 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
     public void testNewItem()
             throws InterruptedException, MediaWikiApiErrorException, IOException {
         List<EntityEdit> batch = new ArrayList<>();
+        MonolingualTextValue alias = Datamodel.makeMonolingualTextValue("my new alias", "en");
+        StatementEdit statement = TestingData.generateStatementAddition(TestingData.existingId, TestingData.newIdA);
         batch.add(new ItemEditBuilder(TestingData.existingId)
-                .addAlias(Datamodel.makeMonolingualTextValue("my new alias", "en"))
-                .addStatement(TestingData.generateStatementAddition(TestingData.existingId, TestingData.newIdA))
+                .addAlias(alias)
+                .addStatement(statement)
                 .addContributingRowId(123).build());
         MonolingualTextValue label = Datamodel.makeMonolingualTextValue("better label", "en");
         batch.add(new ItemEditBuilder(TestingData.newIdA).addAlias(label).addContributingRowId(123).build());
@@ -111,6 +126,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         ItemDocument createdNewItem = ItemDocumentBuilder.forItemId(Datamodel.makeWikidataItemIdValue("Q1234"))
                 .withLabel(label).withRevisionId(37828L).build();
         when(editor.createEntityDocument(expectedNewItem, summary, tags)).thenReturn(createdNewItem);
+        when(editor.editEntityDocument(any(), eq(false), eq(summary), eq(tags))).thenReturn(new EditingResult(18439L));
 
         EditBatchProcessor processor = new EditBatchProcessor(fetcher, editor, connection, batch, library, summary, maxlag, tags, 50, 60);
         assertEquals(2, processor.remainingEdits());
@@ -228,6 +244,17 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
 
         when(fetcher.getEntityDocuments(toQids(firstBatch))).thenReturn(toMap(firstBatch));
         when(fetcher.getEntityDocuments(toQids(secondBatch))).thenReturn(toMap(secondBatch));
+        long revId = 1000L;
+        for (ItemDocument doc : fullBatch) {
+            when(editor.editEntityDocument(Datamodel.makeItemUpdate(doc.getEntityId(),
+                    doc.getRevisionId(), Datamodel.makeTermUpdate(Collections.emptyList(), Collections.emptyList()),
+                    Datamodel.makeTermUpdate(Collections.singletonList(description), Collections.emptyList()),
+                    Collections.emptyMap(),
+                    Datamodel.makeStatementUpdate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
+                    Collections.emptyList(), Collections.emptyList()), false, summary, tags))
+                            .thenReturn(new EditingResult(revId));
+            revId++;
+        }
 
         // Run edits
         EditBatchProcessor processor = new EditBatchProcessor(fetcher, editor, connection, batch, library, summary, maxlag, tags, batchSize,
@@ -279,6 +306,15 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
 
         when(fetcher.getEntityDocuments(toMids(firstBatch))).thenReturn(toMapMediaInfo(firstBatch));
         when(fetcher.getEntityDocuments(toMids(secondBatch))).thenReturn(toMapMediaInfo(secondBatch));
+        long revId = 1000L;
+        for (MediaInfoDocument doc : fullBatch) {
+            StatementUpdate statementUpdate = Datamodel.makeStatementUpdate(Collections.emptyList(), Collections.emptyList(),
+                    Collections.emptyList());
+            when(editor.editEntityDocument(Datamodel.makeMediaInfoUpdate((MediaInfoIdValue) doc.getEntityId(),
+                    doc.getRevisionId(), labelsUpdate, statementUpdate), false, summary, tags))
+                            .thenReturn(new EditingResult(revId));
+            revId++;
+        }
 
         // Run edits
         EditBatchProcessor processor = new EditBatchProcessor(fetcher, editor, connection, batch, library, summary, maxlag, tags, batchSize,
@@ -324,6 +360,18 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         // mock mediainfo document fetching
         when(fetcher.getEntityDocuments(toMids(existingDocuments))).thenReturn(toMapMediaInfo(existingDocuments));
 
+        // mock page editing
+        Map<String, String> editParams = new HashMap<>();
+        editParams.put("action", "edit");
+        editParams.put("tags", "my-tag");
+        editParams.put("summary", summary);
+        editParams.put("pageid", "12345");
+        editParams.put("text", "my new wikitext");
+        editParams.put("token", csrfToken);
+        editParams.put("bot", "true");
+        when(connection.sendJsonRequest("POST", editParams))
+                .thenReturn(ParsingUtilities.mapper.readTree(successfulEditResponse));
+
         // Run the processor
         EditBatchProcessor processor = new EditBatchProcessor(fetcher, editor, connection, batch, library, summary, maxlag, tags, 50,
                 60);
@@ -333,14 +381,6 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         // sadly we cannot directly verify a method on the editor here since the editing of pages is not supported
         // there, but rather in our own MediaInfoUtils, so we resort to checking that the corresponding API call was
         // made at the connection level
-        Map<String, String> editParams = new HashMap<>();
-        editParams.put("action", "edit");
-        editParams.put("tags", "my-tag");
-        editParams.put("summary", summary);
-        editParams.put("pageid", "12345");
-        editParams.put("text", "my new wikitext");
-        editParams.put("token", csrfToken);
-        editParams.put("bot", "true");
         verify(connection, times(1)).sendJsonRequest("POST", editParams);
     }
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
@@ -94,14 +94,16 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         List<EntityEdit> batch = new ArrayList<>();
         batch.add(new ItemEditBuilder(TestingData.existingId)
                 .addAlias(Datamodel.makeMonolingualTextValue("my new alias", "en"))
-                .addStatement(TestingData.generateStatementAddition(TestingData.existingId, TestingData.newIdA)).build());
+                .addStatement(TestingData.generateStatementAddition(TestingData.existingId, TestingData.newIdA))
+                .addContributingRowId(123L).build());
         MonolingualTextValue label = Datamodel.makeMonolingualTextValue("better label", "en");
-        batch.add(new ItemEditBuilder(TestingData.newIdA).addAlias(label).build());
+        batch.add(new ItemEditBuilder(TestingData.newIdA).addAlias(label).addContributingRowId(123L).build());
 
         // Plan expected edits
         ItemDocument existingItem = ItemDocumentBuilder.forItemId(TestingData.existingId)
                 .withLabel(Datamodel.makeMonolingualTextValue("pomme", "fr"))
-                .withDescription(Datamodel.makeMonolingualTextValue("fruit délicieux", "fr")).build();
+                .withDescription(Datamodel.makeMonolingualTextValue("fruit délicieux", "fr"))
+                .build();
         when(fetcher.getEntityDocuments(Collections.singletonList(TestingData.existingId.getId())))
                 .thenReturn(Collections.singletonMap(TestingData.existingId.getId(), existingItem));
 
@@ -119,9 +121,6 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         processor.performEdit();
         assertEquals(0, processor.remainingEdits());
         assertEquals(100, processor.progress());
-        processor.performEdit(); // does not do anything
-        assertEquals(0, processor.remainingEdits());
-        assertEquals(100, processor.progress());
 
         NewEntityLibrary expectedLibrary = new NewEntityLibrary();
         expectedLibrary.setId(1234L, "Q1234");
@@ -133,7 +132,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         List<EntityEdit> batch = new ArrayList<>();
         batch.add(new ItemEditBuilder(TestingData.existingId)
                 .addAlias(Datamodel.makeMonolingualTextValue("my new alias", "en"))
-                .build());
+                .addContributingRowId(123L).build());
         ItemDocument existingItem = ItemDocumentBuilder.forItemId(TestingData.existingId)
                 .withLabel(Datamodel.makeMonolingualTextValue("pomme", "fr"))
                 .withDescription(Datamodel.makeMonolingualTextValue("fruit délicieux", "fr")).build();
@@ -160,7 +159,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         List<EntityEdit> batch = new ArrayList<>();
         batch.add(new ItemEditBuilder(TestingData.existingId)
                 .addAlias(Datamodel.makeMonolingualTextValue("my new alias", "en"))
-                .build());
+                .addContributingRowId(123L).build());
         ItemDocument existingItem = ItemDocumentBuilder.forItemId(TestingData.existingId)
                 .withLabel(Datamodel.makeMonolingualTextValue("pomme", "fr"))
                 .withDescription(Datamodel.makeMonolingualTextValue("fruit délicieux", "fr")).build();
@@ -187,7 +186,10 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         String id = "Q389";
         ItemIdValue qid = Datamodel.makeWikidataItemIdValue(id);
         MonolingualTextValue description = Datamodel.makeMonolingualTextValue("village in Nepal", "en");
-        EntityEdit edit = new ItemEditBuilder(qid).addDescription(description, true).build();
+        EntityEdit edit = new ItemEditBuilder(qid)
+                .addDescription(description, true)
+                .addContributingRowId(123L)
+                .build();
         List<EntityEdit> batch = Collections.singletonList(edit);
         when(fetcher.getEntityDocuments(Collections.singletonList(id))).thenReturn(Collections.emptyMap());
 
@@ -211,7 +213,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         List<ItemIdValue> qids = ids.stream().map(e -> Datamodel.makeWikidataItemIdValue(e))
                 .collect(Collectors.toList());
         List<EntityEdit> batch = qids.stream()
-                .map(qid -> new ItemEditBuilder(qid).addDescription(description, true).build())
+                .map(qid -> new ItemEditBuilder(qid).addDescription(description, true).addContributingRowId(123L).build())
                 .collect(Collectors.toList());
 
         int batchSize = 50;
@@ -264,7 +266,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         List<MediaInfoIdValue> mids = ids.stream().map(e -> Datamodel.makeWikimediaCommonsMediaInfoIdValue(e))
                 .collect(Collectors.toList());
         List<EntityEdit> batch = mids.stream()
-                .map(mid -> new MediaInfoEditBuilder(mid).addLabel(label, false).build())
+                .map(mid -> new MediaInfoEditBuilder(mid).addLabel(label, false).addContributingRowId(123L).build())
                 .collect(Collectors.toList());
 
         int batchSize = 50;
@@ -302,7 +304,8 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
     @Test
     public void testEditWikitext() throws MediaWikiApiErrorException, IOException, InterruptedException {
         MediaInfoIdValue mid = Datamodel.makeWikimediaCommonsMediaInfoIdValue("M12345");
-        MediaInfoEdit edit = new MediaInfoEditBuilder(mid).addWikitext("my new wikitext").setOverrideWikitext(true).build();
+        MediaInfoEdit edit = new MediaInfoEditBuilder(mid).addWikitext("my new wikitext").setOverrideWikitext(true)
+                .addContributingRowId(123L).build();
         List<EntityEdit> batch = Collections.singletonList(edit);
         List<MediaInfoDocument> existingDocuments = Collections.singletonList(Datamodel.makeMediaInfoDocument(mid));
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditResultsFormatterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditResultsFormatterTest.java
@@ -21,16 +21,17 @@ import org.openrefine.wikibase.editing.EditBatchProcessor.EditResult;
 public class EditResultsFormatterTest {
 
     String apiEndpoint = "https://my.wikibase.instance/w/api.php";
-    EditResult success1 = new EditResult(Collections.singleton(1), null, null, 1234L, OptionalLong.of(4567L));
-    EditResult success1Dup = new EditResult(Collections.singleton(1), null, null, 111L, OptionalLong.of(3748L));
-    EditResult success2 = new EditResult(Collections.singleton(2), null, null, 555L, OptionalLong.of(8790L));
+    EditResult success1 = new EditResult(Collections.singleton(1), null, null, 1234L, OptionalLong.of(4567L), null);
+    EditResult success1Dup = new EditResult(Collections.singleton(1), null, null, 111L, OptionalLong.of(3748L), null);
+    EditResult success2 = new EditResult(Collections.singleton(2), null, null, 555L, OptionalLong.of(8790L), null);
+    EditResult newEntity = new EditResult(Collections.singleton(2), null, null, 0L, OptionalLong.empty(), "http://foo.com/bar");
     EditResult error1 = new EditResult(Collections.singleton(1), "blocked", "You have been blocked from editing.", 1234L,
-            OptionalLong.empty());
+            OptionalLong.empty(), null);
     EditResult error1Dup = new EditResult(Collections.singleton(1), "illegal-value", "The value supplied is invalid", 111L,
-            OptionalLong.empty());
+            OptionalLong.empty(), null);
     EditResult error2 = new EditResult(Collections.singleton(2), "duplicate-item", "You are attempting to create a duplicate of [[Q1234]]",
-            123L, OptionalLong.empty());
-    EditResult successNoEdit = new EditResult(Collections.singleton(1), null, null, 1234L, OptionalLong.of(1234L));
+            123L, OptionalLong.empty(), null);
+    EditResult successNoEdit = new EditResult(Collections.singleton(1), null, null, 1234L, OptionalLong.of(1234L), null);
 
     Comparator<CellAtRow> comparator = new Comparator<>() {
 
@@ -101,6 +102,19 @@ public class EditResultsFormatterTest {
                 Arrays.asList(
                         new CellAtRow(1, new Cell(
                                 "https://my.wikibase.instance/w/index.php?diff=prev&oldid=4567 https://my.wikibase.instance/w/index.php?diff=prev&oldid=3748",
+                                null))));
+    }
+
+    @Test
+    public void testNewEntity() {
+        EditResultsFormatter formatter = new EditResultsFormatter(apiEndpoint);
+        formatter.add(newEntity);
+
+        List<CellAtRow> results = formatter.toCells().stream().sorted(comparator).collect(Collectors.toList());
+        assertEquals(results,
+                Arrays.asList(
+                        new CellAtRow(2, new Cell(
+                                "http://foo.com/bar",
                                 null))));
     }
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditResultsFormatterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditResultsFormatterTest.java
@@ -21,13 +21,16 @@ import org.openrefine.wikibase.editing.EditBatchProcessor.EditResult;
 public class EditResultsFormatterTest {
 
     String apiEndpoint = "https://my.wikibase.instance/w/api.php";
-    EditResult success1 = new EditResult(Collections.singleton(1), null, null, OptionalLong.of(4567L));
-    EditResult success1Dup = new EditResult(Collections.singleton(1), null, null, OptionalLong.of(3748L));
-    EditResult success2 = new EditResult(Collections.singleton(2), null, null, OptionalLong.of(8790L));
-    EditResult error1 = new EditResult(Collections.singleton(1), "blocked", "You have been blocked from editing.", OptionalLong.empty());
-    EditResult error1Dup = new EditResult(Collections.singleton(1), "illegal-value", "The value supplied is invalid", OptionalLong.empty());
-    EditResult error2 = new EditResult(Collections.singleton(2), "duplicate-item", "You are attempting to create a duplicate of [[Q1234]]",
+    EditResult success1 = new EditResult(Collections.singleton(1), null, null, 1234L, OptionalLong.of(4567L));
+    EditResult success1Dup = new EditResult(Collections.singleton(1), null, null, 111L, OptionalLong.of(3748L));
+    EditResult success2 = new EditResult(Collections.singleton(2), null, null, 555L, OptionalLong.of(8790L));
+    EditResult error1 = new EditResult(Collections.singleton(1), "blocked", "You have been blocked from editing.", 1234L,
             OptionalLong.empty());
+    EditResult error1Dup = new EditResult(Collections.singleton(1), "illegal-value", "The value supplied is invalid", 111L,
+            OptionalLong.empty());
+    EditResult error2 = new EditResult(Collections.singleton(2), "duplicate-item", "You are attempting to create a duplicate of [[Q1234]]",
+            123L, OptionalLong.empty());
+    EditResult successNoEdit = new EditResult(Collections.singleton(1), null, null, 1234L, OptionalLong.of(1234L));
 
     Comparator<CellAtRow> comparator = new Comparator<>() {
 
@@ -50,6 +53,15 @@ public class EditResultsFormatterTest {
                         new CellAtRow(1, new Cell("https://my.wikibase.instance/w/index.php?diff=prev&oldid=4567", null)),
                         new CellAtRow(2,
                                 new Cell(new EvalError("[duplicate-item] You are attempting to create a duplicate of [[Q1234]]"), null))));
+    }
+
+    @Test
+    public void testSuccessesNoEdit() {
+        EditResultsFormatter formatter = new EditResultsFormatter(apiEndpoint);
+        formatter.add(successNoEdit);
+
+        List<CellAtRow> results = formatter.toCells().stream().sorted(comparator).collect(Collectors.toList());
+        assertEquals(results, Collections.emptyList());
     }
 
     @Test

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditResultsFormatterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditResultsFormatterTest.java
@@ -1,0 +1,95 @@
+
+package org.openrefine.wikibase.editing;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.stream.Collectors;
+
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.EvalError;
+import com.google.refine.model.Cell;
+import com.google.refine.model.changes.CellAtRow;
+
+import org.openrefine.wikibase.editing.EditBatchProcessor.EditResult;
+
+public class EditResultsFormatterTest {
+
+    String apiEndpoint = "https://my.wikibase.instance/w/api.php";
+    EditResult success1 = new EditResult(Collections.singleton(1), null, null, OptionalLong.of(4567L));
+    EditResult success1Dup = new EditResult(Collections.singleton(1), null, null, OptionalLong.of(3748L));
+    EditResult success2 = new EditResult(Collections.singleton(2), null, null, OptionalLong.of(8790L));
+    EditResult error1 = new EditResult(Collections.singleton(1), "blocked", "You have been blocked from editing.", OptionalLong.empty());
+    EditResult error1Dup = new EditResult(Collections.singleton(1), "illegal-value", "The value supplied is invalid", OptionalLong.empty());
+    EditResult error2 = new EditResult(Collections.singleton(2), "duplicate-item", "You are attempting to create a duplicate of [[Q1234]]",
+            OptionalLong.empty());
+
+    Comparator<CellAtRow> comparator = new Comparator<>() {
+
+        @Override
+        public int compare(CellAtRow arg0, CellAtRow arg1) {
+            return arg0.row - arg1.row;
+        }
+
+    };
+
+    @Test
+    public void testSuccessesAndFailures() {
+        EditResultsFormatter formatter = new EditResultsFormatter(apiEndpoint);
+        formatter.add(success1);
+        formatter.add(error2);
+
+        List<CellAtRow> results = formatter.toCells().stream().sorted(comparator).collect(Collectors.toList());
+        assertEquals(results,
+                Arrays.asList(
+                        new CellAtRow(1, new Cell("https://my.wikibase.instance/w/index.php?diff=prev&oldid=4567", null)),
+                        new CellAtRow(2,
+                                new Cell(new EvalError("[duplicate-item] You are attempting to create a duplicate of [[Q1234]]"), null))));
+    }
+
+    @Test
+    public void testFailuresHavePriority() {
+        EditResultsFormatter formatter = new EditResultsFormatter(apiEndpoint);
+        formatter.add(success2);
+        formatter.add(error2);
+
+        List<CellAtRow> results = formatter.toCells().stream().sorted(comparator).collect(Collectors.toList());
+        assertEquals(results,
+                Arrays.asList(
+                        new CellAtRow(2,
+                                new Cell(new EvalError("[duplicate-item] You are attempting to create a duplicate of [[Q1234]]"), null))));
+    }
+
+    @Test
+    public void testMultipleErrors() {
+        EditResultsFormatter formatter = new EditResultsFormatter(apiEndpoint);
+        formatter.add(error1);
+        formatter.add(error1Dup);
+
+        List<CellAtRow> results = formatter.toCells().stream().sorted(comparator).collect(Collectors.toList());
+        assertEquals(results,
+                Arrays.asList(
+                        new CellAtRow(1, new Cell(new EvalError(
+                                "[blocked] You have been blocked from editing.; [illegal-value] The value supplied is invalid"), null))));
+    }
+
+    @Test
+    public void testMultipleSuccesses() {
+        EditResultsFormatter formatter = new EditResultsFormatter(apiEndpoint);
+        formatter.add(success1);
+        formatter.add(success1Dup);
+
+        List<CellAtRow> results = formatter.toCells().stream().sorted(comparator).collect(Collectors.toList());
+        assertEquals(results,
+                Arrays.asList(
+                        new CellAtRow(1, new Cell(
+                                "https://my.wikibase.instance/w/index.php?diff=prev&oldid=4567 https://my.wikibase.instance/w/index.php?diff=prev&oldid=3748",
+                                null))));
+    }
+
+}

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/MediaFileUtilsTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/MediaFileUtilsTest.java
@@ -253,14 +253,15 @@ public class MediaFileUtilsTest {
         uploadParams.put("token", csrfToken);
         uploadParams.put("bot", "true");
         JsonNode editJsonResponse = ParsingUtilities.mapper.readTree(successfulEditResponse);
-        when(connection.sendJsonRequest("POST", uploadParams, Collections.emptyMap())).thenReturn(editJsonResponse);
+        when(connection.sendJsonRequest("POST", uploadParams)).thenReturn(editJsonResponse);
 
         MediaFileUtils mediaFileUtils = new MediaFileUtils(connection);
         // For this test, assume the CSRF token has already been fetched
         mediaFileUtils.fetchCsrfToken();
 
-        mediaFileUtils.editPage(12345L, "my new wikitext", "my summary", Collections.emptyList());
+        long revisionId = mediaFileUtils.editPage(12345L, "my new wikitext", "my summary", Collections.emptyList());
 
+        assertEquals(revisionId, 371707L);
         // check the requests were done as expected
         InOrder inOrder = Mockito.inOrder(connection);
         Map<String, String> tokenParams = new HashMap<>();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/ReconEntityRewriterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/ReconEntityRewriterTest.java
@@ -95,14 +95,18 @@ public class ReconEntityRewriterTest {
                 .addStatement(TestingData.generateStatementDeletion(subject, TestingData.existingId))
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
-                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de")).build();
+                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
+                .addContributingRowId(123L)
+                .build();
         EntityEdit rewritten = rewriter.rewrite(update);
         LabeledStatementEntityEdit expected = new ItemEditBuilder(subject)
                 .addStatement(TestingData.generateStatementAddition(subject, newlyCreated))
                 .addStatement(TestingData.generateStatementDeletion(subject, TestingData.existingId))
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
-                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de")).build();
+                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
+                .addContributingRowId(123L)
+                .build();
         assertEquals(rewritten, expected);
     }
 
@@ -113,11 +117,15 @@ public class ReconEntityRewriterTest {
         library.setId(4567L, "Q1234");
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdB)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
-                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de")).build();
+                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
+                .addContributingRowId(123L)
+                .build();
         EntityEdit rewritten = rewriter.rewrite(update);
         LabeledStatementEntityEdit expected = new ItemEditBuilder(newlyCreated)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
-                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de")).build();
+                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
+                .addContributingRowId(123L)
+                .build();
         assertEquals(rewritten, expected);
     }
 
@@ -131,14 +139,18 @@ public class ReconEntityRewriterTest {
                 .addStatement(TestingData.generateStatementDeletion(subject, TestingData.existingId))
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
-                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de")).build();
+                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
+                .addContributingRowId(123L)
+                .build();
         EntityEdit rewritten = rewriter.rewrite(update);
         LabeledStatementEntityEdit expected = new ItemEditBuilder(subject)
                 .addStatement(TestingData.generateStatementAddition(subject, newlyCreated))
                 .addStatement(TestingData.generateStatementDeletion(subject, TestingData.existingId))
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
-                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de")).build();
+                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
+                .addContributingRowId(123L)
+                .build();
         assertEquals(rewritten, expected);
     }
 
@@ -152,14 +164,18 @@ public class ReconEntityRewriterTest {
                 .addStatement(TestingData.generateStatementDeletion(subject, TestingData.existingPropertyId))
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
-                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de")).build();
+                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
+                .addContributingRowId(123L)
+                .build();
         EntityEdit rewritten = rewriter.rewrite(update);
         LabeledStatementEntityEdit expected = new ItemEditBuilder(subject)
                 .addStatement(TestingData.generateStatementAddition(subject, newlyCreatedProperty))
                 .addStatement(TestingData.generateStatementDeletion(subject, TestingData.existingPropertyId))
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
-                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de")).build();
+                .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
+                .addContributingRowId(123L)
+                .build();
         assertEquals(rewritten, expected);
     }
 }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/ReconEntityRewriterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/ReconEntityRewriterTest.java
@@ -96,7 +96,7 @@ public class ReconEntityRewriterTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
                 .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         EntityEdit rewritten = rewriter.rewrite(update);
         LabeledStatementEntityEdit expected = new ItemEditBuilder(subject)
@@ -105,7 +105,7 @@ public class ReconEntityRewriterTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
                 .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertEquals(rewritten, expected);
     }
@@ -118,13 +118,13 @@ public class ReconEntityRewriterTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdB)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
                 .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         EntityEdit rewritten = rewriter.rewrite(update);
         LabeledStatementEntityEdit expected = new ItemEditBuilder(newlyCreated)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
                 .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertEquals(rewritten, expected);
     }
@@ -140,7 +140,7 @@ public class ReconEntityRewriterTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
                 .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         EntityEdit rewritten = rewriter.rewrite(update);
         LabeledStatementEntityEdit expected = new ItemEditBuilder(subject)
@@ -149,7 +149,7 @@ public class ReconEntityRewriterTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
                 .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertEquals(rewritten, expected);
     }
@@ -165,7 +165,7 @@ public class ReconEntityRewriterTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
                 .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         EntityEdit rewritten = rewriter.rewrite(update);
         LabeledStatementEntityEdit expected = new ItemEditBuilder(subject)
@@ -174,7 +174,7 @@ public class ReconEntityRewriterTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("label", "de"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("beschreibung", "de"), false)
                 .addAlias(Datamodel.makeMonolingualTextValue("darstellung", "de"))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertEquals(rewritten, expected);
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/QuickStatementsExporterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/QuickStatementsExporterTest.java
@@ -92,6 +92,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
     public void testImpossibleScheduling() throws IOException {
         StatementEdit sNewAtoNewB = TestingData.generateStatementAddition(newIdA, newIdB);
         TermedStatementEntityEdit update = new ItemEditBuilder(newIdA).addStatement(sNewAtoNewB)
+                .addContributingRowId(123L)
                 .build();
 
         assertEquals(QuickStatementsExporter.impossibleSchedulingErrorMessage, export(update));
@@ -105,7 +106,9 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
          */
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1)
                 .addLabel(Datamodel.makeMonolingualTextValue("some label", "en"), true)
-                .addDescription(Datamodel.makeMonolingualTextValue("some description", "en"), true).build();
+                .addDescription(Datamodel.makeMonolingualTextValue("some description", "en"), true)
+                .addContributingRowId(123L)
+                .build();
 
         assertEquals("Q1377\tLen\t\"some label\"\n" + "Q1377\tDen\t\"some description\"\n", export(update));
     }
@@ -115,7 +118,9 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(newIdA)
                 .addLabel(Datamodel.makeMonolingualTextValue("my new item", "en"), false)
                 .addDescription(Datamodel.makeMonolingualTextValue("isn't it awesome?", "en"), false)
-                .addAlias(Datamodel.makeMonolingualTextValue("fabitem", "en")).build();
+                .addAlias(Datamodel.makeMonolingualTextValue("fabitem", "en"))
+                .addContributingRowId(123L)
+                .build();
 
         assertEquals("CREATE\n" + "LAST\tLen\t\"my new item\"\n" + "LAST\tDen\t\"isn't it awesome?\"\n"
                 + "LAST\tAen\t\"fabitem\"\n", export(update));
@@ -126,6 +131,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1)
                 .addStatement(new StatementEdit(TestingData.generateStatement(qid1, qid2),
                         StatementMerger.FORMER_DEFAULT_STRATEGY, StatementEditingMode.DELETE))
+                .addContributingRowId(123L)
                 .build();
 
         assertEquals("- Q1377\tP38\tQ865528\n", export(update));
@@ -143,7 +149,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         Statement statement = Datamodel.makeStatement(claim, Collections.emptyList(), StatementRank.NORMAL, "");
         StatementEdit statementUpdate = new StatementEdit(statement, StatementMerger.FORMER_DEFAULT_STRATEGY,
                 StatementEditingMode.ADD_OR_MERGE);
-        TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate).addContributingRowId(123L).build();
 
         assertEquals("Q1377\tP38\tQ865528\tP38\tQ1377\n", export(update));
     }
@@ -157,6 +163,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 StatementEditingMode.ADD_OR_MERGE);
 
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate)
+                .addContributingRowId(123L)
                 .build();
 
         assertEquals("Q1377\tP123\tsomevalue\n", export(update));
@@ -171,6 +178,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 StatementEditingMode.ADD_OR_MERGE);
 
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate)
+                .addContributingRowId(123L)
                 .build();
 
         assertEquals("Q1377\tP123\tnovalue\n", export(update));
@@ -202,6 +210,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 StatementEditingMode.ADD_OR_MERGE);
 
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate)
+                .addContributingRowId(123L)
                 .build();
 
         assertEquals(

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/QuickStatementsExporterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/QuickStatementsExporterTest.java
@@ -92,7 +92,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
     public void testImpossibleScheduling() throws IOException {
         StatementEdit sNewAtoNewB = TestingData.generateStatementAddition(newIdA, newIdB);
         TermedStatementEntityEdit update = new ItemEditBuilder(newIdA).addStatement(sNewAtoNewB)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         assertEquals(QuickStatementsExporter.impossibleSchedulingErrorMessage, export(update));
@@ -107,7 +107,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1)
                 .addLabel(Datamodel.makeMonolingualTextValue("some label", "en"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("some description", "en"), true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         assertEquals("Q1377\tLen\t\"some label\"\n" + "Q1377\tDen\t\"some description\"\n", export(update));
@@ -119,7 +119,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("my new item", "en"), false)
                 .addDescription(Datamodel.makeMonolingualTextValue("isn't it awesome?", "en"), false)
                 .addAlias(Datamodel.makeMonolingualTextValue("fabitem", "en"))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         assertEquals("CREATE\n" + "LAST\tLen\t\"my new item\"\n" + "LAST\tDen\t\"isn't it awesome?\"\n"
@@ -131,7 +131,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1)
                 .addStatement(new StatementEdit(TestingData.generateStatement(qid1, qid2),
                         StatementMerger.FORMER_DEFAULT_STRATEGY, StatementEditingMode.DELETE))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         assertEquals("- Q1377\tP38\tQ865528\n", export(update));
@@ -149,7 +149,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         Statement statement = Datamodel.makeStatement(claim, Collections.emptyList(), StatementRank.NORMAL, "");
         StatementEdit statementUpdate = new StatementEdit(statement, StatementMerger.FORMER_DEFAULT_STRATEGY,
                 StatementEditingMode.ADD_OR_MERGE);
-        TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate).addContributingRowId(123L).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate).addContributingRowId(123).build();
 
         assertEquals("Q1377\tP38\tQ865528\tP38\tQ1377\n", export(update));
     }
@@ -163,7 +163,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 StatementEditingMode.ADD_OR_MERGE);
 
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         assertEquals("Q1377\tP123\tsomevalue\n", export(update));
@@ -178,7 +178,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 StatementEditingMode.ADD_OR_MERGE);
 
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         assertEquals("Q1377\tP123\tnovalue\n", export(update));
@@ -210,7 +210,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 StatementEditingMode.ADD_OR_MERGE);
 
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         assertEquals(

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/operations/PerformWikibaseEditsOperationTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/operations/PerformWikibaseEditsOperationTest.java
@@ -62,13 +62,13 @@ public class PerformWikibaseEditsOperationTest extends OperationTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConstructor() {
-        new PerformWikibaseEditsOperation(EngineConfig.reconstruct("{}"), "", 5, "", 60, "tag");
+        new PerformWikibaseEditsOperation(EngineConfig.reconstruct("{}"), "", 5, "", 60, "tag", "editing results");
     }
 
     @Test
     public void testGetTagCandidates() {
         PerformWikibaseEditsOperation operation = new PerformWikibaseEditsOperation(
-                EngineConfig.reconstruct("{}"), "my summary", 5, "", 60, "openrefine-${version}");
+                EngineConfig.reconstruct("{}"), "my summary", 5, "", 60, "openrefine-${version}", null);
         List<String> candidates = operation.getTagCandidates("3.4");
 
         assertEquals(candidates, Arrays.asList("openrefine-3.4", "openrefine"));

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/CommonDescriptionScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/CommonDescriptionScrutinizerTest.java
@@ -20,7 +20,7 @@ public class CommonDescriptionScrutinizerTest extends ScrutinizerTest {
         String description = "good description";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertNoWarningRaised();
@@ -34,7 +34,7 @@ public class CommonDescriptionScrutinizerTest extends ScrutinizerTest {
                 + "long description long description long description long description";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertWarningsRaised(CommonDescriptionScrutinizer.descTooLongType);
@@ -46,7 +46,7 @@ public class CommonDescriptionScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
                 .addLabel(Datamodel.makeMonolingualTextValue(description, "en"), true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertWarningsRaised(CommonDescriptionScrutinizer.descIdenticalWithLabel);
@@ -58,7 +58,7 @@ public class CommonDescriptionScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
                 .addLabel(Datamodel.makeMonolingualTextValue("bonjour", "fr"), true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertNoWarningRaised();
@@ -73,7 +73,7 @@ public class CommonDescriptionScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
                 .addLabel(Datamodel.makeMonolingualTextValue(description, "en"), true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertWarningsRaised(CommonDescriptionScrutinizer.descTooLongType, CommonDescriptionScrutinizer.descIdenticalWithLabel);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/CommonDescriptionScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/CommonDescriptionScrutinizerTest.java
@@ -20,6 +20,7 @@ public class CommonDescriptionScrutinizerTest extends ScrutinizerTest {
         String description = "good description";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertNoWarningRaised();
@@ -33,6 +34,7 @@ public class CommonDescriptionScrutinizerTest extends ScrutinizerTest {
                 + "long description long description long description long description";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertWarningsRaised(CommonDescriptionScrutinizer.descTooLongType);
@@ -44,6 +46,7 @@ public class CommonDescriptionScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
                 .addLabel(Datamodel.makeMonolingualTextValue(description, "en"), true)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertWarningsRaised(CommonDescriptionScrutinizer.descIdenticalWithLabel);
@@ -55,6 +58,7 @@ public class CommonDescriptionScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
                 .addLabel(Datamodel.makeMonolingualTextValue("bonjour", "fr"), true)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertNoWarningRaised();
@@ -69,6 +73,7 @@ public class CommonDescriptionScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
                 .addLabel(Datamodel.makeMonolingualTextValue(description, "en"), true)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertWarningsRaised(CommonDescriptionScrutinizer.descTooLongType, CommonDescriptionScrutinizer.descIdenticalWithLabel);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ConflictsWithScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ConflictsWithScrutinizerTest.java
@@ -65,6 +65,7 @@ public class ConflictsWithScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
+                .addContributingRowId(123L)
                 .build();
 
         Snak snak1 = Datamodel.makeValueSnak(propertyParameterPID, conflictingPropertyValue1);
@@ -94,6 +95,7 @@ public class ConflictsWithScrutinizerTest extends ScrutinizerTest {
 
         TermedStatementEntityEdit update = new ItemEditBuilder(id)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak snak1 = Datamodel.makeValueSnak(propertyParameterPID, conflictingPropertyValue1);
@@ -126,6 +128,7 @@ public class ConflictsWithScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
+                .addContributingRowId(123L)
                 .build();
 
         Snak snak1 = Datamodel.makeValueSnak(propertyParameterPID, conflictingPropertyValue1);
@@ -155,6 +158,7 @@ public class ConflictsWithScrutinizerTest extends ScrutinizerTest {
 
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = new ArrayList<>();
@@ -183,6 +187,7 @@ public class ConflictsWithScrutinizerTest extends ScrutinizerTest {
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
                 .addStatement(add(statement3))
+                .addContributingRowId(123L)
                 .build();
 
         Snak propertySnak1 = Datamodel.makeValueSnak(propertyParameterPID, conflictingPropertyValue1);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ConflictsWithScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ConflictsWithScrutinizerTest.java
@@ -65,7 +65,7 @@ public class ConflictsWithScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak snak1 = Datamodel.makeValueSnak(propertyParameterPID, conflictingPropertyValue1);
@@ -95,7 +95,7 @@ public class ConflictsWithScrutinizerTest extends ScrutinizerTest {
 
         TermedStatementEntityEdit update = new ItemEditBuilder(id)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak snak1 = Datamodel.makeValueSnak(propertyParameterPID, conflictingPropertyValue1);
@@ -128,7 +128,7 @@ public class ConflictsWithScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak snak1 = Datamodel.makeValueSnak(propertyParameterPID, conflictingPropertyValue1);
@@ -158,7 +158,7 @@ public class ConflictsWithScrutinizerTest extends ScrutinizerTest {
 
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = new ArrayList<>();
@@ -187,7 +187,7 @@ public class ConflictsWithScrutinizerTest extends ScrutinizerTest {
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
                 .addStatement(add(statement3))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak propertySnak1 = Datamodel.makeValueSnak(propertyParameterPID, conflictingPropertyValue1);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/DifferenceWithinScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/DifferenceWithinScrutinizerTest.java
@@ -61,6 +61,7 @@ public class DifferenceWithinScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
+                .addContributingRowId(123L)
                 .build();
 
         Snak propertyQualifier = Datamodel.makeValueSnak(propertyParameterPID, lowerBoundPid);
@@ -91,6 +92,7 @@ public class DifferenceWithinScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
+                .addContributingRowId(123L)
                 .build();
 
         Snak propertyQualifier = Datamodel.makeValueSnak(propertyParameterPID, lowerBoundPid);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/DifferenceWithinScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/DifferenceWithinScrutinizerTest.java
@@ -61,7 +61,7 @@ public class DifferenceWithinScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak propertyQualifier = Datamodel.makeValueSnak(propertyParameterPID, lowerBoundPid);
@@ -92,7 +92,7 @@ public class DifferenceWithinScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak propertyQualifier = Datamodel.makeValueSnak(propertyParameterPID, lowerBoundPid);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/DistinctValuesScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/DistinctValuesScrutinizerTest.java
@@ -70,6 +70,7 @@ public class DistinctValuesScrutinizerTest extends StatementScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
+                .addContributingRowId(123L)
                 .build();
 
         List<SnakGroup> constraintQualifiers = new ArrayList<>();
@@ -93,6 +94,7 @@ public class DistinctValuesScrutinizerTest extends StatementScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(delete(statement1))
                 .addStatement(delete(statement2))
+                .addContributingRowId(123L)
                 .build();
 
         List<SnakGroup> constraintQualifiers = new ArrayList<>();
@@ -117,6 +119,7 @@ public class DistinctValuesScrutinizerTest extends StatementScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
+                .addContributingRowId(123L)
                 .build();
 
         List<SnakGroup> constraintQualifiers = new ArrayList<>();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/DistinctValuesScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/DistinctValuesScrutinizerTest.java
@@ -70,7 +70,7 @@ public class DistinctValuesScrutinizerTest extends StatementScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<SnakGroup> constraintQualifiers = new ArrayList<>();
@@ -94,7 +94,7 @@ public class DistinctValuesScrutinizerTest extends StatementScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(delete(statement1))
                 .addStatement(delete(statement2))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<SnakGroup> constraintQualifiers = new ArrayList<>();
@@ -119,7 +119,7 @@ public class DistinctValuesScrutinizerTest extends StatementScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<SnakGroup> constraintQualifiers = new ArrayList<>();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/EnglishDescriptionScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/EnglishDescriptionScrutinizerTest.java
@@ -20,6 +20,7 @@ public class EnglishDescriptionScrutinizerTest extends ScrutinizerTest {
         String description = "good description";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertNoWarningRaised();
@@ -30,6 +31,7 @@ public class EnglishDescriptionScrutinizerTest extends ScrutinizerTest {
         String description = "description with punctuationSign.";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), false)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertWarningsRaised(EnglishDescriptionScrutinizer.descEndsByPunctuationSign);
@@ -40,6 +42,7 @@ public class EnglishDescriptionScrutinizerTest extends ScrutinizerTest {
         String description = "Begin with uppercase";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertWarningsRaised(EnglishDescriptionScrutinizer.descBeginWithUppercase);
@@ -50,6 +53,7 @@ public class EnglishDescriptionScrutinizerTest extends ScrutinizerTest {
         String description = "an article test";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), false)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertWarningsRaised(EnglishDescriptionScrutinizer.descBeginWithArticle);
@@ -61,6 +65,7 @@ public class EnglishDescriptionScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
                 .addLabel(Datamodel.makeMonolingualTextValue(description, "en"), true)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertWarningsRaised(EnglishDescriptionScrutinizer.descEndsByPunctuationSign,

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/EnglishDescriptionScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/EnglishDescriptionScrutinizerTest.java
@@ -20,7 +20,7 @@ public class EnglishDescriptionScrutinizerTest extends ScrutinizerTest {
         String description = "good description";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertNoWarningRaised();
@@ -31,7 +31,7 @@ public class EnglishDescriptionScrutinizerTest extends ScrutinizerTest {
         String description = "description with punctuationSign.";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), false)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertWarningsRaised(EnglishDescriptionScrutinizer.descEndsByPunctuationSign);
@@ -42,7 +42,7 @@ public class EnglishDescriptionScrutinizerTest extends ScrutinizerTest {
         String description = "Begin with uppercase";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertWarningsRaised(EnglishDescriptionScrutinizer.descBeginWithUppercase);
@@ -53,7 +53,7 @@ public class EnglishDescriptionScrutinizerTest extends ScrutinizerTest {
         String description = "an article test";
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), false)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertWarningsRaised(EnglishDescriptionScrutinizer.descBeginWithArticle);
@@ -65,7 +65,7 @@ public class EnglishDescriptionScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(TestingData.newIdA)
                 .addDescription(Datamodel.makeMonolingualTextValue(description, "en"), true)
                 .addLabel(Datamodel.makeMonolingualTextValue(description, "en"), true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertWarningsRaised(EnglishDescriptionScrutinizer.descEndsByPunctuationSign,

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/EntityTypeScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/EntityTypeScrutinizerTest.java
@@ -51,7 +51,7 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
 
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, allowedValue);
@@ -77,7 +77,7 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
 
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, itemValue);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/EntityTypeScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/EntityTypeScrutinizerTest.java
@@ -51,6 +51,7 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
 
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, allowedValue);
@@ -76,6 +77,7 @@ public class EntityTypeScrutinizerTest extends StatementScrutinizerTest {
 
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, itemValue);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
@@ -40,10 +40,12 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testSameFileNameTwice() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit1 = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Some_filename.png")
+                .addContributingRowId(123L)
                 .build();
 
         MediaInfoEdit edit2 = new MediaInfoEditBuilder(TestingData.newMidB)
                 .addFileName("some filename.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit1, edit2);
@@ -62,6 +64,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
                         "very_very_very_very_very_very_very_very_very_very_" +
                         "very_very_very_very_very_very_very_very_very_very_" +
                         "long_filename.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -72,6 +75,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testValidCharactersInFilenameOdiaScript() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("ଫାଇଲ.wav")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -82,6 +86,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testValidCharactersInFilenameNonAscii() {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("সমাচার দর্পণ - ৮ অক্টোবর ১৮৩৬.pdf")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -92,6 +97,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameTab() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Tabs (\t) are not allowed.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -102,6 +108,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameNewLine() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("New lines (\n) are not allowed.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -112,6 +119,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameCarriageReturn() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Carriage returns (\r) are not allowed.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -122,6 +130,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameFormFeed() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Form feeds (\f) are not allowed.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -132,6 +141,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameBackspace() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Backspaces (\b) are not allowed.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -142,6 +152,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameVerticalBar() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("vertical bars (|) are not allowed.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -152,6 +163,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameHTMLEscaped() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("HTML escaped entities such as &nbsp; are not allowed.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -162,6 +174,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testNoExtension() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Look, no extension")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -173,6 +186,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Some_image.png")
                 .addFilePath("tmp/Some_sound.ogg")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -188,6 +202,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
 
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Does exist.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);
@@ -202,6 +217,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
 
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Does exist.png")
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(edit);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
@@ -40,12 +40,12 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testSameFileNameTwice() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit1 = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Some_filename.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         MediaInfoEdit edit2 = new MediaInfoEditBuilder(TestingData.newMidB)
                 .addFileName("some filename.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit1, edit2);
@@ -64,7 +64,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
                         "very_very_very_very_very_very_very_very_very_very_" +
                         "very_very_very_very_very_very_very_very_very_very_" +
                         "long_filename.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -75,7 +75,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testValidCharactersInFilenameOdiaScript() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("ଫାଇଲ.wav")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -86,7 +86,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testValidCharactersInFilenameNonAscii() {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("সমাচার দর্পণ - ৮ অক্টোবর ১৮৩৬.pdf")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -97,7 +97,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameTab() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Tabs (\t) are not allowed.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -108,7 +108,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameNewLine() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("New lines (\n) are not allowed.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -119,7 +119,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameCarriageReturn() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Carriage returns (\r) are not allowed.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -130,7 +130,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameFormFeed() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Form feeds (\f) are not allowed.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -141,7 +141,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameBackspace() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Backspaces (\b) are not allowed.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -152,7 +152,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameVerticalBar() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("vertical bars (|) are not allowed.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -163,7 +163,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testInvalidCharactersInFilenameHTMLEscaped() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("HTML escaped entities such as &nbsp; are not allowed.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -174,7 +174,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
     public void testNoExtension() throws IOException, MediaWikiApiErrorException {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Look, no extension")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -186,7 +186,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Some_image.png")
                 .addFilePath("tmp/Some_sound.ogg")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -202,7 +202,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
 
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Does exist.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);
@@ -217,7 +217,7 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
 
         MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.newMidA)
                 .addFileName("Does exist.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(edit);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FormatScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FormatScrutinizerTest.java
@@ -74,7 +74,7 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P18", value, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = generateFormatConstraint(regularExpression);
@@ -93,7 +93,7 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P18", value, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = generateFormatConstraint(regularExpression);
@@ -112,7 +112,7 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P18", value, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = generateFormatConstraint(regularExpression);
@@ -131,7 +131,7 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P18", value, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = generateFormatConstraint(invalidRegularExpression);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FormatScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FormatScrutinizerTest.java
@@ -74,6 +74,7 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P18", value, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = generateFormatConstraint(regularExpression);
@@ -92,6 +93,7 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P18", value, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = generateFormatConstraint(regularExpression);
@@ -110,6 +112,7 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P18", value, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = generateFormatConstraint(regularExpression);
@@ -128,6 +131,7 @@ public class FormatScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P18", value, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = generateFormatConstraint(invalidRegularExpression);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/InverseConstraintScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/InverseConstraintScrutinizerTest.java
@@ -72,7 +72,7 @@ public class InverseConstraintScrutinizerTest extends StatementScrutinizerTest {
         Statement statement = new StatementImpl("P25", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(propertyParameter, inversePropertyID);
@@ -95,7 +95,7 @@ public class InverseConstraintScrutinizerTest extends StatementScrutinizerTest {
         Statement statement = new StatementImpl("P3373", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(symmetricPropertyID, symmetricEntityIdValue);
@@ -118,7 +118,7 @@ public class InverseConstraintScrutinizerTest extends StatementScrutinizerTest {
         Statement statement = new StatementImpl("P25", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(propertyParameter, inverseEntityIdValue);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/InverseConstraintScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/InverseConstraintScrutinizerTest.java
@@ -72,6 +72,7 @@ public class InverseConstraintScrutinizerTest extends StatementScrutinizerTest {
         Statement statement = new StatementImpl("P25", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(propertyParameter, inversePropertyID);
@@ -94,6 +95,7 @@ public class InverseConstraintScrutinizerTest extends StatementScrutinizerTest {
         Statement statement = new StatementImpl("P3373", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(symmetricPropertyID, symmetricEntityIdValue);
@@ -116,6 +118,7 @@ public class InverseConstraintScrutinizerTest extends StatementScrutinizerTest {
         Statement statement = new StatementImpl("P25", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(propertyParameter, inverseEntityIdValue);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ItemRequiresScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ItemRequiresScrutinizerTest.java
@@ -48,7 +48,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P157", mainSnak, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -74,7 +74,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
                 .addStatement(add(requiredStatement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -100,7 +100,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
                 .addStatement(add(requiredStatement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -123,7 +123,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P157", mainSnak, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -149,7 +149,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(id)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ItemRequiresScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ItemRequiresScrutinizerTest.java
@@ -48,6 +48,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P157", mainSnak, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -73,6 +74,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
                 .addStatement(add(requiredStatement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -98,6 +100,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
                 .addStatement(add(requiredStatement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -120,6 +123,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P157", mainSnak, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -145,6 +149,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(id)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/MultiValueScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/MultiValueScrutinizerTest.java
@@ -48,7 +48,7 @@ public class MultiValueScrutinizerTest extends ScrutinizerTest {
                 .addStatement(add(TestingData.generateStatement(idA, idB)))
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, new ArrayList<>());
@@ -69,11 +69,11 @@ public class MultiValueScrutinizerTest extends ScrutinizerTest {
         ItemEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(TestingData.generateStatement(idA, idB)))
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit updateB = new ItemEditBuilder(idB)
                 .addStatement(add(TestingData.generateStatement(idB, idB)))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, new ArrayList<>());
@@ -94,11 +94,11 @@ public class MultiValueScrutinizerTest extends ScrutinizerTest {
         ItemEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(TestingData.generateStatement(idA, idB)))
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit updateB = new ItemEditBuilder(idB)
                 .addStatement(add(TestingData.generateStatement(idB, idB)))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, new ArrayList<>());

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/MultiValueScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/MultiValueScrutinizerTest.java
@@ -48,6 +48,7 @@ public class MultiValueScrutinizerTest extends ScrutinizerTest {
                 .addStatement(add(TestingData.generateStatement(idA, idB)))
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, new ArrayList<>());
@@ -68,9 +69,11 @@ public class MultiValueScrutinizerTest extends ScrutinizerTest {
         ItemEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(TestingData.generateStatement(idA, idB)))
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
         ItemEdit updateB = new ItemEditBuilder(idB)
                 .addStatement(add(TestingData.generateStatement(idB, idB)))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, new ArrayList<>());
@@ -90,9 +93,12 @@ public class MultiValueScrutinizerTest extends ScrutinizerTest {
         Statement statement = new StatementImpl("P1963", mainSnakValue, idA);
         ItemEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(TestingData.generateStatement(idA, idB)))
-                .addStatement(add(statement)).build();
+                .addStatement(add(statement))
+                .addContributingRowId(123L)
+                .build();
         ItemEdit updateB = new ItemEditBuilder(idB)
                 .addStatement(add(TestingData.generateStatement(idB, idB)))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, new ArrayList<>());

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/NewEntityScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/NewEntityScrutinizerTest.java
@@ -56,7 +56,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
 
     @Test
     public void testTrigger() {
-        ItemEdit update = new ItemEditBuilder(TestingData.newIdA).build();
+        ItemEdit update = new ItemEditBuilder(TestingData.newIdA).addContributingRowId(123L).build();
         scrutinize(update);
         assertWarningsRaised(NewEntityScrutinizer.noDescType, NewEntityScrutinizer.noLabelType,
                 NewEntityScrutinizer.noTypeType, NewEntityScrutinizer.newItemType);
@@ -64,7 +64,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
 
     @Test
     public void testEmptyItem() {
-        ItemEdit update = new ItemEditBuilder(TestingData.existingId).build();
+        ItemEdit update = new ItemEditBuilder(TestingData.existingId).addContributingRowId(123L).build();
         scrutinize(update);
         assertNoWarningRaised();
     }
@@ -76,6 +76,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("bonjour", "fr"), false)
                 .addDescription(Datamodel.makeMonolingualTextValue("interesting item", "en"), true)
                 .addStatement(add(p31Statement))
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertWarningsRaised(NewEntityScrutinizer.newItemType);
@@ -88,6 +89,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addDescription(Datamodel.makeMonolingualTextValue("interesting item", "en"), true)
                 .addStatement(add(p31Statement))
                 .addStatement(delete(TestingData.generateStatement(TestingData.newIdA, TestingData.matchedId)))
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertWarningsRaised(NewEntityScrutinizer.newItemType, NewEntityScrutinizer.deletedStatementsType);
@@ -99,11 +101,13 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("bonjour", "fr"), false)
                 .addDescription(Datamodel.makeMonolingualTextValue("description commune", "fr"), true)
                 .addStatement(add(p31Statement))
+                .addContributingRowId(123L)
                 .build();
         ItemEdit updateB = new ItemEditBuilder(TestingData.newIdB)
                 .addLabel(Datamodel.makeMonolingualTextValue("bonjour", "fr"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("description commune", "fr"), false)
                 .addStatement(add(p31StatementB))
+                .addContributingRowId(123L)
                 .build();
 
         scrutinize(updateA, updateB);
@@ -114,6 +118,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
     @Test
     public void testNewMedia() {
         MediaInfoEdit update = new MediaInfoEditBuilder(TestingData.newMidA)
+                .addContributingRowId(123L)
                 .build();
         scrutinize(update);
         assertWarningsRaised(NewEntityScrutinizer.newMediaType,
@@ -128,6 +133,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addFilePath("/this/path/does/not/exist.jpg")
                 .addFileName("my_file.jpg")
                 .addWikitext("description")
+                .addContributingRowId(123L)
                 .build();
         scrutinizer.setEnableSlowChecks(true);
         scrutinize(update);
@@ -140,6 +146,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addFilePath("https://foo.com/bar.jpg?type=blue")
                 .addFileName("my_file.jpg")
                 .addWikitext("description")
+                .addContributingRowId(123L)
                 .build();
         scrutinizer.setEnableSlowChecks(true);
         scrutinize(update);
@@ -152,6 +159,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addFilePath("/this/path/does/not/exist.jpg")
                 .addFileName("my_file.jpg")
                 .addWikitext("description")
+                .addContributingRowId(123L)
                 .build();
         scrutinizer.setEnableSlowChecks(false);
         scrutinize(update);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/NewEntityScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/NewEntityScrutinizerTest.java
@@ -56,7 +56,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
 
     @Test
     public void testTrigger() {
-        ItemEdit update = new ItemEditBuilder(TestingData.newIdA).addContributingRowId(123L).build();
+        ItemEdit update = new ItemEditBuilder(TestingData.newIdA).addContributingRowId(123).build();
         scrutinize(update);
         assertWarningsRaised(NewEntityScrutinizer.noDescType, NewEntityScrutinizer.noLabelType,
                 NewEntityScrutinizer.noTypeType, NewEntityScrutinizer.newItemType);
@@ -64,7 +64,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
 
     @Test
     public void testEmptyItem() {
-        ItemEdit update = new ItemEditBuilder(TestingData.existingId).addContributingRowId(123L).build();
+        ItemEdit update = new ItemEditBuilder(TestingData.existingId).addContributingRowId(123).build();
         scrutinize(update);
         assertNoWarningRaised();
     }
@@ -76,7 +76,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("bonjour", "fr"), false)
                 .addDescription(Datamodel.makeMonolingualTextValue("interesting item", "en"), true)
                 .addStatement(add(p31Statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertWarningsRaised(NewEntityScrutinizer.newItemType);
@@ -89,7 +89,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addDescription(Datamodel.makeMonolingualTextValue("interesting item", "en"), true)
                 .addStatement(add(p31Statement))
                 .addStatement(delete(TestingData.generateStatement(TestingData.newIdA, TestingData.matchedId)))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertWarningsRaised(NewEntityScrutinizer.newItemType, NewEntityScrutinizer.deletedStatementsType);
@@ -101,13 +101,13 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addLabel(Datamodel.makeMonolingualTextValue("bonjour", "fr"), false)
                 .addDescription(Datamodel.makeMonolingualTextValue("description commune", "fr"), true)
                 .addStatement(add(p31Statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit updateB = new ItemEditBuilder(TestingData.newIdB)
                 .addLabel(Datamodel.makeMonolingualTextValue("bonjour", "fr"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("description commune", "fr"), false)
                 .addStatement(add(p31StatementB))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         scrutinize(updateA, updateB);
@@ -118,7 +118,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
     @Test
     public void testNewMedia() {
         MediaInfoEdit update = new MediaInfoEditBuilder(TestingData.newMidA)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinize(update);
         assertWarningsRaised(NewEntityScrutinizer.newMediaType,
@@ -133,7 +133,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addFilePath("/this/path/does/not/exist.jpg")
                 .addFileName("my_file.jpg")
                 .addWikitext("description")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinizer.setEnableSlowChecks(true);
         scrutinize(update);
@@ -146,7 +146,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addFilePath("https://foo.com/bar.jpg?type=blue")
                 .addFileName("my_file.jpg")
                 .addWikitext("description")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinizer.setEnableSlowChecks(true);
         scrutinize(update);
@@ -159,7 +159,7 @@ public class NewEntityScrutinizerTest extends ScrutinizerTest {
                 .addFilePath("/this/path/does/not/exist.jpg")
                 .addFileName("my_file.jpg")
                 .addWikitext("description")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         scrutinizer.setEnableSlowChecks(false);
         scrutinize(update);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/NoEditsMadeScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/NoEditsMadeScrutinizerTest.java
@@ -44,13 +44,13 @@ public class NoEditsMadeScrutinizerTest extends ScrutinizerTest {
 
     @Test
     public void testNonNull() {
-        scrutinize(new ItemEditBuilder(TestingData.newIdA).addContributingRowId(123L).build());
+        scrutinize(new ItemEditBuilder(TestingData.newIdA).addContributingRowId(123).build());
         assertNoWarningRaised();
     }
 
     @Test
     public void testNull() {
-        scrutinize(new ItemEditBuilder(TestingData.existingId).addContributingRowId(123L).build());
+        scrutinize(new ItemEditBuilder(TestingData.existingId).addContributingRowId(123).build());
         assertWarningsRaised(NoEditsMadeScrutinizer.type);
     }
 }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/NoEditsMadeScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/NoEditsMadeScrutinizerTest.java
@@ -44,13 +44,13 @@ public class NoEditsMadeScrutinizerTest extends ScrutinizerTest {
 
     @Test
     public void testNonNull() {
-        scrutinize(new ItemEditBuilder(TestingData.newIdA).build());
+        scrutinize(new ItemEditBuilder(TestingData.newIdA).addContributingRowId(123L).build());
         assertNoWarningRaised();
     }
 
     @Test
     public void testNull() {
-        scrutinize(new ItemEditBuilder(TestingData.existingId).build());
+        scrutinize(new ItemEditBuilder(TestingData.existingId).addContributingRowId(123L).build());
         assertWarningsRaised(NoEditsMadeScrutinizer.type);
     }
 }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
@@ -76,6 +76,7 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
         Statement statement = makeStatement(mainSnak, qualifierSnak);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak constraintQualifierSnak = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -99,6 +100,7 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
         Statement statement = makeStatement(mainSnak);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak constraintQualifierSnak = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -123,6 +125,7 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
         Statement statement = makeStatement(mainSnak, qualifierSnak);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak constraintQualifierSnak = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QualifierCompatibilityScrutinizerTest.java
@@ -76,7 +76,7 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
         Statement statement = makeStatement(mainSnak, qualifierSnak);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak constraintQualifierSnak = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -100,7 +100,7 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
         Statement statement = makeStatement(mainSnak);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak constraintQualifierSnak = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);
@@ -125,7 +125,7 @@ public class QualifierCompatibilityScrutinizerTest extends StatementScrutinizerT
         Statement statement = makeStatement(mainSnak, qualifierSnak);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak constraintQualifierSnak = Datamodel.makeValueSnak(propertyParameterPID, propertyParameterValue);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QuantityScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QuantityScrutinizerTest.java
@@ -71,7 +71,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
@@ -89,7 +89,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(noBoundsEntity, new ArrayList<>());
@@ -108,7 +108,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
@@ -126,7 +126,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(integerValueEntity, new ArrayList<>());
@@ -145,7 +145,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(integerValueEntity, new ArrayList<>());
@@ -164,7 +164,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(integerValueEntity, new ArrayList<>());
@@ -183,7 +183,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, allowedUnit);
@@ -206,7 +206,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, allowedUnit);
@@ -229,7 +229,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, allowedUnit);
@@ -252,7 +252,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(allowedUnitEntity, new ArrayList<>());
@@ -271,7 +271,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
@@ -289,7 +289,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeNoValueSnak(itemParameterPID);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QuantityScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/QuantityScrutinizerTest.java
@@ -71,6 +71,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
@@ -88,6 +89,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(noBoundsEntity, new ArrayList<>());
@@ -106,6 +108,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
@@ -123,6 +126,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(integerValueEntity, new ArrayList<>());
@@ -141,6 +145,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(integerValueEntity, new ArrayList<>());
@@ -159,6 +164,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(integerValueEntity, new ArrayList<>());
@@ -177,6 +183,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, allowedUnit);
@@ -199,6 +206,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, allowedUnit);
@@ -221,6 +229,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(itemParameterPID, allowedUnit);
@@ -243,6 +252,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(allowedUnitEntity, new ArrayList<>());
@@ -261,6 +271,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
@@ -278,6 +289,7 @@ public class QuantityScrutinizerTest extends ValueScrutinizerTest {
         Statement statement = new StatementImpl("P1083", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeNoValueSnak(itemParameterPID);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/RestrictedPositionScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/RestrictedPositionScrutinizerTest.java
@@ -71,6 +71,7 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
         Statement statement = new StatementImpl("P22", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(propertyScopeParameter, asQualifier);
@@ -91,6 +92,7 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
         Statement statement = new StatementImpl("P22", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(propertyScopeParameter, asMainSnak);
@@ -111,6 +113,7 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
         Statement statement = new StatementImpl("P22", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
@@ -132,6 +135,7 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
                 Collections.singletonList(Datamodel.makeReference(snakGroups)), StatementRank.NORMAL, "");
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
+                .addContributingRowId(123L)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(propertyScopeParameter, asMainSnak);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/RestrictedPositionScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/RestrictedPositionScrutinizerTest.java
@@ -71,7 +71,7 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
         Statement statement = new StatementImpl("P22", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(propertyScopeParameter, asQualifier);
@@ -92,7 +92,7 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
         Statement statement = new StatementImpl("P22", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(propertyScopeParameter, asMainSnak);
@@ -113,7 +113,7 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
         Statement statement = new StatementImpl("P22", mainSnak, idA);
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
@@ -135,7 +135,7 @@ public class RestrictedPositionScrutinizerTest extends SnakScrutinizerTest {
                 Collections.singletonList(Datamodel.makeReference(snakGroups)), StatementRank.NORMAL, "");
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         Snak qualifierSnak = Datamodel.makeValueSnak(propertyScopeParameter, asMainSnak);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/SingleValueScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/SingleValueScrutinizerTest.java
@@ -69,7 +69,7 @@ public class SingleValueScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, new ArrayList<>());
@@ -88,7 +88,7 @@ public class SingleValueScrutinizerTest extends ScrutinizerTest {
         Statement statement1 = new StatementImpl("P21", snak1, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, new ArrayList<>());

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/SingleValueScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/SingleValueScrutinizerTest.java
@@ -69,6 +69,7 @@ public class SingleValueScrutinizerTest extends ScrutinizerTest {
         TermedStatementEntityEdit update = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
                 .addStatement(add(statement2))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, new ArrayList<>());
@@ -87,6 +88,7 @@ public class SingleValueScrutinizerTest extends ScrutinizerTest {
         Statement statement1 = new StatementImpl("P21", snak1, idA);
         TermedStatementEntityEdit updateA = new ItemEditBuilder(idA)
                 .addStatement(add(statement1))
+                .addContributingRowId(123L)
                 .build();
 
         List<Statement> statementList = constraintParameterStatementList(entityIdValue, new ArrayList<>());

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/StatementScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/StatementScrutinizerTest.java
@@ -34,7 +34,7 @@ public abstract class StatementScrutinizerTest extends ScrutinizerTest {
 
     public void scrutinize(Statement statement) {
         TermedStatementEntityEdit update = new ItemEditBuilder((ItemIdValue) statement.getClaim().getSubject())
-                .addStatement(add(statement)).addContributingRowId(123L).build();
+                .addStatement(add(statement)).addContributingRowId(123).build();
         scrutinize(update);
     }
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/StatementScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/StatementScrutinizerTest.java
@@ -34,7 +34,7 @@ public abstract class StatementScrutinizerTest extends ScrutinizerTest {
 
     public void scrutinize(Statement statement) {
         TermedStatementEntityEdit update = new ItemEditBuilder((ItemIdValue) statement.getClaim().getSubject())
-                .addStatement(add(statement)).build();
+                .addStatement(add(statement)).addContributingRowId(123L).build();
         scrutinize(update);
     }
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/UnsourcedScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/UnsourcedScrutinizerTest.java
@@ -74,8 +74,8 @@ public class UnsourcedScrutinizerTest extends StatementScrutinizerTest {
         ItemIdValue id = TestingData.existingId;
         Snak mainSnak = Datamodel.makeSomeValueSnak(propertyIdValue);
         Statement statement = new StatementImpl("P172", mainSnak, id);
-        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123L)
-                .addContributingRowId(123L).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123)
+                .addContributingRowId(123).build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, Collections.emptyList());
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
@@ -93,7 +93,7 @@ public class UnsourcedScrutinizerTest extends StatementScrutinizerTest {
         List<SnakGroup> constraintQualifiers = makeSnakGroupList(referenceSnak);
         List<Statement> itemStatementList = constraintParameterStatementList(entityIdValue, constraintQualifiers);
         Statement statement = itemStatementList.get(0);
-        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123L).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123).build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, Collections.emptyList());
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/UnsourcedScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/UnsourcedScrutinizerTest.java
@@ -74,7 +74,8 @@ public class UnsourcedScrutinizerTest extends StatementScrutinizerTest {
         ItemIdValue id = TestingData.existingId;
         Snak mainSnak = Datamodel.makeSomeValueSnak(propertyIdValue);
         Statement statement = new StatementImpl("P172", mainSnak, id);
-        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123L)
+                .addContributingRowId(123L).build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, Collections.emptyList());
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);
@@ -92,7 +93,7 @@ public class UnsourcedScrutinizerTest extends StatementScrutinizerTest {
         List<SnakGroup> constraintQualifiers = makeSnakGroupList(referenceSnak);
         List<Statement> itemStatementList = constraintParameterStatementList(entityIdValue, constraintQualifiers);
         Statement statement = itemStatementList.get(0);
-        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123L).build();
 
         List<Statement> constraintDefinitions = constraintParameterStatementList(entityIdValue, Collections.emptyList());
         ConstraintFetcher fetcher = mock(ConstraintFetcher.class);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/UseAsQualifierScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/UseAsQualifierScrutinizerTest.java
@@ -48,7 +48,7 @@ public class UseAsQualifierScrutinizerTest extends ScrutinizerTest {
         List<SnakGroup> qualifierList = makeSnakGroupList(statementQualifier);
         List<Statement> statementList = constraintParameterStatementList(useAsQualifierEntityId, qualifierList);
         Statement statement = statementList.get(0);
-        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123L).build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(qualifierPID, qualifierPropertyValue);
         Snak qualifierSnak2 = Datamodel.makeValueSnak(itemParameterPID, qualifierAllowedValue);
@@ -69,7 +69,7 @@ public class UseAsQualifierScrutinizerTest extends ScrutinizerTest {
         List<SnakGroup> qualifierList = makeSnakGroupList(statementQualifier);
         List<Statement> statementList = constraintParameterStatementList(useAsQualifierEntityId, qualifierList);
         Statement statement = statementList.get(0);
-        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123L).build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(qualifierPID, qualifierPropertyValue);
         Snak qualifierSnak2 = Datamodel.makeValueSnak(itemParameterPID, qualifierAllowedValue);
@@ -88,7 +88,7 @@ public class UseAsQualifierScrutinizerTest extends ScrutinizerTest {
         ItemIdValue id = TestingData.existingId;
         List<Statement> statementList = constraintParameterStatementList(useAsQualifierEntityId, new ArrayList<>());
         Statement statement = statementList.get(0);
-        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123L).build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(qualifierPID, qualifierPropertyValue);
         Snak qualifierSnak2 = Datamodel.makeValueSnak(itemParameterPID, qualifierAllowedValue);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/UseAsQualifierScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/UseAsQualifierScrutinizerTest.java
@@ -48,7 +48,7 @@ public class UseAsQualifierScrutinizerTest extends ScrutinizerTest {
         List<SnakGroup> qualifierList = makeSnakGroupList(statementQualifier);
         List<Statement> statementList = constraintParameterStatementList(useAsQualifierEntityId, qualifierList);
         Statement statement = statementList.get(0);
-        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123L).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123).build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(qualifierPID, qualifierPropertyValue);
         Snak qualifierSnak2 = Datamodel.makeValueSnak(itemParameterPID, qualifierAllowedValue);
@@ -69,7 +69,7 @@ public class UseAsQualifierScrutinizerTest extends ScrutinizerTest {
         List<SnakGroup> qualifierList = makeSnakGroupList(statementQualifier);
         List<Statement> statementList = constraintParameterStatementList(useAsQualifierEntityId, qualifierList);
         Statement statement = statementList.get(0);
-        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123L).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123).build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(qualifierPID, qualifierPropertyValue);
         Snak qualifierSnak2 = Datamodel.makeValueSnak(itemParameterPID, qualifierAllowedValue);
@@ -88,7 +88,7 @@ public class UseAsQualifierScrutinizerTest extends ScrutinizerTest {
         ItemIdValue id = TestingData.existingId;
         List<Statement> statementList = constraintParameterStatementList(useAsQualifierEntityId, new ArrayList<>());
         Statement statement = statementList.get(0);
-        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123L).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(id).addStatement(add(statement)).addContributingRowId(123).build();
 
         Snak qualifierSnak1 = Datamodel.makeValueSnak(qualifierPID, qualifierPropertyValue);
         Snak qualifierSnak2 = Datamodel.makeValueSnak(itemParameterPID, qualifierAllowedValue);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ValueScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ValueScrutinizerTest.java
@@ -45,6 +45,6 @@ public abstract class ValueScrutinizerTest extends SnakScrutinizerTest {
     }
 
     public void scrutinizeLabel(MonolingualTextValue text) {
-        scrutinize(new ItemEditBuilder(TestingData.existingId).addLabel(text, true).addContributingRowId(123L).build());
+        scrutinize(new ItemEditBuilder(TestingData.existingId).addLabel(text, true).addContributingRowId(123).build());
     }
 }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ValueScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ValueScrutinizerTest.java
@@ -45,6 +45,6 @@ public abstract class ValueScrutinizerTest extends SnakScrutinizerTest {
     }
 
     public void scrutinizeLabel(MonolingualTextValue text) {
-        scrutinize(new ItemEditBuilder(TestingData.existingId).addLabel(text, true).build());
+        scrutinize(new ItemEditBuilder(TestingData.existingId).addLabel(text, true).addContributingRowId(123L).build());
     }
 }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbExpressionTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbExpressionTest.java
@@ -226,7 +226,8 @@ public class WbExpressionTest<T> extends WikidataRefineTest {
                 row.cells.add(cell);
             }
         }
-        ctxt = new ExpressionContext("http://www.wikidata.org/entity/", Collections.emptyMap(), server.url("/w/api.php").toString(), 0, row,
+        ctxt = new ExpressionContext("http://www.wikidata.org/entity/", Collections.emptyMap(), server.url("/w/api.php").toString(), 123,
+                row,
                 project.columnModel, warningStore);
     }
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbItemEditExprTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbItemEditExprTest.java
@@ -83,7 +83,10 @@ public class WbItemEditExprTest extends WbExpressionTest<ItemEdit> {
     @Test
     public void testEvaluate() {
         setRow(recon("Q3434"), "2010-07-23", "3.898,4.389", "my alias", recon("Q23"));
-        ItemEdit result = new ItemEditBuilder(subject).addAlias(alias).addStatement(fullStatement)
+        ItemEdit result = new ItemEditBuilder(subject)
+                .addAlias(alias)
+                .addStatement(fullStatement)
+                .addContributingRowId(123L)
                 .build();
         evaluatesTo(result, expr);
     }
@@ -105,14 +108,17 @@ public class WbItemEditExprTest extends WbExpressionTest<ItemEdit> {
     @Test
     public void testStatementSkipped() {
         setRow(recon("Q3434"), "2010-07-23", "3.898,invalid4.389", "my alias", recon("Q23"));
-        ItemEdit result = new ItemEditBuilder(subject).addAlias(alias).build();
+        ItemEdit result = new ItemEditBuilder(subject)
+                .addAlias(alias)
+                .addContributingRowId(123L)
+                .build();
         evaluatesTo(result, expr);
     }
 
     @Test
     public void testAliasSkipped() {
         setRow(recon("Q3434"), "2010-07-23", "3.898,4.389", "", recon("Q23"));
-        ItemEdit result = new ItemEditBuilder(subject).addStatement(fullStatement).build();
+        ItemEdit result = new ItemEditBuilder(subject).addStatement(fullStatement).addContributingRowId(123L).build();
         evaluatesTo(result, expr);
     }
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbItemEditExprTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbItemEditExprTest.java
@@ -86,7 +86,7 @@ public class WbItemEditExprTest extends WbExpressionTest<ItemEdit> {
         ItemEdit result = new ItemEditBuilder(subject)
                 .addAlias(alias)
                 .addStatement(fullStatement)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         evaluatesTo(result, expr);
     }
@@ -110,7 +110,7 @@ public class WbItemEditExprTest extends WbExpressionTest<ItemEdit> {
         setRow(recon("Q3434"), "2010-07-23", "3.898,invalid4.389", "my alias", recon("Q23"));
         ItemEdit result = new ItemEditBuilder(subject)
                 .addAlias(alias)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         evaluatesTo(result, expr);
     }
@@ -118,7 +118,7 @@ public class WbItemEditExprTest extends WbExpressionTest<ItemEdit> {
     @Test
     public void testAliasSkipped() {
         setRow(recon("Q3434"), "2010-07-23", "3.898,4.389", "", recon("Q23"));
-        ItemEdit result = new ItemEditBuilder(subject).addStatement(fullStatement).addContributingRowId(123L).build();
+        ItemEdit result = new ItemEditBuilder(subject).addStatement(fullStatement).addContributingRowId(123).build();
         evaluatesTo(result, expr);
     }
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbMediaInfoEditExprTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbMediaInfoEditExprTest.java
@@ -76,7 +76,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
     public void testEvaluate() {
         setRow("", "", "3.898,4.389", "my label", matchedCell);
         MediaInfoEdit result = new MediaInfoEditBuilder(subject).addLabel(label, true).addStatement(fullStatement)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         evaluatesTo(result, expr);
     }
@@ -115,14 +115,14 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
     @Test
     public void testStatementSkipped() {
         setRow("", "", "3.898,invalid4.389", "my label", matchedCell);
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addLabel(label, true).addContributingRowId(123L).build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addLabel(label, true).addContributingRowId(123).build();
         evaluatesTo(result, expr);
     }
 
     @Test
     public void testLabelSkipped() {
         setRow("", "", "3.898,4.389", "", matchedCell);
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addStatement(fullStatement).addContributingRowId(123L).build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addStatement(fullStatement).addContributingRowId(123).build();
         evaluatesTo(result, expr);
     }
 
@@ -148,7 +148,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         setRow("", "", "3.898,4.389", "my label", matchedCell);
 
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").addContributingRowId(123L).build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").addContributingRowId(123).build();
         evaluatesTo(result, filePathExpr);
     }
 
@@ -160,7 +160,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         setRow("", "", "3.898,4.389", "my label", matchedCell);
 
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").addContributingRowId(123L).build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").addContributingRowId(123).build();
         evaluatesTo(result, filePathExpr);
     }
 
@@ -172,7 +172,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         setRow("", "", "3.898,4.389", "my label", matchedCell);
 
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").addContributingRowId(123L).build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").addContributingRowId(123).build();
         evaluatesTo(result, filePathExpr);
     }
 
@@ -198,7 +198,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         setRow("", "", "3.898,4.389", "my label", matchedCell);
 
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFileName("Foo.png").addContributingRowId(123L).build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFileName("Foo.png").addContributingRowId(123).build();
         evaluatesTo(result, filePathExpr);
     }
 
@@ -212,7 +212,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         MediaInfoEdit result = new MediaInfoEditBuilder(subject)
                 .addFileName("Foo-bar.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         evaluatesTo(result, filePathExpr);
         assertEquals(warningStore.getWarnings().stream().map(QAWarning::getType).collect(Collectors.toList()),
@@ -229,7 +229,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
         MediaInfoEdit result = new MediaInfoEditBuilder(subject)
                 .addWikitext("my new wikitext")
                 .setOverrideWikitext(true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         evaluatesTo(result, wikitextExpr);
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbMediaInfoEditExprTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbMediaInfoEditExprTest.java
@@ -76,6 +76,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
     public void testEvaluate() {
         setRow("", "", "3.898,4.389", "my label", matchedCell);
         MediaInfoEdit result = new MediaInfoEditBuilder(subject).addLabel(label, true).addStatement(fullStatement)
+                .addContributingRowId(123L)
                 .build();
         evaluatesTo(result, expr);
     }
@@ -114,14 +115,14 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
     @Test
     public void testStatementSkipped() {
         setRow("", "", "3.898,invalid4.389", "my label", matchedCell);
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addLabel(label, true).build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addLabel(label, true).addContributingRowId(123L).build();
         evaluatesTo(result, expr);
     }
 
     @Test
     public void testLabelSkipped() {
         setRow("", "", "3.898,4.389", "", matchedCell);
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addStatement(fullStatement).build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addStatement(fullStatement).addContributingRowId(123L).build();
         evaluatesTo(result, expr);
     }
 
@@ -147,7 +148,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         setRow("", "", "3.898,4.389", "my label", matchedCell);
 
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").addContributingRowId(123L).build();
         evaluatesTo(result, filePathExpr);
     }
 
@@ -159,7 +160,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         setRow("", "", "3.898,4.389", "my label", matchedCell);
 
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").addContributingRowId(123L).build();
         evaluatesTo(result, filePathExpr);
     }
 
@@ -171,7 +172,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         setRow("", "", "3.898,4.389", "my label", matchedCell);
 
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFilePath("C:\\Foo.png").addContributingRowId(123L).build();
         evaluatesTo(result, filePathExpr);
     }
 
@@ -197,7 +198,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         setRow("", "", "3.898,4.389", "my label", matchedCell);
 
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFileName("Foo.png").build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFileName("Foo.png").addContributingRowId(123L).build();
         evaluatesTo(result, filePathExpr);
     }
 
@@ -209,7 +210,10 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
 
         setRow("", "", "3.898,4.389", "my label", matchedCell);
 
-        MediaInfoEdit result = new MediaInfoEditBuilder(subject).addFileName("Foo-bar.png").build();
+        MediaInfoEdit result = new MediaInfoEditBuilder(subject)
+                .addFileName("Foo-bar.png")
+                .addContributingRowId(123L)
+                .build();
         evaluatesTo(result, filePathExpr);
         assertEquals(warningStore.getWarnings().stream().map(QAWarning::getType).collect(Collectors.toList()),
                 Collections.singletonList(WbMediaInfoEditExpr.REPLACED_CHARACTERS_IN_FILENAME));
@@ -225,6 +229,7 @@ public class WbMediaInfoEditExprTest extends WbExpressionTest<MediaInfoEdit> {
         MediaInfoEdit result = new MediaInfoEditBuilder(subject)
                 .addWikitext("my new wikitext")
                 .setOverrideWikitext(true)
+                .addContributingRowId(123L)
                 .build();
         evaluatesTo(result, wikitextExpr);
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbNameDescExprTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbNameDescExprTest.java
@@ -61,7 +61,7 @@ public class WbNameDescExprTest extends WbExpressionTest<MonolingualTextValue> {
         ItemEditBuilder update = new ItemEditBuilder(subject);
         labelExpr.contributeTo(update, ctxt);
         assertEquals(Collections.singleton(Datamodel.makeMonolingualTextValue("le croissant magnifique", "fr")),
-                update.addContributingRowId(123L).build().getLabels());
+                update.addContributingRowId(123).build().getLabels());
     }
 
     @Test
@@ -71,7 +71,7 @@ public class WbNameDescExprTest extends WbExpressionTest<MonolingualTextValue> {
         ItemEditBuilder update = new ItemEditBuilder(subject);
         descriptionExpr.contributeTo(update, ctxt);
         assertEquals(Collections.singleton(Datamodel.makeMonolingualTextValue("wunderschön", "de")),
-                update.addContributingRowId(123L).build().getDescriptions());
+                update.addContributingRowId(123).build().getDescriptions());
     }
 
     @Test
@@ -81,15 +81,15 @@ public class WbNameDescExprTest extends WbExpressionTest<MonolingualTextValue> {
         ItemEditBuilder update = new ItemEditBuilder(subject);
         aliasExpr.contributeTo(update, ctxt);
         assertEquals(Collections.singleton(Datamodel.makeMonolingualTextValue("snack", "en")),
-                update.addContributingRowId(123L).build().getAliases());
+                update.addContributingRowId(123).build().getAliases());
     }
 
     @Test
     public void testSkipped() throws QAWarningException {
-        ItemEditBuilder update = new ItemEditBuilder(subject).addContributingRowId(123L);
+        ItemEditBuilder update = new ItemEditBuilder(subject).addContributingRowId(123);
         setRow("");
         expr.contributeTo(update, ctxt);
-        assertEquals(new ItemEditBuilder(subject).addContributingRowId(123L).build(), update.build());
+        assertEquals(new ItemEditBuilder(subject).addContributingRowId(123).build(), update.build());
     }
 
     @Test

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbNameDescExprTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WbNameDescExprTest.java
@@ -61,7 +61,7 @@ public class WbNameDescExprTest extends WbExpressionTest<MonolingualTextValue> {
         ItemEditBuilder update = new ItemEditBuilder(subject);
         labelExpr.contributeTo(update, ctxt);
         assertEquals(Collections.singleton(Datamodel.makeMonolingualTextValue("le croissant magnifique", "fr")),
-                update.build().getLabels());
+                update.addContributingRowId(123L).build().getLabels());
     }
 
     @Test
@@ -71,7 +71,7 @@ public class WbNameDescExprTest extends WbExpressionTest<MonolingualTextValue> {
         ItemEditBuilder update = new ItemEditBuilder(subject);
         descriptionExpr.contributeTo(update, ctxt);
         assertEquals(Collections.singleton(Datamodel.makeMonolingualTextValue("wunderschön", "de")),
-                update.build().getDescriptions());
+                update.addContributingRowId(123L).build().getDescriptions());
     }
 
     @Test
@@ -81,15 +81,15 @@ public class WbNameDescExprTest extends WbExpressionTest<MonolingualTextValue> {
         ItemEditBuilder update = new ItemEditBuilder(subject);
         aliasExpr.contributeTo(update, ctxt);
         assertEquals(Collections.singleton(Datamodel.makeMonolingualTextValue("snack", "en")),
-                update.build().getAliases());
+                update.addContributingRowId(123L).build().getAliases());
     }
 
     @Test
     public void testSkipped() throws QAWarningException {
-        ItemEditBuilder update = new ItemEditBuilder(subject);
+        ItemEditBuilder update = new ItemEditBuilder(subject).addContributingRowId(123L);
         setRow("");
         expr.contributeTo(update, ctxt);
-        assertEquals(new ItemEditBuilder(subject).build(), update.build());
+        assertEquals(new ItemEditBuilder(subject).addContributingRowId(123L).build(), update.build());
     }
 
     @Test

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WikibaseSchemaTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WikibaseSchemaTest.java
@@ -154,9 +154,9 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
         Engine engine = new Engine(project);
         List<EntityEdit> updates = schema.evaluate(project, engine);
         List<EntityEdit> expected = new ArrayList<>();
-        TermedStatementEntityEdit update1 = new ItemEditBuilder(qid1).addStatement(statementUpdate1).build();
+        TermedStatementEntityEdit update1 = new ItemEditBuilder(qid1).addStatement(statementUpdate1).addContributingRowId(123L).build();
         expected.add(update1);
-        TermedStatementEntityEdit update2 = new ItemEditBuilder(qid2).addStatement(statementUpdate2).build();
+        TermedStatementEntityEdit update2 = new ItemEditBuilder(qid2).addStatement(statementUpdate2).addContributingRowId(123L).build();
         expected.add(update2);
         assertEquals(expected, updates);
     }
@@ -226,7 +226,7 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
         engine.initializeFromConfig(engineConfig);
         List<EntityEdit> updates = schema.evaluate(project, engine);
         List<EntityEdit> expected = new ArrayList<>();
-        EntityEdit update1 = new ItemEditBuilder(qid1).addStatement(statementUpdate1).build();
+        EntityEdit update1 = new ItemEditBuilder(qid1).addStatement(statementUpdate1).addContributingRowId(123L).build();
         expected.add(update1);
         assertEquals(expected, updates);
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WikibaseSchemaTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WikibaseSchemaTest.java
@@ -154,9 +154,9 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
         Engine engine = new Engine(project);
         List<EntityEdit> updates = schema.evaluate(project, engine);
         List<EntityEdit> expected = new ArrayList<>();
-        TermedStatementEntityEdit update1 = new ItemEditBuilder(qid1).addStatement(statementUpdate1).addContributingRowId(123L).build();
+        TermedStatementEntityEdit update1 = new ItemEditBuilder(qid1).addStatement(statementUpdate1).addContributingRowId(123).build();
         expected.add(update1);
-        TermedStatementEntityEdit update2 = new ItemEditBuilder(qid2).addStatement(statementUpdate2).addContributingRowId(123L).build();
+        TermedStatementEntityEdit update2 = new ItemEditBuilder(qid2).addStatement(statementUpdate2).addContributingRowId(123).build();
         expected.add(update2);
         assertEquals(expected, updates);
     }
@@ -226,7 +226,7 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
         engine.initializeFromConfig(engineConfig);
         List<EntityEdit> updates = schema.evaluate(project, engine);
         List<EntityEdit> expected = new ArrayList<>();
-        EntityEdit update1 = new ItemEditBuilder(qid1).addStatement(statementUpdate1).addContributingRowId(123L).build();
+        EntityEdit update1 = new ItemEditBuilder(qid1).addStatement(statementUpdate1).addContributingRowId(123).build();
         expected.add(update1);
         assertEquals(expected, updates);
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/EntityEditTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/EntityEditTest.java
@@ -45,14 +45,17 @@ public class EntityEditTest {
 
     @Test
     public void testGroupBySubject() {
-        TermedStatementEntityEdit updateA = new ItemEditBuilder(newSubject).addStatement(statementUpdate1).build();
-        TermedStatementEntityEdit updateB = new ItemEditBuilder(sameNewSubject).addStatement(statementUpdate2).build();
-        TermedStatementEntityEdit updateC = new ItemEditBuilder(existingSubject).addLabel(label, true).build();
-        TermedStatementEntityEdit updateD = new ItemEditBuilder(matchedSubject).build();
+        TermedStatementEntityEdit updateA = new ItemEditBuilder(newSubject).addStatement(statementUpdate1).addContributingRowId(123L)
+                .build();
+        TermedStatementEntityEdit updateB = new ItemEditBuilder(sameNewSubject).addStatement(statementUpdate2).addContributingRowId(123L)
+                .build();
+        TermedStatementEntityEdit updateC = new ItemEditBuilder(existingSubject).addLabel(label, true).addContributingRowId(123L).build();
+        TermedStatementEntityEdit updateD = new ItemEditBuilder(matchedSubject).addContributingRowId(123L).build();
         Map<EntityIdValue, EntityEdit> grouped = EntityEdit
                 .groupBySubject(Arrays.asList(updateA, updateB, updateC, updateD));
         TermedStatementEntityEdit mergedUpdate = new ItemEditBuilder(newSubject).addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
+                .addContributingRowId(123L)
                 .build();
         Map<EntityIdValue, TermedStatementEntityEdit> expected = new HashMap<>();
         expected.put(newSubject, mergedUpdate);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/EntityEditTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/EntityEditTest.java
@@ -45,17 +45,17 @@ public class EntityEditTest {
 
     @Test
     public void testGroupBySubject() {
-        TermedStatementEntityEdit updateA = new ItemEditBuilder(newSubject).addStatement(statementUpdate1).addContributingRowId(123L)
+        TermedStatementEntityEdit updateA = new ItemEditBuilder(newSubject).addStatement(statementUpdate1).addContributingRowId(123)
                 .build();
-        TermedStatementEntityEdit updateB = new ItemEditBuilder(sameNewSubject).addStatement(statementUpdate2).addContributingRowId(123L)
+        TermedStatementEntityEdit updateB = new ItemEditBuilder(sameNewSubject).addStatement(statementUpdate2).addContributingRowId(123)
                 .build();
-        TermedStatementEntityEdit updateC = new ItemEditBuilder(existingSubject).addLabel(label, true).addContributingRowId(123L).build();
-        TermedStatementEntityEdit updateD = new ItemEditBuilder(matchedSubject).addContributingRowId(123L).build();
+        TermedStatementEntityEdit updateC = new ItemEditBuilder(existingSubject).addLabel(label, true).addContributingRowId(123).build();
+        TermedStatementEntityEdit updateD = new ItemEditBuilder(matchedSubject).addContributingRowId(123).build();
         Map<EntityIdValue, EntityEdit> grouped = EntityEdit
                 .groupBySubject(Arrays.asList(updateA, updateB, updateC, updateD));
         TermedStatementEntityEdit mergedUpdate = new ItemEditBuilder(newSubject).addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         Map<EntityIdValue, TermedStatementEntityEdit> expected = new HashMap<>();
         expected.put(newSubject, mergedUpdate);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/ItemEditTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/ItemEditTest.java
@@ -97,25 +97,25 @@ public class ItemEditTest {
 
     @Test
     public void testIsNull() {
-        ItemEdit update = new ItemEditBuilder(existingSubject).build();
+        ItemEdit update = new ItemEditBuilder(existingSubject).addContributingRowId(123L).build();
         assertTrue(update.isNull());
-        ItemEdit update2 = new ItemEditBuilder(newSubject).build();
+        ItemEdit update2 = new ItemEditBuilder(newSubject).addContributingRowId(123L).build();
         assertFalse(update2.isNull());
     }
 
     @Test
     public void testIsEmpty() {
-        ItemEdit update = new ItemEditBuilder(existingSubject).build();
+        ItemEdit update = new ItemEditBuilder(existingSubject).addContributingRowId(123L).build();
         assertTrue(update.isEmpty());
-        ItemEdit update2 = new ItemEditBuilder(newSubject).build();
+        ItemEdit update2 = new ItemEditBuilder(newSubject).addContributingRowId(123L).build();
         assertTrue(update2.isEmpty());
     }
 
     @Test
     public void testIsNew() {
-        ItemEdit newUpdate = new ItemEditBuilder(newSubject).build();
+        ItemEdit newUpdate = new ItemEditBuilder(newSubject).addContributingRowId(123L).build();
         assertTrue(newUpdate.isNew());
-        ItemEdit update = new ItemEditBuilder(existingSubject).build();
+        ItemEdit update = new ItemEditBuilder(existingSubject).addContributingRowId(123L).build();
         assertFalse(update.isNew());
     }
 
@@ -123,6 +123,7 @@ public class ItemEditTest {
     public void testAddStatements() {
         ItemEdit update = new ItemEditBuilder(existingSubject).addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
+                .addContributingRowId(123L)
                 .build();
         assertFalse(update.isNull());
         assertEquals(Arrays.asList(statementUpdate1, statementUpdate2), update.getStatementEdits());
@@ -133,14 +134,15 @@ public class ItemEditTest {
     public void testSerializeStatements() throws IOException {
         ItemEdit update = new ItemEditBuilder(existingSubject).addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
+                .addContributingRowId(123L)
                 .build();
         TestUtils.isSerializedTo(update, TestingData.jsonFromFile("updates/entity_update.json"));
     }
 
     @Test
     public void testMerge() {
-        ItemEdit updateA = new ItemEditBuilder(existingSubject).addStatement(statementUpdate1).build();
-        ItemEdit updateB = new ItemEditBuilder(existingSubject).addStatement(statementUpdate2).build();
+        ItemEdit updateA = new ItemEditBuilder(existingSubject).addStatement(statementUpdate1).addContributingRowId(123L).build();
+        ItemEdit updateB = new ItemEditBuilder(existingSubject).addStatement(statementUpdate2).addContributingRowId(123L).build();
         assertNotEquals(updateA, updateB);
         ItemEdit merged = updateA.merge(updateB);
         assertEquals(statementGroups, merged.getStatementGroupEdits().stream().collect(Collectors.toSet()));
@@ -152,12 +154,14 @@ public class ItemEditTest {
         MonolingualTextValue aliasFr = Datamodel.makeMonolingualTextValue("coucou", "fr");
         ItemEdit updateA = new ItemEditBuilder(newSubject).addLabel(label, true).addAlias(aliasEn)
                 .addAlias(aliasFr)
+                .addContributingRowId(123L)
                 .build();
         assertFalse(updateA.isNull());
         ItemDocument normalized = updateA.toNewEntity();
         ItemDocument expectedDocument = ItemDocumentBuilder.forItemId(newSubject).withLabel(label)
                 .withAlias(aliasEn)
-                .withLabel(aliasFr).build();
+                .withLabel(aliasFr)
+                .build();
         assertEquals(expectedDocument, normalized);
     }
 
@@ -165,8 +169,8 @@ public class ItemEditTest {
     public void testMergeLabels() {
         MonolingualTextValue label1 = Datamodel.makeMonolingualTextValue("first label", "en");
         MonolingualTextValue label2 = Datamodel.makeMonolingualTextValue("second label", "en");
-        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, true).build();
-        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, true).build();
+        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, true).addContributingRowId(123L).build();
+        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, true).addContributingRowId(123L).build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(label2), merged.getLabels());
     }
@@ -175,8 +179,8 @@ public class ItemEditTest {
     public void testMergeLabelsIfNew() {
         MonolingualTextValue label1 = Datamodel.makeMonolingualTextValue("first label", "en");
         MonolingualTextValue label2 = Datamodel.makeMonolingualTextValue("second label", "en");
-        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, false).build();
-        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, false).build();
+        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, false).addContributingRowId(123L).build();
+        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, false).addContributingRowId(123L).build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(label1), merged.getLabelsIfNew());
         assertEquals(Collections.emptySet(), merged.getLabels());
@@ -186,8 +190,8 @@ public class ItemEditTest {
     public void testMergeLabelsIfNewOverriding() {
         MonolingualTextValue label1 = Datamodel.makeMonolingualTextValue("first label", "en");
         MonolingualTextValue label2 = Datamodel.makeMonolingualTextValue("second label", "en");
-        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, true).build();
-        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, false).build();
+        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, true).addContributingRowId(123L).build();
+        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, false).addContributingRowId(123L).build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(label1), merged.getLabels());
         assertEquals(Collections.emptySet(), merged.getLabelsIfNew());
@@ -197,8 +201,8 @@ public class ItemEditTest {
     public void testMergeLabelsIfNewOverriding2() {
         MonolingualTextValue label1 = Datamodel.makeMonolingualTextValue("first label", "en");
         MonolingualTextValue label2 = Datamodel.makeMonolingualTextValue("second label", "en");
-        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, false).build();
-        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, true).build();
+        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, false).addContributingRowId(123L).build();
+        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, true).addContributingRowId(123L).build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(label2), merged.getLabels());
         assertEquals(Collections.emptySet(), merged.getLabelsIfNew());
@@ -209,8 +213,10 @@ public class ItemEditTest {
         MonolingualTextValue description1 = Datamodel.makeMonolingualTextValue("first description", "en");
         MonolingualTextValue description2 = Datamodel.makeMonolingualTextValue("second description", "en");
         ItemEdit edit1 = new ItemEditBuilder(existingSubject).addDescription(description1, false)
+                .addContributingRowId(123L)
                 .build();
         ItemEdit edit2 = new ItemEditBuilder(existingSubject).addDescription(description2, false)
+                .addContributingRowId(123L)
                 .build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(description1), merged.getDescriptionsIfNew());
@@ -223,8 +229,10 @@ public class ItemEditTest {
         MonolingualTextValue description1 = Datamodel.makeMonolingualTextValue("first description", "en");
         MonolingualTextValue description2 = Datamodel.makeMonolingualTextValue("second description", "en");
         ItemEdit edit1 = new ItemEditBuilder(existingSubject).addDescription(description1, true)
+                .addContributingRowId(123L)
                 .build();
         ItemEdit edit2 = new ItemEditBuilder(existingSubject).addDescription(description2, false)
+                .addContributingRowId(123L)
                 .build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(description1), merged.getDescriptions());
@@ -236,8 +244,10 @@ public class ItemEditTest {
         MonolingualTextValue description1 = Datamodel.makeMonolingualTextValue("first description", "en");
         MonolingualTextValue description2 = Datamodel.makeMonolingualTextValue("second description", "en");
         ItemEdit update1 = new ItemEditBuilder(existingSubject).addDescription(description1, false)
+                .addContributingRowId(123L)
                 .build();
         ItemEdit update2 = new ItemEditBuilder(existingSubject).addDescription(description2, true)
+                .addContributingRowId(123L)
                 .build();
         ItemEdit merged = update1.merge(update2);
         assertEquals(Collections.singleton(description2), merged.getDescriptions());
@@ -251,6 +261,7 @@ public class ItemEditTest {
         LabeledStatementEntityEdit update = new ItemEditBuilder(existingSubject)
                 .addLabel(label1, false)
                 .addLabel(label2, true)
+                .addContributingRowId(123L)
                 .build();
         assertEquals(Collections.singleton(label2), update.getLabels());
         assertEquals(Collections.emptySet(), update.getLabelsIfNew());
@@ -261,6 +272,7 @@ public class ItemEditTest {
         TermedStatementEntityEdit edit = new ItemEditBuilder(existingSubject)
                 .addAlias(Datamodel.makeMonolingualTextValue("alias", "en"))
                 .addStatement(statementUpdate1)
+                .addContributingRowId(123L)
                 .build();
         ItemDocument itemDocument = ItemDocumentBuilder.forItemId(otherExistingSubject)
                 .withStatement(statement2WithOtherSubject)
@@ -285,6 +297,7 @@ public class ItemEditTest {
         TermedStatementEntityEdit edit = new ItemEditBuilder(newSubject)
                 .addLabel(Datamodel.makeMonolingualTextValue("fr", "bonjour"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("de", "Redewendung"), true)
+                .addContributingRowId(123L)
                 .build();
 
         ItemDocument itemDocument = (ItemDocument) edit.toNewEntity();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/ItemEditTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/ItemEditTest.java
@@ -97,25 +97,25 @@ public class ItemEditTest {
 
     @Test
     public void testIsNull() {
-        ItemEdit update = new ItemEditBuilder(existingSubject).addContributingRowId(123L).build();
+        ItemEdit update = new ItemEditBuilder(existingSubject).addContributingRowId(123).build();
         assertTrue(update.isNull());
-        ItemEdit update2 = new ItemEditBuilder(newSubject).addContributingRowId(123L).build();
+        ItemEdit update2 = new ItemEditBuilder(newSubject).addContributingRowId(123).build();
         assertFalse(update2.isNull());
     }
 
     @Test
     public void testIsEmpty() {
-        ItemEdit update = new ItemEditBuilder(existingSubject).addContributingRowId(123L).build();
+        ItemEdit update = new ItemEditBuilder(existingSubject).addContributingRowId(123).build();
         assertTrue(update.isEmpty());
-        ItemEdit update2 = new ItemEditBuilder(newSubject).addContributingRowId(123L).build();
+        ItemEdit update2 = new ItemEditBuilder(newSubject).addContributingRowId(123).build();
         assertTrue(update2.isEmpty());
     }
 
     @Test
     public void testIsNew() {
-        ItemEdit newUpdate = new ItemEditBuilder(newSubject).addContributingRowId(123L).build();
+        ItemEdit newUpdate = new ItemEditBuilder(newSubject).addContributingRowId(123).build();
         assertTrue(newUpdate.isNew());
-        ItemEdit update = new ItemEditBuilder(existingSubject).addContributingRowId(123L).build();
+        ItemEdit update = new ItemEditBuilder(existingSubject).addContributingRowId(123).build();
         assertFalse(update.isNew());
     }
 
@@ -123,7 +123,7 @@ public class ItemEditTest {
     public void testAddStatements() {
         ItemEdit update = new ItemEditBuilder(existingSubject).addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertFalse(update.isNull());
         assertEquals(Arrays.asList(statementUpdate1, statementUpdate2), update.getStatementEdits());
@@ -134,15 +134,15 @@ public class ItemEditTest {
     public void testSerializeStatements() throws IOException {
         ItemEdit update = new ItemEditBuilder(existingSubject).addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         TestUtils.isSerializedTo(update, TestingData.jsonFromFile("updates/entity_update.json"));
     }
 
     @Test
     public void testMerge() {
-        ItemEdit updateA = new ItemEditBuilder(existingSubject).addStatement(statementUpdate1).addContributingRowId(123L).build();
-        ItemEdit updateB = new ItemEditBuilder(existingSubject).addStatement(statementUpdate2).addContributingRowId(123L).build();
+        ItemEdit updateA = new ItemEditBuilder(existingSubject).addStatement(statementUpdate1).addContributingRowId(123).build();
+        ItemEdit updateB = new ItemEditBuilder(existingSubject).addStatement(statementUpdate2).addContributingRowId(123).build();
         assertNotEquals(updateA, updateB);
         ItemEdit merged = updateA.merge(updateB);
         assertEquals(statementGroups, merged.getStatementGroupEdits().stream().collect(Collectors.toSet()));
@@ -154,7 +154,7 @@ public class ItemEditTest {
         MonolingualTextValue aliasFr = Datamodel.makeMonolingualTextValue("coucou", "fr");
         ItemEdit updateA = new ItemEditBuilder(newSubject).addLabel(label, true).addAlias(aliasEn)
                 .addAlias(aliasFr)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertFalse(updateA.isNull());
         ItemDocument normalized = updateA.toNewEntity();
@@ -169,8 +169,8 @@ public class ItemEditTest {
     public void testMergeLabels() {
         MonolingualTextValue label1 = Datamodel.makeMonolingualTextValue("first label", "en");
         MonolingualTextValue label2 = Datamodel.makeMonolingualTextValue("second label", "en");
-        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, true).addContributingRowId(123L).build();
-        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, true).addContributingRowId(123L).build();
+        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, true).addContributingRowId(123).build();
+        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, true).addContributingRowId(123).build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(label2), merged.getLabels());
     }
@@ -179,8 +179,8 @@ public class ItemEditTest {
     public void testMergeLabelsIfNew() {
         MonolingualTextValue label1 = Datamodel.makeMonolingualTextValue("first label", "en");
         MonolingualTextValue label2 = Datamodel.makeMonolingualTextValue("second label", "en");
-        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, false).addContributingRowId(123L).build();
-        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, false).addContributingRowId(123L).build();
+        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, false).addContributingRowId(123).build();
+        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, false).addContributingRowId(123).build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(label1), merged.getLabelsIfNew());
         assertEquals(Collections.emptySet(), merged.getLabels());
@@ -190,8 +190,8 @@ public class ItemEditTest {
     public void testMergeLabelsIfNewOverriding() {
         MonolingualTextValue label1 = Datamodel.makeMonolingualTextValue("first label", "en");
         MonolingualTextValue label2 = Datamodel.makeMonolingualTextValue("second label", "en");
-        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, true).addContributingRowId(123L).build();
-        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, false).addContributingRowId(123L).build();
+        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, true).addContributingRowId(123).build();
+        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, false).addContributingRowId(123).build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(label1), merged.getLabels());
         assertEquals(Collections.emptySet(), merged.getLabelsIfNew());
@@ -201,8 +201,8 @@ public class ItemEditTest {
     public void testMergeLabelsIfNewOverriding2() {
         MonolingualTextValue label1 = Datamodel.makeMonolingualTextValue("first label", "en");
         MonolingualTextValue label2 = Datamodel.makeMonolingualTextValue("second label", "en");
-        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, false).addContributingRowId(123L).build();
-        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, true).addContributingRowId(123L).build();
+        ItemEdit edit1 = new ItemEditBuilder(existingSubject).addLabel(label1, false).addContributingRowId(123).build();
+        ItemEdit edit2 = new ItemEditBuilder(existingSubject).addLabel(label2, true).addContributingRowId(123).build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(label2), merged.getLabels());
         assertEquals(Collections.emptySet(), merged.getLabelsIfNew());
@@ -213,10 +213,10 @@ public class ItemEditTest {
         MonolingualTextValue description1 = Datamodel.makeMonolingualTextValue("first description", "en");
         MonolingualTextValue description2 = Datamodel.makeMonolingualTextValue("second description", "en");
         ItemEdit edit1 = new ItemEditBuilder(existingSubject).addDescription(description1, false)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit edit2 = new ItemEditBuilder(existingSubject).addDescription(description2, false)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(description1), merged.getDescriptionsIfNew());
@@ -229,10 +229,10 @@ public class ItemEditTest {
         MonolingualTextValue description1 = Datamodel.makeMonolingualTextValue("first description", "en");
         MonolingualTextValue description2 = Datamodel.makeMonolingualTextValue("second description", "en");
         ItemEdit edit1 = new ItemEditBuilder(existingSubject).addDescription(description1, true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit edit2 = new ItemEditBuilder(existingSubject).addDescription(description2, false)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit merged = edit1.merge(edit2);
         assertEquals(Collections.singleton(description1), merged.getDescriptions());
@@ -244,10 +244,10 @@ public class ItemEditTest {
         MonolingualTextValue description1 = Datamodel.makeMonolingualTextValue("first description", "en");
         MonolingualTextValue description2 = Datamodel.makeMonolingualTextValue("second description", "en");
         ItemEdit update1 = new ItemEditBuilder(existingSubject).addDescription(description1, false)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit update2 = new ItemEditBuilder(existingSubject).addDescription(description2, true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit merged = update1.merge(update2);
         assertEquals(Collections.singleton(description2), merged.getDescriptions());
@@ -261,7 +261,7 @@ public class ItemEditTest {
         LabeledStatementEntityEdit update = new ItemEditBuilder(existingSubject)
                 .addLabel(label1, false)
                 .addLabel(label2, true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertEquals(Collections.singleton(label2), update.getLabels());
         assertEquals(Collections.emptySet(), update.getLabelsIfNew());
@@ -272,7 +272,7 @@ public class ItemEditTest {
         TermedStatementEntityEdit edit = new ItemEditBuilder(existingSubject)
                 .addAlias(Datamodel.makeMonolingualTextValue("alias", "en"))
                 .addStatement(statementUpdate1)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemDocument itemDocument = ItemDocumentBuilder.forItemId(otherExistingSubject)
                 .withStatement(statement2WithOtherSubject)
@@ -297,7 +297,7 @@ public class ItemEditTest {
         TermedStatementEntityEdit edit = new ItemEditBuilder(newSubject)
                 .addLabel(Datamodel.makeMonolingualTextValue("fr", "bonjour"), true)
                 .addDescription(Datamodel.makeMonolingualTextValue("de", "Redewendung"), true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
 
         ItemDocument itemDocument = (ItemDocument) edit.toNewEntity();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/MediaInfoEditTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/MediaInfoEditTest.java
@@ -74,8 +74,10 @@ public class MediaInfoEditTest {
 
     @Test
     public void testAddStatements() {
-        MediaInfoEdit update = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate1)
+        MediaInfoEdit update = new MediaInfoEditBuilder(existingSubject)
+                .addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
+                .addContributingRowId(123L)
                 .build();
         assertFalse(update.isNull());
         assertEquals(Arrays.asList(statementUpdate1, statementUpdate2), update.getStatementEdits());
@@ -86,17 +88,19 @@ public class MediaInfoEditTest {
     public void testSerializeStatements() throws IOException {
         MediaInfoEdit update = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
+                .addContributingRowId(123)
                 .build();
         TestUtils.isSerializedTo(update, TestingData.jsonFromFile("updates/mediainfo_update.json"));
     }
 
     @Test
     public void testMerge() {
-        MediaInfoEdit updateA = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate1).build();
-        MediaInfoEdit updateB = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate2).build();
+        MediaInfoEdit updateA = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate1).addContributingRowId(123L).build();
+        MediaInfoEdit updateB = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate2).addContributingRowId(456L).build();
         assertNotEquals(updateA, updateB);
         MediaInfoEdit merged = updateA.merge(updateB);
         assertEquals(statementGroups, merged.getStatementGroupEdits().stream().collect(Collectors.toSet()));
+        assertEquals(Arrays.asList(123L, 456L).stream().collect(Collectors.toSet()), merged.getContributingRowIds());
     }
 
     @Test
@@ -105,6 +109,7 @@ public class MediaInfoEditTest {
                 .addStatement(statementUpdate2)
                 .addFileName("Foo.png")
                 .addFilePath("C:\\Foo.png")
+                .addContributingRowId(123L)
                 .build();
         assertTrue(edit.requiresFetchingExistingState());
 
@@ -119,6 +124,7 @@ public class MediaInfoEditTest {
         MediaInfoEdit edit = new MediaInfoEditBuilder(existingSubject)
                 .addWikitext("my new wikitext")
                 .setOverrideWikitext(true)
+                .addContributingRowId(123L)
                 .build();
         assertFalse(edit.requiresFetchingExistingState());
 
@@ -138,6 +144,7 @@ public class MediaInfoEditTest {
                 .addFileName("Foo.png")
                 .addFilePath(url)
                 .addWikitext("{{wikitext}}")
+                .addContributingRowId(123L)
                 .build();
         assertFalse(edit.requiresFetchingExistingState()); // new entities do not require fetching existing state
 
@@ -160,6 +167,7 @@ public class MediaInfoEditTest {
     public void testToString() {
         MediaInfoEdit edit = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
+                .addContributingRowId(123L)
                 .build();
         assertTrue(edit.toString().contains("M5678"));
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/MediaInfoEditTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/MediaInfoEditTest.java
@@ -77,7 +77,7 @@ public class MediaInfoEditTest {
         MediaInfoEdit update = new MediaInfoEditBuilder(existingSubject)
                 .addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertFalse(update.isNull());
         assertEquals(Arrays.asList(statementUpdate1, statementUpdate2), update.getStatementEdits());
@@ -95,12 +95,12 @@ public class MediaInfoEditTest {
 
     @Test
     public void testMerge() {
-        MediaInfoEdit updateA = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate1).addContributingRowId(123L).build();
-        MediaInfoEdit updateB = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate2).addContributingRowId(456L).build();
+        MediaInfoEdit updateA = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate1).addContributingRowId(123).build();
+        MediaInfoEdit updateB = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate2).addContributingRowId(456).build();
         assertNotEquals(updateA, updateB);
         MediaInfoEdit merged = updateA.merge(updateB);
         assertEquals(statementGroups, merged.getStatementGroupEdits().stream().collect(Collectors.toSet()));
-        assertEquals(Arrays.asList(123L, 456L).stream().collect(Collectors.toSet()), merged.getContributingRowIds());
+        assertEquals(Arrays.asList(123, 456).stream().collect(Collectors.toSet()), merged.getContributingRowIds());
     }
 
     @Test
@@ -109,7 +109,7 @@ public class MediaInfoEditTest {
                 .addStatement(statementUpdate2)
                 .addFileName("Foo.png")
                 .addFilePath("C:\\Foo.png")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertTrue(edit.requiresFetchingExistingState());
 
@@ -124,7 +124,7 @@ public class MediaInfoEditTest {
         MediaInfoEdit edit = new MediaInfoEditBuilder(existingSubject)
                 .addWikitext("my new wikitext")
                 .setOverrideWikitext(true)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertFalse(edit.requiresFetchingExistingState());
 
@@ -144,7 +144,7 @@ public class MediaInfoEditTest {
                 .addFileName("Foo.png")
                 .addFilePath(url)
                 .addWikitext("{{wikitext}}")
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertFalse(edit.requiresFetchingExistingState()); // new entities do not require fetching existing state
 
@@ -167,7 +167,7 @@ public class MediaInfoEditTest {
     public void testToString() {
         MediaInfoEdit edit = new MediaInfoEditBuilder(existingSubject).addStatement(statementUpdate1)
                 .addStatement(statementUpdate2)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertTrue(edit.toString().contains("M5678"));
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/QuickStatementsUpdateSchedulerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/QuickStatementsUpdateSchedulerTest.java
@@ -40,8 +40,8 @@ public class QuickStatementsUpdateSchedulerTest extends UpdateSchedulerTest {
     @Test
     public void testNoNewItem()
             throws ImpossibleSchedulingException {
-        EntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoB).build();
-        EntityEdit updateB = new ItemEditBuilder(existingIdB).addStatement(sBtoA).build();
+        EntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoB).addContributingRowId(123L).build();
+        EntityEdit updateB = new ItemEditBuilder(existingIdB).addStatement(sBtoA).addContributingRowId(123L).build();
         List<EntityEdit> scheduled = schedule(updateA, updateB);
         assertEquals(Arrays.asList(updateA, updateB), scheduled);
     }
@@ -50,11 +50,11 @@ public class QuickStatementsUpdateSchedulerTest extends UpdateSchedulerTest {
     public void testSplitUpdate()
             throws ImpossibleSchedulingException {
         EntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA)
-                .addStatement(sAtoNewB).build();
-        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).build();
-        EntityEdit newUpdateB = new ItemEditBuilder(newIdB).build();
-        EntityEdit splitUpdateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).build();
-        EntityEdit splitUpdateB = new ItemEditBuilder(existingIdA).addStatement(sAtoNewB).build();
+                .addStatement(sAtoNewB).addContributingRowId(123L).build();
+        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).addContributingRowId(123L).build();
+        EntityEdit newUpdateB = new ItemEditBuilder(newIdB).addContributingRowId(123L).build();
+        EntityEdit splitUpdateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).addContributingRowId(123L).build();
+        EntityEdit splitUpdateB = new ItemEditBuilder(existingIdA).addStatement(sAtoNewB).addContributingRowId(123L).build();
         List<EntityEdit> scheduled = schedule(updateA);
         assertSetEquals(Arrays.asList(newUpdateA, splitUpdateA, newUpdateB, splitUpdateB), scheduled);
     }
@@ -62,14 +62,20 @@ public class QuickStatementsUpdateSchedulerTest extends UpdateSchedulerTest {
     @Test(expectedExceptions = ImpossibleSchedulingException.class)
     public void testImpossibleForQS()
             throws ImpossibleSchedulingException {
-        TermedStatementEntityEdit update = new ItemEditBuilder(newIdA).addStatement(sNewAtoNewB).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(newIdA)
+                .addStatement(sNewAtoNewB)
+                .addContributingRowId(123L)
+                .build();
         schedule(update);
     }
 
     @Test
     public void testSelfEditOnNewITem()
             throws ImpossibleSchedulingException {
-        TermedStatementEntityEdit update = new ItemEditBuilder(newIdA).addStatement(sNewAtoNewA).build();
+        TermedStatementEntityEdit update = new ItemEditBuilder(newIdA)
+                .addStatement(sNewAtoNewA)
+                .addContributingRowId(123L)
+                .build();
         assertEquals(Arrays.asList(update), schedule(update));
     }
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/QuickStatementsUpdateSchedulerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/QuickStatementsUpdateSchedulerTest.java
@@ -40,8 +40,8 @@ public class QuickStatementsUpdateSchedulerTest extends UpdateSchedulerTest {
     @Test
     public void testNoNewItem()
             throws ImpossibleSchedulingException {
-        EntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoB).addContributingRowId(123L).build();
-        EntityEdit updateB = new ItemEditBuilder(existingIdB).addStatement(sBtoA).addContributingRowId(123L).build();
+        EntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoB).addContributingRowId(123).build();
+        EntityEdit updateB = new ItemEditBuilder(existingIdB).addStatement(sBtoA).addContributingRowId(123).build();
         List<EntityEdit> scheduled = schedule(updateA, updateB);
         assertEquals(Arrays.asList(updateA, updateB), scheduled);
     }
@@ -50,11 +50,11 @@ public class QuickStatementsUpdateSchedulerTest extends UpdateSchedulerTest {
     public void testSplitUpdate()
             throws ImpossibleSchedulingException {
         EntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA)
-                .addStatement(sAtoNewB).addContributingRowId(123L).build();
-        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).addContributingRowId(123L).build();
-        EntityEdit newUpdateB = new ItemEditBuilder(newIdB).addContributingRowId(123L).build();
-        EntityEdit splitUpdateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).addContributingRowId(123L).build();
-        EntityEdit splitUpdateB = new ItemEditBuilder(existingIdA).addStatement(sAtoNewB).addContributingRowId(123L).build();
+                .addStatement(sAtoNewB).addContributingRowId(123).build();
+        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).addContributingRowId(123).build();
+        EntityEdit newUpdateB = new ItemEditBuilder(newIdB).addContributingRowId(123).build();
+        EntityEdit splitUpdateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).addContributingRowId(123).build();
+        EntityEdit splitUpdateB = new ItemEditBuilder(existingIdA).addStatement(sAtoNewB).addContributingRowId(123).build();
         List<EntityEdit> scheduled = schedule(updateA);
         assertSetEquals(Arrays.asList(newUpdateA, splitUpdateA, newUpdateB, splitUpdateB), scheduled);
     }
@@ -64,7 +64,7 @@ public class QuickStatementsUpdateSchedulerTest extends UpdateSchedulerTest {
             throws ImpossibleSchedulingException {
         TermedStatementEntityEdit update = new ItemEditBuilder(newIdA)
                 .addStatement(sNewAtoNewB)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         schedule(update);
     }
@@ -74,7 +74,7 @@ public class QuickStatementsUpdateSchedulerTest extends UpdateSchedulerTest {
             throws ImpossibleSchedulingException {
         TermedStatementEntityEdit update = new ItemEditBuilder(newIdA)
                 .addStatement(sNewAtoNewA)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         assertEquals(Arrays.asList(update), schedule(update));
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/UpdateSchedulerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/UpdateSchedulerTest.java
@@ -74,17 +74,17 @@ public abstract class UpdateSchedulerTest {
     @Test
     public void testNewItemNotMentioned()
             throws ImpossibleSchedulingException {
-        TermedStatementEntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).addContributingRowId(123L).build();
+        TermedStatementEntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).addContributingRowId(123).build();
         List<EntityEdit> scheduled = schedule(updateA);
-        TermedStatementEntityEdit newUpdate = new ItemEditBuilder(newIdA).addContributingRowId(123L).build();
+        TermedStatementEntityEdit newUpdate = new ItemEditBuilder(newIdA).addContributingRowId(123).build();
         assertEquals(Arrays.asList(newUpdate, updateA), scheduled);
     }
 
     @Test
     public void testNewItemMentioned()
             throws ImpossibleSchedulingException {
-        TermedStatementEntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).addContributingRowId(123L).build();
-        TermedStatementEntityEdit newUpdate = new ItemEditBuilder(newIdA).addStatement(sNewAtoB).addContributingRowId(123L).build();
+        TermedStatementEntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).addContributingRowId(123).build();
+        TermedStatementEntityEdit newUpdate = new ItemEditBuilder(newIdA).addStatement(sNewAtoB).addContributingRowId(123).build();
         List<EntityEdit> scheduled = schedule(updateA, newUpdate);
         assertEquals(Arrays.asList(newUpdate, updateA), scheduled);
     }
@@ -94,12 +94,12 @@ public abstract class UpdateSchedulerTest {
             throws ImpossibleSchedulingException {
         ItemEdit update1 = new ItemEditBuilder(existingIdA)
                 .addStatement(sAtoB)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit update2 = new ItemEditBuilder(existingIdA)
                 .addLabel(Datamodel.makeMonolingualTextValue("hello", "fr"), true)
                 .addStatement(sAtoB)
-                .addContributingRowId(456L)
+                .addContributingRowId(456)
                 .build();
         TermedStatementEntityEdit merged = update1.merge(update2);
         assertEquals(Collections.singletonList(merged), schedule(update1, update2));
@@ -111,11 +111,11 @@ public abstract class UpdateSchedulerTest {
         ItemEdit update1 = new ItemEditBuilder(newIdA)
                 .addLabel(Datamodel.makeMonolingualTextValue("hello", "fr"), true)
                 .addStatement(sNewAtoB)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
         ItemEdit update2 = new ItemEditBuilder(newIdA)
                 .addLabel(Datamodel.makeMonolingualTextValue("hello", "fr"), true)
-                .addContributingRowId(456L)
+                .addContributingRowId(456)
                 .build();
         ItemEdit merged = update1.merge(update2);
         assertEquals(Collections.singletonList(merged), schedule(update1, update2));

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/UpdateSchedulerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/UpdateSchedulerTest.java
@@ -74,17 +74,17 @@ public abstract class UpdateSchedulerTest {
     @Test
     public void testNewItemNotMentioned()
             throws ImpossibleSchedulingException {
-        TermedStatementEntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).build();
+        TermedStatementEntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).addContributingRowId(123L).build();
         List<EntityEdit> scheduled = schedule(updateA);
-        TermedStatementEntityEdit newUpdate = new ItemEditBuilder(newIdA).build();
+        TermedStatementEntityEdit newUpdate = new ItemEditBuilder(newIdA).addContributingRowId(123L).build();
         assertEquals(Arrays.asList(newUpdate, updateA), scheduled);
     }
 
     @Test
     public void testNewItemMentioned()
             throws ImpossibleSchedulingException {
-        TermedStatementEntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).build();
-        TermedStatementEntityEdit newUpdate = new ItemEditBuilder(newIdA).addStatement(sNewAtoB).build();
+        TermedStatementEntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA).addContributingRowId(123L).build();
+        TermedStatementEntityEdit newUpdate = new ItemEditBuilder(newIdA).addStatement(sNewAtoB).addContributingRowId(123L).build();
         List<EntityEdit> scheduled = schedule(updateA, newUpdate);
         assertEquals(Arrays.asList(newUpdate, updateA), scheduled);
     }
@@ -92,9 +92,15 @@ public abstract class UpdateSchedulerTest {
     @Test
     public void testMerge()
             throws ImpossibleSchedulingException {
-        ItemEdit update1 = new ItemEditBuilder(existingIdA).addStatement(sAtoB).build();
+        ItemEdit update1 = new ItemEditBuilder(existingIdA)
+                .addStatement(sAtoB)
+                .addContributingRowId(123L)
+                .build();
         ItemEdit update2 = new ItemEditBuilder(existingIdA)
-                .addLabel(Datamodel.makeMonolingualTextValue("hello", "fr"), true).addStatement(sAtoB).build();
+                .addLabel(Datamodel.makeMonolingualTextValue("hello", "fr"), true)
+                .addStatement(sAtoB)
+                .addContributingRowId(456L)
+                .build();
         TermedStatementEntityEdit merged = update1.merge(update2);
         assertEquals(Collections.singletonList(merged), schedule(update1, update2));
     }
@@ -104,9 +110,12 @@ public abstract class UpdateSchedulerTest {
             throws ImpossibleSchedulingException {
         ItemEdit update1 = new ItemEditBuilder(newIdA)
                 .addLabel(Datamodel.makeMonolingualTextValue("hello", "fr"), true)
-                .addStatement(sNewAtoB).build();
+                .addStatement(sNewAtoB)
+                .addContributingRowId(123L)
+                .build();
         ItemEdit update2 = new ItemEditBuilder(newIdA)
                 .addLabel(Datamodel.makeMonolingualTextValue("hello", "fr"), true)
+                .addContributingRowId(456L)
                 .build();
         ItemEdit merged = update1.merge(update2);
         assertEquals(Collections.singletonList(merged), schedule(update1, update2));

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/WikibaseAPIUpdateSchedulerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/WikibaseAPIUpdateSchedulerTest.java
@@ -42,8 +42,8 @@ public class WikibaseAPIUpdateSchedulerTest extends UpdateSchedulerTest {
     @Test
     public void testOrderPreserved()
             throws ImpossibleSchedulingException {
-        ItemEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoB).addContributingRowId(123L).build();
-        ItemEdit updateB = new ItemEditBuilder(existingIdB).addStatement(sBtoA).addContributingRowId(123L).build();
+        ItemEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoB).addContributingRowId(123).build();
+        ItemEdit updateB = new ItemEditBuilder(existingIdB).addStatement(sBtoA).addContributingRowId(123).build();
         List<EntityEdit> scheduled = schedule(updateA, updateB);
         assertEquals(scheduled, Arrays.asList(updateA, updateB));
     }
@@ -53,10 +53,10 @@ public class WikibaseAPIUpdateSchedulerTest extends UpdateSchedulerTest {
             throws ImpossibleSchedulingException {
         ItemEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA)
                 .addStatement(sAtoNewB)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
-        ItemEdit newUpdateA = new ItemEditBuilder(newIdA).addContributingRowId(123L).build();
-        ItemEdit newUpdateB = new ItemEditBuilder(newIdB).addContributingRowId(123L).build();
+        ItemEdit newUpdateA = new ItemEditBuilder(newIdA).addContributingRowId(123).build();
+        ItemEdit newUpdateB = new ItemEditBuilder(newIdB).addContributingRowId(123).build();
         List<EntityEdit> scheduled = schedule(updateA);
         assertSetEquals(scheduled, Arrays.asList(newUpdateA, newUpdateB, updateA));
     }
@@ -67,10 +67,10 @@ public class WikibaseAPIUpdateSchedulerTest extends UpdateSchedulerTest {
         EntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA)
                 .addStatement(sAtoNewB)
                 .addStatement(sAtoB)
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
-        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).addStatement(sNewAtoB).addContributingRowId(123L).build();
-        EntityEdit newUpdateB = new ItemEditBuilder(newIdB).addContributingRowId(123L).build();
+        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).addStatement(sNewAtoB).addContributingRowId(123).build();
+        EntityEdit newUpdateB = new ItemEditBuilder(newIdB).addContributingRowId(123).build();
         List<EntityEdit> scheduled = schedule(updateA, newUpdateA);
         assertEquals(scheduled, Arrays.asList(newUpdateA, newUpdateB, updateA));
     }
@@ -79,9 +79,9 @@ public class WikibaseAPIUpdateSchedulerTest extends UpdateSchedulerTest {
     public void testMediaInfoReferringToNewItem() throws ImpossibleSchedulingException {
         EntityEdit updateMediaInfo = new MediaInfoEditBuilder(existingMediaInfoId)
                 .addStatement(TestingData.generateStatementAddition(existingMediaInfoId, newIdA))
-                .addContributingRowId(123L)
+                .addContributingRowId(123)
                 .build();
-        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).addContributingRowId(123L).build();
+        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).addContributingRowId(123).build();
         List<EntityEdit> scheduled = schedule(updateMediaInfo);
         assertEquals(scheduled, Arrays.asList(newUpdateA, updateMediaInfo));
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/WikibaseAPIUpdateSchedulerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/scheduler/WikibaseAPIUpdateSchedulerTest.java
@@ -42,8 +42,8 @@ public class WikibaseAPIUpdateSchedulerTest extends UpdateSchedulerTest {
     @Test
     public void testOrderPreserved()
             throws ImpossibleSchedulingException {
-        ItemEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoB).build();
-        ItemEdit updateB = new ItemEditBuilder(existingIdB).addStatement(sBtoA).build();
+        ItemEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoB).addContributingRowId(123L).build();
+        ItemEdit updateB = new ItemEditBuilder(existingIdB).addStatement(sBtoA).addContributingRowId(123L).build();
         List<EntityEdit> scheduled = schedule(updateA, updateB);
         assertEquals(scheduled, Arrays.asList(updateA, updateB));
     }
@@ -52,9 +52,11 @@ public class WikibaseAPIUpdateSchedulerTest extends UpdateSchedulerTest {
     public void testUpdateIsNotSplit()
             throws ImpossibleSchedulingException {
         ItemEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA)
-                .addStatement(sAtoNewB).build();
-        ItemEdit newUpdateA = new ItemEditBuilder(newIdA).build();
-        ItemEdit newUpdateB = new ItemEditBuilder(newIdB).build();
+                .addStatement(sAtoNewB)
+                .addContributingRowId(123L)
+                .build();
+        ItemEdit newUpdateA = new ItemEditBuilder(newIdA).addContributingRowId(123L).build();
+        ItemEdit newUpdateB = new ItemEditBuilder(newIdB).addContributingRowId(123L).build();
         List<EntityEdit> scheduled = schedule(updateA);
         assertSetEquals(scheduled, Arrays.asList(newUpdateA, newUpdateB, updateA));
     }
@@ -64,9 +66,11 @@ public class WikibaseAPIUpdateSchedulerTest extends UpdateSchedulerTest {
             throws ImpossibleSchedulingException {
         EntityEdit updateA = new ItemEditBuilder(existingIdA).addStatement(sAtoNewA)
                 .addStatement(sAtoNewB)
-                .addStatement(sAtoB).build();
-        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).addStatement(sNewAtoB).build();
-        EntityEdit newUpdateB = new ItemEditBuilder(newIdB).build();
+                .addStatement(sAtoB)
+                .addContributingRowId(123L)
+                .build();
+        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).addStatement(sNewAtoB).addContributingRowId(123L).build();
+        EntityEdit newUpdateB = new ItemEditBuilder(newIdB).addContributingRowId(123L).build();
         List<EntityEdit> scheduled = schedule(updateA, newUpdateA);
         assertEquals(scheduled, Arrays.asList(newUpdateA, newUpdateB, updateA));
     }
@@ -75,8 +79,9 @@ public class WikibaseAPIUpdateSchedulerTest extends UpdateSchedulerTest {
     public void testMediaInfoReferringToNewItem() throws ImpossibleSchedulingException {
         EntityEdit updateMediaInfo = new MediaInfoEditBuilder(existingMediaInfoId)
                 .addStatement(TestingData.generateStatementAddition(existingMediaInfoId, newIdA))
+                .addContributingRowId(123L)
                 .build();
-        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).build();
+        EntityEdit newUpdateA = new ItemEditBuilder(newIdA).addContributingRowId(123L).build();
         List<EntityEdit> scheduled = schedule(updateMediaInfo);
         assertEquals(scheduled, Arrays.asList(newUpdateA, updateMediaInfo));
     }

--- a/main/src/com/google/refine/model/changes/CellAtRow.java
+++ b/main/src/com/google/refine/model/changes/CellAtRow.java
@@ -35,6 +35,7 @@ package com.google.refine.model.changes;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Objects;
 import java.util.Properties;
 
 import com.google.refine.model.Cell;
@@ -64,5 +65,27 @@ public class CellAtRow {
         Cell cell = semicolon < s.length() - 1 ? Cell.loadStreaming(s.substring(semicolon + 1), pool) : null;
 
         return new CellAtRow(row, cell);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cell, row);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CellAtRow other = (CellAtRow) obj;
+        return Objects.equals(cell, other.cell) && row == other.row;
+    }
+
+    @Override
+    public String toString() {
+        return "CellAtRow [row=" + row + ", cell=" + cell + "]";
     }
 }


### PR DESCRIPTION
Closes #1782. Backports #5944 (see the discussion there).

<s>Depends on #6552 (which is included here, I can rebase once it gets merged), hence the draft status.</s>

This follows the design proposed [on the forum](https://forum.openrefine.org/t/partial-results-of-long-running-operations/482).
The Wikibase upload operation creates a new column (or reuses the column, if it already exists) to store the editing errors of edits related to a given row:
![image](https://github.com/OpenRefine/OpenRefine/assets/309908/b6eb8717-aeac-4c90-b4a6-2bf7e33d2ffc)
It also adds a facet to easily locate rows containing errors:
![image](https://github.com/OpenRefine/OpenRefine/assets/309908/9381c28b-165f-4777-8c63-06d0f8a3861a)

For successful edits it stores a URL to the diff view of the edit (such as https://www.wikidata.org/w/index.php?diff=1920784148&oldid=1919995661).

This also closes #5166, since it makes it possible to relate the errors to the offending lines better.

One could also make the creation of the error-reporting column optional and potentially with a configurable name. It would also be good to make it possible to create the facet manually (just like the judgment / score facets of the reconciliation operation) if it has been closed manually or not restored after reopening the project, but I am not sure where to add the button for that.