### PR TITLE
tests: Remove createCSVProject utilities

### DIFF
--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/testing/WikidataRefineTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/testing/WikidataRefineTest.java
@@ -1,17 +1,14 @@
 
 package org.openrefine.wikibase.testing;
 
-import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 import java.io.File;
 import java.io.Serializable;
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.testng.annotations.BeforeMethod;
 
 import com.google.refine.ProjectManager;
@@ -19,8 +16,6 @@ import com.google.refine.ProjectManagerStub;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.RefineServlet;
 import com.google.refine.RefineServletStub;
-import com.google.refine.RefineTest;
-import com.google.refine.importers.SeparatorBasedImporter;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingManager;
 import com.google.refine.model.Cell;
@@ -35,41 +30,6 @@ public class WikidataRefineTest {
     protected RefineServlet servlet;
     private List<Project> projects = new ArrayList<Project>();
     private List<ImportingJob> importingJobs = new ArrayList<ImportingJob>();
-
-    /**
-     * @deprecated use {@link #createProject(String[], Serializable[][])}
-     */
-    @Deprecated
-    public Project createCSVProject(String input) {
-        return createCSVProject("test project", input);
-    }
-
-    /**
-     * @deprecated use {@link #createProject(String, String[], Serializable[][])}
-     */
-    @Deprecated
-    protected Project createCSVProject(String projectName, String input) {
-        Project project = new Project();
-
-        ProjectMetadata metadata = new ProjectMetadata();
-        metadata.setName(projectName);
-
-        ObjectNode options = mock(ObjectNode.class);
-        RefineTest.prepareImportOptions(options, ",", -1, 0, 0, 1, false, false);
-
-        ImportingJob job = ImportingManager.createJob();
-
-        SeparatorBasedImporter importer = new SeparatorBasedImporter();
-
-        List<Exception> exceptions = new ArrayList<Exception>();
-        importer.parseOneFile(project, metadata, job, "filesource", new StringReader(input), -1, options, exceptions);
-        project.update();
-        ProjectManager.singleton.registerProject(project, metadata);
-
-        projects.add(project);
-        importingJobs.add(job);
-        return project;
-    }
 
     /**
      * Utility method to create a project with pre-defined contents.

--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -43,7 +43,6 @@ import static org.testng.Assert.fail;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -68,7 +67,6 @@ import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
 import com.google.refine.grel.ControlFunctionRegistry;
 import com.google.refine.grel.Function;
-import com.google.refine.importers.SeparatorBasedImporter;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingManager;
 import com.google.refine.io.FileProjectManager;
@@ -142,44 +140,6 @@ public class RefineTest {
                 project.columnModel.addColumn(index, column, true);
             }
         }
-        return project;
-    }
-
-    /**
-     * @deprecated use {@link #createProject(String[], Serializable[][])} instead, so that the project's contents are
-     *             more readable in the test
-     */
-    @Deprecated
-    protected Project createCSVProject(String input) {
-        return createCSVProject("test project", input);
-    }
-
-    /**
-     * @deprecated use {@link #createProject(String, String[], Serializable[][])} instead, so that the project's
-     *             contents are more readable in the test
-     */
-    @Deprecated
-    protected Project createCSVProject(String projectName, String input) {
-
-        Project project = new Project();
-
-        ProjectMetadata metadata = new ProjectMetadata();
-        metadata.setName(projectName);
-
-        ObjectNode options = mock(ObjectNode.class);
-        prepareImportOptions(options, ",", -1, 0, 0, 1, false, false);
-
-        ImportingJob job = ImportingManager.createJob();
-
-        SeparatorBasedImporter importer = new SeparatorBasedImporter();
-
-        List<Exception> exceptions = new ArrayList<Exception>();
-        importer.parseOneFile(project, metadata, job, "filesource", new StringReader(input), -1, options, exceptions);
-        ProjectManager.singleton.registerProject(project, metadata);
-        project.update();
-
-        projects.add(project);
-        importingJobs.add(job);
         return project;
     }
 


### PR DESCRIPTION
Those methods are only part of our test suite, the intention with deprecating them without deleting them was to cater for any in-flight PRs. The only affected PR #6461 is already using the new utilities.

Keeping them longer will block modularization.