### PR TITLE
Don't always trim whitespace for TSV. Fixes #6604

### DIFF
--- a/main/src/com/google/refine/importers/SeparatorBasedImporter.java
+++ b/main/src/com/google/refine/importers/SeparatorBasedImporter.java
@@ -88,7 +88,7 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
         JSONUtilities.safePut(options, "guessCellValueTypes", false);
         JSONUtilities.safePut(options, "processQuotes", !nonNullSeparator.equals("\\t"));
         JSONUtilities.safePut(options, "quoteCharacter", String.valueOf(DEFAULT_QUOTE_CHAR));
-        JSONUtilities.safePut(options, "trimStrings", true); // FIXME: ignored?
+        JSONUtilities.safePut(options, "trimStrings", true);
 
         return options;
     }
@@ -146,6 +146,8 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
         if (tsv) {
             TsvParserSettings settings = new TsvParserSettings();
             settings.setMaxCharsPerColumn(256 * 1024); // TODO: Perhaps use a lower default and make user configurable?
+            settings.setIgnoreLeadingWhitespaces(false);
+            settings.setIgnoreTrailingWhitespaces(false);
             parser = new TsvParser(settings);
         } else {
             CsvParserSettings settings = new CsvParserSettings();

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -240,7 +240,7 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         String input = " data1 " + inputSeparator + " 3.4 " + inputSeparator + " data3 ";
 
         try {
-            prepareOptions(sep, -1, 0, 0, 0, false, false, false);
+            prepareOptions(sep, -1, 0, 0, 0, false, true, false);
             parseOneFile(SUT, new StringReader(input));
         } catch (Exception e) {
             Assert.fail("Exception during file parse", e);


### PR DESCRIPTION
Fixes #6604

Changes proposed in this pull request:
- Turn off whitespace trimming for TSV parser (on by default) and use our optional trimming instead
- Adjust test so that the TSV importer path gets tested (everything was going through the CSV importer instead)

