### PR TITLE
Move commons-lang3 dependency to the server module

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -218,6 +218,7 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons-lang3.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -175,9 +175,19 @@
       <version>${jetty.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.openrefine.dependencies</groupId>
       <artifactId>butterfly</artifactId>
       <version>${butterfly.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -198,6 +208,11 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
       <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Fixes #6660 (see that issue for an explanation of the move).

This also explicitly adds other dependencies to the `server` module: those dependencies were in fact already pulled in (they are transitive dependencies of the module). The point of adding them to the pom file is to make sure we make the dependency on them explicit as we are (apparently) directly referring to some of their classes (so that we don't break if the transitive dependency chain is broken).
