### PR TITLE
Make join handling of empty strings consistent even if they are first in array

### DIFF
--- a/main/src/com/google/refine/expr/functions/arrays/Join.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Join.java
@@ -59,13 +59,16 @@ public class Join implements Function {
 
                 if (v.getClass().isArray() || v instanceof List<?> || v instanceof ArrayNode) {
                     StringBuffer sb = new StringBuffer();
+                    boolean isFirst = true;
                     if (v.getClass().isArray()) {
                         for (Object o : (Object[]) v) {
+                            // TODO: Treat null as empty string like we do everywhere else?
                             if (o != null) {
-                                if (sb.length() > 0) {
+                                if (!isFirst) {
                                     sb.append(separator);
                                 }
-                                sb.append(o.toString());
+                                sb.append(o);
+                                isFirst = false;
                             }
                         }
                     } else if (v instanceof ArrayNode) {
@@ -73,18 +76,21 @@ public class Join implements Function {
                         int l = a.size();
 
                         for (int i = 0; i < l; i++) {
-                            if (sb.length() > 0) {
+                            if (!isFirst) {
                                 sb.append(separator);
                             }
+                            // FIXME: This throws NPE for arrays containing nulls
                             sb.append(JsonValueConverter.convert(a.get(i)).toString());
+                            isFirst = false;
                         }
                     } else {
                         for (Object o : ExpressionUtils.toObjectList(v)) {
                             if (o != null) {
-                                if (sb.length() > 0) {
+                                if (!isFirst) {
                                     sb.append(separator);
                                 }
-                                sb.append(o.toString());
+                                sb.append(o);
+                                isFirst = false;
                             }
                         }
                     }

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
@@ -51,6 +51,11 @@ public class JoinTests extends RefineTest {
         parseEval(bindings, test3);
         String[] test4 = { "['z', '','c','a'].join('-')", "z--c-a" };
         parseEval(bindings, test4);
-    }
+
+        // Issue 3290 - Make sure leading empty strings don't get skipped
+        parseEval(bindings, new String[] { "['',2,3].join('|')", "|2|3" } );
+        parseEval(bindings, new String[] { "[1,'',3].join('|')", "1||3" } );
+        parseEval(bindings, new String[] { "[1,2,''].join('|')", "1|2|" } );
+        parseEval(bindings, new String[] { "['','',''].join('|')", "||" } );
 
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
@@ -58,4 +58,15 @@ public class JoinTests extends RefineTest {
         parseEval(bindings, new String[] { "[1,2,''].join('|')", "1|2|" } );
         parseEval(bindings, new String[] { "['','',''].join('|')", "||" } );
 
+        // Tests for JSON array
+        // Both of the following tests throw NPEs. First is desired behavior, second is current array behavior
+//        parseEval(bindings, new String[] { "'[null,null,null]'.parseJson().join('|')", "||" } );
+//        parseEval(bindings, new String[] { "'[null,null,null]'.parseJson().join('|')", "" } );
+        parseEval(bindings, new String[] { "'[\"\",2,3]'.parseJson().join('|')", "|2|3" } );
+        parseEval(bindings, new String[] { "'[1,2,\"\"]'.parseJson().join('|')", "1|2|" } );
+        parseEval(bindings, new String[] { "'[\"\",\"\",\"\"]'.parseJson().join('|')", "||" } );
+
+        // TODO: Add tests for List<Object> returned from ExpressionUtils.toObjectList()
+    }
+
 }


### PR DESCRIPTION
Fixes #3290

Changes proposed in this pull request:
- Fix algorithm for deciding if we have already added an element to our join string
- Add tests for leading and trailing empty strings
- Add tests for join of JSON array (unrelated to address missing test coverage)
