### PR TITLE
Disable dependabot grouping for java dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,12 +19,7 @@ updates:
       - ">= 10.0.0"
   - dependency-name: "formatter-maven-plugin"
   target-branch: "master"
-  groups:
-    production-dependencies: # Maven dependencies of OpenRefine itself
-      dependency-type: "production"
-    development-dependencies: # Maven plugins
-      dependency-type: "development"
-    
+   
 # For main webapp
 - package-ecosystem: "npm"
   directory: "main/webapp"


### PR DESCRIPTION
Given the failures of #6650, #6656, let's abandon grouping for java dependencies.

I think the grouping for JS dependencies seems to be worth retaining: #6655 is nice.