### PR TITLE
Add-missing-MediaInfoEdit-JavaDoc-parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ tmp/
 test-out/
 /bin
 open-refine.log
-.vscode
+.vscode/
 .metadata # Eclipse plugins specific
 
 # Locally stored "Eclipse launch configurations"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.completion.importOrder": ["#", "java", "javax", "", "com.google.refine", "org.openrefine"],
-}

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
@@ -64,6 +64,8 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
      *            the wikitext to associate to the file (depending on overriding settings)
      * @param overrideWikitext
      *            whether the supplied wikitext should override any existing one
+     * @param contributingRowIds
+     *           the rowIds of the rows that will be contributed for this edit
      */
     public MediaInfoEdit(
             EntityIdValue id,


### PR DESCRIPTION
- adds missing `contributingRowIds` parameter to MediaInfoEdit JavaDocs

@wetneb do you think I worded the parameter description well enough?