### PR TITLE
Extend Exporter interfaces to phase out use of Properties

### DIFF
--- a/modules/core/src/main/java/com/google/refine/browsing/FilteredRows.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/FilteredRows.java
@@ -47,5 +47,5 @@ public interface FilteredRows {
      * @param project
      * @param visitor
      */
-    public void accept(Project project, RowVisitor visitor);
+    void accept(Project project, RowVisitor visitor);
 }

--- a/modules/core/src/main/java/com/google/refine/commands/Command.java
+++ b/modules/core/src/main/java/com/google/refine/commands/Command.java
@@ -218,6 +218,21 @@ public abstract class Command {
     }
 
     /**
+     * Shim for {@link HttpServletRequest#getParameterMap()} which returns single values instead of arrays
+     *
+     * @param request
+     * @return Map of String values, keyed by Strings
+     */
+    static protected Map<String, String> getParameters(HttpServletRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("parameter 'request' should not be null");
+        }
+        Map<String, String> result = new HashMap<>();
+        request.getParameterMap().forEach((k, v) -> result.put(k, v == null ? null : v[0]));
+        return result;
+    }
+
+    /**
      * Utility method for retrieving the CSRF token stored in the "csrf_token" parameter of the request, and checking
      * that it is valid.
      *

--- a/modules/core/src/main/java/com/google/refine/commands/HttpUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/commands/HttpUtilities.java
@@ -150,8 +150,8 @@ abstract public class HttpUtilities {
     }
 
     /**
-     * @deprecated deprecated for v3.8. No internal uses. There is an implementation in the {@link Command} class for
-     *             commands which need it.
+     * @deprecated deprecated for v3.8. No internal uses. There is an implementation in
+     *             {@link Command#getIntegerParameter(HttpServletRequest, String, int)} for commands which need it.
      */
     @Deprecated
     static public int getIntegerParameter(HttpServletRequest request, String name, int def) {

--- a/modules/core/src/main/java/com/google/refine/exporters/CustomizableTabularExporterUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/CustomizableTabularExporterUtilities.java
@@ -74,13 +74,35 @@ abstract public class CustomizableTabularExporterUtilities {
 
     final static private String fullIso8601 = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
+    @Deprecated(since = "3.9")
     static public void exportRows(
             final Project project,
             final Engine engine,
             Properties params,
             final TabularSerializer serializer) {
+        exportRows(project, engine, params.getProperty("options"), serializer);
+    }
 
-        String optionsString = (params != null) ? params.getProperty("options") : null;
+    /**
+     * Export a set of rows determined by the given engine configuration to the TabularSerializer using the given
+     * options.
+     *
+     * @param project
+     *            project to export the rows from
+     * @param engine
+     *            faceted browsing configuration to filter the rows
+     * @param optionsString
+     *            JSON options dictionary serialized as a string
+     * @param serializer
+     *            a serializer which implements the TabularSerializer interface
+     * @since 3.9
+     */
+    static public void exportRows(
+            final Project project,
+            final Engine engine,
+            String optionsString,
+            final TabularSerializer serializer) {
+
         JsonNode optionsTemp = null;
         if (optionsString != null) {
             try {
@@ -181,6 +203,7 @@ abstract public class CustomizableTabularExporterUtilities {
         filteredRows.accept(project, visitor);
     }
 
+    @Deprecated(since = "3.9")
     static public int[] countColumnsRows(
             final Project project,
             final Engine engine,
@@ -365,7 +388,7 @@ abstract public class CustomizableTabularExporterUtilities {
                                 try {
                                     link = new URI(text).toString();
                                 } catch (URISyntaxException e) {
-                                    ;
+                                    // Skip links which are not valid
                                 }
                             }
                         } else if (value instanceof OffsetDateTime) {
@@ -377,11 +400,9 @@ abstract public class CustomizableTabularExporterUtilities {
                     return new CellData(column.getName(), value, text, link);
                 }
             } else {// added for sql exporter
-
                 if (includeNullFieldValue) {
                     return new CellData(column.getName(), "", "", "");
                 }
-
             }
             return null;
         }

--- a/modules/core/src/main/java/com/google/refine/exporters/Exporter.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/Exporter.java
@@ -1,6 +1,7 @@
 /*
 
 Copyright 2010, Google Inc.
+Copyright 2024, OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -33,10 +34,30 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.exporters;
 
+import java.util.Map;
+import java.util.Properties;
+
 public interface Exporter {
 
     /**
      * @return MIME content type handled by exporter
      */
-    public String getContentType();
+    String getContentType();
+
+    /**
+     * Helper to create legacy {@link Properties} from modern {@link Map<String, String>}
+     * 
+     * @param options
+     *            a map of the option key/values to be remapped
+     * @return equivalent Properties object with nulls deleted per our convention
+     */
+    static Properties remapOptions(Map<String, String> options) {
+        Properties legacyOptions = new Properties();
+        for (Map.Entry e : options.entrySet()) {
+            if (e.getValue() != null) { // Properties don't accept null values
+                legacyOptions.put(e.getKey(), e.getValue());
+            }
+        }
+        return legacyOptions;
+    }
 }

--- a/modules/core/src/main/java/com/google/refine/exporters/StreamExporter.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/StreamExporter.java
@@ -1,6 +1,7 @@
 /*
 
 Copyright 2010, Google Inc.
+Copyright 2024, OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -35,13 +36,44 @@ package com.google.refine.exporters;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Map;
 import java.util.Properties;
 
 import com.google.refine.browsing.Engine;
 import com.google.refine.model.Project;
 
+// TODO: Do we want to simplify this and only support one of WriterExporter / StreamExporter
+// This interface is used by OdsExporter and XlsExporter (only)
 public interface StreamExporter extends Exporter {
 
-    public void export(Project project, Properties options, Engine engine, OutputStream outputStream) throws IOException;
+    /**
+     *
+     * @deprecated for 3.9 by tfmorris - use {@link #export(Project, Map, Engine, OutputStream)}
+     */
+    @Deprecated(since = "3.9")
+    default void export(Project project, Properties options, Engine engine, OutputStream outputStream) throws IOException {
+        // We provide a default implementation for new exporters so that they don't have to implement the legacy
+        // interface
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Export a project to an OutputStream using the given faceted browsing engines and options.
+     *
+     * @param project
+     *            the project to be exported
+     * @param options
+     *            option settings to be used for the export
+     * @param engine
+     *            faceted browsing configuration
+     * @param outputStream
+     *            the OutputStream to be written to
+     * @throws IOException
+     * @since 3.9
+     */
+    default void export(Project project, Map<String, String> options, Engine engine, OutputStream outputStream) throws IOException {
+        // Default implementation for modern callers invoking legacy 3rd party extensions
+        export(project, Exporter.remapOptions(options), engine, outputStream);
+    };
 
 }

--- a/modules/core/src/main/java/com/google/refine/exporters/UrlExporter.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/UrlExporter.java
@@ -40,8 +40,14 @@ import java.util.Properties;
 import com.google.refine.browsing.Engine;
 import com.google.refine.model.Project;
 
+/**
+ * @deprecated for 3.9 by tfmorris - this interface is unused internally and will be deleted at the end of the
+ *             deprecation period
+ */
+@Deprecated(since = "3.9")
 public interface UrlExporter extends Exporter {
 
-    public void export(Project project, Properties options, Engine engine, URL url) throws IOException;
+    @Deprecated(since = "3.9")
+    void export(Project project, Properties options, Engine engine, URL url) throws IOException;
 
 }

--- a/modules/core/src/main/java/com/google/refine/exporters/WriterExporter.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/WriterExporter.java
@@ -1,6 +1,7 @@
 /*
 
 Copyright 2010, Google Inc.
+Copyright 2024, OpenRefine contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -35,13 +36,44 @@ package com.google.refine.exporters;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Map;
 import java.util.Properties;
 
 import com.google.refine.browsing.Engine;
 import com.google.refine.model.Project;
 
+// TODO: Do we want to simplify this and only support StreamExporter (stream is more general)
+// or would it be general to provide the exporter with the HttpServletResponse from which we're currently getting the stream/writer?
 public interface WriterExporter extends Exporter {
 
-    public void export(Project project, Properties options, Engine engine, Writer writer) throws IOException;
+    /**
+     *
+     * @param project
+     * @param options
+     * @param engine
+     * @param writer
+     * @throws IOException
+     * @deprecated by tfmorris for 3.9 Implement/use {@link #export(Project, Map, Engine, Writer)}
+     */
+    @Deprecated(since = "3.9")
+    default void export(Project project, Properties options, Engine engine, Writer writer) throws IOException {
+        // We provide a default implementation for new exporters so that they don't have to implement the legacy
+        // interface
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     *
+     * @param project
+     * @param options
+     * @param engine
+     * @param writer
+     * @throws IOException
+     * @since 3.9
+     */
+    default void export(Project project, Map<String, String> options, Engine engine, Writer writer) throws IOException {
+        // Default implementation for modern callers invoking legacy 3rd party extensions
+        export(project, Exporter.remapOptions(options), engine, writer);
+    }
 
 }

--- a/modules/core/src/main/java/com/google/refine/model/Project.java
+++ b/modules/core/src/main/java/com/google/refine/model/Project.java
@@ -61,6 +61,9 @@ import com.google.refine.process.ProcessManager;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.Pool;
 
+/**
+ * Project with all its associated metadata and data
+ */
 public class Project {
 
     final static protected Map<String, Class<? extends OverlayModel>> s_overlayModelClasses = new HashMap<String, Class<? extends OverlayModel>>();


### PR DESCRIPTION
Refs #6419.

This PR includes just the interfaces changes with no changes to the bundled exporters or tests to demonstrate 100% API compatibility:
- replace Properties with Map<String, String> in a new `export` method
- deprecate the old method
- add default implementations for both new and old signature
- add helper utilities

A followup PR based on the work by @karindev in #6460 will migrate the bundled exporters to use the new API. Until the deprecation period expires, exporters which support the new or old interface will continue to work unchanged.