### PR TITLE
apply-operations: Report invalid JSON structure from the backend to the frontend

### DIFF
--- a/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
+++ b/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
@@ -59,18 +59,23 @@ public class ApplyOperationsCommand extends Command {
             respondCSRFError(response);
             return;
         }
-
-        Project project = getProject(request);
-        String jsonString = request.getParameter("operations");
         try {
-            ArrayNode a = ParsingUtilities.evaluateJsonStringToArrayNode(jsonString);
-            int count = a.size();
-            for (int i = 0; i < count; i++) {
-                if (a.get(i) instanceof ObjectNode) {
-                    ObjectNode obj = (ObjectNode) a.get(i);
+            Project project = getProject(request);
+            String jsonString = request.getParameter("operations");
 
-                    reconstructOperation(project, obj);
+            try {
+                ArrayNode a = ParsingUtilities.evaluateJsonStringToArrayNode(jsonString);
+                int count = a.size();
+                for (int i = 0; i < count; i++) {
+                    if (a.get(i) instanceof ObjectNode) {
+                        ObjectNode obj = (ObjectNode) a.get(i);
+
+                        reconstructOperation(project, obj);
+                    }
                 }
+            } catch (IllegalArgumentException e) {
+                respondCodeError(response, e.getMessage(), HttpServletResponse.SC_BAD_REQUEST, null);
+                return;
             }
 
             if (project.processManager.hasPending()) {
@@ -78,7 +83,7 @@ public class ApplyOperationsCommand extends Command {
             } else {
                 respond(response, "{ \"code\" : \"ok\" }");
             }
-        } catch (IOException e) {
+        } catch (Exception e) {
             respondException(response, e);
         }
     }

--- a/main/tests/server/src/com/google/refine/commands/history/ApplyOperationsCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/history/ApplyOperationsCommandTests.java
@@ -79,7 +79,7 @@ public class ApplyOperationsCommandTests extends CommandTestBase {
     @Test
     public void testInvalidJSON() throws Exception {
         when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
-        when(request.getParameter("project")).thenReturn(project.toString());
+        when(request.getParameter("project")).thenReturn(Long.toString(project.id));
         when(request.getParameter("operations")).thenReturn("[{}]");
 
         command.doPost(request, response);

--- a/main/tests/server/src/com/google/refine/commands/history/ApplyOperationsCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/history/ApplyOperationsCommandTests.java
@@ -1,25 +1,91 @@
 
 package com.google.refine.commands.history;
 
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
 import java.io.IOException;
+import java.io.Serializable;
 
 import javax.servlet.ServletException;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.refine.commands.Command;
 import com.google.refine.commands.CommandTestBase;
+import com.google.refine.model.Project;
+import com.google.refine.operations.OperationRegistry;
+import com.google.refine.operations.cell.MassEditOperation;
+import com.google.refine.util.ParsingUtilities;
 
 public class ApplyOperationsCommandTests extends CommandTestBase {
 
+    Project project;
+    String historyJSON = "[\n"
+            + "  {\n"
+            + "    \"op\": \"core/mass-edit\",\n"
+            + "    \"engineConfig\": {\n"
+            + "      \"facets\": [],\n"
+            + "      \"mode\": \"row-based\"\n"
+            + "    },\n"
+            + "    \"columnName\": \"bar\",\n"
+            + "    \"expression\": \"value\",\n"
+            + "    \"edits\": [\n"
+            + "      {\n"
+            + "        \"from\": [\n"
+            + "          \"hello\"\n"
+            + "        ],\n"
+            + "        \"fromBlank\": false,\n"
+            + "        \"fromError\": false,\n"
+            + "        \"to\": \"hallo\"\n"
+            + "      }\n"
+            + "    ],\n"
+            + "    \"description\": \"Mass edit cells in column bar\"\n"
+            + "  }\n"
+            + "]";
+
     @BeforeMethod
-    public void setUpCommand() {
+    public void setUpDependencies() {
         command = new ApplyOperationsCommand();
+        project = createProject(new String[] { "foo", "bar" },
+                new Serializable[][] {
+                        { 1, "hello" },
+                        { null, true }
+                });
+        OperationRegistry.registerOperation(getCoreModule(), "mass-edit", MassEditOperation.class);
     }
 
     @Test
     public void testCSRFProtection() throws ServletException, IOException {
         command.doPost(request, response);
         assertCSRFCheckFailed();
+    }
+
+    @Test
+    public void testInvalidProject() throws Exception {
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("project")).thenReturn(String.format("%d9", project.id));
+        when(request.getParameter("operations")).thenReturn(historyJSON);
+
+        command.doPost(request, response);
+
+        String response = writer.toString();
+        JsonNode node = ParsingUtilities.mapper.readValue(response, JsonNode.class);
+        assertEquals(node.get("code").toString(), "\"error\"");
+    }
+
+    @Test
+    public void testInvalidJSON() throws Exception {
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("project")).thenReturn(project.toString());
+        when(request.getParameter("operations")).thenReturn("[{}]");
+
+        command.doPost(request, response);
+
+        String response = writer.toString();
+        JsonNode node = ParsingUtilities.mapper.readValue(response, JsonNode.class);
+        assertEquals(node.get("code").toString(), "\"error\"");
     }
 }

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -359,11 +359,13 @@ HistoryPanel.prototype._showApplyOperationsDialog = function() {
               // Something might have already been done and so it's good to update
               Refine.update({ everythingChanged: true });
             }
-          }
+            DialogSystem.dismissUntil(level - 1);
+          },
+          onError: function(e) {
+             elmts.errorContainer.text($.i18n('core-project/json-invalid', e.message));   
+          },
         }
     );
-
-    DialogSystem.dismissUntil(level - 1);
   });
 
   elmts.cancelButton.on('click',function() {

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -254,5 +254,5 @@ textarea.history-operation-json {
 
 .history-operation-json-error {
   color: var(--error-red);
-  max-width: 750px;
+  max-width: calc(800px - var(--padding-looser));
 }

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -254,4 +254,5 @@ textarea.history-operation-json {
 
 .history-operation-json-error {
   color: var(--error-red);
+  max-width: 750px;
 }


### PR DESCRIPTION
This adds error reporting to the apply-operations command, for things that are valid JSON but when that JSON does not correspond to a valid operation history (for instance `[{}]`).

This will still accept operations with missing parameters, such as:
```
[
    { "op": "core/mass-edit" }
]
```
Rejecting those sorts of inputs will be done in further PRs.

![image](https://github.com/user-attachments/assets/f048a8d0-29b1-46eb-9372-a7a553b0477e)
