### PR TITLE
Extract column dependencies of GREL expressions

### DIFF
--- a/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
+++ b/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
@@ -33,7 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.expr;
 
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 /**
  * Interface for evaluable expressions in any arbitrary language.
@@ -47,4 +49,19 @@ public interface Evaluable {
      * @return
      */
     public Object evaluate(Properties bindings);
+
+    /**
+     * Returns the names of the columns this expression depends on.
+     *
+     * @param baseColumn
+     *            the name of the column this expression is based on (none if the expression is not evaluated on a
+     *            particular column)
+     * @return none if the columns could not be isolated: in this case, the expression might depend on all columns in
+     *         the project. Note that this is different from returning an empty set, which means that the expression is
+     *         constant.
+     */
+    public default Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
+        return Optional.empty();
+    }
+
 }

--- a/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
+++ b/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
@@ -51,14 +51,16 @@ public interface Evaluable {
     public Object evaluate(Properties bindings);
 
     /**
-     * Returns the names of the columns this expression depends on.
+     * Returns an approximation of the names of the columns this expression depends on. This approximation is designed
+     * to be safe: if a set of column names is returned, then the expression does not read any other column than the
+     * ones mentioned, regardless of the data it is executed on.
      *
      * @param baseColumn
      *            the name of the column this expression is based on (none if the expression is not evaluated on a
      *            particular column)
-     * @return none if the columns could not be isolated: in this case, the expression might depend on all columns in
-     *         the project. Note that this is different from returning an empty set, which means that the expression is
-     *         constant.
+     * @return {@link Optional#empty()} if the columns could not be isolated: in this case, the expression might depend
+     *         on all columns in the project. Note that this is different from returning an empty set, which means that
+     *         the expression is constant.
      */
     public default Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
         return Optional.empty();

--- a/modules/grel/pom.xml
+++ b/modules/grel/pom.xml
@@ -139,6 +139,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.openrefine</groupId>
       <artifactId>core</artifactId>
       <version>${project.version}</version>

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
@@ -33,7 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.grel.ast;
 
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
@@ -59,6 +62,19 @@ public class ControlCallExpr implements Evaluable {
         } catch (Exception e) {
             return new EvalError(e.toString());
         }
+    }
+
+    @Override
+    public final Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
+        Set<String> dependencies = new HashSet<>();
+        for (Evaluable ev : _args) {
+            Optional<Set<String>> deps = ev.getColumnDependencies(baseColumn);
+            if (deps.isEmpty()) {
+                return Optional.empty();
+            }
+            dependencies.addAll(deps.get());
+        }
+        return Optional.of(dependencies);
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
@@ -33,7 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.grel.ast;
 
+import java.util.Collections;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -71,6 +74,22 @@ public class FieldAccessorExpr implements Evaluable {
             return JsonValueConverter.convert(value);
         } else {
             return null;
+        }
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
+        Optional<Set<String>> innerDeps = _inner.getColumnDependencies(baseColumn);
+        if (innerDeps.isPresent()) {
+            return innerDeps;
+        } else {
+            String innerStr = _inner.toString();
+            if ("cells".equals(innerStr) || "row.cells".equals(innerStr)) {
+                return Optional.of(Collections.singleton(_fieldName));
+            }
+            // TODO add support for starred, flagged, rowIndex, which are not real columns
+            // but whose dependency could also be analyzed.
+            return Optional.empty();
         }
     }
 

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
@@ -33,7 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.grel.ast;
 
+import java.util.Collections;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 
@@ -53,6 +56,11 @@ public class LiteralExpr implements Evaluable {
     @Override
     public Object evaluate(Properties bindings) {
         return _value;
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
+        return Optional.of(Collections.emptySet());
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
@@ -34,7 +34,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.grel.ast;
 
 import java.text.Collator;
+import java.util.HashSet;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
@@ -199,6 +202,19 @@ public class OperatorCallExpr implements Evaluable {
             }
         }
         return null;
+    }
+
+    @Override
+    public final Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
+        Set<String> dependencies = new HashSet<>();
+        for (Evaluable ev : _args) {
+            Optional<Set<String>> deps = ev.getColumnDependencies(baseColumn);
+            if (deps.isEmpty()) {
+                return Optional.empty();
+            }
+            dependencies.addAll(deps.get());
+        }
+        return Optional.of(dependencies);
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/VariableExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/VariableExpr.java
@@ -33,7 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.grel.ast;
 
