### PR TITLE
Fix Javadoc error

### DIFF
--- a/modules/core/src/main/java/com/google/refine/exporters/Exporter.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/Exporter.java
@@ -45,7 +45,7 @@ public interface Exporter {
     String getContentType();
 
     /**
-     * Helper to create legacy {@link Properties} from modern {@link Map<String, String>}
+     * Helper to create legacy {@link Properties} from modern {@link Map}
      * 
      * @param options
      *            a map of the option key/values to be remapped


### PR DESCRIPTION
For #6874.

This only fixes the linting error, not the broader fact that the PR workflow doesn't test javadoc generation and the snapshot release pipeline relies on it working.