### PR TITLE
Remove grel registration from RefineTest

### DIFF
--- a/main/src/com/google/refine/expr/MetaParser.java
+++ b/main/src/com/google/refine/expr/MetaParser.java
@@ -73,6 +73,16 @@ abstract public class MetaParser {
         s_languages.put(languagePrefix, new LanguageInfo(name, parser, defaultExpression));
     }
 
+    /**
+     * Unregisters a language.
+     * 
+     * @param languagePrefix
+     *            the prefix with which the language was registered
+     */
+    static public void unregisterLanguageParser(String languagePrefix) {
+        s_languages.remove(languagePrefix.toLowerCase());
+    }
+
     static public LanguageInfo getLanguageInfo(String languagePrefix) {
         return s_languages.get(languagePrefix.toLowerCase());
     }

--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -62,10 +62,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 
-import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.ControlFunctionRegistry;
 import com.google.refine.grel.Function;
-import com.google.refine.grel.Parser;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingManager;
 import com.google.refine.io.FileProjectManager;
@@ -117,7 +115,6 @@ public class RefineTest {
         }
         // This just keeps track of any failed test, for cleanupWorkspace
         testFailed = false;
-        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
     }
 
     @BeforeMethod

--- a/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java
@@ -37,11 +37,15 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.facets.ListFacet.ListFacetConfig;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.TestUtils;
@@ -90,6 +94,16 @@ public class ListFacetTests extends RefineTest {
             + "    {\"v\":{\"v\":\"ebar\",\"l\":\"ebar\"},\"c\":1,\"s\":false},"
             + "    {\"v\":{\"v\":\"foobar\",\"l\":\"true\"},\"c\":0,\"s\":true}"
             + "]}";
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @Test
     public void serializeListFacetConfig() throws JsonParseException, JsonMappingException, IOException {

--- a/main/tests/server/src/com/google/refine/browsing/facets/RangeFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/RangeFacetTests.java
@@ -32,11 +32,15 @@ import java.io.Serializable;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.facets.RangeFacet.RangeFacetConfig;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.TestUtils;
@@ -75,6 +79,16 @@ public class RangeFacetTests extends RefineTest {
             + "\"nonNumericCount\":1,"
             + "\"blankCount\":0,"
             + "\"errorCount\":0}";
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @Test
     public void serializeRangeFacetConfig() throws JsonParseException, JsonMappingException, IOException {

--- a/main/tests/server/src/com/google/refine/browsing/facets/ScatterplotFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/ScatterplotFacetTests.java
@@ -35,12 +35,16 @@ import java.io.Serializable;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.RowFilter;
 import com.google.refine.browsing.facets.ScatterplotFacet.ScatterplotFacetConfig;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.TestUtils;
@@ -81,6 +85,16 @@ public class ScatterplotFacetTests extends RefineTest {
             + "\"from_y\":0.26666666666666666,"
             + "\"to_y\":1"
             + "}";
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @Test
     public void serializeScatterplotFacetConfig() throws JsonParseException, JsonMappingException, IOException {

--- a/main/tests/server/src/com/google/refine/browsing/facets/TimeRangeFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/TimeRangeFacetTests.java
@@ -33,11 +33,15 @@ import java.time.OffsetDateTime;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.facets.TimeRangeFacet.TimeRangeFacetConfig;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.TestUtils;
@@ -76,6 +80,16 @@ public class TimeRangeFacetTests extends RefineTest {
             "          \"type\": \"timerange\",\n" +
             "          \"columnName\": \"my column\"\n" +
             "        }";
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @Test
     public void serializeTimeRangeFacetConfig() throws JsonParseException, JsonMappingException, IOException {

--- a/main/tests/server/src/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
@@ -46,6 +46,7 @@ import org.testng.annotations.Test;
 import com.google.refine.RefineTest;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Cell;
 import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
@@ -70,6 +71,16 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
     private static final String columnName = "Col1";
     private static final int numberOfRows = 5;
     private static final String projectName = "ExpressionNominalValueGrouper";
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @Override
     @BeforeTest

--- a/main/tests/server/src/com/google/refine/commands/expr/PreviewExpressionCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/expr/PreviewExpressionCommandTests.java
@@ -39,11 +39,14 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.commands.Command;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.util.TestUtils;
 
@@ -73,6 +76,16 @@ public class PreviewExpressionCommandTests extends RefineTest {
                         { "e", "f" },
                         { "g", "h" }
                 });
+    }
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/exporters/TemplatingExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/TemplatingExporterTests.java
@@ -53,6 +53,8 @@ import com.google.refine.ProjectMetadata;
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.Engine.Mode;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
 import com.google.refine.model.ModelException;
@@ -68,6 +70,16 @@ public class TemplatingExporterTests extends RefineTest {
     String prefix = "test prefix>";
     String suffix = "<test suffix";
     String rowSeparator = "\n";
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @Override
     @BeforeTest

--- a/main/tests/server/src/com/google/refine/grel/FunctionTests.java
+++ b/main/tests/server/src/com/google/refine/grel/FunctionTests.java
@@ -54,6 +54,7 @@ import org.testng.annotations.Test;
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
 import com.google.refine.expr.EvalError;
+import com.google.refine.expr.MetaParser;
 import com.google.refine.model.Cell;
 import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
@@ -68,6 +69,16 @@ public class FunctionTests extends RefineTest {
     @BeforeTest
     public void init() {
         logger = LoggerFactory.getLogger(this.getClass());
+    }
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
     }
 
     @BeforeMethod

--- a/main/tests/server/src/com/google/refine/grel/GrelTestBase.java
+++ b/main/tests/server/src/com/google/refine/grel/GrelTestBase.java
@@ -24,6 +24,16 @@ public class GrelTestBase extends RefineTest {
 
     protected static Properties bindings = null;
 
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
+
     @BeforeTest
     public void initLogger() {
         logger = LoggerFactory.getLogger(this.getClass());

--- a/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
@@ -43,6 +43,8 @@ import com.google.refine.browsing.DecoratedValue;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.facets.ListFacet;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
@@ -57,6 +59,16 @@ public class BlankDownTests extends RefineTest {
     Project projectToBlankDown = null;
     Project projectForRecordKey = null;
     ListFacet.ListFacetConfig facet;
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @BeforeSuite
     public void registerOperation() {

--- a/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
@@ -43,6 +43,8 @@ import com.google.refine.browsing.DecoratedValue;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.facets.ListFacet;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
@@ -56,6 +58,16 @@ public class FillDownTests extends RefineTest {
     Project project = null;
     Project toFillDown = null;
     ListFacet.ListFacetConfig facet;
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @BeforeSuite
     public void registerOperation() {

--- a/main/tests/server/src/com/google/refine/operations/cell/MassOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MassOperationTests.java
@@ -34,6 +34,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -44,6 +45,8 @@ import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.facets.ListFacet.ListFacetConfig;
 import com.google.refine.expr.EvalError;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationRegistry;
 import com.google.refine.operations.cell.MassEditOperation.Edit;
@@ -54,6 +57,16 @@ public class MassOperationTests extends RefineTest {
 
     private List<Edit> editList;
     private String editsString;
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @BeforeSuite
     public void setUp() {

--- a/main/tests/server/src/com/google/refine/operations/cell/TextTransformOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TextTransformOperationTests.java
@@ -3,6 +3,7 @@ package com.google.refine.operations.cell;
 
 import java.io.Serializable;
 
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -10,6 +11,8 @@ import org.testng.annotations.Test;
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.expr.EvalError;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OnError;
 import com.google.refine.operations.OperationRegistry;
@@ -21,6 +24,16 @@ public class TextTransformOperationTests extends RefineTest {
     @BeforeSuite
     public void registerOperation() {
         OperationRegistry.registerOperation(getCoreModule(), "text-transform", TextTransformOperation.class);
+    }
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
     }
 
     protected Project project;

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -49,6 +49,7 @@ import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -57,6 +58,8 @@ import com.google.refine.RefineTest;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.ExpressionUtils;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
 import com.google.refine.model.ModelException;
@@ -100,6 +103,16 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
             "    \"progress\" : 0,\n" +
             "    \"status\" : \"pending\"\n" +
             " }";
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @BeforeTest
     public void initOperation() {

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionOperationTests.java
@@ -30,6 +30,7 @@ package com.google.refine.operations.column;
 import java.io.Serializable;
 import java.util.Collections;
 
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -40,6 +41,8 @@ import com.google.refine.browsing.Engine.Mode;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.facets.ListFacet;
 import com.google.refine.expr.EvalError;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OnError;
 import com.google.refine.operations.OperationRegistry;
@@ -49,6 +52,16 @@ import com.google.refine.util.TestUtils;
 public class ColumnAdditionOperationTests extends RefineTest {
 
     protected Project project;
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
 
     @BeforeSuite
     public void registerOperation() {

--- a/main/tests/server/src/com/google/refine/operations/row/RowFlagOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowFlagOperationTests.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -42,6 +43,8 @@ import com.google.refine.browsing.DecoratedValue;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.facets.ListFacet.ListFacetConfig;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationRegistry;
 import com.google.refine.util.ParsingUtilities;
@@ -55,6 +58,16 @@ public class RowFlagOperationTests extends RefineTest {
     @BeforeSuite
     public void registerOperation() {
         OperationRegistry.registerOperation(getCoreModule(), "row-flag", RowFlagOperation.class);
+    }
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
     }
 
     @BeforeMethod

--- a/main/tests/server/src/com/google/refine/operations/row/RowRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowRemovalOperationTests.java
@@ -46,8 +46,10 @@ import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.RowVisitor;
 import com.google.refine.browsing.facets.ListFacet.ListFacetConfig;
+import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.functions.FacetCount;
 import com.google.refine.grel.Function;
+import com.google.refine.grel.Parser;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.Cell;
 import com.google.refine.model.ModelException;
@@ -95,6 +97,7 @@ public class RowRemovalOperationTests extends RefineTest {
 
     @BeforeMethod
     public void SetUp() throws IOException, ModelException {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
         projectIssue567 = createProjectWithColumns("RowRemovalOperationTests", "Column A");
         project = createProject(new String[] { "foo", "bar", "hello" },
                 new Serializable[][] {
@@ -121,6 +124,7 @@ public class RowRemovalOperationTests extends RefineTest {
 
     @AfterMethod
     public void TearDown() {
+        MetaParser.unregisterLanguageParser("grel");
         projectIssue567 = null;
         engine = null;
         bindings = null;

--- a/main/tests/server/src/com/google/refine/operations/row/RowStarOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowStarOperationTests.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -42,6 +43,8 @@ import com.google.refine.browsing.DecoratedValue;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.facets.ListFacet.ListFacetConfig;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationRegistry;
 import com.google.refine.util.ParsingUtilities;
@@ -55,6 +58,16 @@ public class RowStarOperationTests extends RefineTest {
     @BeforeSuite
     public void registerOperation() {
         OperationRegistry.registerOperation(getCoreModule(), "row-star", RowStarOperation.class);
+    }
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
     }
 
     @BeforeMethod


### PR DESCRIPTION
This removes the final dependency from RefineTest to GREL by not registering GREL in it by default.
Instead, we register and unregister it in each test that relies on it.

~Draft because it depends on #6502 and #6571. Once those are merged, the diffs will be smaller.~