### PR TITLE
Implement new Exporter interface for bundled exporters

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/exporters/QuickStatementsExporter.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/exporters/QuickStatementsExporter.java
@@ -27,8 +27,8 @@ package org.openrefine.wikibase.exporters;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -76,7 +76,7 @@ public class QuickStatementsExporter implements WriterExporter {
     }
 
     @Override
-    public void export(Project project, Properties options, Engine engine, Writer writer)
+    public void export(Project project, Map<String, String> options, Engine engine, Writer writer)
             throws IOException {
         WikibaseSchema schema = (WikibaseSchema) project.overlayModels.get("wikibaseSchema");
         if (schema == null) {

--- a/extensions/wikibase/src/org/openrefine/wikibase/exporters/SchemaExporter.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/exporters/SchemaExporter.java
@@ -3,7 +3,7 @@ package org.openrefine.wikibase.exporters;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Properties;
+import java.util.Map;
 
 import com.google.refine.browsing.Engine;
 import com.google.refine.exporters.WriterExporter;
@@ -20,7 +20,7 @@ public class SchemaExporter implements WriterExporter {
     }
 
     @Override
-    public void export(Project project, Properties options, Engine engine, Writer writer) throws IOException {
+    public void export(Project project, Map<String, String> options, Engine engine, Writer writer) throws IOException {
         WikibaseSchema schema = (WikibaseSchema) project.overlayModels.get("wikibaseSchema");
         if (schema == null) {
             schema = new WikibaseSchema();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/QuickStatementsExporterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/QuickStatementsExporterTest.java
@@ -31,7 +31,8 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
@@ -83,9 +84,9 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         Engine engine = new Engine(project);
 
         StringWriter writer = new StringWriter();
-        Properties properties = new Properties();
+        Map<String, String> properties = new HashMap<>();
         exporter.export(project, properties, engine, writer);
-        assertEquals(TestingData.inceptionWithNewQS, writer.toString());
+        assertEquals(writer.toString(), TestingData.inceptionWithNewQS);
     }
 
     @Test
@@ -227,7 +228,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 });
         Engine engine = new Engine(project);
         StringWriter writer = new StringWriter();
-        Properties properties = new Properties();
+        Map<String, String> properties = new HashMap<>();
         exporter.export(project, properties, engine, writer);
         assertEquals(QuickStatementsExporter.noSchemaErrorMessage, writer.toString());
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/QuickStatementsExporterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/QuickStatementsExporterTest.java
@@ -31,7 +31,6 @@ import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.testng.annotations.Test;
@@ -84,8 +83,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
         Engine engine = new Engine(project);
 
         StringWriter writer = new StringWriter();
-        Map<String, String> properties = new HashMap<>();
-        exporter.export(project, properties, engine, writer);
+        exporter.export(project, Map.of(), engine, writer);
         assertEquals(writer.toString(), TestingData.inceptionWithNewQS);
     }
 
@@ -96,12 +94,12 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 .addContributingRowId(123)
                 .build();
 
-        assertEquals(QuickStatementsExporter.impossibleSchedulingErrorMessage, export(update));
+        assertEquals(export(update), QuickStatementsExporter.impossibleSchedulingErrorMessage);
     }
 
     @Test
     public void testNameDesc() throws IOException {
-        /**
+        /*
          * Adding labels and description without overriding is not supported by QS, so we fall back on adding them with
          * overriding.
          */
@@ -111,7 +109,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 .addContributingRowId(123)
                 .build();
 
-        assertEquals("Q1377\tLen\t\"some label\"\n" + "Q1377\tDen\t\"some description\"\n", export(update));
+        assertEquals(export(update), "Q1377\tLen\t\"some label\"\n" + "Q1377\tDen\t\"some description\"\n");
     }
 
     @Test
@@ -123,8 +121,8 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 .addContributingRowId(123)
                 .build();
 
-        assertEquals("CREATE\n" + "LAST\tLen\t\"my new item\"\n" + "LAST\tDen\t\"isn't it awesome?\"\n"
-                + "LAST\tAen\t\"fabitem\"\n", export(update));
+        assertEquals(export(update), "CREATE\n" + "LAST\tLen\t\"my new item\"\n" + "LAST\tDen\t\"isn't it awesome?\"\n"
+                + "LAST\tAen\t\"fabitem\"\n");
     }
 
     @Test
@@ -135,7 +133,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 .addContributingRowId(123)
                 .build();
 
-        assertEquals("- Q1377\tP38\tQ865528\n", export(update));
+        assertEquals(export(update), "- Q1377\tP38\tQ865528\n");
     }
 
     @Test
@@ -152,7 +150,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 StatementEditingMode.ADD_OR_MERGE);
         TermedStatementEntityEdit update = new ItemEditBuilder(qid1).addStatement(statementUpdate).addContributingRowId(123).build();
 
-        assertEquals("Q1377\tP38\tQ865528\tP38\tQ1377\n", export(update));
+        assertEquals(export(update), "Q1377\tP38\tQ865528\tP38\tQ1377\n");
     }
 
     @Test
@@ -167,7 +165,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 .addContributingRowId(123)
                 .build();
 
-        assertEquals("Q1377\tP123\tsomevalue\n", export(update));
+        assertEquals(export(update), "Q1377\tP123\tsomevalue\n");
     }
 
     @Test
@@ -182,7 +180,7 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 .addContributingRowId(123)
                 .build();
 
