### PR TITLE
Update pom.xml Adding David as Developer Emeritus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,11 +47,11 @@
 
   <developers>
     <developer>
-      <id>dfhuynh</id>
-      <name>David F. Huynh</name>
-      <url>https://github.com/dfhuynh</url>
+      <id>contributors</id>
+      <name>OpenRefine Contributors</name>
+      <url>https://github.com/OpenRefine/OpenRefine/graphs/contributors</url>
       <roles>
-        <role>Developer Emeritus</role>
+        <role>Contributor</role>
       </roles>  
     </developer>
   </developers>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
       <id>dfhuynh</id>
       <name>David F. Huynh</name>
       <url>https://github.com/dfhuynh</url>
+      <roles>
+        <role>Developer Emeritus</role>
+      </roles>  
     </developer>
   </developers>
 


### PR DESCRIPTION
- several other open source projects assign the role Developer Emeritus, which we should do properly for David to avoid confusion.
