### PR TITLE
grel: Prepare tests for modularization

### DIFF
--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -63,9 +63,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 
-import com.google.refine.expr.Evaluable;
-import com.google.refine.expr.MetaParser;
-import com.google.refine.expr.ParsingException;
 import com.google.refine.grel.ControlFunctionRegistry;
 import com.google.refine.grel.Function;
 import com.google.refine.importers.SeparatorBasedImporter;
@@ -417,39 +414,6 @@ public class RefineTest {
         } else {
             return function.call(bindings, args);
         }
-    }
-
-    /**
-     * Parse and evaluate a GREL expression and compare the result to the expect value
-     *
-     * @param bindings
-     * @param test
-     * @throws ParsingException
-     */
-    protected void parseEval(Properties bindings, String[] test)
-            throws ParsingException {
-        Evaluable eval = MetaParser.parse("grel:" + test[0]);
-        Object result = eval.evaluate(bindings);
-        if (test[1] != null) {
-            Assert.assertNotNull(result, "Expected " + test[1] + " for test " + test[0]);
-            Assert.assertEquals(result.toString(), test[1], "Wrong result for expression: " + test[0]);
-        } else {
-            Assert.assertNull(result, "Wrong result for expression: " + test[0]);
-        }
-    }
-
-    /**
-     * Parse and evaluate a GREL expression and compare the result an expected type using instanceof
-     *
-     * @param bindings
-     * @param test
-     * @throws ParsingException
-     */
-    protected void parseEvalType(Properties bindings, String test, @SuppressWarnings("rawtypes") Class clazz)
-            throws ParsingException {
-        Evaluable eval = MetaParser.parse("grel:" + test);
-        Object result = eval.evaluate(bindings);
-        Assert.assertTrue(clazz.isInstance(result), "Wrong result type for expression: " + test);
     }
 
     @AfterMethod

--- a/main/tests/server/src/com/google/refine/expr/functions/CoalesceTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/CoalesceTests.java
@@ -33,37 +33,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.expr.functions;
 
