### PR TITLE
fixes #6164 remove waitForOrOperation() usage and the helper itself

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.numeric.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.numeric.cy.js
@@ -38,16 +38,19 @@ describe(__filename, function () {
     cy.get('.slider-widget-bracket').eq(1)
     .trigger('mousedown',{ force: true })
     .trigger('mousemove',-130,0,{ force: true })
-    .trigger('mouseup',{ force: true })
+    .trigger('mouseup',{ force: true });
+    cy.get('.facet-range-status').contains('0 — 45');
     cy.get('#summary-bar').contains('72 matching rows');
 
     // wait for the numeric facet to be refreshed before next mouse events
     cy.get('.browsing-panel-indicator').should("not.be.visible");
 
+    // sliding entire selection by the body (middle)
     cy.get('.slider-widget-draggable').eq(0)
     .trigger('mousedown',{ force: true })
     .trigger('mousemove',130,0,{ force: true })
     .trigger('mouseup',{ force: true });
+    cy.get('.facet-range-status').contains('23 — 68');
     cy.get('#summary-bar').contains('74 matching rows');
 
     // wait for the numeric facet to be refreshed before next mouse events
@@ -57,7 +60,8 @@ describe(__filename, function () {
     cy.get('.slider-widget-bracket').eq(0)
     .trigger('mousedown',{ force: true })
     .trigger('mousemove',130,0,{ force: true })
-    .trigger('mouseup',{ force: true })
+    .trigger('mouseup',{ force: true });
+    cy.get('.facet-range-status').contains('66 — 68');
     cy.get('#summary-bar').contains('3 matching rows');
   });
 

--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.numeric.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.numeric.cy.js
@@ -41,20 +41,24 @@ describe(__filename, function () {
     .trigger('mouseup',{ force: true })
     cy.get('#summary-bar').contains('72 matching rows');
 
-    //sliding the middle portion in numeric facet
+    // wait for the numeric facet to be refreshed before next mouse events
+    cy.get('.browsing-panel-indicator').should("not.be.visible");
+
     cy.get('.slider-widget-draggable').eq(0)
-      // FIXME: These are the last two uses of the hated waitForOrOperation
-    .trigger('mousedown',{ force: true }).waitForOrOperation()
+    .trigger('mousedown',{ force: true })
     .trigger('mousemove',130,0,{ force: true })
-    .trigger('mouseup',{ force: true }).waitForOrOperation();
-    cy.get('#summary-bar').contains('70 matching rows');
+    .trigger('mouseup',{ force: true });
+    cy.get('#summary-bar').contains('74 matching rows');
+
+    // wait for the numeric facet to be refreshed before next mouse events
+    cy.get('.browsing-panel-indicator').should("not.be.visible");
 
     //sliding the left slider
     cy.get('.slider-widget-bracket').eq(0)
     .trigger('mousedown',{ force: true })
     .trigger('mousemove',130,0,{ force: true })
     .trigger('mouseup',{ force: true })
-    cy.get('#summary-bar').contains('4 matching rows');
+    cy.get('#summary-bar').contains('3 matching rows');
   });
 
   it('Test for checkboxes and reset button', function () {

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -190,21 +190,6 @@ Cypress.Commands.add('navigateTo', (target) => {
 });
 
 /**
- * Wait for OpenRefine to finish an Ajax load
- *
- * @deprecated
- *
- * NOTE: This command is unreliable because if you call it after starting an operation e.g. with a click(), the loading
- * indicator may have come and gone already by the time waitForOrOperation() is called, causing the cypress test to
- * wait forever on ajax_in_progress=true until it fails due to timeout.
- *
- */
-Cypress.Commands.add('waitForOrOperation', () => {
-  cy.get('body[ajax_in_progress="true"]');
-  cy.get('body[ajax_in_progress="false"]');
-});
-
-/**
  * Utility method to fill something into the expression input
  */
 Cypress.Commands.add('typeExpression', (expression, options = {}) => {


### PR DESCRIPTION
Fixes #6164 

Changes proposed in this pull request:
- Usage of `waitForOrOperation()` helper function has been removed from cypress test.
- The helper function itself as well has been removed.
- In-between checks have been added to achieve waiting and to satisfy test conditions.

Steps taken before commit:
- [x]  run lint, clean, build
- [x]  run cypress tests (PASSED)
- [x]  run java tests (PASSED)

Final result:
![image](https://github.com/user-attachments/assets/9d14b158-ff7d-428c-9723-bfdd1c63b12d)
