### PR TITLE
ui: Fix dialog warning of history overwriting for some operations

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/undo_redo/warn_for_history_deletion.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/undo_redo/warn_for_history_deletion.cy.js
@@ -83,4 +83,50 @@ describe(__filename, function () {
     // There are no future changes anymore, since they have been deleted
     cy.get('.history-panel-body .history-future a').should('not.exist');
   });
+
+  it('Apply a text transform after undoing some changes', function () {
+    cy.loadAndVisitProject('food.mini');
+
+    // delete NDB_No
+    cy.deleteColumn('NDB_No');
+    cy.get('#or-proj-undoRedo').should('to.contain', '1 / 1');
+    cy.get('.history-panel-body .history-now').should(
+      'to.contain',
+      'Remove column NDB_No'
+    );
+
+    // Open the Undo/Redo panel
+    cy.get('#or-proj-undoRedo').click();
+
+    // undo the change
+    cy.get(
+      '.history-panel-body .history-past a.history-entry:first-of-type'
+    ).click();
+    cy.get('.history-panel-body .history-now').should(
+      'to.contain',
+      'Create project'
+    );
+    cy.get('.history-panel-body .history-future').should(
+      'to.contain',
+      'Remove column NDB_No'
+    );
+
+    cy.columnActionClick('Shrt_Desc', ['Edit cells', 'Transform']);
+
+    cy.typeExpression('value.replace("E","e")');
+    cy.get('.dialog-footer .button-primary').click();
+
+    // ensure we get a dialog warning us for deletion of changes
+    cy.get('.dialog-header').should('to.contain', 'Confirm deletion of project history');
+    // confirm the dialog   
+    cy.get('.dialog-footer .button-primary').contains('Apply anyway').click();
+
+    // ensure value has been changed in the grid
+    cy.get('.menu-container.data-table-cell-editor').should('not.exist');
+    cy.assertCellEquals(1, 'Shrt_Desc', 'BUTTeR,WHIPPeD,WITH SALT');
+
+    // There are no future changes anymore, since they have been deleted
+    cy.get('.history-panel-body .history-future a').should('not.exist');
+  });
+
 });

--- a/main/webapp/modules/core/scripts/dialogs/column-reordering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/column-reordering-dialog.js
@@ -86,6 +86,7 @@ ColumnReorderingDialog.prototype._dismiss = function() {
 };
 
 ColumnReorderingDialog.prototype._commit = function() {
+    var self = this;
     var columnNames = this._elmts.columnContainer.find('div').map(function() { return this.getAttribute("column"); }).get();
     
     Refine.postCoreProcess(
@@ -93,8 +94,9 @@ ColumnReorderingDialog.prototype._commit = function() {
         null,
         { "columnNames" : JSON.stringify(columnNames) }, 
         { modelsChanged: true, rowIdsPreserved: true }, // TODO could add recordIdsPreserved: true if the record key column did not change
-        { includeEngine: false }
+        { 
+          includeEngine: false,
+          onDone: function() { self._dismiss(); }
+        }
     );
-    
-    this._dismiss();
 };

--- a/main/webapp/modules/core/scripts/dialogs/common-transform-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/common-transform-dialog.js
@@ -106,29 +106,32 @@ commonTransformDialog.prototype._dismiss = function() {
 
 
 commonTransformDialog.prototype._commit = function(expression) {
-      var doTextTransform = function(columnName, expression, onError, repeat, repeatCount) {
+  var self = this;
+  var columnNames = [];
+  this._elmts.columnContainer.find('div').each(function() {
+    if ($(this).find('input[type="checkbox"]')[0].checked) {
+      var name = this.getAttribute('column');
+      columnNames.push(name);
+    }
+  });
+  var doTextTransform = function(index, expression, onError, repeat, repeatCount) {
+    if (index < columnNames.length) {
       Refine.postCoreProcess(
         "text-transform",
         {
-          columnName: columnName, 
+          columnName: columnNames[index], 
           expression: expression, 
           onError: onError,
           repeat: repeat,
           repeatCount: repeatCount
         },
         null,
-        { cellsChanged: true, rowIdsPreserved: true }
+        { cellsChanged: true, rowIdsPreserved: true },
+        { onDone: function() { doTextTransform(index + 1, expression, onError, repeat, repeatCount) } }
       );
-  };
-
-	this._elmts.columnContainer.find('div').each(function() {
-    if ($(this).find('input[type="checkbox"]')[0].checked) {
-      var name = this.getAttribute('column');
-	    doTextTransform(name,expression, "keep-original", false, "");
+    } else {
+      self._dismiss();
     }
-  });
-  
-    
-    this._dismiss();
-    
+  };
+  doTextTransform(0, expression, "keep-original", false, "");
 };

--- a/main/webapp/modules/core/scripts/dialogs/expression-column-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-column-dialog.js
@@ -1,5 +1,5 @@
 
-var doTextTransform = function(columnName, expression, onError, repeat, repeatCount) {
+var doTextTransform = function(columnName, expression, onError, repeat, repeatCount, onDone) {
     Refine.postCoreProcess(
       "text-transform",
       {
@@ -10,7 +10,8 @@ var doTextTransform = function(columnName, expression, onError, repeat, repeatCo
         repeatCount: repeatCount
       },
       null,
-      { cellsChanged: true, rowIdsPreserved: true }
+      { cellsChanged: true, rowIdsPreserved: true },
+      { onDone }
     );
 };
 
@@ -87,7 +88,6 @@ ExpressionColumnDialog.prototype._dismiss = function() {
 
 ExpressionColumnDialog.prototype._transform = function() {
   this._postSelect();
-  this._dismiss();
 };
 
 ExpressionColumnDialog.prototype._postSelect = function() {
@@ -96,7 +96,7 @@ ExpressionColumnDialog.prototype._postSelect = function() {
     if ($(this).find('input[type="checkbox"]')[0].checked) {
       var name = this.getAttribute('column');
       // alert("doTextTransform on: " + name + "; expression: " + self._expression);
-	  doTextTransform(name, self._expression, self._onError, self._repeat, self._repeatCount)
+	  doTextTransform(name, self._expression, self._onError, self._repeat, self._repeatCount, self._dismiss)
     }
   });
   

--- a/main/webapp/modules/core/scripts/facets/list-facet.js
+++ b/main/webapp/modules/core/scripts/facets/list-facet.js
@@ -583,8 +583,6 @@ class ListFacet extends Facet {
     var commit = function() {
       var text = elmts.textarea[0].value;
 
-      MenuSystem.dismissAll();
-
       var edit = { to : text };
       if (choice === self._blankChoice) {
         edit.fromBlank = true;
@@ -609,6 +607,7 @@ class ListFacet extends Facet {
         },
         {
           onDone: function(o) {
+            MenuSystem.dismissAll();
             var selection = [];
             var gotSelection = false;
             for (var i = 0; i < self._selection.length; i++) {

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
@@ -32,7 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
-  var doTextTransform = function(expression, onError, repeat, repeatCount) {
+  var doTextTransform = function(expression, onError, repeat, repeatCount, onDone) {
     Refine.postCoreProcess(
       "text-transform",
       {
@@ -42,7 +42,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         repeatCount: repeatCount
       },
       { expression: expression },
-      { cellsChanged: true }
+      { cellsChanged: true },
+      { onDone },
     );
   };
 
@@ -72,9 +73,9 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         previewWidget.getExpression(true),
         $('input[name="text-transform-dialog-onerror-choice"]:checked')[0].value,
         elmts.repeatCheckbox[0].checked,
-        elmts.repeatCountInput[0].value
+        elmts.repeatCountInput[0].value,
+        dismiss
       );
-      dismiss();
     });
 
     var o = DataTableView.sampleVisibleRows(column);
@@ -285,8 +286,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         text_to_find = '"'+text_to_find+'"';
       }
       expression = 'value.replace('+text_to_find+',"'+replacement_text+'")';
-      doTextTransform(expression, "keep-original", false, "");
-      dismiss();
+      doTextTransform(expression, "keep-original", false, "", dismiss);
     });
   };
 
@@ -383,10 +383,9 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         "split-multi-value-cells",
         config,
         null,
-        { rowsChanged: true }
+        { rowsChanged: true },
+        { onDone: dismiss }
       );
-
-      dismiss();
     });
   };
 
@@ -701,9 +700,9 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         "key-value-columnize",
         config,
         null,
-        { modelsChanged: true }
+        { modelsChanged: true },
+        { onDone: dismiss }
       );
-      dismiss();
     });
 
     var valueColumnIndex = -1;

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
@@ -166,9 +166,9 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           httpHeaders: JSON.stringify(elmts.setHttpHeadersContainer.find("input").serializeArray())
         },
         null,
-        { modelsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
+        { modelsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true },
+        { onDone: dismiss }
       );
-      dismiss();
     });
   };
 
@@ -358,9 +358,9 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         "split-column", 
         config,
         null,
-        { modelsChanged: true }
+        { modelsChanged: true },
+        { onDone: dismiss }
       );
-      dismiss();
     });
   }; 
   
@@ -399,7 +399,6 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       // function called in a callback
       var deleteColumns = function() {
         if (deleteJoinedColumns) {
-          console.log (theProject);
           var columnsToKeep = theProject.columnModel.columns
           .map (function (col) {return col.name;})
           .filter (function(colName) {
@@ -466,7 +465,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           },
           { expression: expression },
           { modelsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true },
-          { onFinallyDone: deleteColumns}
+          { onDone: dismiss, onFinallyDone: deleteColumns}
         );
       } 
       else {
@@ -476,7 +475,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
             onError,
             repeat,
             repeatCount,
-            { onFinallyDone: deleteColumns});
+            { onDone: dismiss, onFinallyDone: deleteColumns});
       }
     };
     // core of doJoinColumn
@@ -549,7 +548,6 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       });
     elmts.okButton.on('click',function() {
       transform();
-      dismiss();
     });
     elmts.cancelButton.on('click',function() {
       dismiss();

--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -221,10 +221,9 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
             schemaSpace: service.schemaSpace
         },
         null,
-        { cellsChanged: true, columnStatsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
+        { cellsChanged: true, columnStatsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true },
+        { onDone: function() { DialogSystem.dismissUntil(level - 1); } }
         );
-
-        DialogSystem.dismissUntil(level - 1);
     });
 
     $('<button class="button"></button>').text($.i18n('core-buttons/cancel')).on('click',function() {
@@ -395,9 +394,9 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
           "recon-copy-across-columns", 
           null,
           config,
-          { rowsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true }
+          { rowsChanged: true, rowIdsPreserved: true, recordIdsPreserved: true },
+          { onDone: dismiss }
         );
-        dismiss();
       }
     });
   };


### PR DESCRIPTION
Closes #6746.

Somehow I missed a lot of places where the callbacks to dismiss the operation dialog had to be moved to the `Refine.postCoreProcess` call. I am not sure how this went unnoticed, because I remember testing this manually…
I reviewed all calls of `Refine.postCoreProcess` and made the necessary changes.

When running an operation which is configured in a dialog, the new dialog warning against history overwriting is shown when the user validates the operation dialog. I realized that one could instead choose to display the warning when the operation dialog is first opened. This could be a follow-up change if we prefer this design.