### PR TITLE
Avoid creating identical facets in reconciliation and Wikibase editing operations

### DIFF
--- a/main/webapp/modules/core/scripts/facets/facet.js
+++ b/main/webapp/modules/core/scripts/facets/facet.js
@@ -32,14 +32,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 class Facet {
+  // Facet constructors shouldn't make any changes to the DOM yet.
+  // Any such effects should go in prepareUI(), which is called
+  // after adding the facet by the BrowsingEngine.
   constructor(div, config, options) {
   	this._div = div;
   	this._config = config;
   	this._options = options || {};
   	this._minimizeState = false;
-  	
-  	Refine.showLeftPanel();
   };
+
+  // Do any changes to the UI when the facet is added, before
+  // the facet is supplied with any state.
+  prepareUI() {
+    Refine.showLeftPanel();
+  }
 
   _minimize() {
   	if(!this._minimizeState) {

--- a/main/webapp/modules/core/scripts/facets/facet.js
+++ b/main/webapp/modules/core/scripts/facets/facet.js
@@ -71,6 +71,17 @@ class Facet {
   	this._options = null;
   };
 
+  // Method to be overriden by subclasses to return a value which
+  // should generally be unique among all facets currently open. This is to
+  // avoid automatically opening facets defined with the exact same type.
+  uniquenessCriterion() {
+    // This default implementation returns a Javascript object, so that
+    // by default no deduplication happens, to avoid preventing legitimate
+    // opening of distinct facets. This works because `new Object() != new Object()`
+    // (no deep equality).
+    return new Object() 
+  }
+
   dispose() {
   };
 };

--- a/main/webapp/modules/core/scripts/facets/list-facet.js
+++ b/main/webapp/modules/core/scripts/facets/list-facet.js
@@ -105,6 +105,14 @@ class ListFacet extends Facet {
     (this._errorChoice !== null && this._errorChoice.s);
   };
 
+  uniquenessCriterion() {
+    return JSON.stringify([
+      "list",
+      this._config.columnName,
+      this._config.expression
+    ]);
+  }
+
   updateState(data, column) {
     this._data = data;
     this._column = column;

--- a/main/webapp/modules/core/scripts/facets/list-facet.js
+++ b/main/webapp/modules/core/scripts/facets/list-facet.js
@@ -51,6 +51,10 @@ class ListFacet extends Facet {
     this._data = null;
 
     this._initialHeightSet = false;
+  };
+
+  prepareUI() {
+    Refine.showLeftPanel();
     this._initializeUI();
     this._update();
   };

--- a/main/webapp/modules/core/scripts/facets/range-facet.js
+++ b/main/webapp/modules/core/scripts/facets/range-facet.js
@@ -266,6 +266,14 @@ class RangeFacet extends Facet {
     this._elmts.statusDiv.html($.i18n('core-facets/value-range', this._formatter.format(this._from), this._formatter.format(this._to)));
   };
 
+  uniquenessCriterion() {
+    return JSON.stringify([
+      'range',
+      this._config.expression,
+      this._config.columnName
+    ]);
+  }
+
   updateState(data) {
     if ("min" in data && "max" in data) {
       this._error = false;

--- a/main/webapp/modules/core/scripts/facets/scatterplot-facet.js
+++ b/main/webapp/modules/core/scripts/facets/scatterplot-facet.js
@@ -284,6 +284,17 @@ class ScatterplotFacet extends Facet {
     return "command/core/get-scatterplot?" + $.param(params);
   };
 
+  uniquenessCriterion() {
+    return JSON.stringify([
+      'scatterplot',
+      this._config.ex, // expression for X
+      this._config.cx, // columnName for X
+      this._config.ey, // expression for Y
+      this._config.cy, // column name for Y
+      this._config.r // rotation
+    ]);
+  }
+
   updateState(data) {
     if ("error" in data) {
       this._error = true;

--- a/main/webapp/modules/core/scripts/facets/text-search-facet.js
+++ b/main/webapp/modules/core/scripts/facets/text-search-facet.js
@@ -154,6 +154,13 @@ class TextSearchFacet extends Facet {
 
   };
 
+  uniquenessCriterion() {
+    return JSON.stringify([
+      'text-search',
+      this._config.columnName
+    ]);
+  }
+
   updateState(data) {
     this._update();
   };

--- a/main/webapp/modules/core/scripts/facets/text-search-facet.js
+++ b/main/webapp/modules/core/scripts/facets/text-search-facet.js
@@ -40,7 +40,10 @@ class TextSearchFacet extends Facet {
 
     this._query = config.query || null;
     this._timerID = null;
+  }
 
+  prepareUI() {
+    Refine.showLeftPanel();
     this._initializeUI();
     this._update();
   };

--- a/main/webapp/modules/core/scripts/facets/timerange-facet.js
+++ b/main/webapp/modules/core/scripts/facets/timerange-facet.js
@@ -277,6 +277,14 @@ class TimeRangeFacet extends Facet{
     }
   };
 
+  uniquenessCriterion() {
+    return JSON.stringify([
+      'timerange',
+      this._config.expression,
+      this._config.columnName,
+    ]);
+  }
+
   updateState(data) {
     if ("min" in data && "max" in data) {
       this._error = false;

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -169,7 +169,7 @@ BrowsingEngine.prototype.getJSON = function(keepUnrestrictedFacets, except) {
   return a;
 };
 
-BrowsingEngine.prototype.addFacet = function(type, config, options) {
+BrowsingEngine.prototype.addFacet = function(type, config, options, avoidDuplicates) {
   var elmt = this._createFacetContainer();
   var facet;
   switch (type) {
@@ -187,6 +187,14 @@ BrowsingEngine.prototype.addFacet = function(type, config, options) {
     break;
   default:
     facet = new ListFacet(elmt, config, options);
+  }
+
+  if (avoidDuplicates) {
+    let criterion = facet.uniquenessCriterion();
+    if (this._facets.findIndex(existingFacet => existingFacet.facet.uniquenessCriterion() == criterion) != -1) {
+      // skip addition of the facet because it already exists
+      return;
+    }
   }
 
   this._facets.push({ elmt: elmt, facet: facet });

--- a/main/webapp/modules/core/scripts/project/browsing-engine.js
+++ b/main/webapp/modules/core/scripts/project/browsing-engine.js
@@ -63,6 +63,7 @@ function BrowsingEngine(div, facetConfigs) {
       }
 
       this._facets.push({ elmt: elmt, facet: facet });
+      facet.prepareUI();
     }
   }
 }
@@ -189,6 +190,7 @@ BrowsingEngine.prototype.addFacet = function(type, config, options) {
   }
 
   this._facets.push({ elmt: elmt, facet: facet });
+  facet.prepareUI();
 
   ui.leftPanelTabs.tabs();
   ui.leftPanelTabs.on( "tabsactivate", ( event, ui ) =>  {

--- a/main/webapp/modules/core/scripts/project/process-panel.js
+++ b/main/webapp/modules/core/scripts/project/process-panel.js
@@ -230,7 +230,8 @@ ProcessPanel.prototype._perform = function(jobs) {
         ui.browsingEngine.addFacet(
             job.facetType,
             job.facetConfig,
-            job.facetOptions
+            job.facetOptions,
+            true
         );
       } catch (e) {
         //


### PR DESCRIPTION
Fixes #6863 following the approach defined there.

A small refactoring was required, to separate out facet UI initialization from facet constructors, so that facets can be checked for duplicates before they appear onscsreen.

Not including a Cypress test because the corresponding operations are not covered in Cypress tests yet, because of their reliance on external services (there used to be a test of reconciliation which spun `reconcile-csv` locally but it was removed because it was flaky and required running the service separately for the test suite to pass).

The diffs shown by GitHub seem off, probably because of CRLF/LF differences (see #6841).