### PR TITLE
exclude oro license from trying to download

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -127,6 +127,7 @@
           <connectTimeout>10000</connectTimeout>
           <cleanLicensesOutputDirectory>true</cleanLicensesOutputDirectory>
           <licensesConfigFile>${basedir}/manual_licenses.xml</licensesConfigFile>
+          <excludedArtifacts>oro</excludedArtifacts>  
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
- excludes oro dependency for license download (since it fails) during build

