### PR TITLE
fix #6764

### DIFF
--- a/main/webapp/modules/core/externals/jquery-ui/css/ui-lightness/jquery-ui.css
+++ b/main/webapp/modules/core/externals/jquery-ui/css/ui-lightness/jquery-ui.css
@@ -860,7 +860,7 @@ button.ui-button::-moz-focus-inner {
 .ui-tabs .ui-tabs-nav li.ui-tabs-active .ui-tabs-anchor,
 .ui-tabs .ui-tabs-nav li.ui-state-disabled .ui-tabs-anchor,
 .ui-tabs .ui-tabs-nav li.ui-tabs-loading .ui-tabs-anchor {
-	cursor: text;
+	cursor: default;
 }
 .ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-active .ui-tabs-anchor {
 	cursor: pointer;

--- a/main/webapp/modules/core/externals/jquery-ui/css/ui-lightness/jquery-ui.css
+++ b/main/webapp/modules/core/externals/jquery-ui/css/ui-lightness/jquery-ui.css
@@ -860,7 +860,7 @@ button.ui-button::-moz-focus-inner {
 .ui-tabs .ui-tabs-nav li.ui-tabs-active .ui-tabs-anchor,
 .ui-tabs .ui-tabs-nav li.ui-state-disabled .ui-tabs-anchor,
 .ui-tabs .ui-tabs-nav li.ui-tabs-loading .ui-tabs-anchor {
-	cursor: default;
+	cursor: text;
 }
 .ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-active .ui-tabs-anchor {
 	cursor: pointer;

--- a/main/webapp/modules/core/styles/jquery-ui-overrides.css
+++ b/main/webapp/modules/core/styles/jquery-ui-overrides.css
@@ -35,6 +35,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   padding: 0;
 }
 
+.ui-tabs .ui-tabs-nav li.ui-tabs-active .ui-tabs-anchor,
+.ui-tabs .ui-tabs-nav li.ui-state-disabled .ui-tabs-anchor,
+.ui-tabs .ui-tabs-nav li.ui-tabs-loading .ui-tabs-anchor {
+	cursor: default;
+}
+
 .ui-widget-content, .ui-tabs .ui-widget-header {
   border: none;
   background: none;
@@ -83,6 +89,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   border-bottom: none;
   background: var(--background-primary);
 }
+
 
 .ui-tabs .ui-tabs-nav .ui-state-active a,
 .ui-tabs .ui-tabs-nav .ui-state-active a:link,


### PR DESCRIPTION
Fixes #6764 
Before:
![openrefine_before](https://github.com/user-attachments/assets/0bdf5855-02e2-49ee-ac99-d624a083929c)

After:
![openrefine_after](https://github.com/user-attachments/assets/116194af-8380-47dd-9171-877f58aebd19)

Changes proposed in this pull request: Add the below in `main/webapp/modules/core/styles/jquery-ui-overrides.css`
```
.ui-tabs .ui-tabs-nav li.ui-tabs-active .ui-tabs-anchor,
.ui-tabs .ui-tabs-nav li.ui-state-disabled .ui-tabs-anchor,
.ui-tabs .ui-tabs-nav li.ui-tabs-loading .ui-tabs-anchor {
	cursor: default;
}
```