### PR TITLE
fix resultSummary div in Clustering dialog has unnecessary squishyness

### DIFF
--- a/main/webapp/modules/core/styles/dialogs/clustering-dialog.css
+++ b/main/webapp/modules/core/styles/dialogs/clustering-dialog.css
@@ -55,12 +55,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   margin: 1em 0;
   display: grid;
   grid-template-columns: repeat(4, auto);
-  justify-content: space-between;
   align-items: baseline;
   background: #eee;
   border: 1px #ccc solid;
-  padding: 0.5em;
-  gap: 0.5em;
+  padding: 0.25em;
+  gap: 0.25em;
 }
 
 .control-group {


### PR DESCRIPTION
Fixes #6840

Changes proposed in this pull request:
- Since grid-template-columns: repeat(4, auto); was already right in .clustering-dialog-control-row so no changes required
- padding and gap are changed to 0.25em both
- justify content was unnecessary
