### PR TITLE
Fix type of error message returned by the Filter GREL control

### DIFF
--- a/main/resources/com/google/refine/grel/ControlEvalError.properties
+++ b/main/resources/com/google/refine/grel/ControlEvalError.properties
@@ -13,4 +13,4 @@ expects_second_arg_var_name={0} expects second argument to be a variable name
 expects_second_arg_index_var_name={0} expects second argument to be the index's variable name
 expects_third_arg_element_var_name={0} expects second argument to be the element's variable name
 expects_second_third_args_different={0} expects the second and third arguments to be different variable names
-expects_array_arg={0} is not an array
+expects_array_arg={0} expects an array as its first argument

--- a/main/resources/com/google/refine/grel/ControlEvalError.properties
+++ b/main/resources/com/google/refine/grel/ControlEvalError.properties
@@ -13,3 +13,4 @@ expects_second_arg_var_name={0} expects second argument to be a variable name
 expects_second_arg_index_var_name={0} expects second argument to be the index's variable name
 expects_third_arg_element_var_name={0} expects second argument to be the element's variable name
 expects_second_third_args_different={0} expects the second and third arguments to be different variable names
+expects_array_arg={0} is not an array

--- a/main/resources/com/google/refine/grel/ControlEvalError.properties
+++ b/main/resources/com/google/refine/grel/ControlEvalError.properties
@@ -13,4 +13,4 @@ expects_second_arg_var_name={0} expects second argument to be a variable name
 expects_second_arg_index_var_name={0} expects second argument to be the index's variable name
 expects_third_arg_element_var_name={0} expects second argument to be the element's variable name
 expects_second_third_args_different={0} expects the second and third arguments to be different variable names
-expects_array_arg={0} expects an array as its first argument
+expects_first_arg_array={0} expects an array as its first argument

--- a/main/resources/com/google/refine/grel/ControlEvalError.properties
+++ b/main/resources/com/google/refine/grel/ControlEvalError.properties
@@ -1,4 +1,3 @@
-filter=First argument is not an array
 foreach_index=First argument to forEachIndex is not an array or JSON object
 foreach=First argument to forEach is not an array or JSON object
 for_range=First, second, and third arguments of forRange must all be numbers

--- a/main/src/com/google/refine/grel/controls/Filter.java
+++ b/main/src/com/google/refine/grel/controls/Filter.java
@@ -40,6 +40,7 @@ import java.util.Properties;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
+import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.util.JsonValueConverter;
@@ -67,7 +68,7 @@ public class Filter implements Control {
         if (ExpressionUtils.isError(o)) {
             return o;
         } else if (!ExpressionUtils.isArrayOrCollection(o) && !(o instanceof ArrayNode)) {
-            return ControlEvalError.filter();
+            return new EvalError(ControlEvalError.expects_array_arg(o));
         }
 
         String name = ((VariableExpr) args[1]).getName();

--- a/main/src/com/google/refine/grel/controls/Filter.java
+++ b/main/src/com/google/refine/grel/controls/Filter.java
@@ -68,7 +68,7 @@ public class Filter implements Control {
         if (ExpressionUtils.isError(o)) {
             return o;
         } else if (!ExpressionUtils.isArrayOrCollection(o) && !(o instanceof ArrayNode)) {
-            return new EvalError(ControlEvalError.expects_array_arg(ControlFunctionRegistry.getControlName(this)));
+            return new EvalError(ControlEvalError.expects_first_arg_array(ControlFunctionRegistry.getControlName(this)));
         }
 
         String name = ((VariableExpr) args[1]).getName();

--- a/main/src/com/google/refine/grel/controls/Filter.java
+++ b/main/src/com/google/refine/grel/controls/Filter.java
@@ -68,7 +68,7 @@ public class Filter implements Control {
         if (ExpressionUtils.isError(o)) {
             return o;
         } else if (!ExpressionUtils.isArrayOrCollection(o) && !(o instanceof ArrayNode)) {
-            return new EvalError(ControlEvalError.expects_array_arg(o));
+            return new EvalError(ControlEvalError.expects_array_arg(ControlFunctionRegistry.getControlName(this)));
         }
 
         String name = ((VariableExpr) args[1]).getName();

--- a/main/tests/server/src/com/google/refine/grel/controls/FilterTests.java
+++ b/main/tests/server/src/com/google/refine/grel/controls/FilterTests.java
@@ -28,12 +28,13 @@
 package com.google.refine.grel.controls;
 
 import static org.testng.Assert.assertThrows;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.assertTrue;
 
 import java.util.Properties;
 
 import org.testng.annotations.Test;
 
+import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
@@ -48,21 +49,17 @@ public class FilterTests extends GrelTestBase {
         TestUtils.isSerializedTo(new Filter(), json);
     }
 
-    private void assertEvaluatesToSuccess(String expression)  {
-        try {
-            Evaluable eval = MetaParser.parse("grel:" + expression);
-            Object result = eval.evaluate(bindings);
-        }
-        catch (ParsingException e) {
-            fail("Expression returned error : " + expression);
-        }
+    private void assertEvaluatesToError(String expression) throws ParsingException {
+        Evaluable eval = MetaParser.parse("grel:" + expression);
+        Object result = eval.evaluate(bindings);
+        assertTrue(result instanceof EvalError, "Expression evaluation error : " + expression);
     }
 
     @Test
     public void testInvalidParams() throws ParsingException {
         bindings = new Properties();
         bindings.put("v", "");
-        assertEvaluatesToSuccess("filter('test', v, v)");
+        assertEvaluatesToError("filter('test', v, 1)");
 
         assertThrows("Didn't throw a ParsingException for wrong argument type", ParsingException.class,
                 () -> MetaParser.parse("grel:filter([], 1, 1)"));

--- a/main/tests/server/src/com/google/refine/grel/controls/FilterTests.java
+++ b/main/tests/server/src/com/google/refine/grel/controls/FilterTests.java
@@ -61,6 +61,11 @@ public class FilterTests extends GrelTestBase {
         bindings.put("v", "");
         assertParseError("filter('test', v, v)");
         try {
+            assertParseError("filter([], 1, 1)");
+            fail("Didn't throw a ParsingException for wrong argument type");
+        } catch (ParsingException e) {
+        }
+        try {
             assertParseError("filter([], v)");
             fail("Didn't throw a ParsingException for 2 arguments");
         } catch (ParsingException e) {


### PR DESCRIPTION
Filter class argument type mismatch

Fixes #6694 

Changes proposed in this pull request:
- Filter class now returns proper error if the argument is invalid
- Updated Filter test for params validation

