### PR TITLE
refactor GetRowsCommand.internalRespond method

### DIFF
--- a/main/src/com/google/refine/commands/row/GetRowsCommand.java
+++ b/main/src/com/google/refine/commands/row/GetRowsCommand.java
@@ -226,7 +226,7 @@ public class GetRowsCommand extends Command {
 
             // Pool all the recons occurring in the rows seen
             for (WrappedRow currentWrappedRow : rowWriter.results) {
-                pool_reconstructions(pool, currentWrappedRow);
+                poolReconstructions(pool, currentWrappedRow);
             }
 
             List<WrappedRow> wrappedRows = rowWriter.results;
@@ -289,7 +289,7 @@ public class GetRowsCommand extends Command {
         }
     }
 
-    private static void pool_reconstructions(Pool pool, WrappedRow currentWrappedRow) {
+    private static void poolReconstructions(Pool pool, WrappedRow currentWrappedRow) {
         for (Cell cell : currentWrappedRow.row.cells) {
             if (cell != null && cell.recon != null) {
                 pool.pool(cell.recon);


### PR DESCRIPTION
split up method, rename variables

Changes proposed in this pull request:
- extract lines 194-202 to a new method "getRowsForImportJob" to handle the retrieval of rows from an importing job
- rename variable "rwv" -> "rowWriter"
- extract lines 233-259 into "visitRowsOrRecords"
- extract lines 263-267 that pools the reconstructions in a new method called "poolReconstructions" for clarity and reusability
