### PR TITLE
facets: Add missing backslash escaping in duplicate facet expression

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/menu-facets.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-facets.js
@@ -168,7 +168,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           id: "core/duplicates-facet",
           label: $.i18n('core-views/duplicates-facet'),
           click: function() {
-            let columnName = column.name.replace(/'/g, "\\'");
+            let columnName = column.name.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
             ui.browsingEngine.addFacet(
                 "list",
                 {


### PR DESCRIPTION
When running the duplicates facet on a column with a backslash in the column name, the GREL expression which underpins the facet can be wrong as the backslash isn't correctly escaped.

Addresses https://github.com/OpenRefine/OpenRefine/security/code-scanning/29 (which is not publicly visible).