+import java.util.Collections;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.google.refine.expr.Evaluable;
 
@@ -55,6 +58,16 @@ public class VariableExpr implements Evaluable {
     @Override
     public Object evaluate(Properties bindings) {
         return bindings.get(_name);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
+        if (("value".equals(_name) || "cell".equals(_name) || "recon".equals(_name)) && baseColumn.isPresent()) {
+            return Optional.of(Collections.singleton(baseColumn.get()));
+        } else if ("cells".equals(_name) || "row".equals(_name) || "record".equals(_name)) {
+            return Optional.empty();
+        }
+        return Optional.of(Collections.emptySet());
     }
 
     @Override

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ControlCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ControlCallExprTest.java
@@ -1,0 +1,41 @@
+
+package com.google.refine.grel.ast;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Optional;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.Evaluable;
+import com.google.refine.grel.Control;
+
+public class ControlCallExprTest extends ExprTestBase {
+
+    Control control;
+
+    @BeforeMethod
+    public void setUpControl() {
+        control = mock(Control.class);
+    }
+
+    @Test
+    public void testConstant() {
+        Evaluable c = new ControlCallExpr(new Evaluable[] { constant }, control);
+        assertEquals(c.getColumnDependencies(baseColumn), set());
+    }
+
+    @Test
+    public void testUnion() {
+        Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, currentColumn }, control);
+        assertEquals(c.getColumnDependencies(baseColumn), set("a", "b", "baseColumn"));
+    }
+
+    @Test
+    public void testUnanalyzable() {
+        Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, unanalyzable }, control);
+        assertEquals(c.getColumnDependencies(baseColumn), Optional.empty());
+    }
+}

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ExprTestBase.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ExprTestBase.java
@@ -1,0 +1,50 @@
+
+package com.google.refine.grel.ast;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.testng.annotations.BeforeMethod;
+
+import com.google.refine.expr.Evaluable;
+
+/**
+ * Base class to test expression classes. Contains utilities to test column dependency extraction.
+ * 
+ * @author Antonin Delpeuch
+ */
+public class ExprTestBase {
+
+    protected Optional<String> baseColumn = Optional.of("baseColumn");
+    protected Evaluable currentColumn;
+    protected Evaluable unanalyzable;
+    protected Evaluable twoColumns;
+    protected Evaluable constant;
+
+    @BeforeMethod
+    public void setUp() {
+        currentColumn = mock(Evaluable.class);
+        unanalyzable = mock(Evaluable.class);
+        twoColumns = mock(Evaluable.class);
+        constant = mock(Evaluable.class);
+
+        when(currentColumn.getColumnDependencies(baseColumn))
+                .thenReturn(set("baseColumn"));
+        when(unanalyzable.getColumnDependencies(baseColumn))
+                .thenReturn(Optional.empty());
+        when(twoColumns.getColumnDependencies(baseColumn))
+                .thenReturn(set("a", "b"));
+        when(constant.getColumnDependencies(baseColumn))
+                .thenReturn(set());
+    }
+
+    protected Optional<Set<String>> set(String... strings) {
+        return Optional.of(Arrays.asList(strings).stream().collect(Collectors.toSet()));
+    }
+
+}

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/FieldAccessorExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/FieldAccessorExprTest.java
@@ -1,0 +1,38 @@
+
+package com.google.refine.grel.ast;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Optional;
+
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.Evaluable;
+
+public class FieldAccessorExprTest extends ExprTestBase {
+
+    @Test
+    public void testInnerAnalyzable() {
+        Evaluable ev = new FieldAccessorExpr(constant, "foo");
+        assertEquals(ev.getColumnDependencies(baseColumn), set());
+        ev = new FieldAccessorExpr(currentColumn, "foo");
+        assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
+        ev = new FieldAccessorExpr(twoColumns, "foo");
+        assertEquals(ev.getColumnDependencies(baseColumn), set("a", "b"));
+    }
+
+    @Test
+    public void testUnanalyzable() {
+        when(unanalyzable.toString()).thenReturn("bar");
+        Evaluable ev = new FieldAccessorExpr(unanalyzable, "foo");
+        assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
+    }
+
+    @Test
+    public void testCells() {
+        when(unanalyzable.toString()).thenReturn("cells");
+        Evaluable ev = new FieldAccessorExpr(unanalyzable, "foo");
+        assertEquals(ev.getColumnDependencies(baseColumn), set("foo"));
+    }
+}

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/FunctionCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/FunctionCallExprTest.java
@@ -1,0 +1,35 @@
+
+package com.google.refine.grel.ast;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Optional;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.Evaluable;
+import com.google.refine.grel.Function;
+
+public class FunctionCallExprTest extends ExprTestBase {
+
+    protected Function function;
+
+    @BeforeTest
+    public void setUpFunction() {
+        function = mock(Function.class);
+    }
+
+    @Test
+    public void testUnion() {
+        Evaluable ev = new FunctionCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, function);
+        assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
+    }
+
+    @Test
+    public void testUnanalyzable() {
+        Evaluable ev = new FunctionCallExpr(new Evaluable[] { currentColumn, unanalyzable }, function);
+        assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
+    }
+}

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/LiteralExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/LiteralExprTest.java
@@ -29,6 +29,9 @@ package com.google.refine.grel.ast;
 
 import static org.testng.Assert.assertEquals;
 
