### PR TITLE
Remove uses of JUnit. Fixes #6791.

### DIFF
--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/manifests/ManifestTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/manifests/ManifestTest.java
@@ -3,6 +3,7 @@ package org.openrefine.wikibase.manifests;
 
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+// The version below has parameter order backwards from the standard TestNG assertEquals we use everywhere else
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.io.IOException;

--- a/main/tests/server/src/com/google/refine/ProjectManagerTests.java
+++ b/main/tests/server/src/com/google/refine/ProjectManagerTests.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import java.lang.reflect.Field;
 import java.time.Instant;
@@ -238,8 +238,8 @@ public class ProjectManagerTests extends RefineTest {
     }
 
     protected void AssertProjectRegistered() {
-        Assert.assertEquals(SUT.getProject(project.id), project);
-        Assert.assertEquals(SUT.getProjectMetadata(project.id), metadata);
+        assertEquals(SUT.getProject(project.id), project);
+        assertEquals(SUT.getProjectMetadata(project.id), metadata);
     }
 
     protected void whenGetSaveTimes(Project proj, ProjectMetadata meta) {

--- a/main/tests/server/src/com/google/refine/expr/functions/strings/LevenshteinDistanceTest.java
+++ b/main/tests/server/src/com/google/refine/expr/functions/strings/LevenshteinDistanceTest.java
@@ -33,7 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.expr.functions.strings;
 
-import org.junit.Assert;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
 import org.testng.annotations.Test;
 
 import com.google.refine.expr.EvalError;
@@ -43,29 +45,29 @@ public class LevenshteinDistanceTest extends GrelTestBase {
 
     @Test
     public void testValidArguments() {
-        Assert.assertEquals(invoke("levenshteinDistance", new Object[] { "New York", "NewYork" }), 1.0);
-        Assert.assertEquals(invoke("levenshteinDistance", new Object[] { "M. Makeba", "Miriam Makeba" }), 5.0);
+        assertEquals(invoke("levenshteinDistance", new Object[] { "New York", "NewYork" }), 1.0);
+        assertEquals(invoke("levenshteinDistance", new Object[] { "M. Makeba", "Miriam Makeba" }), 5.0);
     }
 
     @Test
     public void testInvalidArguments() {
-        Assert.assertTrue(invoke("levenshteinDistance") instanceof EvalError);
-        Assert.assertTrue(invoke("levenshteinDistance", new Object[] { "test" }) instanceof EvalError);
-        Assert.assertTrue(invoke("levenshteinDistance", new Object[] { "test", new Object() }) instanceof EvalError);
+        assertTrue(invoke("levenshteinDistance") instanceof EvalError);
+        assertTrue(invoke("levenshteinDistance", new Object[] { "test" }) instanceof EvalError);
+        assertTrue(invoke("levenshteinDistance", new Object[] { "test", new Object() }) instanceof EvalError);
     }
 
     @Test
     public void testEmptyStrings() {
-        Assert.assertEquals(invoke("levenshteinDistance", new Object[] { "", "" }), 0.0);
+        assertEquals(invoke("levenshteinDistance", new Object[] { "", "" }), 0.0);
     }
 
     @Test
     public void testSingleCharacterStrings() {
-        Assert.assertEquals(invoke("levenshteinDistance", new Object[] { "a", "b" }), 1.0);
+        assertEquals(invoke("levenshteinDistance", new Object[] { "a", "b" }), 1.0);
     }
 
     @Test
     public void testDifferentLengthStrings() {
-        Assert.assertEquals(invoke("levenshteinDistance", new Object[] { "", "abc" }), 3.0);
+        assertEquals(invoke("levenshteinDistance", new Object[] { "", "abc" }), 3.0);
     }
 }

--- a/main/tests/server/src/com/google/refine/expr/util/CalenderParserTest.java
+++ b/main/tests/server/src/com/google/refine/expr/util/CalenderParserTest.java
@@ -1,10 +1,10 @@
 
 package com.google.refine.expr.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+// TODO: The static import below should really use the native parameter ordering, but we're too lazy to switch all the calls
+import static org.testng.AssertJUnit.assertEquals; // JUnit compatible parameter order
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -182,132 +182,100 @@ public class CalenderParserTest {
         assertEquals(expected, CalendarParser.getOrderString(input));
     }
 
-    @Test
-    public void shouldThrowExceptionWhenNegativeNumberInDateStr_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Found negative number in date \"-22/02/2024\"")
+    public void shouldThrowExceptionWhenNegativeNumberInDateStr_parseTest() throws CalendarParserException {
         String dateStr = "-22/02/2024";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.DD_MM_YY));
