### PR TITLE
Fix preservation of pagination when matching a single cell

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/reconcile/actions/cell-buttons.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/reconcile/actions/cell-buttons.cy.js
@@ -51,6 +51,30 @@ describe('In-cell reconciliation buttons', () => {
         //confirming the no. of candidates after we click on see less
         cy.getCell(0, 'species').find('.data-table-recon-candidate:visible').should('have.length', 4);
     });
+
+    it('Matching a single cell preserves pagination', () => {
+        cy.visitOpenRefine();
+        cy.navigateTo('Import project');
+        cy.get('.grid-layout').should('to.contain', 'Locate an existing Refine project file');
+        cy.get('#project-tar-file-input').attachFile('reconciled-project-no-automatch.zip')
+        cy.get('#import-project-button').click();
+
+        // Set a smaller page number to make sure there are multiple pages
+        cy.get('.viewPanel-pagingControls-page:nth-of-type(1)').click();
+        // Go to the next page
+        cy.get('.viewpanel-paging .action').first().click();
+        // Check that we have a single row in view (second page)
+        cy.get('.data-table tbody tr').should('have.length', 1);
+
+        // Match the first recon candidate in the cell
+        cy.get('.data-table-recon-match').first().click();
+
+        // Make sure the cell is matched (no recon candidates are visible anymore)
+        cy.get('.data-table-recon-match').should('not.exist');
+        // We are still in the second page
+        cy.get('.data-table tbody tr').should('have.length', 1);
+    });
+
 });
 
 

--- a/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
@@ -411,7 +411,7 @@ class ReconCellRenderer {
       command,
       params,
       bodyParams,
-      { cellsChanged: true, columnStatsChanged: columnStatsChanged },
+      { columnStatsChanged: columnStatsChanged },
       {
         onDone: function(o) {
           if (o.cell.r) {

--- a/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-renderers/recon-renderer.js
@@ -122,7 +122,7 @@ class ReconCellRenderer {
               a.attr("href", encodeURI(service.view.url.replace("{{id}}", candidate.id)));
             }
 
-            self.previewOnHover(service, candidate, liSpan.parent(), liSpan, true, rowIndex, cellIndex, cell);
+            self.previewOnHover(service, candidate, liSpan.parent(), liSpan, true, rowIndex, cellIndex, cell, cellUI);
 
             var score;
             if (candidate.score < 1) {


### PR DESCRIPTION
Fixes #6695.

Changes proposed in this pull request:
- revert #6239 which forces the re-fetching and re-rendering of the entire grid
- add missing `cellUI` parameter to enable in-place rendering of the updated cell after a single match action
- add a Cypress regression test

I would like to backport this to 3.8.