### PR TITLE
tests: Final de-coupling between GREL and core tests

### DIFF
--- a/main/tests/server/src/com/google/refine/RefineTest.java
+++ b/main/tests/server/src/com/google/refine/RefineTest.java
@@ -62,8 +62,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 
-import com.google.refine.grel.ControlFunctionRegistry;
-import com.google.refine.grel.Function;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingManager;
 import com.google.refine.io.FileProjectManager;
@@ -355,25 +353,6 @@ public class RefineTest {
     static public void verifyGetArrayOption(String name, ObjectNode options) {
         verify(options, times(1)).has(name);
         verify(options, times(1)).get(name);
-    }
-
-    /**
-     * Lookup a control function by name and invoke it with a variable number of args
-     */
-    protected static Object invoke(String name, Object... args) {
-        // registry uses static initializer, so no need to set it up
-        Function function = ControlFunctionRegistry.getFunction(name);
-        if (bindings == null) {
-            bindings = new Properties();
-        }
-        if (function == null) {
-            throw new IllegalArgumentException("Unknown function " + name);
-        }
-        if (args == null) {
-            return function.call(bindings, new Object[0]);
-        } else {
-            return function.call(bindings, args);
-        }
     }
 
     @AfterMethod

--- a/main/tests/server/src/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
@@ -45,8 +45,6 @@ import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.expr.Evaluable;
-import com.google.refine.expr.MetaParser;
-import com.google.refine.grel.Parser;
 import com.google.refine.model.Cell;
 import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
@@ -66,21 +64,18 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
     private static String stringStringValue = "a";
 
     private static ExpressionNominalValueGrouper grouper;
-    private static Evaluable eval;
+    private static Evaluable eval = new Evaluable() {
+
+        @Override
+        public Object evaluate(Properties bindings) {
+            return bindings.get("value");
+        }
+
+    };
     private static final int cellIndex = 0;
     private static final String columnName = "Col1";
     private static final int numberOfRows = 5;
     private static final String projectName = "ExpressionNominalValueGrouper";
-
-    @BeforeMethod
-    public void registerGRELParser() {
-        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
-    }
-
-    @AfterMethod
-    public void unregisterGRELParser() {
-        MetaParser.unregisterLanguageParser("grel");
-    }
 
     @Override
     @BeforeTest
@@ -110,7 +105,6 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
             project.rows.add(row);
         }
         // create grouper
-        eval = MetaParser.parse("value");
         grouper = new ExpressionNominalValueGrouper(eval, columnName, cellIndex);
         try {
             grouper.start(project);
@@ -138,7 +132,6 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
             project.rows.add(row);
         }
         // create grouper
-        eval = MetaParser.parse("value");
         grouper = new ExpressionNominalValueGrouper(eval, columnName, cellIndex);
         try {
             grouper.start(project);
@@ -166,7 +159,6 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
             project.rows.add(row);
         }
         // create grouper
-        eval = MetaParser.parse("value");
         grouper = new ExpressionNominalValueGrouper(eval, columnName, cellIndex);
         try {
             grouper.start(project);
@@ -199,7 +191,6 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
         bindings = new Properties();
         bindings.put("project", project);
 
-        eval = MetaParser.parse("value");
         grouper = new ExpressionNominalValueGrouper(eval, "col2", 1);
         try {
             grouper.start(project);

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/PhoneticTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/PhoneticTests.java
@@ -33,9 +33,8 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.clustering.binning.ColognePhoneticKeyer;
+import com.google.refine.clustering.binning.Keyer;
 import com.google.refine.clustering.binning.KeyerFactory;
-import com.google.refine.clustering.binning.Metaphone3Keyer;
 import com.google.refine.expr.EvalError;
 import com.google.refine.grel.GrelTestBase;
 
@@ -43,8 +42,14 @@ public class PhoneticTests extends GrelTestBase {
 
     @BeforeTest
     public void registerKeyers() {
-        KeyerFactory.put("metaphone3", new Metaphone3Keyer());
-        KeyerFactory.put("cologne-phonetic", new ColognePhoneticKeyer());
+        KeyerFactory.put("mock-keyer", new Keyer() {
+
+            @Override
+            public String key(String string, Object... params) {
+                return string.toLowerCase();
+            }
+
+        });
     }
 
     @Test
@@ -63,10 +68,6 @@ public class PhoneticTests extends GrelTestBase {
 
     @Test
     public void testValidParameters() {
-        assertEquals(invoke("phonetic", "hello", "metaphone3"), "HL");
-        assertEquals(invoke("phonetic", "hello", "cologne-phonetic"), "05");
-        assertEquals(invoke("phonetic", "hello", "soundex"), "H400");
-        assertEquals(invoke("phonetic", "hello", "metaphone"), "HL");
-        assertEquals(invoke("phonetic", "hello", "doublemetaphone"), "HL");
+        assertEquals(invoke("phonetic", "HeLlo", "mock-keyer"), "hello");
     }
 }

--- a/main/tests/server/src/com/google/refine/grel/FunctionTests.java
+++ b/main/tests/server/src/com/google/refine/grel/FunctionTests.java
@@ -51,7 +51,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.MetaParser;
@@ -60,7 +59,7 @@ import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 
-public class FunctionTests extends RefineTest {
+public class FunctionTests extends GrelTestBase {
 
     Project project;
     Engine engine;


### PR DESCRIPTION
This cuts the remaining inter-dependencies between GREL and core tests, preparing for the extraction of new Maven modules:
* a `core` module (which could also be named differently to avoid the confusion with the current `main`), containing the core classes defining OpenRefine's data model and main interfaces (what is a project, an operation, an importer, an expression language…). This module will have minimal dependencies to external libraries (such as Butterfly, Jackson and so on)
* a `grel` module which contains the implementation of our default expression language

The `main` module will then contain the implementation of the operations, importers, exporters (and so on) available by default in OpenRefine. This module will depend on the required external libraries to implement this functionality (POI, ODF parsing, Jena, and so on).