-        assertEquals("Q1377\tP123\tnovalue\n", export(update));
+        assertEquals(export(update), "Q1377\tP123\tnovalue\n");
     }
 
     /**
@@ -215,8 +213,8 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 .build();
 
         assertEquals(
-                "Q1377\tP38\tQ865528\tP38\tQ1377\tS38\tQ865528\n" + "Q1377\tP38\tQ865528\tP38\tQ1377\tS38\tQ1377\n",
-                export(update));
+                export(update),
+                "Q1377\tP38\tQ865528\tP38\tQ1377\tS38\tQ865528\n" + "Q1377\tP38\tQ865528\tP38\tQ1377\tS38\tQ1377\n");
     }
 
     @Test
@@ -228,13 +226,12 @@ public class QuickStatementsExporterTest extends WikidataRefineTest {
                 });
         Engine engine = new Engine(project);
         StringWriter writer = new StringWriter();
-        Map<String, String> properties = new HashMap<>();
-        exporter.export(project, properties, engine, writer);
-        assertEquals(QuickStatementsExporter.noSchemaErrorMessage, writer.toString());
+        exporter.export(project, Map.of(), engine, writer);
+        assertEquals(writer.toString(), QuickStatementsExporter.noSchemaErrorMessage);
     }
 
     @Test
     public void testGetContentType() {
-        assertEquals("text/plain", exporter.getContentType());
+        assertEquals(exporter.getContentType(), "text/plain");
     }
 }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/SchemaExporterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/SchemaExporterTest.java
@@ -4,7 +4,8 @@ package org.openrefine.wikibase.exporters;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringWriter;
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -29,7 +30,7 @@ public class SchemaExporterTest extends WikidataRefineTest {
                 });
         Engine engine = new Engine(project);
         StringWriter writer = new StringWriter();
-        Properties properties = new Properties();
+        Map<String, String> properties = new HashMap<String, String>();
         exporter.export(project, properties, engine, writer);
         TestUtils.assertEqualsAsJson(writer.toString(),
                 "{\"entityEdits\":[],\"siteIri\":null,\"mediaWikiApiEndpoint\":null,\"entityTypeSiteIRI\":{}}");

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/SchemaExporterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/SchemaExporterTest.java
@@ -4,7 +4,6 @@ package org.openrefine.wikibase.exporters;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringWriter;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.testng.annotations.Test;
@@ -30,8 +29,7 @@ public class SchemaExporterTest extends WikidataRefineTest {
                 });
         Engine engine = new Engine(project);
         StringWriter writer = new StringWriter();
-        Map<String, String> properties = new HashMap<String, String>();
-        exporter.export(project, properties, engine, writer);
+        exporter.export(project, Map.of(), engine, writer);
         TestUtils.assertEqualsAsJson(writer.toString(),
                 "{\"entityEdits\":[],\"siteIri\":null,\"mediaWikiApiEndpoint\":null,\"entityTypeSiteIRI\":{}}");
     }

--- a/main/src/com/google/refine/commands/project/ExportRowsCommand.java
+++ b/main/src/com/google/refine/commands/project/ExportRowsCommand.java
@@ -67,7 +67,6 @@ public class ExportRowsCommand extends Command {
     private static final Logger logger = LoggerFactory.getLogger("ExportRowsCommand");
 
     @Deprecated(since = "3.9")
-    @SuppressWarnings("unchecked")
     static public Properties getRequestParameters(HttpServletRequest request) {
         Properties options = new Properties();
 
@@ -82,7 +81,7 @@ public class ExportRowsCommand extends Command {
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
-        // This command triggers evaluation expression and therefore requires CSRF-protection
+        // This command triggers expression evaluation and therefore requires CSRF-protection
         if (!hasValidCSRFToken(request)) {
             respondCSRFError(response);
             return;
@@ -134,12 +133,14 @@ public class ExportRowsCommand extends Command {
                 response.setCharacterEncoding(encoding != null ? encoding : "UTF-8");
                 Writer writer = encoding == null ? response.getWriter() : new OutputStreamWriter(response.getOutputStream(), encoding);
 
+                // Legacy exporters are supported by the default method implementation for the new export() method
                 ((WriterExporter) exporter).export(project, params, engine, writer);
                 writer.close();
             } else if (exporter instanceof StreamExporter) {
                 response.setCharacterEncoding("UTF-8");
 
                 OutputStream stream = response.getOutputStream();
+                // Legacy exporters are supported by the default method implementation for the new export() method
                 ((StreamExporter) exporter).export(project, params, engine, stream);
                 stream.close();
             } else {

--- a/main/src/com/google/refine/exporters/CsvExporter.java
+++ b/main/src/com/google/refine/exporters/CsvExporter.java
@@ -36,7 +36,7 @@ package com.google.refine.exporters;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -84,10 +84,10 @@ public class CsvExporter implements WriterExporter {
     }
 
     @Override
-    public void export(Project project, Properties params, Engine engine, final Writer writer)
+    public void export(Project project, Map<String, String> params, Engine engine, final Writer writer)
             throws IOException {
 
-        String optionsString = (params == null) ? null : params.getProperty("options");
+        String optionsString = (params == null) ? null : params.get("options");
         Configuration options = new Configuration();
         if (optionsString != null) {
             try {
@@ -105,8 +105,8 @@ public class CsvExporter implements WriterExporter {
         final String lineSeparator = options.lineSeparator;
         final boolean quoteAll = options.quoteAll;
 
-        final boolean printColumnHeader = (params != null && params.getProperty("printColumnHeader") != null)
-                ? Boolean.parseBoolean(params.getProperty("printColumnHeader"))
+        final boolean printColumnHeader = (params != null && params.get("printColumnHeader") != null)
+                ? Boolean.parseBoolean(params.get("printColumnHeader"))
                 : true;
 
         AbstractWriter csvWriter;

--- a/main/src/com/google/refine/exporters/CsvExporter.java
+++ b/main/src/com/google/refine/exporters/CsvExporter.java
@@ -153,7 +153,7 @@ public class CsvExporter implements WriterExporter {
             }
         };
 
-        CustomizableTabularExporterUtilities.exportRows(project, engine, params, serializer);
+        CustomizableTabularExporterUtilities.exportRows(project, engine, optionsString, serializer);
 
     }
 

--- a/main/src/com/google/refine/exporters/HtmlTableExporter.java
+++ b/main/src/com/google/refine/exporters/HtmlTableExporter.java
@@ -123,6 +123,6 @@ public class HtmlTableExporter implements WriterExporter {
         };
 
         CustomizableTabularExporterUtilities.exportRows(
-                project, engine, params, serializer);
+                project, engine, params.get("options"), serializer);
     }
 }

--- a/main/src/com/google/refine/exporters/HtmlTableExporter.java
+++ b/main/src/com/google/refine/exporters/HtmlTableExporter.java
@@ -36,7 +36,7 @@ package com.google.refine.exporters;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.text.StringEscapeUtils;
@@ -53,7 +53,7 @@ public class HtmlTableExporter implements WriterExporter {
     }
 
     @Override
-    public void export(final Project project, Properties params, Engine engine, final Writer writer)
+    public void export(final Project project, Map<String, String> params, Engine engine, final Writer writer)
             throws IOException {
 
         TabularSerializer serializer = new TabularSerializer() {

--- a/main/src/com/google/refine/exporters/OdsExporter.java
+++ b/main/src/com/google/refine/exporters/OdsExporter.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.odftoolkit.odfdom.doc.OdfSpreadsheetDocument;
@@ -58,7 +58,7 @@ public class OdsExporter implements StreamExporter {
     }
 
     @Override
-    public void export(final Project project, Properties params, Engine engine,
+    public void export(final Project project, Map<String, String> params, Engine engine,
             OutputStream outputStream) throws IOException {
 
         final OdfSpreadsheetDocument odfDoc;

--- a/main/src/com/google/refine/exporters/OdsExporter.java
+++ b/main/src/com/google/refine/exporters/OdsExporter.java
@@ -133,7 +133,7 @@ public class OdsExporter implements StreamExporter {
         };
 
         CustomizableTabularExporterUtilities.exportRows(
-                project, engine, params, serializer);
+                project, engine, params.get("optipns"), serializer);
 
         try {
             odfDoc.save(outputStream);

--- a/main/src/com/google/refine/exporters/OdsExporter.java
+++ b/main/src/com/google/refine/exporters/OdsExporter.java
@@ -133,7 +133,7 @@ public class OdsExporter implements StreamExporter {
         };
 
         CustomizableTabularExporterUtilities.exportRows(
-                project, engine, params.get("optipns"), serializer);
+                project, engine, params == null ? null : params.get("options"), serializer);
 
         try {
             odfDoc.save(outputStream);

--- a/main/src/com/google/refine/exporters/TemplatingExporter.java
+++ b/main/src/com/google/refine/exporters/TemplatingExporter.java
@@ -35,7 +35,7 @@ package com.google.refine.exporters;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Properties;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -83,16 +83,16 @@ public class TemplatingExporter implements WriterExporter {
     }
 
     @Override
-    public void export(Project project, Properties options, Engine engine, Writer writer) throws IOException {
-        String limitString = options.getProperty("limit");
+    public void export(Project project, Map<String, String> options, Engine engine, Writer writer) throws IOException {
+        String limitString = options.get("limit");
         int limit = limitString != null ? Integer.parseInt(limitString) : -1;
 
-        String sortingJson = options.getProperty("sorting");
+        String sortingJson = options.get("sorting");
 
-        String templateString = options.getProperty("template");
-        String prefixString = options.getProperty("prefix");
-        String suffixString = options.getProperty("suffix");
-        String separatorString = options.getProperty("separator");
+        String templateString = options.get("template");
+        String prefixString = options.get("prefix");
+        String suffixString = options.get("suffix");
+        String separatorString = options.get("separator");
 
         Template template;
         try {
@@ -105,7 +105,7 @@ public class TemplatingExporter implements WriterExporter {
         template.setSuffix(suffixString);
         template.setSeparator(separatorString);
 
-        if (!"true".equals(options.getProperty("preview"))) {
+        if (!"true".equals(options.get("preview"))) {
             TemplateConfig config = new TemplateConfig(templateString, prefixString,
                     suffixString, separatorString);
             project.getMetadata().getPreferenceStore().put("exporters.templating.template",

--- a/main/src/com/google/refine/exporters/XlsExporter.java
+++ b/main/src/com/google/refine/exporters/XlsExporter.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.poi.common.usermodel.HyperlinkType;
@@ -71,7 +71,7 @@ public class XlsExporter implements StreamExporter {
     }
 
     @Override
-    public void export(final Project project, Properties params, Engine engine,
+    public void export(final Project project, Map<String, String> params, Engine engine,
             OutputStream outputStream) throws IOException {
 
         final Workbook wb = xml ? new SXSSFWorkbook() : new HSSFWorkbook();

--- a/main/src/com/google/refine/exporters/XlsExporter.java
+++ b/main/src/com/google/refine/exporters/XlsExporter.java
@@ -153,7 +153,7 @@ public class XlsExporter implements StreamExporter {
         };
 
         CustomizableTabularExporterUtilities.exportRows(
-                project, engine, params, serializer);
+                project, engine, params.get("options"), serializer);
 
         wb.write(outputStream);
         outputStream.flush();

--- a/main/src/com/google/refine/exporters/sql/SqlExporter.java
+++ b/main/src/com/google/refine/exporters/sql/SqlExporter.java
@@ -162,7 +162,7 @@ public class SqlExporter implements WriterExporter {
             }
         };
 
-        CustomizableTabularExporterUtilities.exportRows(project, engine, params, serializer);
+        CustomizableTabularExporterUtilities.exportRows(project, engine, params.get("options"), serializer);
     }
 
 }

--- a/main/src/com/google/refine/exporters/sql/SqlExporter.java
+++ b/main/src/com/google/refine/exporters/sql/SqlExporter.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
@@ -67,7 +67,7 @@ public class SqlExporter implements WriterExporter {
     }
 
     @Override
-    public void export(final Project project, Properties params, Engine engine, final Writer writer)
+    public void export(final Project project, Map<String, String> params, Engine engine, final Writer writer)
             throws IOException {
         if (logger.isDebugEnabled()) {
             logger.debug("export sql with params: {}", params);

--- a/main/tests/server/src/com/google/refine/exporters/CsvExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/CsvExporterTests.java
@@ -23,8 +23,8 @@ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Properties;
+import java.util.Map;
 
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -69,7 +69,7 @@ public class CsvExporterTests extends RefineTest {
     StringWriter writer;
     Project project;
     Engine engine;
-    Properties options;
+    Map<String, String> options;
 
     // System Under Test
     CsvExporter SUT;
@@ -80,7 +80,7 @@ public class CsvExporterTests extends RefineTest {
         writer = new StringWriter();
         project = new Project();
         engine = new Engine(project);
-        options = mock(Properties.class);
+        options = mock(Map.class);
     }
 
     @AfterMethod
@@ -106,20 +106,20 @@ public class CsvExporterTests extends RefineTest {
     @Test
     public void exportSimpleCsvNoHeader() throws IOException {
         CreateGrid(2, 2);
-        when(options.getProperty("printColumnHeader")).thenReturn("false");
+        when(options.get("printColumnHeader")).thenReturn("false");
 
         SUT.export(project, options, engine, writer);
 
         assertEqualsSystemLineEnding(writer.toString(), "row0cell0,row0cell1\n" +
                 "row1cell0,row1cell1\n");
 
-        verify(options, times(2)).getProperty("printColumnHeader");
+        verify(options, times(2)).get("printColumnHeader");
     }
 
     @Test
     public void exportSimpleCsvCustomLineSeparator() throws IOException {
         CreateGrid(2, 2);
-        when(options.getProperty("options")).thenReturn("{\"lineSeparator\":\"X\"}");
+        when(options.get("options")).thenReturn("{\"lineSeparator\":\"X\"}");
 
         SUT.export(project, options, engine, writer);
 
@@ -131,7 +131,7 @@ public class CsvExporterTests extends RefineTest {
     @Test
     public void exportSimpleCsvQuoteAll() throws IOException {
         CreateGrid(2, 2);
-        when(options.getProperty("options")).thenReturn("{\"quoteAll\":\"true\"}");
+        when(options.get("options")).thenReturn("{\"quoteAll\":\"true\"}");
 
         SUT.export(project, options, engine, writer);
 
@@ -214,15 +214,15 @@ public class CsvExporterTests extends RefineTest {
      * @Ignore
      * @Test public void exportDateColumnsPreVersion28(){ CreateGrid(1,2); Calendar calendar = Calendar.getInstance();
      *       Date date = new Date();
-     * 
+     *
      *       when(options.getProperty("printColumnHeader")).thenReturn("false"); project.rows.get(0).cells.set(0, new
      *       Cell(calendar, null)); project.rows.get(0).cells.set(1, new Cell(date, null));
-     * 
+     *
      *       try { SUT.export(project, options, engine, writer); } catch (IOException e) { Assert.fail(); }
-     * 
+     *
      *       String expectedOutput = ParsingUtilities.instantToLocalDateTimeString(calendar.toInstant()) + "," +
      *       ParsingUtilities.instantToLocalDateTimeString(date.toInstant()) + "\n";
-     * 
+     *
      *       assertEqualsSystemLineEnding(writer.toString(), expectedOutput); }
      */
     // helper methods

