### PR TITLE
Revised allocateID and generateID function

### DIFF
--- a/main/src/com/google/refine/history/HistoryEntry.java
+++ b/main/src/com/google/refine/history/HistoryEntry.java
@@ -96,7 +96,9 @@ public class HistoryEntry {
     }
 
     static public long allocateID() {
-        return Math.round(Math.random() * 1000000) + System.currentTimeMillis();
+        //        return Math.round(Math.random() * 1000000) + System.currentTimeMillis();
+        return (System.currentTimeMillis() << 20) + (long)(Math.random() * (1 << 20));
+
     }
 
     @JsonCreator

--- a/main/src/com/google/refine/model/Project.java
+++ b/main/src/com/google/refine/model/Project.java
@@ -78,7 +78,9 @@ public class Project {
     final static Logger logger = LoggerFactory.getLogger(Project.class);
 
     static public long generateID() {
-        return System.currentTimeMillis() + Math.round(Math.random() * 1000000000000L);
+
+//        return System.currentTimeMillis() + Math.round(Math.random() * 1000000000000L);
+        return (System.currentTimeMillis() << 20) + (long)(Math.random() * (1 << 20));
     }
 
     /**


### PR DESCRIPTION
Fixes #6471 

Changes proposed in this pull request:
- This pull request updates the allocateID() and generateID() method to use higher-order random numbers
- By shifting the current timestamp 20 bits left, it adds a random number up to 1 million (2^20) to the lower bits.

- 
