### PR TITLE
Fix #5989

### DIFF
--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -117,6 +117,7 @@ div.viewpanel-pagesize span:first-of-type {
 .data-table td {
   border-bottom: 0.02rem dotted #ddd;
   border-right: 0.02rem solid #ddd;
+  position: relative;
 }
 
 .data-table-header td, .data-table-header th {
@@ -222,7 +223,6 @@ table.data-table td.column-header, table.data-table th.column-header {
 div.data-table-cell-content {
   line-height: 1.2;
   color: #222;
-  position: relative;
   white-space: pre-wrap;
 }
 


### PR DESCRIPTION
Fixes #5989 

1. Remove CSS rule `position: relative` from `div.data-table-cell-content`.
2. Add CSS rule `position: relative` to `.data-table td`

Before:
![image](https://github.com/user-attachments/assets/1e31dc52-4ed3-4c3d-a6ff-285832fce8eb)

After:
![image](https://github.com/user-attachments/assets/751771e4-8abd-4c12-90cb-dd4b7dc3ac2b)
