### PR TITLE
GREL Zip function

### DIFF
--- a/main/resources/com/google/refine/grel/EvalErrorMessage.properties
+++ b/main/resources/com/google/refine/grel/EvalErrorMessage.properties
@@ -54,6 +54,7 @@ expects_two_args={0} expects two arguments
 expects_at_least_one_arg={0} expects at least one argument
 expects_at_least_two_args={0} expects at least two arguments
 expects_one_non_null_arg={0} expects one non-null argument
+expects_at_least_two_or_more_array_args={0} expects 2 or more arrays as arguments
 
 # Unknown
 unknown_time_unit=Unknown time unit {0}

--- a/main/resources/com/google/refine/grel/FunctionDescription.properties
+++ b/main/resources/com/google/refine/grel/FunctionDescription.properties
@@ -6,6 +6,7 @@ arr_join=Joins the items in the array with sep, and returns it all as a string.
 arr_reverse=Reverses array a.
 arr_sort=Sorts the array in ascending order. Sorting is case-sensitive, uppercase first and lowercase second.
 arr_uniques=Returns the array with duplicates removed. Case-sensitive.
+arr_zip=Combine two or more arrays into a single array of arrays, where the elements at the same index from the input arrays are paired together to form a sub-array in the output array.
 
 # 2. Booleans
 bool_and=Uses the logical operator AND on two or more booleans to output a boolean. Evaluates multiple statements into booleans, then returns true if all the statements are true. For example, (1 < 3).and(1 < 0) returns false because one condition is true and one is false.

--- a/main/resources/com/google/refine/grel/FunctionDescription.properties
+++ b/main/resources/com/google/refine/grel/FunctionDescription.properties
@@ -6,7 +6,7 @@ arr_join=Joins the items in the array with sep, and returns it all as a string.
 arr_reverse=Reverses array a.
 arr_sort=Sorts the array in ascending order. Sorting is case-sensitive, uppercase first and lowercase second.
 arr_uniques=Returns the array with duplicates removed. Case-sensitive.
-arr_zip=Combine two or more arrays into a single array of arrays, where the elements at the same index from the input arrays are paired together to form a sub-array in the output array.
+arr_zip=Combines two or more arrays into a single array of arrays, where the elements at the same index from the input arrays are grouped together to form a sub-array in the output array.
 
 # 2. Booleans
 bool_and=Uses the logical operator AND on two or more booleans to output a boolean. Evaluates multiple statements into booleans, then returns true if all the statements are true. For example, (1 < 3).and(1 < 0) returns false because one condition is true and one is false.

--- a/main/src/com/google/refine/expr/functions/arrays/Zip.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Zip.java
@@ -61,14 +61,7 @@ public class Zip implements Function {
                 } else if (v.getClass().isArray()) {
                     iterators.add(Arrays.stream((Object[]) v).spliterator());
                 } else if (v instanceof ArrayNode) {
-                    ArrayNode a = (ArrayNode) v;
-                    List<Object> ziparg = new ArrayList<>();
-                    if (a.isArray()) {
-                        for (JsonNode objNode : a) {
-                            ziparg.add(objNode);
-                        }
-                    }
-                    iterators.add(ziparg.stream().spliterator());
+                    iterators.add(((ArrayNode) v).spliterator());
                 } else {
                     iterators.add(((List<Object>) v).spliterator());
                 }

