### PR TITLE
Unify shades of red used for errors

### DIFF
--- a/extensions/wikibase/module/styles/dialogs/add-wikibase-dialog.css
+++ b/extensions/wikibase/module/styles/dialogs/add-wikibase-dialog.css
@@ -9,7 +9,7 @@
 }
 
 .add-wikibase-dialog .invalid-manifest {
-  color: red;
+  color: var(--error-red);
 }
 
 .save-new-template-dialog-input-group select {

--- a/extensions/wikibase/module/styles/dialogs/import-schema-dialog.css
+++ b/extensions/wikibase/module/styles/dialogs/import-schema-dialog.css
@@ -1,6 +1,6 @@
 .wikibase-invalid-schema {
   margin-top: 10px;
-  color: red;
+  color: var(--error-red);
 }
 
 .wikibase-schema-textarea {

--- a/extensions/wikibase/module/styles/dialogs/manage-account-dialog.css
+++ b/extensions/wikibase/module/styles/dialogs/manage-account-dialog.css
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 .wikibase-invalid-credentials {
-  color: red;
+  color: var(--error-red);
   padding-bottom: 0.3rem;
 }
 

--- a/extensions/wikibase/module/styles/dialogs/schema-management-dialog.css
+++ b/extensions/wikibase/module/styles/dialogs/schema-management-dialog.css
@@ -19,7 +19,7 @@
 }
 
 .wikibase-import-template-error {
-  color: red;
+  color: var(--error-red);
 }
 
 .wikibase-import-template-label {

--- a/extensions/wikibase/module/styles/schema-alignment.css
+++ b/extensions/wikibase/module/styles/schema-alignment.css
@@ -144,7 +144,7 @@
 }
 
 .wbs-unvalidated-input {
-  border: 1px solid red !important;
+  border: 1px solid var(--error-red) !important;
   background-color: #ffbfbf;
 }
 

--- a/main/webapp/modules/core/styles/dialogs/expression-preview-dialog.css
+++ b/main/webapp/modules/core/styles/dialogs/expression-preview-dialog.css
@@ -46,7 +46,7 @@ textarea.expression-preview-code {
 }
 
 .expression-preview-parsing-status.error {
-  color: red;
+  color: var(--error-red);
 }
 
 #expression-preview-tabs-preview,

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   margin: 5px;
   text-align: center;
   background: #fff0f4;
-  color: #c51244;
+  color: var(--error-red);
   padding: 4px 4px;
   border-radius: 4px;
   border: 1px solid #ccc;

--- a/main/webapp/modules/core/styles/theme.css
+++ b/main/webapp/modules/core/styles/theme.css
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   --notification-primary: #fe8;
   --faint-grey: #ddd;
   --light-grey: #999;
-  --error-red: #c51244;
+  --error-red: red;
   --dialog-frame: #3a5774;
   --dialog-border: #c1d9ff;
   --dialog-header: #e0edfe;

--- a/main/webapp/modules/core/styles/theme.css
+++ b/main/webapp/modules/core/styles/theme.css
@@ -50,6 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   --notification-primary: #fe8;
   --faint-grey: #ddd;
   --light-grey: #999;
+  --error-red: #c51244;
   --dialog-frame: #3a5774;
   --dialog-border: #c1d9ff;
   --dialog-header: #e0edfe;

--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -295,7 +295,7 @@ div.data-table-cell-content-numeric>a.data-table-cell-edit {
 }
 
 .data-table-error {
-  color: red;
+  color: var(--error-red);
 }
 
 div.data-table-recon-candidates {


### PR DESCRIPTION
Our color palette does not yet include a shade of red, which is the color we tend to use to report errors.

A lot of places in our CSS use `color: red`, but I assume that's primarily we "wanted to have this text in red" rather than asserting that `#ff0000` is the shade of red we want.

In e4bdca9c95f7645fb4e206031f73bd70e284bae3, @ostephens hasn't been as lazy as the rest of us and picked an explicit color, `#c51244` for errors reported in the facets area. So maybe it's a sensible choice? This PR uses it in all other places I could find via a new CSS variable. I'm happy with other values.

## Cell errors before
![image](https://github.com/user-attachments/assets/66c43c05-a428-4bbf-9948-ba7643965d82)
## Cell errors after
![image](https://github.com/user-attachments/assets/a757882e-c5b1-4475-ac1d-76dca4c5b53e)

## Dialog errors before

![image](https://github.com/user-attachments/assets/c5faf4ae-3d34-4bd7-96b7-403dc8f39687)

## Dialog errors after

![image](https://github.com/user-attachments/assets/b0b10dd7-348f-416f-b007-c469d0e91b30)
