### PR TITLE
CR char added in import flow for CSV/TSV/Clipboard when last record has no value set in the last cell/column

### DIFF
--- a/main/src/com/google/refine/expr/ExpressionUtils.java
+++ b/main/src/com/google/refine/expr/ExpressionUtils.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.CharMatcher;
 
 import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
@@ -111,7 +112,7 @@ public class ExpressionUtils {
     static public boolean isNonBlankData(Object o) {
         return o != null &&
                 !(o instanceof EvalError) &&
-                (!(o instanceof String) || ((String) o).length() > 0);
+                (!(o instanceof String) || !CharMatcher.javaIsoControl().removeFrom((String) o).isEmpty());
     }
 
     static public boolean isTrue(Object o) {


### PR DESCRIPTION
CR char added in import flow for CSV/TSV/Clipboard when last record has no value set in the last cell/column

Fixes #6691 

Changes proposed in this pull request:
- Update the isNonBlankData method in ExpressionUtils to do empty check post control character removal 
- This will ignore strings with only control characters
- Tested with CSV/TSV file and Clipboard import flows
