### PR TITLE
Change release manager to Tom

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -57,7 +57,7 @@ The Release Manager is responsible to
 * Coordinate with the community to select which issues and pull requests are part of new releases
 * Prepare and coordinate publishing new releases
 
-The current Release Manager is [Antonin Delpeuch](https://github.com/wetneb).
+The current Release Manager is [Tom Morris](https://github.com/tfmorris).
 
 ### Steering Committee
 The steering committee oversees the general direction of the project and initiates connections and collaborations with other organizations and projects.


### PR DESCRIPTION
As part of my gradual off-boarding I propose that @tfmorris heads the release process for 3.9.
The release process is described here: https://openrefine.org/docs/technical-reference/version-release-process

I would transfer to him the credentials necessary to maintain the release pipeline (Google API credentials, Apple notarization, GPG keys…), so that he's operational on issues such as #6713