-        assertEquals(String.format("Found negative number in date \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.DD_MM_YY);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenYearMissingDD_MM_YY_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Year missing from \"20/01/\"")
+    public void shouldThrowExceptionWhenYearMissingDD_MM_YY_parseTest() throws CalendarParserException {
         String dateStr = "20/01/";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.DD_MM_YY));
-        assertEquals(String.format("Year missing from \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.DD_MM_YY);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenMonthMissingDD_MM_YY_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Month missing from \"20//2024\"")
+    public void shouldThrowExceptionWhenMonthMissingDD_MM_YY_parseTest() throws CalendarParserException {
         String dateStr = "20//2024";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.DD_MM_YY));
-        assertEquals(String.format("Month missing from \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.DD_MM_YY);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenDateMissingMM_DD_YY_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "^Day missing from .*")
+    public void shouldThrowExceptionWhenDateMissingMM_DD_YY_parseTest() throws CalendarParserException {
         String dateStr = "01//2024";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.MM_DD_YY));
-        assertEquals(String.format("Day missing from \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.MM_DD_YY);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenMonthAndYearAreMissingDD_MM_YY_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "^Year and month missing from .*")
+    public void shouldThrowExceptionWhenMonthAndYearAreMissingDD_MM_YY_parseTest() throws CalendarParserException {
         String dateStr = "20/";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.DD_MM_YY));
-        assertEquals(String.format("Year and month missing from \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.DD_MM_YY);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenMonthAndDayAreMissingYY_DD_MM_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "^Day and month missing from .*")
+    public void shouldThrowExceptionWhenMonthAndDayAreMissingYY_DD_MM_parseTest() throws CalendarParserException {
         String dateStr = "2024-";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Day and month missing from \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenHourValueIsBad_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Bad hour 28 in .*")
+    public void shouldThrowExceptionWhenHourValueIsBad_parseTest() throws CalendarParserException {
         String dateStr = "20/01/2024 28:30:54:003 pm +05:30";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Bad hour 28 in \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenHourIsBad_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Bad hour string \"1hour\" in .*")
+    public void shouldThrowExceptionWhenHourIsBad_parseTest() throws CalendarParserException {
         String dateStr = "20/01/2024 1hour:30:54:003 pm +05:30";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Bad hour string \"1hour\" in \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenMinuteValueIsBad_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Bad minute 90 in .*")
+    public void shouldThrowExceptionWhenMinuteValueIsBad_parseTest() throws CalendarParserException {
         String dateStr = "20/01/2024 8:90:54:003 pm +05:30";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Bad minute 90 in \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenMinuteIsBad_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Bad minute string \"30Minute\" in .*")
+    public void shouldThrowExceptionWhenMinuteIsBad_parseTest() throws CalendarParserException {
         String dateStr = "20/01/2024 2:30Minute:54:003 pm +05:30";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Bad minute string \"30Minute\" in \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenSecondValueIsBad_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Bad second 94 in .*")
+    public void shouldThrowExceptionWhenSecondValueIsBad_parseTest() throws CalendarParserException {
         String dateStr = "20/01/2024 8:30:94:003 pm +05:30";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Bad second 94 in \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenSecondIsBad_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Bad second string \"54Sec\" in .*")
+    public void shouldThrowExceptionWhenSecondIsBad_parseTest() throws CalendarParserException {
         String dateStr = "20/01/2024 2:30:54Sec:003 pm +05:30";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Bad second string \"54Sec\" in \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenMilliSecondValueIsBad_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Bad millisecond 1111 in .*")
+    public void shouldThrowExceptionWhenMilliSecondValueIsBad_parseTest() throws CalendarParserException {
         String dateStr = "20/01/2024 8:30:44:1111 pm +05:30";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Bad millisecond 1111 in \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenMilliSecondIsBad_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Bad millisecond string \"003milli\" in .*")
+    public void shouldThrowExceptionWhenMilliSecondIsBad_parseTest() throws CalendarParserException {
         String dateStr = "20/01/2024 2:30:54:003milli pm +05:30";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Bad millisecond string \"003milli\" in \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenBadTime_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "Unrecognized time \"hour:minute:second\" in date .*")
+    public void shouldThrowExceptionWhenBadTime_parseTest() throws CalendarParserException {
         String dateStr = "20/01/2024 hour:minute:second";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Unrecognized time \"hour:minute:second\" in date \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
-    @Test
-    public void shouldThrowExceptionWhenBadTimeZone_parseTest() {
+    @Test(expectedExceptions = CalendarParserException.class, expectedExceptionsMessageRegExp = "^Bad time zone minute offset \"30min\" in .*")
+    public void shouldThrowExceptionWhenBadTimeZone_parseTest() throws CalendarParserException {
         String dateStr = "20/01/2024 8:30:54:003 pm +05:30min";
-        CalendarParserException exception = assertThrows(CalendarParserException.class,
-                () -> CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM));
-        assertEquals(String.format("Bad time zone minute offset \"30min\" in \"%s\"", dateStr), exception.getMessage());
+        CalendarParser.parse(dateStr, CalendarParser.YY_DD_MM);
     }
 
     private static Calendar getCalendar(int year, int month, int date, int hour, int minutes, int seconds, int milliSeconds,

--- a/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/SeparatorBasedImporterTests.java
@@ -33,8 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.importers;
 
-import static org.testng.AssertJUnit.assertEquals;
-import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 import java.io.File;
 import java.io.IOException;
@@ -584,7 +584,7 @@ public class SeparatorBasedImporterTests extends ImporterTest {
     public void testThatDefaultGuessIsATabSeparatorAndDefaultProcessQuotesToFalse() {
         ObjectNode options = SUT.createParserUIInitializationData(
                 job, new LinkedList<>(), "text/json");
-        assertEquals("\\t", options.get("separator").textValue());
+        assertEquals(options.get("separator").textValue(), "\\t");
         assertFalse(options.get("processQuotes").asBoolean());
     }
 
@@ -593,7 +593,7 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         List<ObjectNode> fileRecords = prepareFileRecords("food.small.csv");
         ObjectNode options = SUT.createParserUIInitializationData(
                 job, fileRecords, "text/csv");
-        assertEquals(",", options.get("separator").textValue());
+        assertEquals(options.get("separator").textValue(), ",");
     }
 
     @Test
@@ -601,7 +601,7 @@ public class SeparatorBasedImporterTests extends ImporterTest {
         List<ObjectNode> fileRecords = prepareFileRecords("movies-condensed.tsv");
         ObjectNode options = SUT.createParserUIInitializationData(
                 job, fileRecords, "text/tsv");
-        assertEquals("\\t", options.get("separator").textValue());
+        assertEquals(options.get("separator").textValue(), "\\t");
         assertFalse(options.get("processQuotes").asBoolean());
     }
 

--- a/main/tests/server/src/com/google/refine/importers/XmlImporterTests.java
+++ b/main/tests/server/src/com/google/refine/importers/XmlImporterTests.java
@@ -33,8 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.importers;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/packaging/THIRD-PARTY.txt
+++ b/packaging/THIRD-PARTY.txt
@@ -41,7 +41,6 @@ Lists of 109 third-party dependencies.
      (CDDL/GPLv2+CE) JavaBeans Activation Framework API jar (javax.activation:javax.activation-api:1.2.0 - http://java.net/all/javax.activation-api/)
      (CDDL + GPLv2 with classpath exception) Java Servlet API (javax.servlet:javax.servlet-api:4.0.1 - https://javaee.github.io/servlet-spec/)
      (CDDL 1.1) (GPL2 w/ CPE) jaxb-api (javax.xml.bind:jaxb-api:2.3.1 - https://github.com/javaee/jaxb-spec/jaxb-api)
-     (Eclipse Public License 1.0) JUnit (junit:junit:4.13 - http://junit.org)
      (The Apache Software License, Version 2.0) jsonic (net.arnx:jsonic:1.2.11 - http://jsonic.sourceforge.jp/)
      (Apache License, Version 2.0) Byte Buddy (without dependencies) (net.bytebuddy:byte-buddy:1.12.22 - https://bytebuddy.net/byte-buddy)
      (Apache License, Version 2.0) Byte Buddy agent (net.bytebuddy:byte-buddy-agent:1.12.22 - https://bytebuddy.net/byte-buddy-agent)


### PR DESCRIPTION
Fixes #6791

Changes proposed in this pull request:
- migrates usages of org.junit.Assert to org.testng.Assert
- migrates usages of org.junit.assertThrows to TestNG annotations
- migrates some uses of org.testng.AssertJUnit.assertEquals to org.testng.Assert.assertEquals, swapping the order of parameters (unless they were in the wrong order to start with)
- adds TODOs for remaining uses of org.testng.AssertJUnit (which uses the JUnit parameter order)

