### PR TITLE
Group dependabot updates and reduce their frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
 - package-ecosystem: maven
   directory: "/"
   schedule:
-    interval: daily
+    interval: "weekly"
   open-pull-requests-limit: 15
   ignore:
   - dependency-name: com.thoughtworks.xstream:xstream
@@ -19,24 +19,32 @@ updates:
       - ">= 10.0.0"
   - dependency-name: "formatter-maven-plugin"
   target-branch: "master"
+  groups:
+    production-dependencies: # Maven dependencies of OpenRefine itself
+      dependency-type: "production"
+    development-dependencies: # Maven plugins
+      dependency-type: "development"
     
 # For main webapp
 - package-ecosystem: "npm"
   directory: "main/webapp"
   schedule:
-    interval: "daily"
-# For documentation website
-- package-ecosystem: "npm" # For Yarn
-  directory: "docs/"
-  schedule:
-    interval: "monthly"
+    interval: "weekly"
 # For github actions
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "monthly"
+  groups:
+    actions:
+       patterns:
+         - "*"
 # For cypress test_suite
 - package-ecosystem: "npm"
   directory: "main/tests/cypress"
   schedule:
-    interval: "daily"
+    interval: "weekly"
+  groups:
+    cypress:
+      patterns:
+        - "*"


### PR DESCRIPTION
This is an attempt to save a bit of computation time in the CI and group updates together, by batching dependency updates in weekly batches.

It would also mean a less crowded PR list and less such PRs to approve. I don't know if it's going to be workable, for instance if it's going to be easy to split the updates if the CI fails, but I propose we give it a try and see if we like it.

More info on this feature of dependabot:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups