### PR TITLE
Fix flaky Cypress tests

### DIFF
--- a/main/tests/cypress/cypress/e2e/create-project/preview_project.cy.js
+++ b/main/tests/cypress/cypress/e2e/create-project/preview_project.cy.js
@@ -83,6 +83,10 @@ describe(__filename, function () {
       'to.contain',
       'Configure parsing options'
     );
+
+    // Make sure all our column headers are rendered before starting over so we don't get errors from a deleted project
+    cy.get('table.data-table tr').eq(0).should('to.contain', 'Energ_Kcal');
+
     cy.get('button[bind="startOverButton"]').click();
 
     cy.get('#or-create-question').should(

--- a/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/add_columns_based_on_this_column.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/add_columns_based_on_this_column.cy.js
@@ -28,8 +28,13 @@ describe(__filename, function () {
     cy.waitForDialogPanel();
 
     cy.get('input[bind="columnNameInput"]').type('Test_Python_toLower');
+
+    cy.get('textarea.expression-preview-code').clear()
     cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
-    cy.typeExpression('return value.lower()',{timeout: 10000});
+    // Wait for Jython interpreter to load (as indicated by changed error message)
+    cy.get('.expression-preview-parsing-status').contains('Internal error');
+
+    cy.typeExpression('return value.lower()');
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child',{timeout: 10000}
     ).should('to.contain', 'butter,with salt');
@@ -48,7 +53,12 @@ describe(__filename, function () {
     cy.waitForDialogPanel();
 
     cy.get('input[bind="columnNameInput"]').type('Test_Clojure_toLower');
+
+    cy.get('textarea.expression-preview-code').clear().type('(');
     cy.get('select[bind="expressionPreviewLanguageSelect"]').select('clojure');
+    // Wait for Clojure interpreter to load (as indicated by changed error message)
+    cy.get('.expression-preview-parsing-status').contains('Syntax error reading source at (2:1).');
+
     cy.typeExpression('(.. value (toLowerCase) )');
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'

--- a/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
@@ -200,8 +200,16 @@ describe(__filename, function () {
     // Make sure it's in the local project history, not the global history
     cy.get('#expression-preview-tabs-history .expression-preview-table-wrapper tr:nth-child(2) td:nth-child(3)')
       .should('to.contain', "This");
-    // The next one down should be from a previous project, so should be in the global list
-    cy.get('#expression-preview-tabs-history .expression-preview-table-wrapper tr:nth-child(3) td:nth-child(3)')
+
+    // To test global expression saving, we need a new project
+    cy.loadAndVisitProject('food.mini');
+    loadExpressionPanel();
+    cy.get('#expression-preview-tabs li').contains('History').click();
+    // The top one should now be from a previous project, so should be in the global list
+    cy.get('#expression-preview-tabs-history .expression-preview-table-wrapper tr:nth-child(2) td:last-child')
+      .should('be.visible')
+      .should('to.have.text', uniqueExpression);
+    cy.get('#expression-preview-tabs-history .expression-preview-table-wrapper tr:nth-child(2) td:nth-child(3)')
       .should('to.contain', "Other");
   });
 

--- a/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
@@ -12,6 +12,20 @@ function generateUniqueExpression() {
   return `value+${Date.now()}`;
 }
 
+function selectPython() {
+  cy.get('textarea.expression-preview-code').clear()
+  cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
+  // Wait for Jython interpreter to load (as indicated by changed error message)
+  cy.get('.expression-preview-parsing-status').contains('Internal error');
+}
+
+function selectClojure() {
+  cy.get('textarea.expression-preview-code').clear().type('(');
+  cy.get('select[bind="expressionPreviewLanguageSelect"]').select('clojure');
+  // Wait for Clojure interpreter to load (as indicated by changed error message)
+  cy.get('.expression-preview-parsing-status').contains('Syntax error reading source at (2:1).');
+}
+
 describe(__filename, function () {
   it('Test the layout of the expression panel', function () {
     cy.loadAndVisitProject('food.mini');
@@ -46,8 +60,8 @@ describe(__filename, function () {
   it('Test a valid Python expression', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
-    cy.typeExpression('return value.lower()',{timeout: 10000});
+    selectPython();
+    cy.typeExpression('return value.lower()');
     cy.get('.expression-preview-parsing-status').contains('No syntax error.');
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child',{timeout: 10000}
@@ -57,7 +71,7 @@ describe(__filename, function () {
   it('Test a valid Clojure expression', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    cy.get('select[bind="expressionPreviewLanguageSelect"]').select('clojure');
+    selectClojure();
     cy.typeExpression('(.. value (toLowerCase) )');
     cy.get('.expression-preview-parsing-status').contains('No syntax error.');
     cy.get(
@@ -75,15 +89,15 @@ describe(__filename, function () {
   it('Test a Python syntax error', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
-    cy.typeExpression('(;)',{timeout: 10000});
+    selectPython();
+    cy.typeExpression('(;)');
     cy.get('.expression-preview-parsing-status').contains('Internal error');
   });
 
   it('Test a Clojure syntax error', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    cy.get('select[bind="expressionPreviewLanguageSelect"]').select('clojure');
+    selectClojure();
     cy.typeExpression('(;)');
     cy.get('.expression-preview-parsing-status').contains(
       'Syntax error reading source'
@@ -102,8 +116,8 @@ describe(__filename, function () {
   it('Test a Python language error', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
-    cy.typeExpression('return value.thisPythonFunctionDoesNotExists()',{timeout: 10000});
+    selectPython();
+    cy.typeExpression('return value.thisPythonFunctionDoesNotExists()');
 
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'
@@ -113,7 +127,7 @@ describe(__filename, function () {
   it('Test a Clojure language error', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    cy.get('select[bind="expressionPreviewLanguageSelect"]').select('clojure');
+    selectClojure();
     cy.typeExpression('(.. value (thisClojureFunctionDoesNotExists) )');
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -206,10 +206,9 @@ Cypress.Commands.add('waitForOrOperation', () => {
 
 /**
  * Utility method to fill something into the expression input
- * Need to wait for OpenRefine to preview the result, hence the cy.wait
  */
 Cypress.Commands.add('typeExpression', (expression, options = {}) => {
-    cy.get('textarea.expression-preview-code', options).type(expression);
+    cy.get('textarea.expression-preview-code', options).clear().type(expression);
     const expectedText = expression.length <= 30 ? expression : `${expression.substring(0, 30)} ...`;
     cy.get('tbody > tr:nth-child(1) > td:nth-child(3)', options).should('contain', expectedText);
 });


### PR DESCRIPTION
Fixes #6824

Changes proposed in this pull request:
- Fixes races in Python & Clojure tests by waiting for the interpreters to initialize before attempting to use them (followup to first attempt in #6195)
- Fix global expression history test so that it doesn't always fail the first time through with a clean environment (bug in test that was added in #6377 for issue #6362)
- Wait for the preview grid to be fully rendered before clicking the Start Over button (probably a race that's been there since day 1)