--- a/main/tests/server/src/com/google/refine/exporters/CsvExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/CsvExporterTests.java
@@ -40,8 +40,22 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.io.Writer;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Stream;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.univocity.parsers.common.AbstractWriter;
+import com.univocity.parsers.csv.CsvFormat;
+import com.univocity.parsers.csv.CsvWriter;
+import com.univocity.parsers.csv.CsvWriterSettings;
+import com.univocity.parsers.tsv.TsvFormat;
+import com.univocity.parsers.tsv.TsvWriter;
+import com.univocity.parsers.tsv.TsvWriterSettings;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -56,6 +70,7 @@ import com.google.refine.model.Column;
 import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
+import com.google.refine.util.ParsingUtilities;
 
 public class CsvExporterTests extends RefineTest {
 
@@ -209,6 +224,13 @@ public class CsvExporterTests extends RefineTest {
                 ",row2cell1,row2cell2\n");
     }
 
+    @Test
+    void exportLegacyExporter() throws IOException {
+        WriterExporter exporter = new LegacyTestExporter();
+        exporter.export(project, options, engine, writer);
+
+    }
+
     // all date type cells are in unified format
     /**
      * @Ignore
@@ -248,4 +270,109 @@ public class CsvExporterTests extends RefineTest {
             project.rows.add(row);
         }
     }
+
+    // This is a copy of the CSV exporter as it existed before the API update
+    class LegacyTestExporter implements WriterExporter {
+
+        CsvFormat DEFAULT_FORMAT = new CsvWriterSettings().getFormat();
+        TsvFormat TSV_FORMAT = new TsvWriterSettings().getFormat();
+        char DEFAULT_SEPARATOR = DEFAULT_FORMAT.getDelimiter();
+        String DEFAULT_LINE_ENDING = DEFAULT_FORMAT.getLineSeparatorString();
+
+        final Logger logger = LoggerFactory.getLogger("CsvExporter");
+        char separator;
+
+        public LegacyTestExporter() {
+            separator = ','; // Comma separated-value is default
+        }
+
+        public LegacyTestExporter(char separator) {
+            this.separator = separator;
+        }
+
+        private class Configuration {
+
+            @JsonProperty("separator")
+            protected String separator = null;
+            @JsonProperty("lineSeparator")
+            protected String lineSeparator = DEFAULT_LINE_ENDING;
+            @JsonProperty("quoteAll")
+            protected boolean quoteAll = false;
+        }
+
+        @Override
+        public void export(Project project, Properties params, Engine engine, final Writer writer)
+                throws IOException {
+
+            String optionsString = (params == null) ? null : params.getProperty("options");
+            Configuration options = new Configuration();
+            if (optionsString != null) {
+                try {
+                    options = ParsingUtilities.mapper.readValue(optionsString, Configuration.class);
+                } catch (IOException e) {
+                    // Ignore and keep options null.
+                    e.printStackTrace();
+                }
+            }
+            if (options.separator == null) {
+                options.separator = Character.toString(separator);
+            }
+
+            final String separator = options.separator;
+            final String lineSeparator = options.lineSeparator;
+            final boolean quoteAll = options.quoteAll;
+
+            final boolean printColumnHeader = (params != null && params.getProperty("printColumnHeader") != null)
+                    ? Boolean.parseBoolean(params.getProperty("printColumnHeader"))
+                    : true;
+
+            AbstractWriter csvWriter;
+            if ("\t".equals(separator)) {
+                TsvWriterSettings tsvSettings = new TsvWriterSettings();
+                csvWriter = new TsvWriter(writer, tsvSettings);
+            } else {
+                CsvWriterSettings settings = new CsvWriterSettings();
+                settings.setQuoteAllFields(quoteAll); // CSV only
+                settings.getFormat().setLineSeparator(lineSeparator);
+                settings.getFormat().setDelimiter(separator);
+
+                // Required for our test exportCsvWithQuote which wants the value "line has \"quote\""
+                // to be exported as "\"line has \"\"quote\"\"", although the default of literal value
+                // without the extra quoting is arguably cleaner
+                settings.setEscapeUnquotedValues(true);
+                settings.setQuoteEscapingEnabled(true);
+
+                csvWriter = new CsvWriter(writer, settings);
+            }
+
+            TabularSerializer serializer = new TabularSerializer() {
+
+                @Override
+                public void startFile(JsonNode options) {
+                }
+
+                @Override
+                public void endFile() {
+                }
+
+                @Override
+                public void addRow(List<CellData> cells, boolean isHeader) {
+                    if (!isHeader || printColumnHeader) {
+                        Stream<String> strings = cells.stream()
+                                .map(cellData -> (cellData != null && cellData.text != null) ? cellData.text : "");
+                        csvWriter.writeRow(strings.toArray());
+                    }
+                }
+            };
+
+            CustomizableTabularExporterUtilities.exportRows(project, engine, params, serializer);
+
+        }
+
+        @Override
+        public String getContentType() {
+            return "text/plain";
+        }
+    }
+
 }

--- a/main/tests/server/src/com/google/refine/exporters/CsvExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/CsvExporterTests.java
@@ -226,27 +226,13 @@ public class CsvExporterTests extends RefineTest {
 
     @Test
     void exportLegacyExporter() throws IOException {
+        CreateGrid(1, 1);
         WriterExporter exporter = new LegacyTestExporter();
         exporter.export(project, options, engine, writer);
-
+        assertEqualsSystemLineEnding(writer.toString(), "column0\n" +
+                "row0cell0\n");
     }
 
-    // all date type cells are in unified format
-    /**
-     * @Ignore
-     * @Test public void exportDateColumnsPreVersion28(){ CreateGrid(1,2); Calendar calendar = Calendar.getInstance();
-     *       Date date = new Date();
-     *
-     *       when(options.getProperty("printColumnHeader")).thenReturn("false"); project.rows.get(0).cells.set(0, new
-     *       Cell(calendar, null)); project.rows.get(0).cells.set(1, new Cell(date, null));
-     *
-     *       try { SUT.export(project, options, engine, writer); } catch (IOException e) { Assert.fail(); }
-     *
-     *       String expectedOutput = ParsingUtilities.instantToLocalDateTimeString(calendar.toInstant()) + "," +
-     *       ParsingUtilities.instantToLocalDateTimeString(date.toInstant()) + "\n";
-     *
-     *       assertEqualsSystemLineEnding(writer.toString(), expectedOutput); }
-     */
     // helper methods
 
     protected void CreateColumns(int noOfColumns) {

--- a/main/tests/server/src/com/google/refine/exporters/HtmlExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/HtmlExporterTests.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Properties;
+import java.util.Map;
 
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -75,7 +75,7 @@ public class HtmlExporterTests extends RefineTest {
     ProjectMetadata projectMetadata;
     Project project;
     Engine engine;
-    Properties options;
+    Map<String, String> options;
 
     // System Under Test
     WriterExporter SUT;
@@ -90,7 +90,7 @@ public class HtmlExporterTests extends RefineTest {
         projectMetadata.setName(TEST_PROJECT_NAME);
         ProjectManager.singleton.registerProject(project, projectMetadata);
         engine = new Engine(project);
-        options = mock(Properties.class);
+        options = mock(Map.class);
     }
 
     @AfterMethod
@@ -134,7 +134,7 @@ public class HtmlExporterTests extends RefineTest {
     @Test(enabled = false)
     public void exportSimpleHtmlTableNoHeader() {
         CreateGrid(2, 2);
-        when(options.getProperty("printColumnHeader")).thenReturn("false");
+        when(options.get("printColumnHeader")).thenReturn("false");
         try {
             SUT.export(project, options, engine, writer);
         } catch (IOException e) {
@@ -152,7 +152,7 @@ public class HtmlExporterTests extends RefineTest {
                 "</table>\n" +
                 "</body>\n" +
                 "</html>\n");
-        verify(options, times(2)).getProperty("printColumnHeader");
+        verify(options, times(2)).get("printColumnHeader");
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/exporters/OdsExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/OdsExporterTests.java
@@ -39,7 +39,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 
 import org.odftoolkit.odfdom.doc.OdfDocument;
 import org.odftoolkit.odfdom.doc.table.OdfTable;
@@ -76,7 +76,7 @@ public class OdsExporterTests extends RefineTest {
     ProjectMetadata projectMetadata;
     Project project;
     Engine engine;
-    Properties options;
+    Map<String, String> options;
 
     // System Under Test
     StreamExporter SUT;
@@ -91,7 +91,7 @@ public class OdsExporterTests extends RefineTest {
         projectMetadata.setName(TEST_PROJECT_NAME);
         ProjectManager.singleton.registerProject(project, projectMetadata);
         engine = new Engine(project);
-        options = mock(Properties.class);
+        options = mock(Map.class);
     }
 
     @AfterMethod

--- a/main/tests/server/src/com/google/refine/exporters/TemplatingExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/TemplatingExporterTests.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Properties;
+import java.util.Map;
 
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -52,7 +52,6 @@ import com.google.refine.ProjectManagerStub;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
-import com.google.refine.browsing.Engine.Mode;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
 import com.google.refine.model.Cell;
@@ -92,7 +91,7 @@ public class TemplatingExporterTests extends RefineTest {
     ProjectMetadata projectMetadata;
     Project project;
     Engine engine;
-    Properties options;
+    Map<String, String> options;
 
     // System Under Test
     WriterExporter SUT;
@@ -107,7 +106,7 @@ public class TemplatingExporterTests extends RefineTest {
         projectMetadata.setName(TEST_PROJECT_NAME);
         ProjectManager.singleton.registerProject(project, projectMetadata);
         engine = new Engine(project);
-        options = mock(Properties.class);
+        options = mock(Map.class);
     }
 
     @AfterMethod
@@ -123,13 +122,10 @@ public class TemplatingExporterTests extends RefineTest {
     @Test
     public void exportEmptyTemplate() throws IOException {
 
-//        when(options.getProperty("limit")).thenReturn("100"); // optional integer
-//        when(options.getProperty("sorting")).thenReturn(""); //optional
-        when(options.getProperty("template")).thenReturn("a template that should never get used");
-        when(options.getProperty("prefix")).thenReturn(prefix);
-        when(options.getProperty("suffix")).thenReturn(suffix);
-        when(options.getProperty("separator")).thenReturn(rowSeparator);
-//        when(options.getProperty("preview")).thenReturn("false"); // optional true|false
+        when(options.get("template")).thenReturn("a template that should never get used");
+        when(options.get("prefix")).thenReturn(prefix);
+        when(options.get("suffix")).thenReturn(suffix);
+        when(options.get("separator")).thenReturn(rowSeparator);
 
         SUT.export(project, options, engine, writer);
 
@@ -142,13 +138,10 @@ public class TemplatingExporterTests extends RefineTest {
         String template = rowPrefix + "${column0}" + cellSeparator + "${column1}";
 //      String template = "boilerplate${column0}{{4+3}}${column1}";
 
-//        when(options.getProperty("limit")).thenReturn("100"); // optional integer
-//        when(options.getProperty("sorting")).thenReturn(""); //optional
-        when(options.getProperty("template")).thenReturn(template);
-        when(options.getProperty("prefix")).thenReturn(prefix);
-        when(options.getProperty("suffix")).thenReturn(suffix);
-        when(options.getProperty("separator")).thenReturn(rowSeparator);
-//        when(options.getProperty("preview")).thenReturn("false"); // optional true|false
+        when(options.get("template")).thenReturn(template);
+        when(options.get("prefix")).thenReturn(prefix);
+        when(options.get("suffix")).thenReturn(suffix);
+        when(options.get("separator")).thenReturn(rowSeparator);
 
         SUT.export(project, options, engine, writer);
 
@@ -162,16 +155,13 @@ public class TemplatingExporterTests extends RefineTest {
     @Test()
     public void exportTemplateWithEmptyCells() throws IOException {
 
-//      when(options.getProperty("limit")).thenReturn("100"); // optional integer
-//      when(options.getProperty("sorting")).thenReturn(""); //optional
-        when(options.getProperty("template"))
+        when(options.get("template"))
                 .thenReturn(rowPrefix + "${column0}" + cellSeparator + "${column1}" + cellSeparator + "${column2}");
-        when(options.getProperty("template"))
+        when(options.get("template"))
                 .thenReturn(rowPrefix + "${column0}" + cellSeparator + "${column1}" + cellSeparator + "${column2}");
-        when(options.getProperty("prefix")).thenReturn(prefix);
-        when(options.getProperty("suffix")).thenReturn(suffix);
-        when(options.getProperty("separator")).thenReturn(rowSeparator);
-//      when(options.getProperty("preview")).thenReturn("false"); // optional true|false
+        when(options.get("prefix")).thenReturn(prefix);
+        when(options.get("suffix")).thenReturn(suffix);
+        when(options.get("separator")).thenReturn(rowSeparator);
 
         CreateGrid(3, 3);
 
@@ -192,14 +182,12 @@ public class TemplatingExporterTests extends RefineTest {
     @Test()
     public void exportTemplateWithLimit() throws IOException {
 
-        when(options.getProperty("limit")).thenReturn("2"); // optional integer
-//      when(options.getProperty("sorting")).thenReturn(""); //optional
-        when(options.getProperty("template"))
+        when(options.get("limit")).thenReturn("2"); // optional integer
+        when(options.get("template"))
                 .thenReturn(rowPrefix + "${column0}" + cellSeparator + "${column1}" + cellSeparator + "${column2}");
-        when(options.getProperty("prefix")).thenReturn(prefix);
-        when(options.getProperty("suffix")).thenReturn(suffix);
-        when(options.getProperty("separator")).thenReturn(rowSeparator);
-//      when(options.getProperty("preview")).thenReturn("false"); // optional true|false
+        when(options.get("prefix")).thenReturn(prefix);
+        when(options.get("suffix")).thenReturn(suffix);
+        when(options.get("separator")).thenReturn(rowSeparator);
 
         CreateGrid(3, 3);
 
@@ -233,13 +221,10 @@ public class TemplatingExporterTests extends RefineTest {
             project.rows.add(row);
         }
         String template = rowPrefix + "${column0}" + cellSeparator + "${column1}";
-        when(options.getProperty("template")).thenReturn(template);
-        when(options.getProperty("prefix")).thenReturn(prefix);
-        when(options.getProperty("suffix")).thenReturn(suffix);
-        when(options.getProperty("separator")).thenReturn(rowSeparator);
-        Engine engine = new Engine(project);
-        engine.setMode(Mode.RecordBased);
-        project.update();
+        when(options.get("template")).thenReturn(template);
+        when(options.get("prefix")).thenReturn(prefix);
+        when(options.get("suffix")).thenReturn(suffix);
+        when(options.get("separator")).thenReturn(rowSeparator);
 
         SUT.export(project, options, engine, writer);
 
@@ -258,10 +243,10 @@ public class TemplatingExporterTests extends RefineTest {
     public void exportTemplateWithProperEscaping() throws IOException {
         CreateGrid(2, 2);
         String template = rowPrefix + "{{\"\\}\\}\"}}" + cellSeparator + "{{\"\\}\\}\"}}";
-        when(options.getProperty("template")).thenReturn(template);
-        when(options.getProperty("prefix")).thenReturn(prefix);
-        when(options.getProperty("suffix")).thenReturn(suffix);
-        when(options.getProperty("separator")).thenReturn(rowSeparator);
+        when(options.get("template")).thenReturn(template);
+        when(options.get("prefix")).thenReturn(prefix);
+        when(options.get("suffix")).thenReturn(suffix);
+        when(options.get("separator")).thenReturn(rowSeparator);
         SUT.export(project, options, engine, writer);
 
         Assert.assertEquals(writer.toString(),

--- a/main/tests/server/src/com/google/refine/exporters/TemplatingExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/TemplatingExporterTests.java
@@ -33,11 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.exporters;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.slf4j.LoggerFactory;
@@ -106,7 +104,8 @@ public class TemplatingExporterTests extends RefineTest {
         projectMetadata.setName(TEST_PROJECT_NAME);
         ProjectManager.singleton.registerProject(project, projectMetadata);
         engine = new Engine(project);
-        options = mock(Map.class);
+        writer = new StringWriter();
+        options = new HashMap<String, String>();
     }
 
     @AfterMethod
@@ -122,10 +121,11 @@ public class TemplatingExporterTests extends RefineTest {
     @Test
     public void exportEmptyTemplate() throws IOException {
 
-        when(options.get("template")).thenReturn("a template that should never get used");
-        when(options.get("prefix")).thenReturn(prefix);
-        when(options.get("suffix")).thenReturn(suffix);
-        when(options.get("separator")).thenReturn(rowSeparator);
+        String template = "a template that should never get used";
+        options.put("template", template);
+        options.put("prefix", prefix);
+        options.put("suffix", suffix);
+        options.put("separator", rowSeparator);
 
         SUT.export(project, options, engine, writer);
 
@@ -136,12 +136,10 @@ public class TemplatingExporterTests extends RefineTest {
     public void exportSimpleTemplate() throws IOException {
         CreateGrid(2, 2);
         String template = rowPrefix + "${column0}" + cellSeparator + "${column1}";
-//      String template = "boilerplate${column0}{{4+3}}${column1}";
-
-        when(options.get("template")).thenReturn(template);
-        when(options.get("prefix")).thenReturn(prefix);
-        when(options.get("suffix")).thenReturn(suffix);
-        when(options.get("separator")).thenReturn(rowSeparator);
+        options.put("template", template);
+        options.put("prefix", prefix);
+        options.put("suffix", suffix);
+        options.put("separator", rowSeparator);
 
         SUT.export(project, options, engine, writer);
 
@@ -155,13 +153,11 @@ public class TemplatingExporterTests extends RefineTest {
     @Test()
     public void exportTemplateWithEmptyCells() throws IOException {
 
-        when(options.get("template"))
-                .thenReturn(rowPrefix + "${column0}" + cellSeparator + "${column1}" + cellSeparator + "${column2}");
-        when(options.get("template"))
-                .thenReturn(rowPrefix + "${column0}" + cellSeparator + "${column1}" + cellSeparator + "${column2}");
-        when(options.get("prefix")).thenReturn(prefix);
-        when(options.get("suffix")).thenReturn(suffix);
-        when(options.get("separator")).thenReturn(rowSeparator);
+        String template = rowPrefix + "${column0}" + cellSeparator + "${column1}" + cellSeparator + "${column2}";
+        options.put("template", template);
+        options.put("prefix", prefix);
+        options.put("suffix", suffix);
+        options.put("separator", rowSeparator);
 
         CreateGrid(3, 3);
 
@@ -182,12 +178,12 @@ public class TemplatingExporterTests extends RefineTest {
     @Test()
     public void exportTemplateWithLimit() throws IOException {
 
-        when(options.get("limit")).thenReturn("2"); // optional integer
-        when(options.get("template"))
-                .thenReturn(rowPrefix + "${column0}" + cellSeparator + "${column1}" + cellSeparator + "${column2}");
-        when(options.get("prefix")).thenReturn(prefix);
-        when(options.get("suffix")).thenReturn(suffix);
-        when(options.get("separator")).thenReturn(rowSeparator);
+        String template = rowPrefix + "${column0}" + cellSeparator + "${column1}" + cellSeparator + "${column2}";
+        options.put("limit", "2");
+        options.put("template", template);
+        options.put("prefix", prefix);
+        options.put("suffix", suffix);
+        options.put("separator", rowSeparator);
 
         CreateGrid(3, 3);
 
@@ -221,10 +217,10 @@ public class TemplatingExporterTests extends RefineTest {
             project.rows.add(row);
         }
         String template = rowPrefix + "${column0}" + cellSeparator + "${column1}";
-        when(options.get("template")).thenReturn(template);
-        when(options.get("prefix")).thenReturn(prefix);
-        when(options.get("suffix")).thenReturn(suffix);
-        when(options.get("separator")).thenReturn(rowSeparator);
+        options.put("template", template);
+        options.put("prefix", prefix);
+        options.put("suffix", suffix);
+        options.put("separator", rowSeparator);
 
         SUT.export(project, options, engine, writer);
 
@@ -243,10 +239,11 @@ public class TemplatingExporterTests extends RefineTest {
     public void exportTemplateWithProperEscaping() throws IOException {
         CreateGrid(2, 2);
         String template = rowPrefix + "{{\"\\}\\}\"}}" + cellSeparator + "{{\"\\}\\}\"}}";
-        when(options.get("template")).thenReturn(template);
-        when(options.get("prefix")).thenReturn(prefix);
-        when(options.get("suffix")).thenReturn(suffix);
-        when(options.get("separator")).thenReturn(rowSeparator);
+        options.put("template", template);
+        options.put("prefix", prefix);
+        options.put("suffix", suffix);
+        options.put("separator", rowSeparator);
+
         SUT.export(project, options, engine, writer);
 
         Assert.assertEquals(writer.toString(),

--- a/main/tests/server/src/com/google/refine/exporters/TemplatingExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/TemplatingExporterTests.java
@@ -50,6 +50,7 @@ import com.google.refine.ProjectManagerStub;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine;
+import com.google.refine.browsing.Engine.Mode;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
 import com.google.refine.model.Cell;
@@ -105,7 +106,7 @@ public class TemplatingExporterTests extends RefineTest {
         ProjectManager.singleton.registerProject(project, projectMetadata);
         engine = new Engine(project);
         writer = new StringWriter();
-        options = new HashMap<String, String>();
+        options = new HashMap<>();
     }
 
     @AfterMethod
@@ -221,6 +222,9 @@ public class TemplatingExporterTests extends RefineTest {
         options.put("prefix", prefix);
         options.put("suffix", suffix);
         options.put("separator", rowSeparator);
+        Engine engine = new Engine(project);
+        engine.setMode(Mode.RecordBased);
+        project.update();
 
         SUT.export(project, options, engine, writer);
 

--- a/main/tests/server/src/com/google/refine/exporters/TsvExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/TsvExporterTests.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Map;
 import java.util.Properties;
 
 import org.slf4j.LoggerFactory;
@@ -69,7 +70,7 @@ public class TsvExporterTests extends RefineTest {
     StringWriter writer;
     Project project;
     Engine engine;
-    Properties options;
+    Map<String, String> options;
 
     // System Under Test
     CsvExporter SUT;
@@ -80,7 +81,7 @@ public class TsvExporterTests extends RefineTest {
         writer = new StringWriter();
         project = new Project();
         engine = new Engine(project);
-        options = mock(Properties.class);
+        options = mock(Map.class);
     }
 
     @AfterMethod
@@ -90,6 +91,13 @@ public class TsvExporterTests extends RefineTest {
         project = null;
         engine = null;
         options = null;
+    }
+
+    // TODO: Do we actually want this to be supported? If so, we need to test legacy API
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void exportLegacyApiThrows() throws IOException {
+        CreateGrid(2, 2);
+        SUT.export(project, new Properties(), engine, writer);
     }
 
     @Test
@@ -107,14 +115,14 @@ public class TsvExporterTests extends RefineTest {
     @Test
     public void exportSimpleTsvNoHeader() throws IOException {
         CreateGrid(2, 2);
-        when(options.getProperty("printColumnHeader")).thenReturn("false");
+        when(options.get("printColumnHeader")).thenReturn("false");
 
         SUT.export(project, options, engine, writer);
 
         assertEqualsSystemLineEnding(writer.toString(), "row0cell0\trow0cell1\n" +
                 "row1cell0\trow1cell1\n");
 
-        verify(options, times(2)).getProperty("printColumnHeader");
+        verify(options, times(2)).get("printColumnHeader");
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/exporters/TsvExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/TsvExporterTests.java
@@ -93,7 +93,7 @@ public class TsvExporterTests extends RefineTest {
         options = null;
     }
 
-    // TODO: Do we actually want this to be supported? If so, we need to test legacy API
+    // TODO: We need to test the flip side of this with the framework calling legacy exporters.
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public void exportLegacyApiThrows() throws IOException {
         CreateGrid(2, 2);

--- a/main/tests/server/src/com/google/refine/exporters/XlsExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/XlsExporterTests.java
@@ -43,7 +43,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.OffsetDateTime;
-import java.util.Properties;
+import java.util.Map;
 
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.SpreadsheetVersion;
@@ -80,7 +80,7 @@ public class XlsExporterTests extends RefineTest {
     ProjectMetadata projectMetadata;
     Project project;
     Engine engine;
-    Properties options;
+    Map<String, String> options;
 
     // System Under Test
     StreamExporter SUT;
@@ -95,7 +95,7 @@ public class XlsExporterTests extends RefineTest {
         projectMetadata.setName(TEST_PROJECT_NAME);
         ProjectManager.singleton.registerProject(project, projectMetadata);
         engine = new Engine(project);
-        options = mock(Properties.class);
+        options = mock(Map.class);
     }
 
     @AfterMethod
@@ -200,14 +200,14 @@ public class XlsExporterTests extends RefineTest {
 
     public void exportSimpleXlsNoHeader() throws IOException {
         CreateGrid(2, 2);
-        when(options.getProperty("printColumnHeader")).thenReturn("false");
+        when(options.get("printColumnHeader")).thenReturn("false");
 
         SUT.export(project, options, engine, stream);
 
         Assert.assertEquals(stream.toString(), "row0cell0,row0cell1\n" +
                 "row1cell0,row1cell1\n");
 
-        verify(options, times(2)).getProperty("printColumnHeader");
+        verify(options, times(2)).get("printColumnHeader");
     }
 
     public void exportXlsWithEmptyCells() throws IOException {

--- a/main/tests/server/src/com/google/refine/exporters/XlsxExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/XlsxExporterTests.java
@@ -41,7 +41,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
-import java.util.Properties;
+import java.util.Map;
 
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.xssf.usermodel.XSSFCell;
@@ -81,7 +81,7 @@ public class XlsxExporterTests extends RefineTest {
     ProjectMetadata projectMetadata;
     Project project;
     Engine engine;
-    Properties options;
+    Map<String, String> options;
 
     // System Under Test
     StreamExporter SUT;
@@ -96,7 +96,7 @@ public class XlsxExporterTests extends RefineTest {
         projectMetadata.setName(TEST_PROJECT_NAME);
         ProjectManager.singleton.registerProject(project, projectMetadata);
         engine = new Engine(project);
-        options = mock(Properties.class);
+        options = mock(Map.class);
     }
 
     @AfterMethod

--- a/main/tests/server/src/com/google/refine/exporters/sql/SqlExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/sql/SqlExporterTests.java
@@ -275,11 +275,7 @@ public class SqlExporterTests extends RefineTest {
         optionsJson.put("trimColumnNames", true);
 
         when(options.get("options")).thenReturn(optionsJson.toString());
-        try {
-            SUT.export(project, options, engine, writer);
-        } catch (IOException e) {
-            Assert.fail();
-        }
+        SUT.export(project, options, engine, writer);
 
         String result = writer.toString();
         logger.debug("\nresult:={} ", result);

--- a/main/tests/server/src/com/google/refine/exporters/sql/SqlExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/sql/SqlExporterTests.java
@@ -23,8 +23,8 @@ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -40,7 +40,7 @@ import static org.testng.Assert.assertNotEquals;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.List;
-import java.util.Properties;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -82,7 +82,7 @@ public class SqlExporterTests extends RefineTest {
     ProjectMetadata projectMetadata;
     Project project;
     Engine engine;
-    Properties options;
+    Map<String, String> options;
     SqlCreateBuilder sqlCreateBuilder;
     SqlInsertBuilder sqlInsertBuilder;
 
@@ -99,7 +99,7 @@ public class SqlExporterTests extends RefineTest {
         projectMetadata.setName(TEST_PROJECT_NAME);
         ProjectManager.singleton.registerProject(project, projectMetadata);
         engine = new Engine(project);
-        options = mock(Properties.class);
+        options = mock(Map.class);
     }
 
     @AfterMethod
@@ -120,7 +120,7 @@ public class SqlExporterTests extends RefineTest {
         createNonZeroScaleNumericGrid(2, 2);
         String tableName = "sql_table_test";
         String optionsString = createOptionsFromProject(tableName, SqlData.SQL_TYPE_NUMERIC, null).toString();
-        when(options.getProperty("options")).thenReturn(optionsString);
+        when(options.get("options")).thenReturn(optionsString);
 
         SUT.export(project, options, engine, writer);
 
@@ -162,7 +162,7 @@ public class SqlExporterTests extends RefineTest {
         createGrid(2, 2);
         String tableName = "sql_table_test";
         String optionsString = createOptionsFromProject(tableName, null, null).toString();
-        when(options.getProperty("options")).thenReturn(optionsString);
+        when(options.get("options")).thenReturn(optionsString);
 
         SUT.export(project, options, engine, writer);
 
@@ -180,7 +180,7 @@ public class SqlExporterTests extends RefineTest {
         String tableName = "sql_table_test";
         ObjectNode optionsJson = (ObjectNode) createOptionsFromProject(tableName, null, null);
         optionsJson.put("includeStructure", false);
-        when(options.getProperty("options")).thenReturn(optionsJson.toString());
+        when(options.get("options")).thenReturn(optionsJson.toString());
 
         SUT.export(project, options, engine, writer);
 
@@ -201,7 +201,7 @@ public class SqlExporterTests extends RefineTest {
         String tableName = "sql_table_test";
         ObjectNode optionsJson = (ObjectNode) createOptionsFromProject(tableName, null, null);
         optionsJson.put("includeContent", false);
-        when(options.getProperty("options")).thenReturn(optionsJson.toString());
+        when(options.get("options")).thenReturn(optionsJson.toString());
 
         SUT.export(project, options, engine, writer);
 
@@ -224,7 +224,7 @@ public class SqlExporterTests extends RefineTest {
         optionsJson.put("includeStructure", true);
         optionsJson.put("includeDropStatement", true);
 
-        when(options.getProperty("options")).thenReturn(optionsJson.toString());
+        when(options.get("options")).thenReturn(optionsJson.toString());
 
         SUT.export(project, options, engine, writer);
 
@@ -274,8 +274,12 @@ public class SqlExporterTests extends RefineTest {
         optionsJson.put("convertNulltoEmptyString", true);
         optionsJson.put("trimColumnNames", true);
 
-        when(options.getProperty("options")).thenReturn(optionsJson.toString());
-        SUT.export(project, options, engine, writer);
+        when(options.get("options")).thenReturn(optionsJson.toString());
+        try {
+            SUT.export(project, options, engine, writer);
+        } catch (IOException e) {
+            Assert.fail();
+        }
 
         String result = writer.toString();
         logger.debug("\nresult:={} ", result);
@@ -302,7 +306,7 @@ public class SqlExporterTests extends RefineTest {
         optionsJson.put("includeDropStatement", true);
         optionsJson.put("convertNulltoEmptyString", true);
 
-        when(options.getProperty("options")).thenReturn(optionsJson.toString());
+        when(options.get("options")).thenReturn(optionsJson.toString());
 
         SUT.export(project, options, engine, writer);
 
@@ -325,7 +329,7 @@ public class SqlExporterTests extends RefineTest {
         optionsJson.put("includeDropStatement", true);
         optionsJson.put("convertNulltoEmptyString", true);
 
-        when(options.getProperty("options")).thenReturn(optionsJson.toString());
+        when(options.get("options")).thenReturn(optionsJson.toString());
         SUT.export(project, options, engine, writer);
 
         String result = writer.toString();
@@ -349,7 +353,7 @@ public class SqlExporterTests extends RefineTest {
         optionsJson.put("includeDropStatement", true);
         optionsJson.put("convertNulltoEmptyString", true);
 
-        when(options.getProperty("options")).thenReturn(optionsJson.toString());
+        when(options.get("options")).thenReturn(optionsJson.toString());
         SUT.export(project, options, engine, writer);
 
         String result = writer.toString();

--- a/modules/core/src/main/java/com/google/refine/exporters/CustomizableTabularExporterUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/CustomizableTabularExporterUtilities.java
@@ -207,7 +207,7 @@ abstract public class CustomizableTabularExporterUtilities {
     static public int[] countColumnsRows(
             final Project project,
             final Engine engine,
-            Properties params) {
+            Map<String, String> params) {
         RowCountingTabularSerializer serializer = new RowCountingTabularSerializer();
         exportRows(project, engine, params, serializer);
         return new int[] { serializer.columns, serializer.rows };

--- a/modules/core/src/main/java/com/google/refine/exporters/CustomizableTabularExporterUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/CustomizableTabularExporterUtilities.java
@@ -49,7 +49,6 @@ import java.util.TimeZone;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -80,7 +79,12 @@ abstract public class CustomizableTabularExporterUtilities {
             final Engine engine,
             Properties params,
             final TabularSerializer serializer) {
-        exportRows(project, engine, params.getProperty("options"), serializer);
+        try {
+            exportRows(project, engine, params.getProperty("options"), serializer);
+        } catch (IOException e) {
+            // This is what our legacy error "handling" did
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -101,15 +105,11 @@ abstract public class CustomizableTabularExporterUtilities {
             final Project project,
             final Engine engine,
             String optionsString,
-            final TabularSerializer serializer) {
+            final TabularSerializer serializer) throws IOException {
 
         JsonNode optionsTemp = null;
         if (optionsString != null) {
-            try {
-                optionsTemp = ParsingUtilities.mapper.readTree(optionsString);
-            } catch (IOException e) {
-                // Ignore and keep options null.
-            }
+            optionsTemp = ParsingUtilities.mapper.readTree(optionsString);
         }
         final JsonNode options = optionsTemp;
 
@@ -124,7 +124,7 @@ abstract public class CustomizableTabularExporterUtilities {
         if (columnOptionArray == null) {
             List<Column> columns = project.columnModel.columns;
 
-            columnNames = new ArrayList<String>(columns.size());
+            columnNames = new ArrayList<>(columns.size());
             for (Column column : columns) {
                 String name = column.getName();
                 columnNames.add(name);
@@ -133,18 +133,13 @@ abstract public class CustomizableTabularExporterUtilities {
         } else {
             int count = columnOptionArray.size();
 
-            columnNames = new ArrayList<String>(count);
-            for (int i = 0; i < count; i++) {
-                JsonNode columnOptions = columnOptionArray.get(i);
+            columnNames = new ArrayList<>(count);
+            for (JsonNode columnOptions : columnOptionArray) {
                 if (columnOptions != null) {
                     String name = JSONUtilities.getString(columnOptions, "name", null);
                     if (name != null) {
                         columnNames.add(name);
-                        try {
-                            columnNameToFormatter.put(name, ParsingUtilities.mapper.treeToValue(columnOptions, ColumnOptions.class));
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                        }
+                        columnNameToFormatter.put(name, ParsingUtilities.mapper.treeToValue(columnOptions, ColumnOptions.class));
                     }
                 }
             }
@@ -175,7 +170,6 @@ abstract public class CustomizableTabularExporterUtilities {
                     Column column = project.columnModel.getColumnByName(columnName);
                     CellFormatter formatter = columnNameToFormatter.get(columnName);
                     CellData cellData = formatter.format(
-                            project,
                             column,
                             row.getCell(column.getCellIndex()));
 
@@ -203,11 +197,14 @@ abstract public class CustomizableTabularExporterUtilities {
         filteredRows.accept(project, visitor);
     }
 
+    /**
+     * @deprecated since 3.9 with no replacement. Unused internally.
+     */
     @Deprecated(since = "3.9")
     static public int[] countColumnsRows(
             final Project project,
             final Engine engine,
-            Map<String, String> params) {
+            Properties params) {
         RowCountingTabularSerializer serializer = new RowCountingTabularSerializer();
         exportRows(project, engine, params, serializer);
         return new int[] { serializer.columns, serializer.rows };
@@ -349,7 +346,12 @@ abstract public class CustomizableTabularExporterUtilities {
             }
         }
 
+        @Deprecated(since = "3.10")
         CellData format(Project project, Column column, Cell cell) {
+            return format(column, cell);
+        }
+
+        CellData format(Column column, Cell cell) {
             if (cell != null) {
                 String link = null;
                 String text = null;

--- a/modules/core/src/main/java/com/google/refine/exporters/CustomizableTabularExporterUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/CustomizableTabularExporterUtilities.java
@@ -109,7 +109,11 @@ abstract public class CustomizableTabularExporterUtilities {
 
         JsonNode optionsTemp = null;
         if (optionsString != null) {
-            optionsTemp = ParsingUtilities.mapper.readTree(optionsString);
+            try {
+                optionsTemp = ParsingUtilities.mapper.readTree(optionsString);
+            } catch (IOException e) {
+                // Ignore and keep options null.
+            }
         }
         final JsonNode options = optionsTemp;
 

--- a/modules/core/src/main/java/com/google/refine/exporters/Exporter.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/Exporter.java
@@ -53,7 +53,7 @@ public interface Exporter {
      */
     static Properties remapOptions(Map<String, String> options) {
         Properties legacyOptions = new Properties();
-        for (Map.Entry e : options.entrySet()) {
+        for (Map.Entry<String, String> e : options.entrySet()) {
             if (e.getValue() != null) { // Properties don't accept null values
                 legacyOptions.put(e.getKey(), e.getValue());
             }

--- a/modules/core/src/main/java/com/google/refine/exporters/StreamExporter.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/StreamExporter.java
@@ -54,7 +54,7 @@ public interface StreamExporter extends Exporter {
     default void export(Project project, Properties options, Engine engine, OutputStream outputStream) throws IOException {
         // We provide a default implementation for new exporters so that they don't have to implement the legacy
         // interface
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Legacy exporter interface not supported by new exporters");
     }
 
     /**
@@ -69,6 +69,7 @@ public interface StreamExporter extends Exporter {
      * @param outputStream
      *            the OutputStream to be written to
      * @throws IOException
+     *             if there's an error during the export
      * @since 3.9
      */
     default void export(Project project, Map<String, String> options, Engine engine, OutputStream outputStream) throws IOException {

--- a/modules/core/src/main/java/com/google/refine/exporters/TabularSerializer.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/TabularSerializer.java
@@ -33,7 +33,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * An interface to be implemented by exporters which use
- * {@link CustomizableTabularExporterUtilities#exportRows(com.google.refine.model.Project, com.google.refine.browsing.Engine, java.util.Properties, TabularSerializer)}
+ * {@link CustomizableTabularExporterUtilities#exportRows(com.google.refine.model.Project, com.google.refine.browsing.Engine, String, TabularSerializer)}
  *
  */
 public interface TabularSerializer {

--- a/modules/core/src/main/java/com/google/refine/exporters/WriterExporter.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/WriterExporter.java
@@ -43,6 +43,7 @@ import com.google.refine.browsing.Engine;
 import com.google.refine.model.Project;
 
 // TODO: Do we want to simplify this and only support StreamExporter (stream is more general)
+// TODO: Also re-review / rethink this design to make sure it's sound
 // or would it be general to provide the exporter with the HttpServletResponse from which we're currently getting the stream/writer?
 public interface WriterExporter extends Exporter {
 
@@ -59,7 +60,7 @@ public interface WriterExporter extends Exporter {
     default void export(Project project, Properties options, Engine engine, Writer writer) throws IOException {
         // We provide a default implementation for new exporters so that they don't have to implement the legacy
         // interface
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("Legacy exporter interface not supported by new exporters");
     }
 
     /**


### PR DESCRIPTION
Fixes #6419. Based on @karindev 's  work in #6460 adapted to the modified interface in #6796 (which is a prerequisite for this).

Changes proposed in this pull request:
- Update all bundled exporters and tests to the new API
- Add test to make sure legacy exporter still works

NOTE: Compatibility is **only** provided for OpenRefine calling legacy exporters. There is no compatibility for a legacy third party framework (if any such frameworks exist) to call via the old API exporters which implement the new API.