--- a/main/src/com/google/refine/expr/functions/arrays/Zip.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Zip.java
@@ -1,0 +1,153 @@
+/*
+
+Copyright 2010, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+package com.google.refine.expr.functions.arrays;
+
+import static java.util.stream.Collectors.toCollection;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.Streams;
+
+import com.google.refine.expr.EvalError;
+import com.google.refine.expr.ExpressionUtils;
+import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.EvalErrorMessage;
+import com.google.refine.grel.Function;
+import com.google.refine.grel.FunctionDescription;
+
+public class Zip implements Function {
+
+    @Override
+    public Object call(Properties bindings, Object[] args) {
+        if (args.length == 1) {
+            Object[] v = (Object[]) args[0];
+            List<ArrayList> output = new ArrayList<>();
+            ArrayList arg1 = new ArrayList<>();
+            ArrayList arg2 = new ArrayList<>();
+
+            boolean isFirst = true;
+            if (v != null) {
+                for (Object o : v) {
+                    if (o.getClass().isArray() || o instanceof List<?> || o instanceof ArrayNode) {
+                        if (o.getClass().isArray()) {
+                            arg2.addAll(Arrays.asList((Object[]) o));
+                        } else if (o instanceof ArrayNode) {
+                            ArrayNode a = (ArrayNode) o;
+                            if (a.isArray()) {
+                                for (JsonNode objNode : a) {
+                                    arg2.add(objNode);
+                                }
+                            }
+                        } else {
+                            for (Object z : ExpressionUtils.toObjectList(o)) {
+                                if (z != null) {
+                                    arg2.add(z.toString());
+                                } else {
+                                    arg2.add(z);
+                                }
+                            }
+                        }
+                        if (isFirst) {
+                            for (Object x : arg2) {
+                                arg1 = new ArrayList() {
+
+                                    {
+                                        add(x);
+                                    }
+                                };
+                                output.add(arg1);
+                            }
+                        } else {
+                            output = (List<ArrayList>) Streams.zip(output.stream(),
+                                    arg2.stream(),
+                                    (a, b) -> collectElements(a, b))
+                                    .collect(Collectors.toList());
+                        }
+                        isFirst = false;
+                    }
+                    arg2.clear();
+                }
+            }
+            return output;
+        }
+        return new EvalError(EvalErrorMessage.expects_one_array(ControlFunctionRegistry.getFunctionName(this)));
+    }
+
+    @Override
+    public String getDescription() {
+        return FunctionDescription.arr_join();
+    }
+
+    @Override
+    public String getParams() {
+        return "array a, string sep";
+    }
+
+    @Override
+    public String getReturns() {
+        return "string";
+    }
+
+    private static ArrayList collectElements(Object a, Object b) {
+        ArrayList returnList = new ArrayList<>();
+
+        if (a == null) {
+            returnList.add(a);
+        } else if (a instanceof ArrayList) {
+            ArrayList x = (ArrayList) a;
+            returnList = (ArrayList) x.stream().collect(toCollection(ArrayList::new));
+        } else {
+            returnList.add(a.toString());
+        }
+
+        if (b == null) {
+            returnList.add(b);
+        } else if (b instanceof ArrayList) {
+            ArrayList y = (ArrayList) b;
+            int i;
+            for (i = 0; i < y.size(); i++) {
+                returnList.add(y.get(i).toString());
+            }
+        } else {
+            returnList.add(b.toString());
+        }
+        return returnList;
+    }
+}

--- a/main/src/com/google/refine/expr/functions/arrays/Zip.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Zip.java
@@ -84,12 +84,13 @@ public class Zip implements Function {
             while (!done)  {
                 List<Object> currentElements = new ArrayList<>();
                 for (Spliterator<?> iterator : iterators) {
-                    Object[] elementHolder = new Object[1];
-                    if (iterator.tryAdvance(e -> elementHolder[0] = e)) {
-                        currentElements.add(elementHolder[0]);
+                    if (!iterator.tryAdvance(e -> currentElements.add(e)) {
+                        done = true;
                     }
                 }
-                output.add(new ArrayList<>(currentElements));
+                if (!done) {
+                    output.add(currentElements);
+                }
             }
             return output;
         }

--- a/main/src/com/google/refine/expr/functions/arrays/Zip.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Zip.java
@@ -125,8 +125,8 @@ public class Zip implements Function {
         return "string";
     }
 
-    private static ArrayList collectElements(Object a, Object b) {
-        ArrayList returnList = new ArrayList<>();
+    private static List collectElements(Object a, Object b) {
+        List returnList = new ArrayList<>();
 
         if (a == null) {
             returnList.add(a);

--- a/main/src/com/google/refine/expr/functions/arrays/Zip.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Zip.java
@@ -80,10 +80,9 @@ public class Zip implements Function {
             }
 
             List<List> output = new ArrayList<>();
-            List<Object> currentElements = new ArrayList<>(minSize);
-
-            for (int i = 0; i < minSize; i++) {
-                currentElements.clear();
+            boolean done = false;
+            while (!done)  {
+                List<Object> currentElements = new ArrayList<>();
                 for (Spliterator<?> iterator : iterators) {
                     Object[] elementHolder = new Object[1];
                     if (iterator.tryAdvance(e -> elementHolder[0] = e)) {

--- a/main/src/com/google/refine/expr/functions/arrays/Zip.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Zip.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Spliterator;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import com.google.refine.expr.EvalError;

--- a/main/src/com/google/refine/expr/functions/arrays/Zip.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Zip.java
@@ -58,9 +58,9 @@ public class Zip implements Function {
     public Object call(Properties bindings, Object[] args) {
         if (args.length == 1) {
             Object[] v = (Object[]) args[0];
-            List<ArrayList> output = new ArrayList<>();
-            ArrayList arg1 = new ArrayList<>();
-            ArrayList arg2 = new ArrayList<>();
+            List<List> output = new ArrayList<>();
+            List arg1 = new ArrayList<>();
+            List arg2 = new ArrayList<>();
 
             boolean isFirst = true;
             if (v != null) {

--- a/main/src/com/google/refine/expr/functions/arrays/Zip.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Zip.java
@@ -86,7 +86,7 @@ public class Zip implements Function {
                 } else {
                     for (Object z : ExpressionUtils.toObjectList(v)) {
                         if (z != null) {
-                            ziparg2.add(z.toString());
+                            ziparg2.add(z);
                         } else {
                             ziparg2.add(z);
                         }
@@ -140,7 +140,7 @@ public class Zip implements Function {
             ArrayList x = (ArrayList) a;
             returnList = (ArrayList) x.stream().collect(toCollection(ArrayList::new));
         } else {
-            returnList.add(a.toString());
+            returnList.add(a);
         }
 
         if (b == null) {
@@ -149,10 +149,10 @@ public class Zip implements Function {
             ArrayList y = (ArrayList) b;
             int i;
             for (i = 0; i < y.size(); i++) {
-                returnList.add(y.get(i).toString());
+                returnList.add(y.get(i));
             }
         } else {
-            returnList.add(b.toString());
+            returnList.add(b);
         }
         return returnList;
     }

--- a/main/src/com/google/refine/expr/functions/arrays/Zip.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Zip.java
@@ -74,17 +74,12 @@ public class Zip implements Function {
                 }
             }
 
-            int minSize = Integer.MAX_VALUE;
-            for (Spliterator<?> iterator : iterators) {
-                minSize = Math.min(minSize, (int) iterator.estimateSize());
-            }
-
             List<List> output = new ArrayList<>();
             boolean done = false;
-            while (!done)  {
+            while (!done) {
                 List<Object> currentElements = new ArrayList<>();
                 for (Spliterator<?> iterator : iterators) {
-                    if (!iterator.tryAdvance(e -> currentElements.add(e)) {
+                    if (!iterator.tryAdvance(e -> currentElements.add(e))) {
                         done = true;
                     }
                 }

--- a/main/src/com/google/refine/expr/functions/arrays/Zip.java
+++ b/main/src/com/google/refine/expr/functions/arrays/Zip.java
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2010, Google Inc.
+Copyright 2024, OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/main/src/com/google/refine/grel/ControlFunctionRegistry.java
+++ b/main/src/com/google/refine/grel/ControlFunctionRegistry.java
@@ -57,6 +57,7 @@ import com.google.refine.expr.functions.arrays.Join;
 import com.google.refine.expr.functions.arrays.Reverse;
 import com.google.refine.expr.functions.arrays.Sort;
 import com.google.refine.expr.functions.arrays.Uniques;
+import com.google.refine.expr.functions.arrays.Zip;
 import com.google.refine.expr.functions.booleans.And;
 import com.google.refine.expr.functions.booleans.Not;
 import com.google.refine.expr.functions.booleans.Or;
@@ -292,6 +293,7 @@ public class ControlFunctionRegistry {
         registerFunction("sort", new Sort());
         registerFunction("uniques", new Uniques());
         registerFunction("inArray", new InArray());
+        registerFunction("zip", new Zip());
 
         registerFunction("now", new Now());
         registerFunction("inc", new Inc());

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -81,14 +81,11 @@ public class ZipTests extends GrelTestBase {
         List arg2 = Lists.newArrayList("A","B","C");
         List arg3 = Lists.newArrayList("Ben", null, "Hen");
 
-        List<List> output = new ArrayList<>();
-        output.add(Lists.newArrayList(1, "A", "Ben"));
-        output.add(Lists.newArrayList(null, "B", null));
-        output.add(Lists.newArrayList(3.142, "C", "Hen"));
+        List<List> expected = List.of(
+                Lists.newArrayList(1, "A", "Ben"),
+                Lists.newArrayList(null, "B", null),
+                Lists.newArrayList(3.142, "C", "Hen"));
 
-        List<List> testOutput =  (List<List>) invoke("zip", arg1, arg2, arg3);
-        for(int i=0; i < output.size(); ++i) {
-            Assert.assertTrue(testOutput.get(i).equals(output.get(i)));
-        }
+        assertEquals(invoke("zip", arg1, arg2, arg3), expected);
     }
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -65,13 +65,13 @@ public class ZipTests extends GrelTestBase {
 
     @Test
     public void testZipwithStrArrays() {
-        List arg1 = Lists.newArrayList("Ben", "Den", "Hen");
-        List arg2 = Lists.newArrayList("A","B","C");
+        List arg1 = List.of("Ben", "Den", "Hen");
+        List arg2 = List.of("A", "B", "C");
 
-        List<List> output = new ArrayList<>();
-        output.add(Lists.newArrayList("Ben", "A"));
-        output.add(Lists.newArrayList("Den", "B"));
-        output.add(Lists.newArrayList("Hen", "C"));
+        List<List> expected = List.of(
+                List.of("Ben", "A"),
+                List.of("Den", "B"),
+                List.of("Hen", "C"));
 
         assertEquals(invoke("zip", arg1, arg2), expected);
 

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -52,7 +52,7 @@ public class ZipTests extends GrelTestBase {
     }
 
     @Test
-    public void testZipwithIntArrays() {
+    public void testZipWithIntArrays() {
         List arg1 = List.of(1, 2, 3);
         List arg2 = List.of(7.89, 8.90, 9.01);
 

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -1,0 +1,48 @@
+
+package com.google.refine.expr.functions.arrays;
+
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.ParsingException;
+import com.google.refine.grel.GrelTestBase;
+
+public class ZipTests extends GrelTestBase {
+
+    @Test
+    public void zipArray() throws ParsingException {
+        String[] test = { "[ [1,2,3], ['A','B','C'] ].zip()", "[[1, A], [2, B], [3, C]]" };
+        parseEval(bindings, test);
+
+        String[] test1 = { "[[1,2,3], ['A','B','C'], ['X','Y','Z']].zip()", "[[1, A, X], [2, B, Y], [3, C, Z]]" };
+        parseEval(bindings, test1);
+
+        String[] test2 = { "[[1,2], ['A','B','C'], ['X','Y','Z']].zip()", "[[1, A, X], [2, B, Y]]" };
+        parseEval(bindings, test2);
+
+        String[] test3 = { "[[1,2,3], ['A','B'], ['X','Y','Z']].zip()", "[[1, A, X], [2, B, Y]]" };
+        parseEval(bindings, test3);
+
+        String[] test4 = { "[[1,2,3], ['A','B','C'], ['X','Y']].zip()", "[[1, A, X], [2, B, Y]]" };
+        parseEval(bindings, test4);
+
+        String[] test5 = { "[[1,2,3], ['A','B','C'], []].zip()", "[]" };
+        parseEval(bindings, test5);
+
+        String[] test6 = {
+                "[ [\"Bob has a cat & dog\", \"Cat's name is Dotty\", \"Dog's name is Dots\"], [11, 22, 33, 44, 55], ['Doe', 'Foe', 456, 789]].zip()",
+                "[[Bob has a cat & dog, 11, Doe], [Cat's name is Dotty, 22, Foe], [Dog's name is Dots, 33, 456]]" };
+        parseEval(bindings, test6);
+
+        String[] test7 = { "[[1,2,3], ['A',null,'C'], ['X','Y']].zip()", "[[1, A, X], [2, null, Y]]" };
+        parseEval(bindings, test7);
+
+        // Tests for JSON array
+        String[] test8 = {
+                "[ [\"Bob has a cat & dog\", \"Cat's name is Dotty\", \"Dog's name is Dots\"], [11, 22, 33, 44, 55], '[\"Doe\", \"Foe\", 456, 789]'.parseJson() ].zip()",
+                "[[Bob has a cat & dog, 11, \"Doe\"], [Cat's name is Dotty, 22, \"Foe\"], [Dog's name is Dots, 33, 456]]" };
+        parseEval(bindings, test8);
+
+        // TODO: Add tests for List<Object> returned from ExpressionUtils.toObjectList()
+    }
+
+}

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -8,6 +8,7 @@ import java.util.List;
 import com.google.common.collect.Lists;
 import org.testng.annotations.Test;
 
+import com.google.refine.expr.EvalError;
 import com.google.refine.expr.ParsingException;
 import com.google.refine.grel.GrelTestBase;
 
@@ -75,10 +76,11 @@ public class ZipTests extends GrelTestBase {
 
         assertEquals(invoke("zip", arg1, arg2), expected);
     }
+
     @Test
     public void testZipwithAllTypeArrays() {
-        List arg1 = Lists.newArrayList(1,null,3.142);
-        List arg2 = Lists.newArrayList("A","B","C");
+        List arg1 = Lists.newArrayList(1, null, 3.142);
+        List arg2 = Lists.newArrayList("A", "B", "C");
         List arg3 = Lists.newArrayList("Ben", null, "Hen");
 
         List<List> expected = List.of(
@@ -87,5 +89,21 @@ public class ZipTests extends GrelTestBase {
                 Lists.newArrayList(3.142, "C", "Hen"));
 
         assertEquals(invoke("zip", arg1, arg2, arg3), expected);
+    }
+
+    @Test
+    public void testZipforParams() {
+        List arg1 = List.of(1, 2, 3);
+        List arg2 = List.of(7.89, 8.90, 9.01);
+
+        List<List> expected = List.of(
+                List.of(1, 7.89),
+                List.of(2, 8.90),
+                List.of(3, 9.01));
+
+        assertEquals(((EvalError) (invoke("zip", arg1, arg2, null))).message, "zip expects 2 or more arrays as arguments");
+
+        assertEquals(((EvalError) (invoke("zip", arg1, arg2, "test", null))).message, "zip expects 2 or more arrays as arguments");
+
     }
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -60,10 +60,7 @@ public class ZipTests extends GrelTestBase {
         output.add(Lists.newArrayList(2, 8.90));
         output.add(Lists.newArrayList(3, 9.01));
 
-        List<List> testOutput =  (List<List>) invoke("zip", arg1, arg2);
-        for(int i=0; i < output.size(); ++i) {
-            Assert.assertTrue(testOutput.get(i).equals(output.get(i)));
-        }
+        assertEquals(invoke("zip", arg1, arg2), expected);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -65,7 +65,7 @@ public class ZipTests extends GrelTestBase {
     }
 
     @Test
-    public void testZipwithStrArrays() {
+    public void testZipWithStrArrays() {
         List arg1 = List.of("Ben", "Den", "Hen");
         List arg2 = List.of("A", "B", "C");
 

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -96,11 +96,6 @@ public class ZipTests extends GrelTestBase {
         List arg1 = List.of(1, 2, 3);
         List arg2 = List.of(7.89, 8.90, 9.01);
 
-        List<List> expected = List.of(
-                List.of(1, 7.89),
-                List.of(2, 8.90),
-                List.of(3, 9.01));
-
         assertEquals(((EvalError) (invoke("zip", arg1, arg2, null))).message, "zip expects 2 or more arrays as arguments");
 
         assertEquals(((EvalError) (invoke("zip", arg1, arg2, "test", null))).message, "zip expects 2 or more arrays as arguments");

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -10,35 +10,35 @@ public class ZipTests extends GrelTestBase {
 
     @Test
     public void zipArray() throws ParsingException {
-        String[] test = { "[ [1,2,3], ['A','B','C'] ].zip()", "[[1, A], [2, B], [3, C]]" };
+        String[] test = { "zip([1,2,3], ['A','B','C'])", "[[1, A], [2, B], [3, C]]" };
         parseEval(bindings, test);
 
-        String[] test1 = { "[[1,2,3], ['A','B','C'], ['X','Y','Z']].zip()", "[[1, A, X], [2, B, Y], [3, C, Z]]" };
+        String[] test1 = { "zip([1,2,3], ['A','B','C'], ['X','Y','Z'])", "[[1, A, X], [2, B, Y], [3, C, Z]]" };
         parseEval(bindings, test1);
 
-        String[] test2 = { "[[1,2], ['A','B','C'], ['X','Y','Z']].zip()", "[[1, A, X], [2, B, Y]]" };
+        String[] test2 = { "zip([1,2], ['A','B','C'], ['X','Y','Z'])", "[[1, A, X], [2, B, Y]]" };
         parseEval(bindings, test2);
 
-        String[] test3 = { "[[1,2,3], ['A','B'], ['X','Y','Z']].zip()", "[[1, A, X], [2, B, Y]]" };
+        String[] test3 = { "zip([1,2,3], ['A','B'], ['X','Y','Z'])", "[[1, A, X], [2, B, Y]]" };
         parseEval(bindings, test3);
 
-        String[] test4 = { "[[1,2,3], ['A','B','C'], ['X','Y']].zip()", "[[1, A, X], [2, B, Y]]" };
+        String[] test4 = { "zip([1,2,3], ['A','B','C'], ['X','Y'])", "[[1, A, X], [2, B, Y]]" };
         parseEval(bindings, test4);
 
-        String[] test5 = { "[[1,2,3], ['A','B','C'], []].zip()", "[]" };
+        String[] test5 = { "zip([1,2,3], ['A','B','C'], [])", "[]" };
         parseEval(bindings, test5);
 
         String[] test6 = {
-                "[ [\"Bob has a cat & dog\", \"Cat's name is Dotty\", \"Dog's name is Dots\"], [11, 22, 33, 44, 55], ['Doe', 'Foe', 456, 789]].zip()",
+                "zip( [\"Bob has a cat & dog\", \"Cat's name is Dotty\", \"Dog's name is Dots\"], [11, 22, 33, 44, 55], ['Doe', 'Foe', 456, 789])",
                 "[[Bob has a cat & dog, 11, Doe], [Cat's name is Dotty, 22, Foe], [Dog's name is Dots, 33, 456]]" };
         parseEval(bindings, test6);
 
-        String[] test7 = { "[[1,2,3], ['A',null,'C'], ['X','Y']].zip()", "[[1, A, X], [2, null, Y]]" };
+        String[] test7 = { "zip([1,2,3], ['A',null,'C'], ['X','Y'])", "[[1, A, X], [2, null, Y]]" };
         parseEval(bindings, test7);
 
         // Tests for JSON array
         String[] test8 = {
-                "[ [\"Bob has a cat & dog\", \"Cat's name is Dotty\", \"Dog's name is Dots\"], [11, 22, 33, 44, 55], '[\"Doe\", \"Foe\", 456, 789]'.parseJson() ].zip()",
+                "zip([\"Bob has a cat & dog\", \"Cat's name is Dotty\", \"Dog's name is Dots\"], [11, 22, 33, 44, 55], '[\"Doe\", \"Foe\", 456, 789]'.parseJson() )",
                 "[[Bob has a cat & dog, 11, \"Doe\"], [Cat's name is Dotty, 22, \"Foe\"], [Dog's name is Dots, 33, 456]]" };
         parseEval(bindings, test8);
 

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -92,7 +92,7 @@ public class ZipTests extends GrelTestBase {
     }
 
     @Test
-    public void testZipforParams() {
+    public void testZipForParams() {
         List arg1 = List.of(1, 2, 3);
         List arg2 = List.of(7.89, 8.90, 9.01);
 

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -52,13 +52,13 @@ public class ZipTests extends GrelTestBase {
 
     @Test
     public void testZipwithIntArrays() {
-        List arg1 = Lists.newArrayList(1,2,3);
-        List arg2 = Lists.newArrayList(7.89,8.90,9.01);
+        List arg1 = List.of(1, 2, 3);
+        List arg2 = List.of(7.89, 8.90, 9.01);
 
-        List<List> output = new ArrayList<>();
-        output.add(Lists.newArrayList(1, 7.89));
-        output.add(Lists.newArrayList(2, 8.90));
-        output.add(Lists.newArrayList(3, 9.01));
+        List<List> expected = List.of(
+                List.of(1, 7.89),
+                List.of(2, 8.90),
+                List.of(3, 9.01));
 
         assertEquals(invoke("zip", arg1, arg2), expected);
     }

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -1,6 +1,11 @@
 
 package com.google.refine.expr.functions.arrays;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.refine.expr.ParsingException;
@@ -45,4 +50,52 @@ public class ZipTests extends GrelTestBase {
         // TODO: Add tests for List<Object> returned from ExpressionUtils.toObjectList()
     }
 
+    @Test
+    public void testZipwithIntArrays() {
+        List arg1 = Lists.newArrayList(1,2,3);
+        List arg2 = Lists.newArrayList(7.89,8.90,9.01);
+
+        List<List> output = new ArrayList<>();
+        output.add(Lists.newArrayList(1, 7.89));
+        output.add(Lists.newArrayList(2, 8.90));
+        output.add(Lists.newArrayList(3, 9.01));
+
+        List<List> testOutput =  (List<List>) invoke("zip", arg1, arg2);
+        for(int i=0; i < output.size(); ++i) {
+            Assert.assertTrue(testOutput.get(i).equals(output.get(i)));
+        }
+    }
+
+    @Test
+    public void testZipwithStrArrays() {
+        List arg1 = Lists.newArrayList("Ben", "Den", "Hen");
+        List arg2 = Lists.newArrayList("A","B","C");
+
+        List<List> output = new ArrayList<>();
+        output.add(Lists.newArrayList("Ben", "A"));
+        output.add(Lists.newArrayList("Den", "B"));
+        output.add(Lists.newArrayList("Hen", "C"));
+
+        List<List> testOutput =  (List<List>) invoke("zip", arg1, arg2);
+        for(int i=0; i < output.size(); ++i) {
+            Assert.assertTrue(testOutput.get(i).equals(output.get(i)));
+        }
+    }
+
+    @Test
+    public void testZipwithAllTypeArrays() {
+        List arg1 = Lists.newArrayList(1,null,3.142);
+        List arg2 = Lists.newArrayList("A","B","C");
+        List arg3 = Lists.newArrayList("Ben", null, "Hen");
+
+        List<List> output = new ArrayList<>();
+        output.add(Lists.newArrayList(1, "A", "Ben"));
+        output.add(Lists.newArrayList(null, "B", null));
+        output.add(Lists.newArrayList(3.142, "C", "Hen"));
+
+        List<List> testOutput =  (List<List>) invoke("zip", arg1, arg2, arg3);
+        for(int i=0; i < output.size(); ++i) {
+            Assert.assertTrue(testOutput.get(i).equals(output.get(i)));
+        }
+    }
 }

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -1,11 +1,11 @@
 
 package com.google.refine.expr.functions.arrays;
 
-import java.util.ArrayList;
+import static org.testng.AssertJUnit.assertEquals;
+
 import java.util.List;
 
 import com.google.common.collect.Lists;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.refine.expr.ParsingException;
@@ -74,7 +74,7 @@ public class ZipTests extends GrelTestBase {
                 List.of("Hen", "C"));
 
         assertEquals(invoke("zip", arg1, arg2), expected);
-
+    }
     @Test
     public void testZipwithAllTypeArrays() {
         List arg1 = Lists.newArrayList(1,null,3.142);

--- a/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/arrays/ZipTests.java
@@ -73,11 +73,7 @@ public class ZipTests extends GrelTestBase {
         output.add(Lists.newArrayList("Den", "B"));
         output.add(Lists.newArrayList("Hen", "C"));
 
-        List<List> testOutput =  (List<List>) invoke("zip", arg1, arg2);
-        for(int i=0; i < output.size(); ++i) {
-            Assert.assertTrue(testOutput.get(i).equals(output.get(i)));
-        }
-    }
+        assertEquals(invoke("zip", arg1, arg2), expected);
 
     @Test
     public void testZipwithAllTypeArrays() {


### PR DESCRIPTION
Zip function addition to GREL

Fixes #5440 

Changes proposed in this pull request:
- Zip function takes in a 2 or more Array parameters and generates output which is an Array of arrays 
- The length of the output will be that of the shortest input parameter
- Supports text, number, date
- Usage - zip(array 1, array 2, ...)
- Examples
1. zip( [1, 2], ["A", "B"] ) produces [ [ 1, "A" ], [ 2, "B" ] ]
2. zip( [1, 2], ["A", "B"] , [ now(), now() ] ) produces  [ 1, "A", "2024-08-01T09:24:02.063008Z" ], [ 2, "B", "2024-08-01T09:24:02.063017Z" ] ]
