### PR TITLE
Increase timeouts on Windows systems for FetchURLs test

### DIFF
--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -214,7 +214,7 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
                     true,
                     null);
 
-            runOperation(op, project, 3000);
+            runOperation(op, project, 10000);
 
             int newCol = project.columnModel.getColumnByName("junk").getCellIndex();
             // Inspect rows


### PR DESCRIPTION
During `mvn test` there's a failure for FetchURLs.

Changes proposed in this pull request:
- Increases runOperation timeout from 3000ms to 10000ms in test `ColumnAdditionByFetchingURLsOperationTests`
