### PR TITLE
Dry up Cypress Clojure/Python tests

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/add_columns_based_on_this_column.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/add_columns_based_on_this_column.cy.js
@@ -30,13 +30,10 @@ describe(__filename, function () {
     cy.get('input[bind="columnNameInput"]').type('Test_Python_toLower');
 
     cy.get('textarea.expression-preview-code').clear()
-    cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
-    // Wait for Jython interpreter to load (as indicated by changed error message)
-    cy.get('.expression-preview-parsing-status').contains('Internal error');
-
+    cy.selectPython();
     cy.typeExpression('return value.lower()');
     cy.get(
-      '.expression-preview-table-wrapper tr:nth-child(2) td:last-child',{timeout: 10000}
+      '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'
     ).should('to.contain', 'butter,with salt');
     cy.confirmDialogPanel();
 
@@ -53,12 +50,7 @@ describe(__filename, function () {
     cy.waitForDialogPanel();
 
     cy.get('input[bind="columnNameInput"]').type('Test_Clojure_toLower');
-
-    cy.get('textarea.expression-preview-code').clear().type('(');
-    cy.get('select[bind="expressionPreviewLanguageSelect"]').select('clojure');
-    // Wait for Clojure interpreter to load (as indicated by changed error message)
-    cy.get('.expression-preview-parsing-status').contains('Syntax error reading source');
-
+    cy.selectClojure();
     cy.typeExpression('(.. value (toLowerCase) )');
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'

--- a/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
@@ -12,20 +12,6 @@ function generateUniqueExpression() {
   return `value+${Date.now()}`;
 }
 
-function selectPython() {
-  cy.get('textarea.expression-preview-code').clear()
-  cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
-  // Wait for Jython interpreter to load (as indicated by changed error message)
-  cy.get('.expression-preview-parsing-status').contains('Internal error');
-}
-
-function selectClojure() {
-  cy.get('textarea.expression-preview-code').clear().type('(');
-  cy.get('select[bind="expressionPreviewLanguageSelect"]').select('clojure');
-  // Wait for Clojure interpreter to load (as indicated by changed error message)
-  cy.get('.expression-preview-parsing-status').contains('Syntax error reading source');
-}
-
 describe(__filename, function () {
   it('Test the layout of the expression panel', function () {
     cy.loadAndVisitProject('food.mini');
@@ -60,7 +46,7 @@ describe(__filename, function () {
   it('Test a valid Python expression', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    selectPython();
+    cy.selectPython();
     cy.typeExpression('return value.lower()');
     cy.get('.expression-preview-parsing-status').contains('No syntax error.');
     cy.get(
@@ -71,7 +57,7 @@ describe(__filename, function () {
   it('Test a valid Clojure expression', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    selectClojure();
+    cy.selectClojure();
     cy.typeExpression('(.. value (toLowerCase) )');
     cy.get('.expression-preview-parsing-status').contains('No syntax error.');
     cy.get(
@@ -89,7 +75,7 @@ describe(__filename, function () {
   it('Test a Python syntax error', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    selectPython();
+    cy.selectPython();
     cy.typeExpression('(;)');
     cy.get('.expression-preview-parsing-status').contains('Internal error');
   });
@@ -97,7 +83,7 @@ describe(__filename, function () {
   it('Test a Clojure syntax error', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    selectClojure();
+    cy.selectClojure();
     cy.typeExpression('(;)');
     cy.get('.expression-preview-parsing-status').contains(
       'Syntax error reading source'
@@ -116,7 +102,7 @@ describe(__filename, function () {
   it('Test a Python language error', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    selectPython();
+    cy.selectPython();
     cy.typeExpression('return value.thisPythonFunctionDoesNotExists()');
 
     cy.get(
@@ -127,7 +113,7 @@ describe(__filename, function () {
   it('Test a Clojure language error', function () {
     cy.loadAndVisitProject('food.mini');
     loadExpressionPanel();
-    selectClojure();
+    cy.selectClojure();
     cy.typeExpression('(.. value (thisClojureFunctionDoesNotExists) )');
     cy.get(
       '.expression-preview-table-wrapper tr:nth-child(2) td:last-child'

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -214,6 +214,26 @@ Cypress.Commands.add('typeExpression', (expression, options = {}) => {
 });
 
 /**
+ * Utility method to select the Python/Jython interpreter
+ */
+Cypress.Commands.add('selectPython', () => {
+  cy.get('textarea.expression-preview-code').clear()
+  cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
+  // Wait for Jython interpreter to load (as indicated by changed error message)
+  cy.get('.expression-preview-parsing-status').contains('Internal error');
+});
+
+/**
+ * Utility method to select the Clojure interpreter
+ */
+Cypress.Commands.add('selectClojure', () => {
+  cy.get('textarea.expression-preview-code').clear().type('(');
+  cy.get('select[bind="expressionPreviewLanguageSelect"]').select('clojure');
+  // Wait for Clojure interpreter to load (as indicated by changed error message)
+  cy.get('.expression-preview-parsing-status').contains('Syntax error reading source');
+});
+
+/**
  * Delete a column from the grid
  */
 Cypress.Commands.add('deleteColumn', (columnName) => {


### PR DESCRIPTION
Refs #6824. Improves on #6825.

Changes proposed in this pull request:
- Refactor the tests so that there's only a single copy of the Python/Clojure selection code
