### PR TITLE
Increase TSV/CSV column limit to 32K (from 512). Fixes #6723

### DIFF
--- a/main/src/com/google/refine/importers/SeparatorBasedImporter.java
+++ b/main/src/com/google/refine/importers/SeparatorBasedImporter.java
@@ -69,6 +69,10 @@ import com.google.refine.util.JSONUtilities;
 
 public class SeparatorBasedImporter extends TabularImportingParserBase {
 
+    // Excel limits: 1M rows x 16K columns, 32K characters max per cell
+    public static final int MAX_COLUMNS = 16 * 1024; // default 512
+    // TODO: Perhaps use a lower default and make user configurable?
+    public static final int MAX_CHARACTERS_PER_CELL = 32 * 1024; // default 4096
     public static final int GUESSER_LINE_COUNT = 100;
     char DEFAULT_QUOTE_CHAR = new CsvParserSettings().getFormat().getQuote();
 
@@ -145,7 +149,8 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
         AbstractParser parser;
         if (tsv) {
             TsvParserSettings settings = new TsvParserSettings();
-            settings.setMaxCharsPerColumn(256 * 1024); // TODO: Perhaps use a lower default and make user configurable?
+            settings.setMaxCharsPerColumn(MAX_CHARACTERS_PER_CELL);
+            settings.setMaxColumns(MAX_COLUMNS);
             settings.setIgnoreLeadingWhitespaces(false);
             settings.setIgnoreTrailingWhitespaces(false);
             parser = new TsvParser(settings);
@@ -161,7 +166,8 @@ public class SeparatorBasedImporter extends TabularImportingParserBase {
                 settings.setUnescapedQuoteHandling(UnescapedQuoteHandling.RAISE_ERROR);
             }
             settings.setKeepQuotes(!processQuotes);
-            settings.setMaxCharsPerColumn(256 * 1024); // TODO: Perhaps use a lower default and make user configurable?
+            settings.setMaxCharsPerColumn(MAX_CHARACTERS_PER_CELL);
+            settings.setMaxColumns(MAX_COLUMNS);
             parser = new CsvParser(settings);
         }
         try (final LineNumberReader lnReader = new LineNumberReader(reader);) {

--- a/main/tests/server/src/com/google/refine/importers/ImporterTest.java
+++ b/main/tests/server/src/com/google/refine/importers/ImporterTest.java
@@ -96,7 +96,7 @@ public abstract class ImporterTest extends RefineTest {
                 -1,
                 options,
                 exceptions);
-        assertEquals(exceptions.size(), 0);
+        assertEquals(exceptions.size(), 0, "Unexpected exception(s) thrown: " + exceptions);
         project.update();
     }
 
@@ -111,7 +111,7 @@ public abstract class ImporterTest extends RefineTest {
                 -1,
                 options,
                 exceptions);
-        assertEquals(exceptions.size(), 0);
+        assertEquals(exceptions.size(), 0, "Unexpected exception(s) thrown: " + exceptions);
         project.update();
     }
 
@@ -143,7 +143,7 @@ public abstract class ImporterTest extends RefineTest {
                 -1,
                 options,
                 exceptions);
-        assertEquals(exceptions.size(), 0);
+        assertEquals(exceptions.size(), 0, "Unexpected exception(s) thrown: " + exceptions);
         XmlImportUtilities.createColumnsFromImport(project, rootColumnGroup);
         project.columnModel.update();
     }

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -46,6 +46,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.input.CharSequenceReader;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -294,6 +295,39 @@ public class SeparatorBasedImporterTests extends ImporterTest {
                 new String[] { "col1", "col2", "col3", numberedColumn(4), numberedColumn(5), numberedColumn(6) },
                 new Serializable[][] {
                         { "data1", "data2", "data3", "data4", "data5", "data6" },
+                });
+        assertProjectEquals(project, expectedProject);
+    }
+
+    @Test(dataProvider = "CSV-TSV-AutoDetermine")
+    public void readManyColumns(String sep) {
+        // create input
+        int width = 16 * 1024; // Excel supports 16K columns max, so let's test that
+        String inputSeparator = sep == null ? "\t" : sep;
+        StringBuilder input = new StringBuilder();
+        String[] colNames = new String[width];
+        for (int i = 0; i < width; i++) {
+            String name = "col" + (i + 1);
+            input.append(name + inputSeparator);
+            colNames[i] = name;
+        }
+        input = input.deleteCharAt(input.length() - 1); // we don't need the last separator
+        input.append('\n');
+        String[] data = new String[width];
+        for (int i = 0; i < width; i++) {
+            String value = "data" + (i + 1);
+            input.append(value + inputSeparator);
+            data[i] = value;
+        }
+        input = input.deleteCharAt(input.length() - 1); // we don't need the last separator
+
+        prepareOptions(sep, -1, 0, 0, 1, false, false);
+        parseOneFile(SUT, new CharSequenceReader(input));
+
+        Project expectedProject = createProject(
+                colNames,
+                new Serializable[][] {
+                        data,
                 });
         assertProjectEquals(project, expectedProject);
     }


### PR DESCRIPTION
Fixes #6723 

Changes proposed in this pull request:
- Increase TSV/CSV column limit to 32K (from 512)
- Make cryptic test assertion failures easier to understand

