### PR TITLE
fix: Positioning of drop placeholder for file import

### DIFF
--- a/main/webapp/modules/core/styles/index/default-importing-sources.css
+++ b/main/webapp/modules/core/styles/index/default-importing-sources.css
@@ -52,13 +52,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 .file-input-container {
     position: relative;
+    width: fit-content;
 }
 
 .file-input-text {
     position: absolute;
     top: 50%;
-    left: 50%;
-    transform: translate(-65%, 0%);
+    left: 0px;
+    width: 100%;
     pointer-events: none;
     text-align: center;
     color: #555;


### PR DESCRIPTION
Closes #6735.

The fix avoids the `65%` which was chosen to fix the text approximately as this value can depend on font size and ensures that the width of the containing element matches that of the file input.
