### PR TITLE
wikibase: Alert the user when they do not provide an edit summary

### DIFF
--- a/extensions/wikibase/module/scripts/dialogs/perform-edits-dialog.js
+++ b/extensions/wikibase/module/scripts/dialogs/perform-edits-dialog.js
@@ -33,11 +33,6 @@ PerformEditsDialog.launch = function(logged_in_username, max_severity) {
     var formCopy = hiddenIframe.find("#wikibase-perform-edits-form");
     formCopy.trigger('submit');
 
-    if (elmts.editSummary.val().length === 0) {
-      elmts.editSummary.trigger('focus');
-      return;
-    }
-
     if (elmts.maxlag.val().length === 0) {
       elmts.maxlag.val(WikibaseManager.getSelectedWikibaseMaxlag());
     }


### PR DESCRIPTION
Closes #6306 

Changes proposed in this pull request:
- Unfortunately, i couldn't configure the request for a working "required" tag inside the HTML code. 
- Directly implementing the "required" tag in the appropriate HTML "input" tag did not work, since the form isn't directly submitted from the HTML code, but from a JavaScript code that doesn't recognize the "required" tag.
- Although, as i noticed in different parts off the project, problems as such are dealt with the pop-up window that follows: 
![Screenshot 2024-05-07 202645](https://github.com/OpenRefine/OpenRefine/assets/115114218/7a8a0dfd-7d6e-41d2-a34a-e22e01025e78)
-(The previous message pops-up when the user clicks "next" without choosing a file in the "create project" section).
-What this PR changes, is instead of focusing to the box next to "summary", it pops-up the following message:
![Screenshot 2024-05-07 202618](https://github.com/OpenRefine/OpenRefine/assets/115114218/a836bc83-ba39-48ed-aafa-8fcc58046b28)
-(This validation message was already implemented inside the code but never reached).