+import java.util.Collections;
+import java.util.Optional;
+
 import org.testng.annotations.Test;
 
 public class LiteralExprTest {
@@ -37,6 +40,14 @@ public class LiteralExprTest {
     public void intLiteralToString() {
         LiteralExpr expr = new LiteralExpr(42);
         assertEquals("42", expr.toString());
+    }
+
+    @Test
+    public void columnDependencies() {
+        LiteralExpr expr = new LiteralExpr(34);
+        assertEquals(expr.getColumnDependencies(Optional.of("column")), Optional.of(Collections.emptySet()));
+        LiteralExpr string = new LiteralExpr("foo");
+        assertEquals(string.getColumnDependencies(Optional.of("foo")), Optional.of(Collections.emptySet()));
     }
 
     @Test

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/OperatorCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/OperatorCallExprTest.java
@@ -3,13 +3,14 @@ package com.google.refine.grel.ast;
 
 import static org.testng.Assert.assertEquals;
 
+import java.util.Optional;
 import java.util.Properties;
 
 import org.testng.annotations.Test;
 
 import com.google.refine.expr.Evaluable;
 
-public class OperatorCallExprTest {
+public class OperatorCallExprTest extends ExprTestBase {
 
     private OperatorCallExpr expr;
     private Evaluable arg1;
@@ -50,6 +51,18 @@ public class OperatorCallExprTest {
         expr = new OperatorCallExpr(new Evaluable[] { arg1, arg2 }, "/");
         result = expr.evaluate(new Properties());
         assertEquals(Double.NEGATIVE_INFINITY, result);
+    }
+
+    @Test
+    public void testUnion() {
+        Evaluable ev = new OperatorCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, "+");
+        assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
+    }
+
+    @Test
+    public void testUnanalyzable() {
+        Evaluable ev = new OperatorCallExpr(new Evaluable[] { currentColumn, unanalyzable }, "+");
+        assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
     }
 }
 

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/VariableExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/VariableExprTest.java
@@ -1,0 +1,39 @@
+
+package com.google.refine.grel.ast;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Optional;
+
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.Evaluable;
+
+public class VariableExprTest extends ExprTestBase {
+
+    @Test
+    public void testBaseColumn() {
+        Evaluable ev = new VariableExpr("value");
+        assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
+        ev = new VariableExpr("cell");
+        assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
+        ev = new VariableExpr("recon");
+        assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
+    }
+
+    @Test
+    public void testUnanalyzable() {
+        Evaluable ev = new VariableExpr("cells");
+        assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
+        ev = new VariableExpr("row");
+        assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
+        ev = new VariableExpr("record");
+        assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
+    }
+
+    @Test
+    public void testSingleton() {
+        Evaluable ev = new VariableExpr("foo");
+        assertEquals(ev.getColumnDependencies(baseColumn), set());
+    }
+}


### PR DESCRIPTION
This adds support for extracting the columns a GREL expression depends on.

This is a building block towards the support for analyzing the column dependencies of an operation, for instance to check that those columns exist in the project before applying the operation, or to visualize the dependencies of operations in a graph-based view.

As many static analysis tasks, the full problem is undecidable so this is meant to provide an approximation of it which is safe, meaning that if we succeed in extracting a set of columns for an expression, the expression is guaranteed not to rely on other columns. When the heuristics fail to return a set of columns, the expression may rely on any column.