### PR TITLE
File type detection fails when multiple files are imported at once

### DIFF
--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -235,6 +235,7 @@ function registerImporting() {
   IM.registerExtension(".txt", "text");
   IM.registerExtension(".csv", "text/line-based/*sv");
   IM.registerExtension(".tsv", "text/line-based/*sv");
+  IM.registerExtension(".md", "text");
 
   IM.registerExtension(".xml", "text/xml");
   IM.registerExtension(".atom", "text/xml");


### PR DESCRIPTION
Added definition for MD format files

Fixes #6772 

Changes proposed in this pull request:
- Added definition for MD format files 
- Performed test with multiple file formats
- 
