### PR TITLE
Fix Google Data extension to use JSON instead of JSONP

### DIFF
--- a/extensions/gdata/module/scripts/index/importing-controller.js
+++ b/extensions/gdata/module/scripts/index/importing-controller.js
@@ -70,7 +70,7 @@ Refine.GDataImportingController.prototype.startImportingDocument = function(doc)
             function(data2) {
             dismiss();
 
-            if (data2.status == 'ok') {
+            if (data2.status === 'ok') {
                 self._doc = doc;
                 self._jobID = data.jobID;
                 self._options = data2.options;
@@ -106,7 +106,7 @@ Refine.GDataImportingController.prototype.getOptions = function() {
     return def;
   };
 
-  if (this._doc.type != 'table') {
+  if (this._doc.type !== 'table') {
     this._parsingPanelElmts.sheetRecordContainer.find('input').each(function() {
       if (this.checked) {
         options.sheetUrl = this.getAttribute('sheetUrl');
@@ -217,7 +217,7 @@ Refine.GDataImportingController.prototype._showParsingPanel = function() {
 
   this._parsingPanelElmts.projectNameInput[0].value = this._doc.title;
 
-  if (this._doc.type != 'table') {
+  if (this._doc.type !== 'table') {
     var sheetTable = this._parsingPanelElmts.sheetRecordContainer[0];
     $.each(this._options.worksheets, function(i, v) {
       var id = 'gdata_worksheet-' + Math.round(Math.random() * 1000000);
@@ -320,7 +320,7 @@ Refine.GDataImportingController.prototype._updatePreview = function() {
         "options" : JSON.stringify(self.getOptions())
         },
         function(result) {
-        if (result.status == "ok") {
+        if (result.status === "ok") {
             self._getPreviewData(function(projectData) {
             self._parsingPanelElmts.progressPanel.hide();
             self._parsingPanelElmts.dataPanel.show();
@@ -363,7 +363,7 @@ Refine.GDataImportingController.prototype._getPreviewData = function(callback, n
           result.rowModel = data;
           callback(result);
         },
-        "jsonp"
+        "json"
       );
     },
     "json"
@@ -372,7 +372,7 @@ Refine.GDataImportingController.prototype._getPreviewData = function(callback, n
 
 Refine.GDataImportingController.prototype._createProject = function() {
   var projectName = jQueryTrim(this._parsingPanelElmts.projectNameInput[0].value);
-  if (projectName.length == 0) {
+  if (projectName.length === 0) {
     DialogSystem.alert($.i18n('gdata-import/please-name-project'));
     this._parsingPanelElmts.projectNameInput.focus();
     return;
@@ -393,7 +393,7 @@ Refine.GDataImportingController.prototype._createProject = function() {
         "options" : JSON.stringify(options)
         },
         function(o) {
-        if (o.status == 'error') {
+        if (o.status === 'error') {
             DialogSystem.alert(o.message);
         } else {
             var start = new Date();

--- a/main/src/com/google/refine/commands/row/GetRowsCommand.java
+++ b/main/src/com/google/refine/commands/row/GetRowsCommand.java
@@ -189,6 +189,7 @@ public class GetRowsCommand extends Command {
             throws ServletException, IOException {
 
         try {
+            checkJSONP(request); // We used to support JSONP, but don't anymore
             Project project = null;
 
             // This command also supports retrieving rows for an importing job.

--- a/main/src/com/google/refine/commands/row/GetRowsCommand.java
+++ b/main/src/com/google/refine/commands/row/GetRowsCommand.java
@@ -292,6 +292,8 @@ public class GetRowsCommand extends Command {
                     rwv.totalRows, start, end, limit, pool, previousPageEnd, nextPageStart);
 
             respondJSON(response, result);
+        } catch (IllegalJsonpException e2) {
+            respondNoJsonpException(request, response);
         } catch (Exception e) {
             respondException(response, e);
         }

--- a/modules/core/src/main/java/com/google/refine/commands/Command.java
+++ b/modules/core/src/main/java/com/google/refine/commands/Command.java
@@ -79,31 +79,31 @@ public abstract class Command {
             throws ServletException, IOException {
 
         throw new UnsupportedOperationException();
-    };
+    }
 
     public void doGet(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
 
         throw new UnsupportedOperationException();
-    };
+    }
 
     public void doHead(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
 
         throw new UnsupportedOperationException();
-    };
+    }
 
     public void doPut(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
 
         throw new UnsupportedOperationException();
-    };
+    }
 
     public void doDelete(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
 
         throw new UnsupportedOperationException();
-    };
+    }
 
     /**
      * Whether each request to this command should be logged. For some commands that can get called too frequently, such

--- a/modules/core/src/main/java/com/google/refine/commands/Command.java
+++ b/modules/core/src/main/java/com/google/refine/commands/Command.java
@@ -158,8 +158,10 @@ public abstract class Command {
     /**
      * Check for attempts to use JSONP with a `callback` parameter and throw an exception if found.
      *
-     * @param request the request to be checked
-     * @throws IllegalJsonpException when a JSONP style call is found
+     * @param request
+     *            the request to be checked
+     * @throws IllegalJsonpException
+     *             when a JSONP style call is found
      */
     protected static void checkJSONP(HttpServletRequest request) {
         if (request.getParameter("callback") != null) {
@@ -170,10 +172,12 @@ public abstract class Command {
     /**
      * Utility method for retrieving the Project object having the ID specified in the "project" URL parameter.
      *
-     * @param request the HTTP request to be parsed
-     * @return the {@link  Project} identified by the ID in the "project" parameter
-     * @throws ServletException if there's no "project" parameter, it's badly formatted, or doesn't a have a project
-     * associated with the ID.
+     * @param request
+     *            the HTTP request to be parsed
+     * @return the {@link Project} identified by the ID in the "project" parameter
+     * @throws ServletException
+     *             if there's no "project" parameter, it's badly formatted, or doesn't a have a project associated with
+     *             the ID.
      */
     protected Project getProject(HttpServletRequest request) throws ServletException {
         if (request == null) {
@@ -200,10 +204,12 @@ public abstract class Command {
     /**
      * Utility method for retrieving the ProjectMetadata object having the ID specified in the "project" URL parameter.
      *
-     * @param request the HTTP request to be parsed
-     * @return the {@link  ProjectMetadata} identified by the ID in the "project" parameter
-     * @throws ServletException if there's no "project" parameter, it's badly formatted, or doesn't a have a project
-     * metadata associated with the ID.
+     * @param request
+     *            the HTTP request to be parsed
+     * @return the {@link ProjectMetadata} identified by the ID in the "project" parameter
+     * @throws ServletException
+     *             if there's no "project" parameter, it's badly formatted, or doesn't a have a project metadata
+     *             associated with the ID.
      */
     protected ProjectMetadata getProjectMetadata(HttpServletRequest request) throws ServletException {
         if (request == null) {
@@ -235,7 +241,8 @@ public abstract class Command {
     /**
      * Shim for {@link HttpServletRequest#getParameterMap()} which returns single values instead of arrays
      *
-     * @param request the HTTP request to be parsed
+     * @param request
+     *            the HTTP request to be parsed
      * @return Map of String values, keyed by Strings
      */
     static protected Map<String, String> getParameters(HttpServletRequest request) {
@@ -251,7 +258,8 @@ public abstract class Command {
      * Utility method for retrieving the CSRF token stored in the "csrf_token" parameter of the request, and checking
      * that it is valid.
      *
-     * @param request HTTP request to be checked
+     * @param request
+     *            HTTP request to be checked
      * @return true if token is valid or false if it is not
      * @throws ServletException
      */


### PR DESCRIPTION
Fixes #6897 

Changes proposed in this pull request:
- Switch Google extension to use JSON since JSONP has been removed from the GetRows command
- Attempt to provide useful error messages to callers who use JSONP with the GetRows command
- 
