### PR TITLE
Introduce AbstractOperation::validate() to check operation parameters

### DIFF
--- a/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
+++ b/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
@@ -86,6 +86,7 @@ public class ApplyOperationsCommand extends Command {
     protected void reconstructOperation(Project project, ObjectNode obj) throws IOException {
         AbstractOperation operation = ParsingUtilities.mapper.convertValue(obj, AbstractOperation.class);
         if (operation != null && !(operation instanceof UnknownOperation)) {
+            operation.validate();
             try {
                 Process process = operation.createProcess(project, new Properties());
 

--- a/modules/core/src/main/java/com/google/refine/model/AbstractOperation.java
+++ b/modules/core/src/main/java/com/google/refine/model/AbstractOperation.java
@@ -40,27 +40,37 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 
+import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.operations.OperationRegistry;
 import com.google.refine.operations.OperationResolver;
 import com.google.refine.process.Process;
 import com.google.refine.process.QuickHistoryEntryProcess;
 
-/*
- *  An abstract operation can be applied to different but similar
- *  projects.
+/**
+ * An operation can be applied to different but similar projects. Instances of this class store the metadata describing
+ * the operation before it is carried out, such as the names of the columns it applies to, the configuration of any
+ * facets to be observed by the operation, and so on. Any data obtained from executing the operation on the project
+ * should be stored in a {@link Change} instead.
+ * 
+ * Operations need to be (de)serializable in JSON via Jackson, used for project persistence and in the extract/apply
+ * dialog of the history panel. Validation of the operation's parameters should not happen during deserialization, but
+ * in the {@link #validate()} method.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.PROPERTY, property = "op", visible = true) // for
-                                                                                                                 // UnknownOperation,
-                                                                                                                 // which
-                                                                                                                 // needs
-                                                                                                                 // to
-                                                                                                                 // read
-                                                                                                                 // its
-                                                                                                                 // own
-                                                                                                                 // id
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.PROPERTY, property = "op", visible = true)
 @JsonTypeIdResolver(OperationResolver.class)
 abstract public class AbstractOperation {
+
+    /**
+     * Checks whether the parameters of this operation are suitably filled. Those checks should not happen in the
+     * deserialization constructor as it would risk rejecting JSON certain representations at project loading time.
+     * 
+     * @throws IllegalArgumentException
+     *             if any parameter is missing or inconsistent
+     */
+    public void validate() throws IllegalArgumentException {
+
+    }
 
     public Process createProcess(Project project, Properties options) throws Exception {
         return new QuickHistoryEntryProcess(project, getBriefDescription(null)) {


### PR DESCRIPTION
Most operations don't check their parameters before execution, so when they are deserialized from invalid JSON payloads, this can lead to execution errors which ought to be prevented earlier.

This introduces a validate() method on operations giving them the opportunity to check the validity of their parameters. It would intuitively be more natural to do those checks in the operation constructors, as it would guarantee that if you have an instance of an operation, it has suitable parameters, but if we were to do this, we would run into the risk that deserializing operations fail at the loading of a project (for instance: say I use an extension which provides a custom expression language, which I then use in an operation. If I then remove the extension, I wouldn't be able to open my project anymore)

For now this PR just contains the basic scaffold without implementing any checks in any operation, just to validate the general approach. I would then migrate the error-checking done in `Command` classes into the `validate()` methods of the corresponding operations (so it's not duplicated).