### PR TITLE
wikibase: Fix NPE when empty edits are scheduled

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
@@ -193,7 +193,7 @@ public class EditBatchProcessor {
                 newEntityUrl = createdDocId.getSiteIri() + createdDocId.getId();
             } else {
                 // Existing entities
-                EntityUpdate entityUpdate;
+                EntityUpdate entityUpdate = null;
                 if (update.requiresFetchingExistingState()) {
                     String entityId = update.getEntityId().getId();
                     if (currentDocs.get(entityId) != null) {
@@ -202,7 +202,7 @@ public class EditBatchProcessor {
                         logger.warn(String.format("Skipping editing of %s as it could not be retrieved", entityId));
                         entityUpdate = null;
                     }
-                } else {
+                } else if (!update.isEmpty()) {
                     entityUpdate = update.toEntityUpdate(null);
                 }
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
@@ -144,6 +144,24 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
     }
 
     @Test
+    public void testEmptyEdit()
+            throws InterruptedException, MediaWikiApiErrorException, IOException {
+        List<EntityEdit> batch = new ArrayList<>();
+        batch.add(new ItemEditBuilder(TestingData.existingId).addContributingRowId(123).build());
+
+        // Plan expected edits
+        when(fetcher.getEntityDocuments(Collections.emptyList()))
+                .thenReturn(Collections.emptyMap());
+
+        EditBatchProcessor processor = new EditBatchProcessor(fetcher, editor, connection, batch, library, summary, maxlag, tags, 50, 60);
+        assertEquals(1, processor.remainingEdits());
+        assertEquals(0, processor.progress());
+        processor.performEdit();
+        assertEquals(0, processor.remainingEdits());
+        assertEquals(100, processor.progress());
+    }
+
+    @Test
     public void testFallbackToSecondTag() throws Exception {
         List<EntityEdit> batch = new ArrayList<>();
         batch.add(new ItemEditBuilder(TestingData.existingId)


### PR DESCRIPTION
Closes #6775.

Somehow, empty edits can be scheduled: this makes sure that they are caught and appropriately ignored.
