### PR TITLE
Restore line ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=off
+* text=auto
 
 # Custom for Visual Studio
 *.cs     diff=csharp


### PR DESCRIPTION
For reasons I don't understand, source file line ending normalization was disabled in 9c7cbcb6 (without updating the associated comment). This PR reenables it so that we don't get PRs like the draft #6770 which have every single file listed as modified with whitespace (ie line ending) changes.