### PR TITLE
Fix flaky Cypress tests

### DIFF
--- a/main/tests/cypress/cypress/e2e/create-project/preview_project.cy.js
+++ b/main/tests/cypress/cypress/e2e/create-project/preview_project.cy.js
@@ -20,7 +20,6 @@ describe(__filename, function () {
     // Since the quotes in our input file aren't escaped, they aren't legal for any separator except comma(,)
     cy.get('input[bind="processQuoteMarksCheckbox"]').uncheck();
     cy.get('[type="radio"]').check('tab');
-    cy.waitForImportUpdate();
 
     cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
     cy.get('table.data-table tr')
@@ -29,7 +28,6 @@ describe(__filename, function () {
 
     cy.get('input[bind="columnSeparatorInput"]').type('{backspace};');
     cy.get('[type="radio"]').check('custom');
-    cy.waitForImportUpdate();
 
     cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
     cy.get('table.data-table tr')
@@ -39,7 +37,6 @@ describe(__filename, function () {
     // Re-enable quotes for CSV case since they're now in a legal configuration
     cy.get('input[bind="processQuoteMarksCheckbox"]').check();
     cy.get('[type="radio"]').check('comma');
-    cy.waitForImportUpdate();
 
     cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
     cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
@@ -51,7 +48,6 @@ describe(__filename, function () {
 
     cy.get('input[bind="columnNamesCheckbox"]').check();
 
-    cy.waitForImportUpdate();
     cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
     cy.get('table.data-table tr').eq(1).should('to.contain', 'NDB_No');
     cy.get('table.data-table tr').eq(1).should('to.contain', 'Shrt_Desc');
@@ -110,7 +106,6 @@ describe(__filename, function () {
 
     cy.get('input[bind="ignoreInput"]').type('{backspace}1');
     cy.get('input[bind="ignoreCheckbox"]').check();
-    cy.waitForImportUpdate();
 
     cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
     cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
@@ -123,10 +118,8 @@ describe(__filename, function () {
   it('Tests parse-next of parsing options', function () {
     navigateToProjectPreview();
     cy.get('input[bind="columnNamesCheckbox"]').check();
-    cy.waitForImportUpdate();
     cy.get('input[bind="headerLinesInput"]').type('{backspace}0');
     cy.get('input[bind="headerLinesCheckbox"]').check();
-    cy.waitForImportUpdate();
 
     cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
     cy.get('table.data-table tr').eq(1).should('to.contain', 'NDB_No');
@@ -138,7 +131,6 @@ describe(__filename, function () {
     navigateToProjectPreview();
     cy.get('input[bind="skipInput"]').type('{backspace}1');
     cy.get('input[bind="skipCheckbox"]').check();
-    cy.waitForImportUpdate();
 
     cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
     cy.get('table.data-table tr').eq(1).should('to.contain', '01002');
@@ -152,7 +144,6 @@ describe(__filename, function () {
     navigateToProjectPreview();
     cy.get('input[bind="limitInput"]').type('{backspace}1');
     cy.get('input[bind="limitCheckbox"]').check();
-    cy.waitForImportUpdate();
 
     cy.get('table.data-table tr').eq(1).should('to.contain', '1.');
     cy.get('table.data-table tr').eq(1).should('to.contain', '01001');
@@ -165,7 +156,6 @@ describe(__filename, function () {
   it('Tests attempt to parse into numbers of parsing options', function () {
     navigateToProjectPreview();
     cy.get('input[bind="guessCellValueTypesCheckbox"]').check();
-    cy.waitForImportUpdate();
 
     cy.get('table.data-table tr').eq(1).should('to.contain', '15.87');
     cy.get('table.data-table tr').eq(1).should('to.contain', '717');

--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.numeric.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.numeric.cy.js
@@ -31,7 +31,8 @@ describe(__filename, function () {
     cy.get('.dialog-footer button').contains('OK').click();
     cy.get('#refine-tabs-facets').should('exist');
 
-    cy.waitForOrOperation();
+    // Wait for numeric facet to be populated before trying to manipulate it
+    cy.get('.facet-range-status').contains('0 — 94')
 
     //sliding the right slider
     cy.get('.slider-widget-bracket').eq(1)

--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.numeric.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.numeric.cy.js
@@ -43,6 +43,7 @@ describe(__filename, function () {
 
     //sliding the middle portion in numeric facet
     cy.get('.slider-widget-draggable').eq(0)
+      // FIXME: These are the last two uses of the hated waitForOrOperation
     .trigger('mousedown',{ force: true }).waitForOrOperation()
     .trigger('mousemove',130,0,{ force: true })
     .trigger('mouseup',{ force: true }).waitForOrOperation();

--- a/main/tests/cypress/cypress/e2e/project/grid/column/transpose/cell_accross_columns.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/transpose/cell_accross_columns.cy.js
@@ -47,7 +47,6 @@ describe(__filename, function () {
       .type('Address');
 
     cy.confirmDialogPanel();
-    cy.waitForOrOperation();
     cy.assertNotificationContainingText(
       'Transpose cells in columns starting with Street'
     );
@@ -101,7 +100,6 @@ describe(__filename, function () {
     );
 
     cy.confirmDialogPanel();
-    cy.waitForOrOperation();
     cy.assertNotificationContainingText(
       'Transpose cells in columns starting with Street'
     );

--- a/main/tests/cypress/cypress/e2e/project/grid/column/transpose/columnize.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/transpose/columnize.cy.js
@@ -29,7 +29,6 @@ describe(__filename, function () {
     cy.get('select[bind="noteColumnSelect"]').select('Source');
 
     cy.confirmDialogPanel();
-    cy.waitForOrOperation();
     cy.assertNotificationContainingText(
       'Columnize by key column Field and value column Data with note column Source'
     );
@@ -66,7 +65,6 @@ describe(__filename, function () {
     cy.get('select[bind="valueColumnSelect"]').select('Data');
 
     cy.confirmDialogPanel();
-    cy.waitForOrOperation();
     cy.assertNotificationContainingText(
       'Columnize by key column Field and value column Data'
     );

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -10,79 +10,8 @@
 
 import 'cypress-file-upload';
 
-// /**
-//  * Reconcile a column
-//  * Internally using the "apply" behavior for not having to go through the whole user interface
-//  */
-// Cypress.Commands.add('reconcileColumn', (columnName, autoMatch = true) => {
-//   cy.setPreference(
-//     'reconciliation.standardServices',
-//     encodeURIComponent(
-//       JSON.stringify([
-//         {
-//           name: 'CSV Reconciliation service',
-//           identifierSpace: 'http://localhost:8000/',
-//           schemaSpace: 'http://localhost:8000/',
-//           defaultTypes: [],
-//           view: { url: 'http://localhost:8000/view/{{id}}' },
-//           preview: {
-//             width: 500,
-//             url: 'http://localhost:8000/view/{{id}}',
-//             height: 350,
-//           },
-//           suggest: {
-//             entity: {
-//               service_url: 'http://localhost:8000',
-//               service_path: '/suggest',
-//               flyout_service_url: 'http://localhost:8000',
-//               flyout_sercice_path: '/flyout',
-//             },
-//           },
-//           url: 'http://localhost:8000/reconcile',
-//           ui: { handler: 'ReconStandardServicePanel', access: 'jsonp' },
-//         },
-//       ])
-//     )
-//   ).then(() => {
-//     const apply = [
-//       {
-//         op: 'core/recon',
-//         engineConfig: {
-//           facets: [],
-//           mode: 'row-based',
-//         },
-//         columnName: columnName,
-//         config: {
-//           mode: 'standard-service',
-//           service: 'http://localhost:8000/reconcile',
-//           identifierSpace: 'http://localhost:8000/',
-//           schemaSpace: 'http://localhost:8000/',
-//           type: {
-//             id: '/csv-recon',
-//             name: 'CSV-recon',
-//           },
-//           autoMatch: autoMatch,
-//           columnDetails: [],
-//           limit: 0,
-//         },
-//         description: 'Reconcile cells in column species to type /csv-recon',
-//       },
-//     ];
-//     cy.get('a#or-proj-undoRedo').click();
-//     cy.get('#refine-tabs-history .history-panel-controls')
-//       .contains('Apply')
-//       .click();
-//     cy.get('.dialog-container .history-operation-json').invoke(
-//       'val',
-//       JSON.stringify(apply)
-//     );
-//     cy.get('.dialog-container button[bind="applyButton"]').click();
-//   });
-// });
-
 /**
- * Reconcile a column
- * Internally using the "apply" behavior for not having to go through the whole user interface
+ * Check that a column is reconciled
  */
 Cypress.Commands.add('assertColumnIsReconciled', (columnName) => {
   cy.get(

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -276,22 +276,6 @@ Cypress.Commands.add('waitForOrOperation', () => {
 });
 
 /**
- * Wait for OpenRefine parsing options to be updated
- *
- * @deprecated
- *
- * NOTE: This command is unreliable because if you call it after starting an operation e.g. with a click(), the loading
- * indicator may have come and gone already by the time waitForImportUpdate() is called, causing the cypress test to
- * wait forever on ('#or-import-updating').should('be.visible') until it fails due to timeout.
- *
- */
-Cypress.Commands.add('waitForImportUpdate', () => {
-  cy.get('#or-import-updating').should('be.visible');
-  cy.get('#or-import-updating').should('not.be.visible');
-  cy.wait(1500); // eslint-disable-line
-});
-
-/**
  * Utility method to fill something into the expression input
  * Need to wait for OpenRefine to preview the result, hence the cy.wait
  */

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -228,7 +228,7 @@ Cypress.Commands.add('assertGridEquals', (values) => {
   cy.get('table.data-table').should((table) => {
     const headers = Cypress.$('table.data-table th')
       .filter(function (index, element) {
-        return element.innerText != 'All';
+        return element.innerText !== 'All';
       })
       .map(function (index, element) {
         return element.innerText;
@@ -403,9 +403,9 @@ Cypress.Commands.add(
 
 /**
  * Performs drag and drop on target and source item
- * sourcSelector jquery selector for the element to be dragged
- * targetSelector jquery selector for the element to be dropped on
- * position position relative to the target element to perform the drop
+ * sourceSelector - jquery selector for the element to be dragged
+ * targetSelector - jquery selector for the element to be dropped on
+ * position - position relative to the target element to perform the drop
  */
 Cypress.Commands.add('dragAndDrop', (sourceSelector, targetSelector, position = 'center') => {
   cy.get(sourceSelector).trigger('mousedown', { which: 1 });

--- a/main/tests/cypress/cypress/support/e2e.js
+++ b/main/tests/cypress/cypress/support/e2e.js
@@ -59,7 +59,7 @@ before(() => {
 // We want to catch some Javascript exception that we consider harmless
 Cypress.on('uncaught:exception', (err, runnable) => {
   // This message occasionally appears with edge
-  // Doesn't seems like a blocket, and the test should not fail 
+  // Doesn't seem like a blocker, and the test should not fail
   if (err.message.includes("Cannot read property 'offsetTop' of undefined")
       || err.message.includes("Cannot read properties of undefined (reading 'offsetTop')")
     ) {
@@ -67,4 +67,14 @@ Cypress.on('uncaught:exception', (err, runnable) => {
   }
   // we still want to ensure there are no other unexpected
   // errors, so we let them fail the test
+})
+
+// enable debugging of failing tests
+Cypress.on('fail', (error, runnable) => {
+  debugger
+
+  // we now have access to the err instance
+  // and the mocha runnable this failed on
+
+  throw error // throw error to have test still fail
 })

--- a/main/tests/cypress/cypress/support/e2e.js
+++ b/main/tests/cypress/cypress/support/e2e.js
@@ -40,7 +40,7 @@ beforeEach(() => {
 afterEach(() => {
   // DISABLE_PROJECT_CLEANUP is used to disable projects deletion
   // Mostly used in CI/CD for performances
-  if(parseInt(Cypress.env('DISABLE_PROJECT_CLEANUP')) != 1){
+  if(parseInt(Cypress.env('DISABLE_PROJECT_CLEANUP')) !== 1){
     cy.cleanupProjects();
   }
 });


### PR DESCRIPTION
Fixes #6747

Changes proposed in this pull request:
- Fix the flaky numeric facet test by waiting for the slider to achieve the desired state rather than trying to catch a transient
- Remove all uses of the deprecated waitForImportUpdate
- Add support for debugging tests (developer feature)
- Remove dead code and clean up a few flagged warnings
