### PR TITLE
Refetch reconcile service manifest for new changes (#3645)

### DIFF
--- a/main/webapp/modules/core/scripts/reconciliation/recon-dialog.js
+++ b/main/webapp/modules/core/scripts/reconciliation/recon-dialog.js
@@ -222,12 +222,20 @@ ReconDialog.prototype._onAddStandardService = function() {
  */
 ReconDialog.prototype._refetchServiceManifest = function(service, f) {
   var dismissBusy = DialogSystem.showBusy($.i18n('core-recon/contact-service')+"...");
-  $.ajax({ url: service.url })
+  // First, try with CORS (default "json" dataType)
+  $.ajax({ url: service.url, dataType: 'json', timeout: 5000 })
     .done(function() {
       ReconciliationManager.reRegisterService(service, f, true);
     })
     .fail(function(jqXHR, textStatus, errorThrown) {
-      alert($.i18n('core-recon/error-contact')+': ' + textStatus + ' : ' + errorThrown + ' - ' + service.url);
+      // If it fails, try with JSONP
+      $.ajax({ url: service.url, dataType: 'jsonp', timeout: 5000 })
+        .done(function() {
+          ReconciliationManager.reRegisterService(service, f, true);
+        })
+        .fail(function(jqXHR, textStatus, errorThrown) {
+          alert($.i18n('core-recon/error-contact')+': ' + textStatus + ' : ' + errorThrown + ' - ' + service.url);
+        })
     })
     .always(function() { dismissBusy(); });
 };

--- a/main/webapp/modules/core/scripts/reconciliation/recon-dialog.js
+++ b/main/webapp/modules/core/scripts/reconciliation/recon-dialog.js
@@ -60,7 +60,10 @@ ReconDialog.prototype._createDialog = function() {
   this._elmts.cancelButton.on('click',function() { self._dismiss(); });
   this._elmts.nextButton.on('click',function() { 
     if(self._record){
-    self._nextDialog(self._column, self._selectedServiceRecordIndex, self._serviceRecords, self._record, self.previousRecord);
+      // refetch selected service manifest then navigate to next dialog on success
+      self._refetchServiceManifest(self._record.service, function() {
+        self._nextDialog(self._column, self._selectedServiceRecordIndex, self._serviceRecords, self._record, self.previousRecord);
+      });
     }
     else{
       var message = document.getElementById('popup-message');
@@ -211,4 +214,20 @@ ReconDialog.prototype._onAddStandardService = function() {
   elmts.input.trigger('focus').trigger('select');
 };
 
-
+/**
+ * Refetches the manifest for a reconciliation service and re-registers it.
+ * 
+ * @param {Object} service - The reconciliation service object
+ * @param {Function} [f] - Optional callback function to execute after re-registering
+ */
+ReconDialog.prototype._refetchServiceManifest = function(service, f) {
+  var dismissBusy = DialogSystem.showBusy($.i18n('core-recon/contact-service')+"...");
+  $.ajax({ url: service.url })
+    .done(function() {
+      ReconciliationManager.reRegisterService(service, f, true);
+    })
+    .fail(function(jqXHR, textStatus, errorThrown) {
+      alert($.i18n('core-recon/error-contact')+': ' + textStatus + ' : ' + errorThrown + ' - ' + service.url);
+    })
+    .always(function() { dismissBusy(); });
+};

--- a/main/webapp/modules/core/scripts/reconciliation/recon-manager.js
+++ b/main/webapp/modules/core/scripts/reconciliation/recon-manager.js
@@ -146,6 +146,22 @@ ReconciliationManager.unregisterService = function(service, f) {
   ReconciliationManager.save(f);
 };
 
+/**
+ * Re-registers a service.
+ * 
+ * @param {Object} service - The service to re-register
+ * @param {Function} f - Optional callback function to execute after re-registering
+ * @param {boolean} silent - If true, suppresses any error alerts
+ */
+ReconciliationManager.reRegisterService = function(service, f, silent) {
+  var self = this;
+  if ("url" in service) {
+    self.unregisterService(service, function () {
+      self.registerStandardService(service.url, f, silent);
+    });
+  }
+}
+
 ReconciliationManager.save = function(f) {
   Refine.wrapCSRF(function(token) {
     $.ajax({

--- a/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
+++ b/main/webapp/modules/core/scripts/reconciliation/standard-service-panel.js
@@ -43,7 +43,6 @@ function ReconStandardServicePanel(column, service, container) {
 ReconStandardServicePanel.prototype._guessTypes = function(f) {
   var self = this;
   var dismissBusy = self.showBusyReconciling();
-
   Refine.postCSRF(
     "command/core/guess-types-of-column?" + $.param({
       project: theProject.id, 


### PR DESCRIPTION
Fixes #3645 

Changes proposed in this pull request:
- `ReconciliationManager.refetchServiceManifest` function has been created which can be used to refetch reconcile service  manifest provided service object as input.
- Then the function has been used in `ReconStandardServicePanel` to fetch the latest manifest of selected service.

Steps taken before commit:
- [x] run lint, clean, build
- [x] run cypress tests (PASSED)
- [x] run java tests (PASSED)

Final result:
[Before]
![Screenshot_2024-09-28_20-44-12](https://github.com/user-attachments/assets/f550d51e-f72d-4ba5-bd35-0486ebd5605d)
[After manifest is modified (adding preview) and restarted, then on type-guessing panel]
![Screenshot_2024-09-28_20-42-12](https://github.com/user-attachments/assets/59d0762b-2ca5-4cf2-aa14-24c7db0bc83b)


