### PR TITLE
refactoring: Introduce base interface for GREL expressions

### DIFF
--- a/main/src/com/google/refine/templating/Parser.java
+++ b/main/src/com/google/refine/templating/Parser.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
+import com.google.refine.grel.GrelEvaluable;
 import com.google.refine.grel.ast.FieldAccessorExpr;
 import com.google.refine.grel.ast.VariableExpr;
 
@@ -96,11 +97,12 @@ public class Parser {
 
                     fragments.add(
                             new DynamicFragment(
-                                    new FieldAccessorExpr(
+                                    new GrelEvaluable(
                                             new FieldAccessorExpr(
-                                                    new VariableExpr("cells"),
-                                                    columnName),
-                                            "value")));
+                                                    new FieldAccessorExpr(
+                                                            new VariableExpr("cells"),
+                                                            columnName),
+                                                    "value"))));
 
                     continue;
                 }

--- a/modules/grel/src/main/java/com/google/refine/grel/Control.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/Control.java
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import com.google.refine.expr.Evaluable;
+import com.google.refine.grel.ast.GrelExpr;
 
 /**
  * Interface of GREL controls such as if, forEach, forNonBlank, with. A control can decide which part of the code to
@@ -47,9 +47,9 @@ import com.google.refine.expr.Evaluable;
  */
 public interface Control {
 
-    public Object call(Properties bindings, Evaluable[] args);
+    public Object call(Properties bindings, GrelExpr[] args);
 
-    public String checkArguments(Evaluable[] args);
+    public String checkArguments(GrelExpr[] args);
 
     @JsonProperty("description")
     public String getDescription();

--- a/modules/grel/src/main/java/com/google/refine/grel/GrelEvaluable.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/GrelEvaluable.java
@@ -1,0 +1,32 @@
+
+package com.google.refine.grel;
+
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+import com.google.refine.expr.Evaluable;
+import com.google.refine.grel.ast.GrelExpr;
+
+/**
+ * An evaluable made out of a GREL expression.
+ */
+public class GrelEvaluable implements Evaluable {
+
+    private GrelExpr _expr;
+
+    public GrelEvaluable(GrelExpr expr) {
+        _expr = expr;
+    }
+
+    @Override
+    public Object evaluate(Properties bindings) {
+        return _expr.evaluate(bindings);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
+        return _expr.getColumnDependencies(baseColumn);
+    }
+
+}

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
@@ -39,18 +39,17 @@ import java.util.Properties;
 import java.util.Set;
 
 import com.google.refine.expr.EvalError;
-import com.google.refine.expr.Evaluable;
 import com.google.refine.grel.Control;
 
 /**
  * An abstract syntax tree node encapsulating a control call, such as "if".
  */
-public class ControlCallExpr implements Evaluable {
+public class ControlCallExpr implements GrelExpr {
 
-    final protected Evaluable[] _args;
+    final protected GrelExpr[] _args;
     final protected Control _control;
 
-    public ControlCallExpr(Evaluable[] args, Control c) {
+    public ControlCallExpr(GrelExpr[] args, Control c) {
         _args = args;
         _control = c;
     }
@@ -67,7 +66,7 @@ public class ControlCallExpr implements Evaluable {
     @Override
     public final Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
         Set<String> dependencies = new HashSet<>();
-        for (Evaluable ev : _args) {
+        for (GrelExpr ev : _args) {
             Optional<Set<String>> deps = ev.getColumnDependencies(baseColumn);
             if (deps.isEmpty()) {
                 return Optional.empty();
@@ -81,7 +80,7 @@ public class ControlCallExpr implements Evaluable {
     public String toString() {
         StringBuffer sb = new StringBuffer();
 
-        for (Evaluable ev : _args) {
+        for (GrelExpr ev : _args) {
             if (sb.length() > 0) {
                 sb.append(", ");
             }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
@@ -41,7 +41,6 @@ import java.util.Set;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
-import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.HasFields;
 import com.google.refine.expr.util.JsonValueConverter;
@@ -50,12 +49,12 @@ import com.google.refine.expr.util.JsonValueConverter;
  * An abstract syntax tree node encapsulating a field accessor, e.g., "cell.value" is accessing the field named "value"
  * on the variable called "cell".
  */
-public class FieldAccessorExpr implements Evaluable {
+public class FieldAccessorExpr implements GrelExpr {
 
-    final protected Evaluable _inner;
+    final protected GrelExpr _inner;
     final protected String _fieldName;
 
-    public FieldAccessorExpr(Evaluable inner, String fieldName) {
+    public FieldAccessorExpr(GrelExpr inner, String fieldName) {
         _inner = inner;
         _fieldName = fieldName;
     }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FunctionCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FunctionCallExpr.java
@@ -40,7 +40,6 @@ import java.util.Properties;
 import java.util.Set;
 
 import com.google.refine.expr.EvalError;
-import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.functions.Get;
 import com.google.refine.grel.Function;
@@ -50,12 +49,12 @@ import com.google.refine.grel.Function;
  * before the function is applied. If any argument is an error, the function is not applied, and the error is the result
  * of the expression.
  */
-public class FunctionCallExpr implements Evaluable {
+public class FunctionCallExpr implements GrelExpr {
 
-    final protected Evaluable[] _args;
+    final protected GrelExpr[] _args;
     final protected Function _function;
 
-    public FunctionCallExpr(Evaluable[] args, Function f) {
+    public FunctionCallExpr(GrelExpr[] args, Function f) {
         _args = args;
         _function = f;
     }
@@ -88,7 +87,7 @@ public class FunctionCallExpr implements Evaluable {
         }
         // TODO distinguish functions which are "pure" and those which access external data, like cross or facetCount
         Set<String> dependencies = new HashSet<>();
-        for (Evaluable ev : _args) {
+        for (GrelExpr ev : _args) {
             Optional<Set<String>> deps = ev.getColumnDependencies(baseColumn);
             if (deps.isEmpty()) {
                 return Optional.empty();
@@ -102,7 +101,7 @@ public class FunctionCallExpr implements Evaluable {
     public String toString() {
         StringBuffer sb = new StringBuffer();
 
-        for (Evaluable ev : _args) {
+        for (GrelExpr ev : _args) {
             if (sb.length() > 0) {
                 sb.append(", ");
             }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/GrelExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/GrelExpr.java
@@ -1,0 +1,43 @@
+
+package com.google.refine.grel.ast;
+
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * A GREL expression, which can be evaluated in a given context.
+ * <p>
+ * This is introduced to serve as base class for all GREL expressions, instead of
+ * {@link com.google.refine.expr.Evaluable} which is the base class for all evaluables in OpenRefine.
+ */
+public interface GrelExpr {
+
+    /**
+     * Returns the value of the expression in a given context.
+     * 
+     * @param bindings
+     *            the evaluation context, mapping variable names to their values
+     * @return the result of the evaluation of the expression
+     */
+    public Object evaluate(Properties bindings);
+
+    /**
+     * For GREL expressions, toString should return the source code of the expression (without the "grel:" prefix).
+     */
+    public String toString();
+
+    /**
+     * Returns an approximation of the names of the columns this expression depends on. This approximation is designed
+     * to be safe: if a set of column names is returned, then the expression does not read any other column than the
+     * ones mentioned, regardless of the data it is executed on.
+     *
+     * @param baseColumn
+     *            the name of the column this expression is based on (none if the expression is not evaluated on a
+     *            particular column)
+     * @return {@link Optional#empty()} if the columns could not be isolated: in this case, the expression might depend
+     *         on all columns in the project. Note that this is different from returning an empty set, which means that
+     *         the expression is constant.
+     */
+    public Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn);
+}

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
@@ -40,12 +40,10 @@ import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 
-import com.google.refine.expr.Evaluable;
-
 /**
  * An abstract syntax tree node encapsulating a literal value.
  */
-public class LiteralExpr implements Evaluable {
+public class LiteralExpr implements GrelExpr {
 
     final protected Object _value;
 

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
@@ -39,18 +39,17 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
-import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 
 /**
  * An abstract syntax tree node encapsulating an operator call, such as "+".
  */
-public class OperatorCallExpr implements Evaluable {
+public class OperatorCallExpr implements GrelExpr {
 
-    final protected Evaluable[] _args;
+    final protected GrelExpr[] _args;
     final protected String _op;
 
-    public OperatorCallExpr(Evaluable[] args, String op) {
+    public OperatorCallExpr(GrelExpr[] args, String op) {
         _args = args;
         _op = op;
     }
@@ -207,7 +206,7 @@ public class OperatorCallExpr implements Evaluable {
     @Override
     public final Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
         Set<String> dependencies = new HashSet<>();
-        for (Evaluable ev : _args) {
+        for (GrelExpr ev : _args) {
             Optional<Set<String>> deps = ev.getColumnDependencies(baseColumn);
             if (deps.isEmpty()) {
                 return Optional.empty();
@@ -221,7 +220,7 @@ public class OperatorCallExpr implements Evaluable {
     public String toString() {
         StringBuffer sb = new StringBuffer();
 
-        for (Evaluable ev : _args) {
+        for (GrelExpr ev : _args) {
             if (sb.length() > 0) {
                 sb.append(' ');
                 sb.append(_op);

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/VariableExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/VariableExpr.java
@@ -38,12 +38,10 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
-import com.google.refine.expr.Evaluable;
-
 /**
  * An abstract syntax tree node encapsulating the retrieval of a variable's content.
  */
-public class VariableExpr implements Evaluable {
+public class VariableExpr implements GrelExpr {
 
     final protected String _name;
 

--- a/modules/grel/src/main/java/com/google/refine/grel/controls/Filter.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/controls/Filter.java
@@ -41,19 +41,19 @@ import java.util.Properties;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import com.google.refine.expr.EvalError;
-import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.util.JsonValueConverter;
 import com.google.refine.grel.Control;
 import com.google.refine.grel.ControlDescription;
 import com.google.refine.grel.ControlEvalError;
 import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.ast.GrelExpr;
 import com.google.refine.grel.ast.VariableExpr;
 
 public class Filter implements Control {
 
     @Override
-    public String checkArguments(Evaluable[] args) {
+    public String checkArguments(GrelExpr[] args) {
         if (args.length != 3) {
             return ControlEvalError.expects_three_args(ControlFunctionRegistry.getControlName(this));
         } else if (!(args[1] instanceof VariableExpr)) {
@@ -63,7 +63,7 @@ public class Filter implements Control {
     }
 
     @Override
-    public Object call(Properties bindings, Evaluable[] args) {
+    public Object call(Properties bindings, GrelExpr[] args) {
         Object o = args[0].evaluate(bindings);
         if (ExpressionUtils.isError(o)) {
             return o;

--- a/modules/grel/src/main/java/com/google/refine/grel/controls/ForEach.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/controls/ForEach.java
@@ -43,19 +43,19 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import com.google.refine.expr.EvalError;
-import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.util.JsonValueConverter;
 import com.google.refine.grel.Control;
 import com.google.refine.grel.ControlDescription;
 import com.google.refine.grel.ControlEvalError;
 import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.ast.GrelExpr;
 import com.google.refine.grel.ast.VariableExpr;
 
 public class ForEach implements Control {
 
     @Override
-    public String checkArguments(Evaluable[] args) {
+    public String checkArguments(GrelExpr[] args) {
         if (args.length != 3) {
             return ControlEvalError.expects_three_args(ControlFunctionRegistry.getControlName(this));
         } else if (!(args[1] instanceof VariableExpr)) {
@@ -65,7 +65,7 @@ public class ForEach implements Control {
     }
 
     @Override
-    public Object call(Properties bindings, Evaluable[] args) {
+    public Object call(Properties bindings, GrelExpr[] args) {
         Object o = args[0].evaluate(bindings);
         if (ExpressionUtils.isError(o)) {
             return o;

--- a/modules/grel/src/main/java/com/google/refine/grel/controls/ForEachIndex.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/controls/ForEachIndex.java
@@ -44,19 +44,19 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import com.google.refine.expr.EvalError;
-import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.util.JsonValueConverter;
 import com.google.refine.grel.Control;
 import com.google.refine.grel.ControlDescription;
 import com.google.refine.grel.ControlEvalError;
 import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.ast.GrelExpr;
 import com.google.refine.grel.ast.VariableExpr;
 
 public class ForEachIndex implements Control {
 
     @Override
-    public String checkArguments(Evaluable[] args) {
+    public String checkArguments(GrelExpr[] args) {
         if (args.length != 4) {
             return ControlEvalError.expects_four_args(ControlFunctionRegistry.getControlName(this));
         } else if (!(args[1] instanceof VariableExpr)) {
@@ -72,7 +72,7 @@ public class ForEachIndex implements Control {
     }
 
     @Override
-    public Object call(Properties bindings, Evaluable[] args) {
+    public Object call(Properties bindings, GrelExpr[] args) {
         Object o = args[0].evaluate(bindings);
         if (ExpressionUtils.isError(o)) {
             return o;

--- a/modules/grel/src/main/java/com/google/refine/grel/controls/ForNonBlank.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/controls/ForNonBlank.java
@@ -35,18 +35,18 @@ package com.google.refine.grel.controls;
 
 import java.util.Properties;
 
-import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.grel.Control;
 import com.google.refine.grel.ControlDescription;
 import com.google.refine.grel.ControlEvalError;
 import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.ast.GrelExpr;
 import com.google.refine.grel.ast.VariableExpr;
 
 public class ForNonBlank implements Control {
 
     @Override
-    public String checkArguments(Evaluable[] args) {
+    public String checkArguments(GrelExpr[] args) {
         if (args.length != 4) {
             return ControlEvalError.expects_four_args(ControlFunctionRegistry.getControlName(this));
         } else if (!(args[1] instanceof VariableExpr)) {
@@ -56,10 +56,10 @@ public class ForNonBlank implements Control {
     }
 
     @Override
-    public Object call(Properties bindings, Evaluable[] args) {
+    public Object call(Properties bindings, GrelExpr[] args) {
         Object o = args[0].evaluate(bindings);
 
-        Evaluable var = args[1];
+        GrelExpr var = args[1];
         String name = ((VariableExpr) var).getName();
 
         if (ExpressionUtils.isNonBlankData(o)) {

--- a/modules/grel/src/main/java/com/google/refine/grel/controls/ForRange.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/controls/ForRange.java
@@ -38,19 +38,19 @@ import java.util.List;
 import java.util.Properties;
 
 import com.google.refine.expr.EvalError;
-import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.grel.Control;
 import com.google.refine.grel.ControlDescription;
 import com.google.refine.grel.ControlEvalError;
 import com.google.refine.grel.ControlFunctionRegistry;
 import com.google.refine.grel.EvalErrorMessage;
+import com.google.refine.grel.ast.GrelExpr;
 import com.google.refine.grel.ast.VariableExpr;
 
 public class ForRange implements Control {
 
     @Override
-    public String checkArguments(Evaluable[] args) {
+    public String checkArguments(GrelExpr[] args) {
         if (args.length != 5) {
             return ControlEvalError.expects_five_args(ControlFunctionRegistry.getControlName(this));
         } else if (!(args[3] instanceof VariableExpr)) {
@@ -61,7 +61,7 @@ public class ForRange implements Control {
     }
 
     @Override
-    public Object call(Properties bindings, Evaluable[] args) {
+    public Object call(Properties bindings, GrelExpr[] args) {
         Object fromO = args[0].evaluate(bindings);
         Object toO = args[1].evaluate(bindings);
         Object stepO = args[2].evaluate(bindings);

--- a/modules/grel/src/main/java/com/google/refine/grel/controls/If.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/controls/If.java
@@ -35,17 +35,17 @@ package com.google.refine.grel.controls;
 
 import java.util.Properties;
 
-import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.grel.Control;
 import com.google.refine.grel.ControlDescription;
 import com.google.refine.grel.ControlEvalError;
 import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.ast.GrelExpr;
 
 public class If implements Control {
 
     @Override
-    public String checkArguments(Evaluable[] args) {
+    public String checkArguments(GrelExpr[] args) {
         if (args.length != 3) {
             return ControlEvalError.expects_three_args(ControlFunctionRegistry.getControlName(this));
         }
@@ -53,7 +53,7 @@ public class If implements Control {
     }
 
     @Override
-    public Object call(Properties bindings, Evaluable[] args) {
+    public Object call(Properties bindings, GrelExpr[] args) {
         Object o = args[0].evaluate(bindings);
         if (ExpressionUtils.isError(o)) {
             return o; // bubble the error up

--- a/modules/grel/src/main/java/com/google/refine/grel/controls/IsTest.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/controls/IsTest.java
@@ -36,15 +36,15 @@ package com.google.refine.grel.controls;
 import java.util.Properties;
 
 import com.google.refine.expr.EvalError;
-import com.google.refine.expr.Evaluable;
 import com.google.refine.grel.Control;
 import com.google.refine.grel.ControlEvalError;
 import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.ast.GrelExpr;
 
 abstract class IsTest implements Control {
 
     @Override
-    public String checkArguments(Evaluable[] args) {
+    public String checkArguments(GrelExpr[] args) {
         if (args.length != 1) {
             return ControlEvalError.expects_one_arg(ControlFunctionRegistry.getControlName(this));
         }
@@ -52,7 +52,7 @@ abstract class IsTest implements Control {
     }
 
     @Override
-    public Object call(Properties bindings, Evaluable[] args) {
+    public Object call(Properties bindings, GrelExpr[] args) {
         Object o;
         try {
             o = args[0].evaluate(bindings);

--- a/modules/grel/src/main/java/com/google/refine/grel/controls/With.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/controls/With.java
@@ -35,17 +35,17 @@ package com.google.refine.grel.controls;
 
 import java.util.Properties;
 
-import com.google.refine.expr.Evaluable;
 import com.google.refine.grel.Control;
 import com.google.refine.grel.ControlDescription;
 import com.google.refine.grel.ControlEvalError;
 import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.ast.GrelExpr;
 import com.google.refine.grel.ast.VariableExpr;
 
 public class With implements Control {
 
     @Override
-    public String checkArguments(Evaluable[] args) {
+    public String checkArguments(GrelExpr[] args) {
         if (args.length != 3) {
             return ControlEvalError.expects_three_args(ControlFunctionRegistry.getControlName(this));
         } else if (!(args[1] instanceof VariableExpr)) {
@@ -55,7 +55,7 @@ public class With implements Control {
     }
 
     @Override
-    public Object call(Properties bindings, Evaluable[] args) {
+    public Object call(Properties bindings, GrelExpr[] args) {
         Object o = args[0].evaluate(bindings);
         String name = ((VariableExpr) args[1]).getName();
 

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ControlCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ControlCallExprTest.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.refine.expr.Evaluable;
 import com.google.refine.grel.Control;
 
 public class ControlCallExprTest extends ExprTestBase {
@@ -23,19 +22,19 @@ public class ControlCallExprTest extends ExprTestBase {
 
     @Test
     public void testConstant() {
-        Evaluable c = new ControlCallExpr(new Evaluable[] { constant }, control);
+        GrelExpr c = new ControlCallExpr(new GrelExpr[] { constant }, control);
         assertEquals(c.getColumnDependencies(baseColumn), set());
     }
 
     @Test
     public void testUnion() {
-        Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, currentColumn }, control);
+        GrelExpr c = new ControlCallExpr(new GrelExpr[] { twoColumns, currentColumn }, control);
         assertEquals(c.getColumnDependencies(baseColumn), set("a", "b", "baseColumn"));
     }
 
     @Test
     public void testUnanalyzable() {
-        Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, unanalyzable }, control);
+        GrelExpr c = new ControlCallExpr(new GrelExpr[] { twoColumns, unanalyzable }, control);
         assertEquals(c.getColumnDependencies(baseColumn), Optional.empty());
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ExprTestBase.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ExprTestBase.java
@@ -11,8 +11,6 @@ import java.util.stream.Collectors;
 
 import org.testng.annotations.BeforeMethod;
 
-import com.google.refine.expr.Evaluable;
-
 /**
  * Base class to test expression classes. Contains utilities to test column dependency extraction.
  * 
@@ -21,17 +19,17 @@ import com.google.refine.expr.Evaluable;
 public class ExprTestBase {
 
     protected Optional<String> baseColumn = Optional.of("baseColumn");
-    protected Evaluable currentColumn;
-    protected Evaluable unanalyzable;
-    protected Evaluable twoColumns;
-    protected Evaluable constant;
+    protected GrelExpr currentColumn;
+    protected GrelExpr unanalyzable;
+    protected GrelExpr twoColumns;
+    protected GrelExpr constant;
 
     @BeforeMethod
     public void setUp() {
-        currentColumn = mock(Evaluable.class);
-        unanalyzable = mock(Evaluable.class);
-        twoColumns = mock(Evaluable.class);
-        constant = mock(Evaluable.class);
+        currentColumn = mock(GrelExpr.class);
+        unanalyzable = mock(GrelExpr.class);
+        twoColumns = mock(GrelExpr.class);
+        constant = mock(GrelExpr.class);
 
         when(currentColumn.getColumnDependencies(baseColumn))
                 .thenReturn(set("baseColumn"));

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/FieldAccessorExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/FieldAccessorExprTest.java
@@ -8,13 +8,11 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.expr.Evaluable;
-
 public class FieldAccessorExprTest extends ExprTestBase {
 
     @Test
     public void testInnerAnalyzable() {
-        Evaluable ev = new FieldAccessorExpr(constant, "foo");
+        GrelExpr ev = new FieldAccessorExpr(constant, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set());
         ev = new FieldAccessorExpr(currentColumn, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
@@ -25,14 +23,14 @@ public class FieldAccessorExprTest extends ExprTestBase {
     @Test
     public void testUnanalyzable() {
         when(unanalyzable.toString()).thenReturn("bar");
-        Evaluable ev = new FieldAccessorExpr(unanalyzable, "foo");
+        GrelExpr ev = new FieldAccessorExpr(unanalyzable, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
     }
 
     @Test
     public void testCells() {
         when(unanalyzable.toString()).thenReturn("cells");
-        Evaluable ev = new FieldAccessorExpr(unanalyzable, "foo");
+        GrelExpr ev = new FieldAccessorExpr(unanalyzable, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set("foo"));
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/FunctionCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/FunctionCallExprTest.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import com.google.refine.expr.Evaluable;
 import com.google.refine.grel.Function;
 
 public class FunctionCallExprTest extends ExprTestBase {
@@ -23,13 +22,13 @@ public class FunctionCallExprTest extends ExprTestBase {
 
     @Test
     public void testUnion() {
-        Evaluable ev = new FunctionCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, function);
+        GrelExpr ev = new FunctionCallExpr(new GrelExpr[] { constant, currentColumn, twoColumns }, function);
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
     }
 
     @Test
     public void testUnanalyzable() {
-        Evaluable ev = new FunctionCallExpr(new Evaluable[] { currentColumn, unanalyzable }, function);
+        GrelExpr ev = new FunctionCallExpr(new GrelExpr[] { currentColumn, unanalyzable }, function);
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/OperatorCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/OperatorCallExprTest.java
@@ -5,77 +5,81 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import org.testng.annotations.Test;
-
-import com.google.refine.expr.Evaluable;
 
 public class OperatorCallExprTest extends ExprTestBase {
 
     private OperatorCallExpr expr;
-    private Evaluable arg1;
-    private Evaluable arg2;
+    private GrelExpr arg1;
+    private GrelExpr arg2;
     Object result;
 
     @Test
     public void evaluateDivision() {
-        arg1 = new MockEvaluable(10);
-        arg2 = new MockEvaluable(2);
-        expr = new OperatorCallExpr(new Evaluable[] { arg1, arg2 }, "/");
+        arg1 = new MockGrelExpr(10);
+        arg2 = new MockGrelExpr(2);
+        expr = new OperatorCallExpr(new GrelExpr[] { arg1, arg2 }, "/");
         result = expr.evaluate(new Properties());
         assertEquals((long) 5, result);
     }
 
     @Test
     public void evaluateZeroDivideZeroTest() {
-        arg1 = new MockEvaluable(0);
-        arg2 = new MockEvaluable(0);
-        expr = new OperatorCallExpr(new Evaluable[] { arg1, arg2 }, "/");
+        arg1 = new MockGrelExpr(0);
+        arg2 = new MockGrelExpr(0);
+        expr = new OperatorCallExpr(new GrelExpr[] { arg1, arg2 }, "/");
         result = expr.evaluate(new Properties());
         assertEquals(Double.NaN, result);
     }
 
     @Test
     public void evaluatePositiveIntegerDivideZeroTest() {
-        arg1 = new MockEvaluable(3);
-        arg2 = new MockEvaluable(0);
-        expr = new OperatorCallExpr(new Evaluable[] { arg1, arg2 }, "/");
+        arg1 = new MockGrelExpr(3);
+        arg2 = new MockGrelExpr(0);
+        expr = new OperatorCallExpr(new GrelExpr[] { arg1, arg2 }, "/");
         result = expr.evaluate(new Properties());
         assertEquals(Double.POSITIVE_INFINITY, result);
     }
 
     @Test
     public void evaluateNegativeIntegerDivideZeroTest() {
-        arg1 = new MockEvaluable(-3);
-        arg2 = new MockEvaluable(0);
-        expr = new OperatorCallExpr(new Evaluable[] { arg1, arg2 }, "/");
+        arg1 = new MockGrelExpr(-3);
+        arg2 = new MockGrelExpr(0);
+        expr = new OperatorCallExpr(new GrelExpr[] { arg1, arg2 }, "/");
         result = expr.evaluate(new Properties());
         assertEquals(Double.NEGATIVE_INFINITY, result);
     }
 
     @Test
     public void testUnion() {
-        Evaluable ev = new OperatorCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, "+");
+        GrelExpr ev = new OperatorCallExpr(new GrelExpr[] { constant, currentColumn, twoColumns }, "+");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
     }
 
     @Test
     public void testUnanalyzable() {
-        Evaluable ev = new OperatorCallExpr(new Evaluable[] { currentColumn, unanalyzable }, "+");
+        GrelExpr ev = new OperatorCallExpr(new GrelExpr[] { currentColumn, unanalyzable }, "+");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
     }
 }
 
-class MockEvaluable implements Evaluable {
+class MockGrelExpr implements GrelExpr {
 
     private final Object value;
 
-    public MockEvaluable(Object value) {
+    public MockGrelExpr(Object value) {
         this.value = value;
     }
 
     @Override
     public Object evaluate(Properties bindings) {
         return value;
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
+        return Optional.empty();
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/VariableExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/VariableExprTest.java
@@ -7,13 +7,11 @@ import java.util.Optional;
 
 import org.testng.annotations.Test;
 
-import com.google.refine.expr.Evaluable;
-
 public class VariableExprTest extends ExprTestBase {
 
     @Test
     public void testBaseColumn() {
-        Evaluable ev = new VariableExpr("value");
+        GrelExpr ev = new VariableExpr("value");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
         ev = new VariableExpr("cell");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
@@ -23,7 +21,7 @@ public class VariableExprTest extends ExprTestBase {
 
     @Test
     public void testUnanalyzable() {
-        Evaluable ev = new VariableExpr("cells");
+        GrelExpr ev = new VariableExpr("cells");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
         ev = new VariableExpr("row");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
@@ -33,7 +31,7 @@ public class VariableExprTest extends ExprTestBase {
 
     @Test
     public void testSingleton() {
-        Evaluable ev = new VariableExpr("foo");
+        GrelExpr ev = new VariableExpr("foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set());
     }
 }


### PR DESCRIPTION
So far, AST nodes of GREL expressions are `Evaluable` themselves. This refactoring introduces a dedicated base interface for such AST nodes, `GrelExpr`, so that there is no confusion with `Evaluable`, which is meant to be used as interface with the rest of the code (facets, operations and other such components).

This makes it possible to add methods common to all GREL expressions on the `GrelExpr` interface, without polluting the `Evaluable` interface itself.