-import java.util.Properties;
-
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class CoalesceTests extends RefineTest {
+public class CoalesceTests extends GrelTestBase {
 
     private static final Integer[] ZERO_TO_TWO = new Integer[] { 0, 1, 2 };
-
-    @Override
-    @BeforeTest
-    public void init() {
-        logger = LoggerFactory.getLogger(this.getClass());
-    }
-
-    @BeforeMethod
-    public void setUp() {
-        bindings = new Properties();
-    }
-
-    @AfterMethod
-    public void tearDown() {
-        bindings = null;
-    }
 
     @Test
     public void testCoalesceInvalidParams() {

--- a/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/CrossTests.java
@@ -35,17 +35,15 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Properties;
 
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.HasFieldsListImpl;
 import com.google.refine.expr.WrappedCell;
 import com.google.refine.expr.WrappedRow;
+import com.google.refine.grel.GrelTestBase;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
@@ -53,17 +51,11 @@ import com.google.refine.model.Row;
 /**
  * Test cases for cross function.
  */
-public class CrossTests extends RefineTest {
+public class CrossTests extends GrelTestBase {
 
     private static final String ERROR_MSG = "cross expects a cell or value, a project name to look up (optional), and a column name in that project (optional)";
     private static final OffsetDateTime dateTimeValue = OffsetDateTime.parse("2017-05-12T05:45:00+00:00",
             DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-
-    @Override
-    @BeforeTest
-    public void init() {
-        logger = LoggerFactory.getLogger(this.getClass());
-    }
 
     private HasFieldsListImpl emptyList;
 

--- a/main/tests/server/src/com/google/refine/expr/functions/GetTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/GetTests.java
@@ -27,44 +27,15 @@
 
 package com.google.refine.expr.functions;
 
-import java.util.Properties;
-
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.Evaluable;
-import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
-import com.google.refine.model.Project;
+import com.google.refine.grel.GrelTestBase;
 
-public class GetTests extends RefineTest {
-
-    Project project;
-    Properties bindings;
-
-    @Override
-    @BeforeTest
-    public void init() {
-        logger = LoggerFactory.getLogger(this.getClass());
-    }
-
-    @BeforeMethod
-    public void SetUp() {
-        project = new Project();
-        bindings = ExpressionUtils.createBindings(project);
-    }
-
-    @AfterMethod
-    public void TearDown() {
-        project = null;
-        bindings = null;
-    }
+public class GetTests extends GrelTestBase {
 
     @Test
     public void testGetJsonFieldExists() throws ParsingException {

--- a/main/tests/server/src/com/google/refine/expr/functions/JsonizeTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/JsonizeTests.java
@@ -32,11 +32,11 @@ import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.util.CalendarParserException;
+import com.google.refine.grel.GrelTestBase;
 
-public class JsonizeTests extends RefineTest {
+public class JsonizeTests extends GrelTestBase {
 
     @Test
     public void testToString() throws CalendarParserException {

--- a/main/tests/server/src/com/google/refine/expr/functions/ToDateTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/ToDateTests.java
@@ -35,12 +35,12 @@ import java.util.TimeZone;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.util.CalendarParser;
 import com.google.refine.expr.util.CalendarParserException;
+import com.google.refine.grel.GrelTestBase;
 
-public class ToDateTests extends RefineTest {
+public class ToDateTests extends GrelTestBase {
 
     @Test
     public void testToDate() throws CalendarParserException {

--- a/main/tests/server/src/com/google/refine/expr/functions/ToNumberTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/ToNumberTests.java
@@ -34,11 +34,11 @@ import java.util.Properties;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.grel.Function;
+import com.google.refine.grel.GrelTestBase;
 
-public class ToNumberTests extends RefineTest {
+public class ToNumberTests extends GrelTestBase {
 
     private static final Double EPSILON = 0.000001;
     static Properties bindings = new Properties();

--- a/main/tests/server/src/com/google/refine/expr/functions/ToStringTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/ToStringTests.java
@@ -32,12 +32,12 @@ import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.util.CalendarParser;
 import com.google.refine.expr.util.CalendarParserException;
+import com.google.refine.grel.GrelTestBase;
 
-public class ToStringTests extends RefineTest {
+public class ToStringTests extends GrelTestBase {
 
     @Test
     public void testToString() throws CalendarParserException {

--- a/main/tests/server/src/com/google/refine/expr/functions/TypeTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/TypeTests.java
@@ -31,38 +31,17 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Properties;
 
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class TypeTests extends RefineTest {
+public class TypeTests extends GrelTestBase {
 
     static final List<String> listArray = Arrays.asList("v1", "v2", "v3");
     private static OffsetDateTime dateTimeValue = OffsetDateTime.parse("2017-05-12T05:45:00+00:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
-
-    @Override
-    @BeforeTest
-    public void init() {
-        logger = LoggerFactory.getLogger(this.getClass());
-    }
-
-    @BeforeMethod
-    public void setUp() {
-        bindings = new Properties();
-    }
-
-    @AfterMethod
-    public void tearDown() {
-        bindings = null;
-    }
 
     @Test
     public void testTypeInvalidParams() {

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/InArrayTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/InArrayTests.java
@@ -36,10 +36,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class InArrayTests extends RefineTest {
+public class InArrayTests extends GrelTestBase {
 
     static Properties bindings;
     static final List<String> listArray = Arrays.asList("v1", "v2", "v3");

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
@@ -29,10 +29,10 @@ package com.google.refine.expr.functions.arrays;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.ParsingException;
+import com.google.refine.grel.GrelTestBase;
 
-public class JoinTests extends RefineTest {
+public class JoinTests extends GrelTestBase {
 
     @Test
     public void joinArray() throws ParsingException {

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ReverseTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ReverseTests.java
@@ -29,10 +29,10 @@ package com.google.refine.expr.functions.arrays;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.ParsingException;
+import com.google.refine.grel.GrelTestBase;
 
-public class ReverseTests extends RefineTest {
+public class ReverseTests extends GrelTestBase {
 
     @Test
     public void reverseJsonArray() throws ParsingException {

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/SortTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/SortTests.java
@@ -29,11 +29,11 @@ package com.google.refine.expr.functions.arrays;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.ParsingException;
+import com.google.refine.grel.GrelTestBase;
 
-public class SortTests extends RefineTest {
+public class SortTests extends GrelTestBase {
 
     @Test
     public void sortJsonArray() throws ParsingException {

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/UniquesTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/UniquesTests.java
@@ -29,10 +29,10 @@ package com.google.refine.expr.functions.arrays;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.ParsingException;
+import com.google.refine.grel.GrelTestBase;
 
-public class UniquesTests extends RefineTest {
+public class UniquesTests extends GrelTestBase {
 
     @Test
     public void uniquesJsonArray() throws ParsingException {

--- a/main/tests/server/src/com/google/refine/expr/functions/booleans/BooleanTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/booleans/BooleanTests.java
@@ -38,10 +38,10 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class BooleanTests extends RefineTest {
+public class BooleanTests extends GrelTestBase {
 
     private static String TRUTH_TABLE[][] = {
             { "and", "true", "true", "true", "true" },

--- a/main/tests/server/src/com/google/refine/expr/functions/date/DatePartTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/date/DatePartTests.java
@@ -39,9 +39,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
+import com.google.refine.grel.GrelTestBase;
 
-public class DatePartTests extends RefineTest {
+public class DatePartTests extends GrelTestBase {
 
     static Properties bindings;
 

--- a/main/tests/server/src/com/google/refine/expr/functions/date/IncTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/date/IncTests.java
@@ -36,10 +36,10 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class IncTests extends RefineTest {
+public class IncTests extends GrelTestBase {
 
     private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd-HH:mm:ss.SSSSSSSSSX");
 

--- a/main/tests/server/src/com/google/refine/expr/functions/date/NowTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/date/NowTests.java
@@ -35,9 +35,9 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
+import com.google.refine.grel.GrelTestBase;
 
-public class NowTests extends RefineTest {
+public class NowTests extends GrelTestBase {
 
     private DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd-HH:mm:ss.SSSSSSSSSX");
 

--- a/main/tests/server/src/com/google/refine/expr/functions/html/InnerHtmlTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/html/InnerHtmlTests.java
@@ -25,19 +25,24 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-package com.google.refine.expr;
+package com.google.refine.expr.functions.html;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
-import com.google.refine.util.TestUtils;
+import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class EvalErrorTests extends RefineTest {
+public class InnerHtmlTests extends GrelTestBase {
 
     @Test
-    public void serializeEvalError() {
-        EvalError e = new EvalError("This is a critical error");
-        TestUtils.isSerializedTo(e, "{\"type\":\"error\",\"message\":\"This is a critical error\"}");
+    public void testInnerHtml() {
+        Assert.assertTrue(invoke("innerHtml") instanceof EvalError);
+        Assert.assertTrue(invoke("innerHtml", "test") instanceof EvalError);
+
+        EvalError evalError = (EvalError) invoke("innerHtml", "test");
+        Assert.assertEquals(evalError.toString(),
+                "innerHtml() cannot work with this \'string\'. The first parameter is not an HTML Element. Please first use parseHtml(string) and select(query) prior to using this function");
     }
 
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/html/ParseHtmlTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/html/ParseHtmlTests.java
@@ -35,10 +35,10 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class ParseHtmlTests extends RefineTest {
+public class ParseHtmlTests extends GrelTestBase {
 
     static Properties bindings;
     static String h = "<html>\n" +

--- a/main/tests/server/src/com/google/refine/expr/functions/math/RandomNumberTest.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/math/RandomNumberTest.java
@@ -33,35 +33,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.expr.functions.math;
 
-import java.util.Properties;
-
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class RandomNumberTest extends RefineTest {
-
-    @Override
-    @BeforeTest
-    public void init() {
-        logger = LoggerFactory.getLogger(this.getClass());
-    }
-
-    @BeforeMethod
-    public void setUp() throws Exception {
-        bindings = new Properties();
-    }
-
-    @AfterMethod
-    public void tearDown() throws Exception {
-        bindings = null;
-    }
+public class RandomNumberTest extends GrelTestBase {
 
     @Test
     public void testCall() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/ChompTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/ChompTests.java
@@ -31,9 +31,9 @@ import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
+import com.google.refine.grel.GrelTestBase;
 
-public class ChompTests extends RefineTest {
+public class ChompTests extends GrelTestBase {
 
     @Test
     public void testChomp() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/ContainsTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/ContainsTests.java
@@ -29,23 +29,15 @@ package com.google.refine.expr.functions.strings;
 
 import java.util.regex.Pattern;
 
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
+import com.google.refine.grel.GrelTestBase;
 
 /**
  * Test cases for find function.
  */
-public class ContainsTests extends RefineTest {
-
-    @Override
-    @BeforeTest
-    public void init() {
-        logger = LoggerFactory.getLogger(this.getClass());
-    }
+public class ContainsTests extends GrelTestBase {
 
     @Test
     public void testContainsFunction() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/DecodeTest.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/DecodeTest.java
@@ -4,10 +4,10 @@ package com.google.refine.expr.functions.strings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class DecodeTest extends RefineTest {
+public class DecodeTest extends GrelTestBase {
 
     @Test
     public void testDecode() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/DetectLanguageTest.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/DetectLanguageTest.java
@@ -1,25 +1,20 @@
 
 package com.google.refine.expr.functions.strings;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
 import java.util.Map;
 
 import com.optimaize.langdetect.i18n.LdLocale;
-import org.junit.Assert;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class DetectLanguageTest extends RefineTest {
+public class DetectLanguageTest extends GrelTestBase {
 
-    String functionName;
-
-    @Override
-    @BeforeTest
-    public void init() {
-        functionName = "detectLanguage";
-    }
+    String functionName = "detectLanguage";
 
     @Test
     public void testDetectLanguage() {
@@ -30,15 +25,15 @@ public class DetectLanguageTest extends RefineTest {
                 "Ich bin sehr sicher dass dies funktioniert", LdLocale.fromString("de"));
 
         samples.forEach((s, ldLocale) -> {
-            Assert.assertEquals(invoke(functionName, s), ldLocale.getLanguage());
-            Assert.assertTrue(invoke(functionName, s) instanceof String);
+            assertEquals(invoke(functionName, s), ldLocale.getLanguage());
+            assertTrue(invoke(functionName, s) instanceof String);
         });
     }
 
     @Test
     public void testDetectLanguageInvalidParams() {
-        Assert.assertTrue(invoke(functionName) instanceof EvalError);
-        Assert.assertTrue(invoke(functionName,
+        assertTrue(invoke(functionName) instanceof EvalError);
+        assertTrue(invoke(functionName,
                 "Estoy muy seguro de que esto funciona",
                 "Ich bin sehr sicher dass dies funktioniert") instanceof EvalError);
     }

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/DiffTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/DiffTests.java
@@ -37,10 +37,10 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class DiffTests extends RefineTest {
+public class DiffTests extends GrelTestBase {
 
     static Properties bindings;
 
@@ -53,9 +53,8 @@ public class DiffTests extends RefineTest {
     private OffsetDateTime odt7;
     private OffsetDateTime odt8;
 
-    @Override
     @BeforeTest
-    public void init() {
+    public void initDates() {
         logger = LoggerFactory.getLogger(this.getClass());
         odt1 = OffsetDateTime.parse("2011-09-01T10:15:30.123456+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);
         odt2 = OffsetDateTime.parse("2011-12-02T10:16:30.123467+01:00", DateTimeFormatter.ISO_OFFSET_DATE_TIME);

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/EncodeTest.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/EncodeTest.java
@@ -4,10 +4,10 @@ package com.google.refine.expr.functions.strings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class EncodeTest extends RefineTest {
+public class EncodeTest extends GrelTestBase {
 
     @Test
     public void testEncode() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/EndsWithTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/EndsWithTests.java
@@ -32,9 +32,9 @@ import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
+import com.google.refine.grel.GrelTestBase;
 
-public class EndsWithTests extends RefineTest {
+public class EndsWithTests extends GrelTestBase {
 
     @Test
     public void testStartsWith() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/EscapeTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/EscapeTests.java
@@ -32,9 +32,9 @@ import static org.testng.Assert.assertNull;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
+import com.google.refine.grel.GrelTestBase;
 
-public class EscapeTests extends RefineTest {
+public class EscapeTests extends GrelTestBase {
 
     @Test
     public void testEscape() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/FindTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/FindTests.java
@@ -36,12 +36,12 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineServlet;
-import com.google.refine.RefineTest;
+import com.google.refine.grel.GrelTestBase;
 
 /**
  * Test cases for find function.
  */
-public class FindTests extends RefineTest {
+public class FindTests extends GrelTestBase {
 
     static Properties bindings;
 

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/FingerprintTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/FingerprintTests.java
@@ -33,14 +33,12 @@ package com.google.refine.expr.functions.strings;
 
 import java.util.Properties;
 
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
+import com.google.refine.grel.GrelTestBase;
 
-public class FingerprintTests extends RefineTest {
+public class FingerprintTests extends GrelTestBase {
 
     static Properties bindings;
 
@@ -57,12 +55,6 @@ public class FingerprintTests extends RefineTest {
 //        {"œ ӕ","ae oe"},
             { "", "" },
     };
-
-    @Override
-    @BeforeTest
-    public void init() {
-        logger = LoggerFactory.getLogger(this.getClass());
-    }
 
     @Test
     public void testInvalidParams() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/ParseUriTest.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/ParseUriTest.java
@@ -7,11 +7,11 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 import com.google.refine.util.ParsingUtilities;
 
-public class ParseUriTest extends RefineTest {
+public class ParseUriTest extends GrelTestBase {
 
     private String sampleUri;
 

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/PhoneticTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/PhoneticTests.java
@@ -33,13 +33,13 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.clustering.binning.ColognePhoneticKeyer;
 import com.google.refine.clustering.binning.KeyerFactory;
 import com.google.refine.clustering.binning.Metaphone3Keyer;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class PhoneticTests extends RefineTest {
+public class PhoneticTests extends GrelTestBase {
 
     @BeforeTest
     public void registerKeyers() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/RangeTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/RangeTests.java
@@ -32,13 +32,13 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
 /**
  * Tests for the range function.
  */
-public class RangeTests extends RefineTest {
+public class RangeTests extends GrelTestBase {
 
     private static final Integer[] EMPTY_ARRAY = new Integer[0];
 

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/ReplaceEachTest.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/ReplaceEachTest.java
@@ -1,41 +1,43 @@
 
 package com.google.refine.expr.functions.strings;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
 import java.util.Properties;
 
-import org.junit.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.ParsingException;
+import com.google.refine.grel.GrelTestBase;
 
-public class ReplaceEachTest extends RefineTest {
+public class ReplaceEachTest extends GrelTestBase {
 
     @Test
     public void replaceEachValidParams() {
 
-        Assert.assertTrue(
+        assertTrue(
                 invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz", new String[] { "a", "e", "i", "o", "u" }, "A") instanceof String);
-        Assert.assertEquals(invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz", new String[] { "a", "e", "i", "o", "u" }, "A"),
+        assertEquals(invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz", new String[] { "a", "e", "i", "o", "u" }, "A"),
                 "AbcdAfghAjklmnApqrstAvwxyz");
-        Assert.assertEquals(
+        assertEquals(
                 invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz", new String[] { "a", "e", "i", "o", "u" }, new String[] { "A" }),
                 "AbcdAfghAjklmnApqrstAvwxyz");
-        Assert.assertEquals(invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz", new String[] { "a", "e", "i", "o", "u" },
+        assertEquals(invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz", new String[] { "a", "e", "i", "o", "u" },
                 new String[] { "A", "E", "I", "O", "U" }), "AbcdEfghIjklmnOpqrstUvwxyz");
 
     }
 
     @Test
     public void replaceEachInvalidParams() {
-        Assert.assertTrue(invoke("replaceEach") instanceof EvalError);
-        Assert.assertTrue(invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz") instanceof EvalError);
-        Assert.assertTrue(
+        assertTrue(invoke("replaceEach") instanceof EvalError);
+        assertTrue(invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz") instanceof EvalError);
+        assertTrue(
                 invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz", new String[] { "a", "e", "i", "o", "u" }) instanceof EvalError);
-        Assert.assertTrue(invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz", new String[] { "a", "e", "i", "o", "u" }, "A",
+        assertTrue(invoke("replaceEach", "abcdefghijklmnopqrstuvwxyz", new String[] { "a", "e", "i", "o", "u" }, "A",
                 "B") instanceof EvalError);
-        Assert.assertTrue(invoke("replaceEach", new String[] { "a", "e", "i", "o", "u" }, new String[] { "A", "B" },
+        assertTrue(invoke("replaceEach", new String[] { "a", "e", "i", "o", "u" }, new String[] { "A", "B" },
                 "abcdefghijklmnopqrstuvwxyz") instanceof EvalError);
     }
 

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/ReplaceTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/ReplaceTests.java
@@ -32,10 +32,10 @@ import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class ReplaceTests extends RefineTest {
+public class ReplaceTests extends GrelTestBase {
 
     @Test
     public void testReplace() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/SplitTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/SplitTests.java
@@ -34,10 +34,10 @@ import java.util.regex.Pattern;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class SplitTests extends RefineTest {
+public class SplitTests extends GrelTestBase {
 
     @Test
     public void testSplit() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/StartsWithTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/StartsWithTests.java
@@ -32,9 +32,9 @@ import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
+import com.google.refine.grel.GrelTestBase;
 
-public class StartsWithTests extends RefineTest {
+public class StartsWithTests extends GrelTestBase {
 
     @Test
     public void testStartsWith() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/ToLowercaseTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/ToLowercaseTests.java
@@ -30,10 +30,10 @@ package com.google.refine.expr.functions.strings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class ToLowercaseTests extends RefineTest {
+public class ToLowercaseTests extends GrelTestBase {
 
     @Test
     public void testtoLowercaseInvalidParams() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/ToTitlecaseTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/ToTitlecaseTests.java
@@ -30,10 +30,10 @@ package com.google.refine.expr.functions.strings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class ToTitlecaseTests extends RefineTest {
+public class ToTitlecaseTests extends GrelTestBase {
 
     @Test
     public void testToTitlecaseInvalidParams() {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/TrimTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/TrimTests.java
@@ -32,10 +32,10 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class TrimTests extends RefineTest {
+public class TrimTests extends GrelTestBase {
 
     private static String NBSP = "\u00A0";
     private static String ENQUAD = "\u2000";

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/UnescapeTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/UnescapeTests.java
@@ -31,9 +31,9 @@ import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
+import com.google.refine.grel.GrelTestBase;
 
-public class UnescapeTests extends RefineTest {
+public class UnescapeTests extends GrelTestBase {
 
     @Test
     public void testUnescape() {

--- a/main/tests/server/src/com/google/refine/expr/functions/xml/ParseXmlTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/xml/ParseXmlTests.java
@@ -36,10 +36,10 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class ParseXmlTests extends RefineTest {
+public class ParseXmlTests extends GrelTestBase {
 
     static Properties bindings;
     static String x = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +

--- a/main/tests/server/src/com/google/refine/expr/functions/xml/WholeTextTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/xml/WholeTextTests.java
@@ -25,19 +25,23 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-package com.google.refine.expr;
+package com.google.refine.expr.functions.xml;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
-import com.google.refine.util.TestUtils;
+import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class EvalErrorTests extends RefineTest {
+public class WholeTextTests extends GrelTestBase {
 
     @Test
-    public void serializeEvalError() {
-        EvalError e = new EvalError("This is a critical error");
-        TestUtils.isSerializedTo(e, "{\"type\":\"error\",\"message\":\"This is a critical error\"}");
-    }
+    public void testWholeText() {
+        Assert.assertTrue(invoke("wholeText") instanceof EvalError);
+        Assert.assertTrue(invoke("wholeText", "test") instanceof EvalError);
 
+        EvalError evalError = (EvalError) invoke("wholeText", "test");
+        Assert.assertEquals(evalError.toString(),
+                "wholeText() cannot work with this \'string\' and failed as the first parameter is not an XML or HTML Element.  Please first use parseXml() or parseHtml() and select(query) prior to using this function");
+    }
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/xml/XmlTextTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/xml/XmlTextTests.java
@@ -25,19 +25,23 @@
  * POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
 
-package com.google.refine.expr;
+package com.google.refine.expr.functions.xml;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
-import com.google.refine.util.TestUtils;
+import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
 
-public class EvalErrorTests extends RefineTest {
+public class XmlTextTests extends GrelTestBase {
 
     @Test
-    public void serializeEvalError() {
-        EvalError e = new EvalError("This is a critical error");
-        TestUtils.isSerializedTo(e, "{\"type\":\"error\",\"message\":\"This is a critical error\"}");
-    }
+    public void testXmlText() {
+        Assert.assertTrue(invoke("xmlText") instanceof EvalError);
+        Assert.assertTrue(invoke("xmlText", "test") instanceof EvalError);
 
+        EvalError evalError = (EvalError) invoke("xmlText", "test");
+        Assert.assertEquals(evalError.toString(),
+                "xmlText() cannot work with this \'string\' and failed as the first parameter is not an XML or HTML Element.  Please first use parseXml() or parseHtml() and select(query) prior to using this function");
+    }
 }

--- a/main/tests/server/src/com/google/refine/grel/GrelTestBase.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTestBase.java
@@ -1,0 +1,98 @@
+
+package com.google.refine.grel;
+
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+
+import com.google.refine.RefineTest;
+import com.google.refine.expr.Evaluable;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.expr.ParsingException;
+
+/**
+ * Base class for tests of GREL's functionalities
+ */
+public class GrelTestBase extends RefineTest {
+
+    protected Logger logger = null;
+
+    protected static Properties bindings = null;
+
+    @BeforeTest
+    public void initLogger() {
+        logger = LoggerFactory.getLogger(this.getClass());
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        bindings = new Properties();
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        bindings = null;
+    }
+
+    /**
+     * Lookup a control function by name and invoke it with a variable number of args
+     */
+    protected static Object invoke(String name, Object... args) {
+        // registry uses static initializer, so no need to set it up
+        Function function = ControlFunctionRegistry.getFunction(name);
+        if (bindings == null) {
+            bindings = new Properties();
+        }
+        if (function == null) {
+            throw new IllegalArgumentException("Unknown function " + name);
+        }
+        if (args == null) {
+            return function.call(bindings, new Object[0]);
+        } else {
+            return function.call(bindings, args);
+        }
+    }
+
+    /**
+     * Parse and evaluate a GREL expression and compare the result to the expect value
+     *
+     * @param bindings
+     * @param test
+     * @throws ParsingException
+     */
+    protected void parseEval(Properties bindings, String[] test)
+            throws ParsingException {
+        Evaluable eval = MetaParser.parse("grel:" + test[0]);
+        Object result = eval.evaluate(bindings);
+        if (test[1] != null) {
+            Assert.assertNotNull(result, "Expected " + test[1] + " for test " + test[0]);
+            Assert.assertEquals(result.toString(), test[1], "Wrong result for expression: " + test[0]);
+        } else {
+            Assert.assertNull(result, "Wrong result for expression: " + test[0]);
+        }
+    }
+
+    /**
+     * Parse and evaluate a GREL expression and compare the result an expected type using instanceof
+     *
+     * @param bindings
+     * @param test
+     * @throws ParsingException
+     */
+    protected void parseEvalType(Properties bindings, String test, @SuppressWarnings("rawtypes") Class clazz)
+            throws ParsingException {
+        Evaluable eval = MetaParser.parse("grel:" + test);
+        Object result = eval.evaluate(bindings);
+        Assert.assertTrue(clazz.isInstance(result), "Wrong result type for expression: " + test);
+    }
+
+    @AfterMethod
+    public void TearDown() throws Exception {
+        bindings = null;
+    }
+}

--- a/main/tests/server/src/com/google/refine/grel/GrelTests.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTests.java
@@ -37,14 +37,11 @@ import static org.testng.Assert.fail;
 
 import java.util.Properties;
 
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
@@ -52,16 +49,10 @@ import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
 import com.google.refine.model.Project;
 
-public class GrelTests extends RefineTest {
+public class GrelTests extends GrelTestBase {
 
     Project project;
     Properties bindings;
-
-    @Override
-    @BeforeTest
-    public void init() {
-        logger = LoggerFactory.getLogger(this.getClass());
-    }
 
     @BeforeMethod
     public void SetUp() {

--- a/main/tests/server/src/com/google/refine/grel/controls/ForEachIndexTests.java
+++ b/main/tests/server/src/com/google/refine/grel/controls/ForEachIndexTests.java
@@ -33,12 +33,12 @@ import java.util.Properties;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
+import com.google.refine.grel.GrelTestBase;
 import com.google.refine.util.TestUtils;
 
-public class ForEachIndexTests extends RefineTest {
+public class ForEachIndexTests extends GrelTestBase {
 
     @Test
     public void serializeForEachIndex() {

--- a/main/tests/server/src/com/google/refine/grel/controls/ForEachTests.java
+++ b/main/tests/server/src/com/google/refine/grel/controls/ForEachTests.java
@@ -34,14 +34,14 @@ import java.util.Properties;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
+import com.google.refine.grel.GrelTestBase;
 import com.google.refine.util.TestUtils;
 
-public class ForEachTests extends RefineTest {
+public class ForEachTests extends GrelTestBase {
 
     @Test
     public void serializeForEach() {

--- a/main/tests/server/src/com/google/refine/grel/controls/ForRangeTests.java
+++ b/main/tests/server/src/com/google/refine/grel/controls/ForRangeTests.java
@@ -34,14 +34,14 @@ import java.util.stream.Collectors;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
+import com.google.refine.grel.GrelTestBase;
 import com.google.refine.util.TestUtils;
 
-public class ForRangeTests extends RefineTest {
+public class ForRangeTests extends GrelTestBase {
 
     @Test
     public void serializeForRange() {


### PR DESCRIPTION
Changes proposed in this pull request:
- introduce a new base class for GREL tests, which extends our current `RefineTest`. This makes it possible to remove the test utilities that depend on GREL from the RefineTest class, in anticipation for it being in a core Maven module where GREL isn't available
- also splits out some tests that were in `EvalErrorTests` but really belong to the test classes for the functions they actually test. This is also necessary because `EvalError` will live in the core Maven module (being part of the core data model, as they can be stored in Cell), whereas the corresponding functions will be in the GREL module
