### PR TITLE
Fix NullPointerException in forEachIndex

### DIFF
--- a/main/src/com/google/refine/expr/functions/arrays/Join.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Join.java
@@ -59,13 +59,16 @@ public class Join implements Function {
 
                 if (v.getClass().isArray() || v instanceof List<?> || v instanceof ArrayNode) {
                     StringBuffer sb = new StringBuffer();
+                    boolean isFirst = true;
                     if (v.getClass().isArray()) {
                         for (Object o : (Object[]) v) {
+                            // TODO: Treat null as empty string like we do everywhere else?
                             if (o != null) {
-                                if (sb.length() > 0) {
+                                if (!isFirst) {
                                     sb.append(separator);
                                 }
-                                sb.append(o.toString());
+                                sb.append(o);
+                                isFirst = false;
                             }
                         }
                     } else if (v instanceof ArrayNode) {
@@ -73,18 +76,21 @@ public class Join implements Function {
                         int l = a.size();
 
                         for (int i = 0; i < l; i++) {
-                            if (sb.length() > 0) {
+                            if (!isFirst) {
                                 sb.append(separator);
                             }
+                            // FIXME: This throws NPE for arrays containing nulls
                             sb.append(JsonValueConverter.convert(a.get(i)).toString());
+                            isFirst = false;
                         }
                     } else {
                         for (Object o : ExpressionUtils.toObjectList(v)) {
                             if (o != null) {
-                                if (sb.length() > 0) {
+                                if (!isFirst) {
                                     sb.append(separator);
                                 }
-                                sb.append(o.toString());
+                                sb.append(o);
+                                isFirst = false;
                             }
                         }
                     }

--- a/main/src/com/google/refine/grel/controls/ForEachIndex.java
+++ b/main/src/com/google/refine/grel/controls/ForEachIndex.java
@@ -97,8 +97,11 @@ public class ForEachIndex implements Control {
                     Object v = values[i];
 
                     bindings.put(indexName, i);
-                    bindings.put(elementName, v);
-
+                    if (v != null) {
+                        bindings.put(elementName, v);
+                    } else {
+                        bindings.remove(elementName);
+                    }
                     Object r = args[3].evaluate(bindings);
 
                     results.add(r);
@@ -112,7 +115,11 @@ public class ForEachIndex implements Control {
                     Object v = JsonValueConverter.convert(a.get(i));
 
                     bindings.put(indexName, i);
-                    bindings.put(elementName, v);
+                    if (v != null) {
+                        bindings.put(elementName, v);
+                    } else {
+                        bindings.remove(elementName);
+                    }
 
                     Object r = args[3].evaluate(bindings);
 

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
@@ -51,6 +51,11 @@ public class JoinTests extends RefineTest {
         parseEval(bindings, test3);
         String[] test4 = { "['z', '','c','a'].join('-')", "z--c-a" };
         parseEval(bindings, test4);
-    }
+
+        // Issue 3290 - Make sure leading empty strings don't get skipped
+        parseEval(bindings, new String[] { "['',2,3].join('|')", "|2|3" } );
+        parseEval(bindings, new String[] { "[1,'',3].join('|')", "1||3" } );
+        parseEval(bindings, new String[] { "[1,2,''].join('|')", "1|2|" } );
+        parseEval(bindings, new String[] { "['','',''].join('|')", "||" } );
 
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
@@ -58,4 +58,15 @@ public class JoinTests extends RefineTest {
         parseEval(bindings, new String[] { "[1,2,''].join('|')", "1|2|" } );
         parseEval(bindings, new String[] { "['','',''].join('|')", "||" } );
 
+        // Tests for JSON array
+        // Both of the following tests throw NPEs. First is desired behavior, second is current array behavior
+//        parseEval(bindings, new String[] { "'[null,null,null]'.parseJson().join('|')", "||" } );
+//        parseEval(bindings, new String[] { "'[null,null,null]'.parseJson().join('|')", "" } );
+        parseEval(bindings, new String[] { "'[\"\",2,3]'.parseJson().join('|')", "|2|3" } );
+        parseEval(bindings, new String[] { "'[1,2,\"\"]'.parseJson().join('|')", "1|2|" } );
+        parseEval(bindings, new String[] { "'[\"\",\"\",\"\"]'.parseJson().join('|')", "||" } );
+
+        // TODO: Add tests for List<Object> returned from ExpressionUtils.toObjectList()
+    }
+
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/JoinTests.java
@@ -53,18 +53,18 @@ public class JoinTests extends RefineTest {
         parseEval(bindings, test4);
 
         // Issue 3290 - Make sure leading empty strings don't get skipped
-        parseEval(bindings, new String[] { "['',2,3].join('|')", "|2|3" } );
-        parseEval(bindings, new String[] { "[1,'',3].join('|')", "1||3" } );
-        parseEval(bindings, new String[] { "[1,2,''].join('|')", "1|2|" } );
-        parseEval(bindings, new String[] { "['','',''].join('|')", "||" } );
+        parseEval(bindings, new String[] { "['',2,3].join('|')", "|2|3" });
+        parseEval(bindings, new String[] { "[1,'',3].join('|')", "1||3" });
+        parseEval(bindings, new String[] { "[1,2,''].join('|')", "1|2|" });
+        parseEval(bindings, new String[] { "['','',''].join('|')", "||" });
 
         // Tests for JSON array
         // Both of the following tests throw NPEs. First is desired behavior, second is current array behavior
 //        parseEval(bindings, new String[] { "'[null,null,null]'.parseJson().join('|')", "||" } );
 //        parseEval(bindings, new String[] { "'[null,null,null]'.parseJson().join('|')", "" } );
-        parseEval(bindings, new String[] { "'[\"\",2,3]'.parseJson().join('|')", "|2|3" } );
-        parseEval(bindings, new String[] { "'[1,2,\"\"]'.parseJson().join('|')", "1|2|" } );
-        parseEval(bindings, new String[] { "'[\"\",\"\",\"\"]'.parseJson().join('|')", "||" } );
+        parseEval(bindings, new String[] { "'[\"\",2,3]'.parseJson().join('|')", "|2|3" });
+        parseEval(bindings, new String[] { "'[1,2,\"\"]'.parseJson().join('|')", "1|2|" });
+        parseEval(bindings, new String[] { "'[\"\",\"\",\"\"]'.parseJson().join('|')", "||" });
 
         // TODO: Add tests for List<Object> returned from ExpressionUtils.toObjectList()
     }

--- a/main/tests/server/src/com/google/refine/grel/controls/ForEachIndexTests.java
+++ b/main/tests/server/src/com/google/refine/grel/controls/ForEachIndexTests.java
@@ -102,6 +102,16 @@ public class ForEachIndexTests extends RefineTest {
         bindings.put("v", "");
         parseEval(bindings, new String[] { "forEachIndex([5,4,3,2.0], k, v, v*2).join(',')", "10,8,6,4.0" });
         parseEval(bindings, new String[] { "forEachIndex([5,4,3,2.0], k, v, k).join(',')", "0,1,2,3" });
+        parseEval(bindings, new String[] { "forEachIndex(['a','b','c'], k, v, v).join(',')", "a,b,c" });
+        parseEval(bindings, new String[] { "forEachIndex(['','b','c'], k, v, v).join(',')", ",b,c" });
+        parseEval(bindings, new String[] { "forEachIndex(['','',''], k, v, v).join(',')", ",," });
+        // TODO: join() isn't a reliable way to test this because of broken null handling
+//        parseEval(bindings, new String[] { "forEachIndex([null,'b','c'], k, v, v).join(',')", ",b,c" });
+//        parseEval(bindings, new String[] { "forEachIndex(['a',null,'c'], k, v, v).join(',')", "a,,c" });
+        parseEval(bindings, new String[] { "toString(forEachIndex(['a',null,'c'], k, v, v))", "[a, null, c]" });
+        parseEval(bindings, new String[] { "toString(forEachIndex([null,'b','c'], k, v, v))", "[null, b, c]" });
+        parseEval(bindings, new String[] { "forEachIndex(['a','','c'], k, v, v).join(',')", "a,,c" });
+        parseEval(bindings, new String[] { "forEachIndex(['a','b',''], k, v, v).join(',')", "a,b," });
     }
 
     @Test
@@ -111,6 +121,8 @@ public class ForEachIndexTests extends RefineTest {
         bindings.put("v", "");
         parseEval(bindings, new String[] { "forEachIndex('[3,2,1.0]'.parseJson(), k, v, v*2).join(',')", "6,4,2.0" });
         parseEval(bindings, new String[] { "forEachIndex('[3,2,1.0]'.parseJson(), k, v, k).join(',')", "0,1,2" });
+        parseEval(bindings, new String[] { "toString(forEachIndex('[null, null, null]'.parseJson(), k, v, v))", "[null, null, null]" });
+        parseEval(bindings, new String[] { "forEachIndex('[\"\", \"\", \"\"]'.parseJson(), k, v, v).join(',')", ",," });
     }
 
 }


### PR DESCRIPTION
Fixes #6598 

Changes proposed in this pull request:
- Fix NPE when `forEachIndex` is used with an array containing `null`s
- Make sure tests don't use `join()` which has broken handling for `null`s

Note: this is based off branch for PR #6605 so that should be review/merged first
