### PR TITLE
Move error reporting in apply-operations dialog away from alert into dialog

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/undo_redo/apply.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/undo_redo/apply.cy.js
@@ -43,4 +43,28 @@ describe(__filename, function () {
     );
     cy.get('table.data-table thead th[title="Water"]').should('not.to.exist');
   });
+
+  it('Use an invalid JSON payload', function () {
+    cy.loadAndVisitProject('food.mini');
+
+    // find the "apply" button
+    cy.get('#or-proj-undoRedo').click();
+    cy.wait(500); // eslint-disable-line
+    cy.get('#refine-tabs-history .history-panel-controls')
+      .contains('Apply')
+      .click();
+      
+    cy.get('.dialog-container .history-operation-json').type(
+      "[{foo",
+      {
+        parseSpecialCharSequences: false,
+        delay: 0,
+        waitForAnimations: false,
+      }
+    );
+    cy.get('.dialog-container button[bind="applyButton"]').click();
+
+    cy.get('.dialog-container .history-operation-json-error').contains('Invalid JSON format');
+  });
+
 });

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -434,7 +434,7 @@
     "core-project/custom-tabular": "Custom tabular…",
     "core-project/sql-export": "SQL…",
     "core-project/templating": "Templating…",
-    "core-project/json-invalid": "The JSON you pasted is invalid",
+    "core-project/json-invalid": "Invalid JSON format: $1",
     "core-project/undo-history": "Infinite undo history",
     "core-project/mistakes": "Don't worry about making mistakes. Every change you make will be shown here, and you can undo your changes anytime.",
     "core-project/learn-more": "Learn more &raquo;",

--- a/main/webapp/modules/core/scripts/project/history-apply-dialog.html
+++ b/main/webapp/modules/core/scripts/project/history-apply-dialog.html
@@ -5,9 +5,10 @@
       <div class="dialog-instruction"><label for="textareaId" bind="or_proj_pasteJson"></label></div>
       <input type="file" id="file-input" bind="operationJsonButton" style="margin-bottom: 8px;"/>
       <div class="input-container"><textarea spellcheck="false" wrap="off" bind="textarea" id="textareaId" class="history-operation-json" style="min-width: 764px"></textarea></div>
+      <div class="history-operation-json-error" bind="errorContainer"></div>
     </div>
     <div class="dialog-footer" bind="dialogFooter">
-    <button class="button" bind="applyButton"></button>
+    <button class="button button-primary" bind="applyButton"></button>
     <button class="button" bind="cancelButton"></button>
     </div>
   </div>

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -309,14 +309,16 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
             textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
           }
         } catch (error) {
-            window.alert($.i18n('core-project/json-invalid'));
-          }
+          elmts.errorContainer.text($.i18n('core-project/json-invalid', e.message));   
+        }
       };
       reader.readAsText(file);
     };
     fileInput.click();
   });
-  
+  elmts.textarea.on('change', function() {
+     elmts.errorContainer.empty();
+  });
   
   elmts.applyButton.html($.i18n('core-buttons/perform-op'));
   elmts.cancelButton.html($.i18n('core-buttons/cancel'));
@@ -342,7 +344,7 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
       json = fixJson(json);
       json = JSON.parse(json);
     } catch (e) {
-      alert($.i18n('core-project/json-invalid')+".");
+      elmts.errorContainer.text($.i18n('core-project/json-invalid', e.message));   
       return;
     }
 

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -251,3 +251,7 @@ textarea.history-operation-json {
   min-height: 450px;
   min-width: 374px;
 }
+
+.history-operation-json-error {
+  color: var(--error-red);
+}


### PR DESCRIPTION
When trying to apply operations with JSON syntax errors in the "Apply Operation History" dialog, the error currently gets reported as a JS alert. This PR:
* moves the error message into the dialog to make it less agressive
* improves the error message (the content hasn't necessarily been "pasted", so remove reference to that, and include the specifics of why the JSON is invalid)

![image](https://github.com/user-attachments/assets/645953e1-6a08-45d9-94dd-c29fd7a6d95a)
