### PR TITLE
Add user guide link to "Find out more" in clustering user hint

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/clustering-functions-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-functions-dialog.html
@@ -1,7 +1,7 @@
 <div>
     <div>
         <span bind="or_dialog_descr"></span>
-        <a href="" bind="or_dialog_findMore"></a>
+        <a href="https://openrefine.org/docs/manual/cellediting#custom-clustering-methods" bind="or_dialog_findMore"></a>
     </div>
     <div id="clustering-functions-tabs" class="refine-tabs">
         <ul>


### PR DESCRIPTION
Changes proposed in this pull request:
- Add user guide link to "Find out more" in clustering user hint
