### PR TITLE
Fix Uncaught RangeError when using Cell Edit button to change String to Date data type.

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/row/edit_cells.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/row/edit_cells.cy.js
@@ -117,4 +117,21 @@ describe(__filename, function () {
     cy.assertCellEquals(0, 'Water', '42');
     cy.assertCellEquals(1, 'Water', '42');
   });
+
+  it('Test edit a cell to change String to Date data type', function () {
+    cy.loadAndVisitProject('food.mini');
+    cy.getCell(1, 'Water')
+      .trigger('mouseover')
+      .find('.data-table-cell-edit')
+      .click();
+    cy.get('.menu-container.data-table-cell-editor #typeSelectId').select('date');
+    cy.get('.menu-container.data-table-cell-editor').should('exist');
+    cy.get('.menu-container.data-table-cell-editor textarea').type(
+      '2024-12-12'
+    );
+    cy.get('.menu-container button[bind="okButton"]').click();
+    // ensure value has been changed in the grid
+    cy.get('.menu-container.data-table-cell-editor').should('not.exist');
+    cy.assertCellEquals(1, 'Water', '2024-12-12T00:00:00Z');
+  });
 });

--- a/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/cell-ui.js
@@ -172,7 +172,7 @@ DataTableCellUI.prototype._startEdit = function(elmt) {
         alert($.i18n('core-views/not-valid-date'));
         return;
       }
-      value = value.toString("yyyy-MM-ddTHH:mm:ssZ");
+      value = new Date(value).toISOString();
     }
 
     self._focusBeforeEdit.focus();


### PR DESCRIPTION
Fixes #6534 

## Issue
The date entered in the cell is parsed using the `Date.parse()` method which returns a timestamp. This timestamp is converted to a formatted date string using `toString("YYYY-MM-DDTHH:mm:ss.sssZ")`.

but concerning the below link
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Bad_radix

The `toString` method has an optional parameter radix, which should be an integer between 2 and 36. But here the radix is given a string as an argument.

## Changes proposed in this pull request:
- use `toISOString` method on a new Date object constructed using the parsed date value.

![image](https://github.com/user-attachments/assets/f985e577-538c-4099-8c8f-6e3c7a8e7083)
