### PR TITLE
Don't run impsort:sort by default during builds. Fixes #6703

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
       <plugin>
         <groupId>net.revelc.code</groupId>
         <artifactId>impsort-maven-plugin</artifactId>
-        <version>1.9.0</version>
+        <version>1.10.0</version>
         <configuration>
           <groups>java.,javax.,*,com.google.refine,org.openrefine</groups>
           <staticGroups>java,*</staticGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -288,14 +288,6 @@
           <staticGroups>java,*</staticGroups>
           <removeUnused>true</removeUnused>
         </configuration>
-        <executions>
-          <execution>
-            <id>sort-imports</id>
-            <goals>
-              <goal>sort</goal><!-- runs at process-sources phase by default -->
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
       <plugin>
         <groupId>net.revelc.code</groupId>
         <artifactId>impsort-maven-plugin</artifactId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
         <configuration>
           <groups>java.,javax.,*,com.google.refine,org.openrefine</groups>
           <staticGroups>java,*</staticGroups>


### PR DESCRIPTION
Fixes #6703 This is a proposed alternative to #6702.

Changes proposed in this pull request:
- don't run `impsort:sort` by default during builds
- update impsort plugin to 1.11.0

We run `impsort:sort` explicitly with `./refine lint` and `impsort:check` as part of CI, so we don't need the default execution setup.