### PR TITLE
Fix long-running test in StandardReconConfigTests

### DIFF
--- a/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -464,10 +464,8 @@ public class StandardReconConfigTests extends RefineTest {
             RecordedRequest request1 = server.takeRequest();
             assertNotNull(request1);
 
-            // assertions
+            // the error message is unstable and system-dependent, so we are not asserting for its exact contents.
             assertNotNull(returnReconList.get(0).error);
-            assertTrue(returnReconList.get(0).error.contains("failed to respond"));
-            assertNotNull(returnReconList);
         }
     }
 

--- a/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/main/tests/server/src/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -428,6 +428,10 @@ public class StandardReconConfigTests extends RefineTest {
         try (MockWebServer server = new MockWebServer()) {
             server.start();
             HttpUrl url = server.url("/openrefine-wikidata/en/api");
+            // enqueue a few responses to cater for the automatic retries
+            server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+            server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+            server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
             server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
 
             String configJson = " {\n" +
@@ -459,11 +463,10 @@ public class StandardReconConfigTests extends RefineTest {
 
             RecordedRequest request1 = server.takeRequest();
             assertNotNull(request1);
-            String query = request1.getBody().readUtf8Line();
 
             // assertions
             assertNotNull(returnReconList.get(0).error);
-            assertEquals(returnReconList.get(0).error, "Read timed out");
+            assertTrue(returnReconList.get(0).error.contains("failed to respond"));
             assertNotNull(returnReconList);
         }
     }


### PR DESCRIPTION
Closes #6733. The problem was that the connection error was not that of the mocked response, but instead of the attempted retry made by our HTTP client, which was left stalling because no corresponding mocked response had been set up.

<s>Let's see if my assertion is generic enough because I suspect the error message might be platform-dependent.</s> It is indeed platform dependent now that the test is fixed, so I have removed the assertion on the specific error message and just check that some error message is returned.