### PR TITLE
ui: Avoid making unnecessary CSRF token requests

### DIFF
--- a/main/webapp/modules/core/scripts/util/csrf.js
+++ b/main/webapp/modules/core/scripts/util/csrf.js
@@ -1,5 +1,5 @@
 CSRFUtil = {
-    _tokenMaxAge: 1800000 // half an hour in milliseconds (tokens live for 1 hour in the backend)
+    _tokenMaxAge: 30 * 60 * 1000 // half an hour in milliseconds (tokens live for 1 hour in the backend)
 };
 
 

--- a/main/webapp/modules/core/scripts/util/csrf.js
+++ b/main/webapp/modules/core/scripts/util/csrf.js
@@ -1,16 +1,29 @@
-CSRFUtil = {};
+CSRFUtil = {
+    _tokenMaxAge: 1800000 // half an hour in milliseconds (tokens live for 1 hour in the backend)
+};
+
 
 // Requests a CSRF token and calls the supplied callback
 // with the token
 CSRFUtil.wrapCSRF = function(onCSRF) {
-    $.get(
-        "command/core/get-csrf-token",
-        {},
-        function(response) {
-            onCSRF(response['token']);
-        },
-        "json"
-    );
+    let tokenAge = CSRFUtil._tokenMaxAge + 1;
+    if (CSRFUtil._token && CSRFUtil._fetchedOn) {
+        tokenAge = new Date() - CSRFUtil._fetchedOn;
+    }
+    if (tokenAge < CSRFUtil._tokenMaxAge) {
+        onCSRF(CSRFUtil._token);
+    } else {
+        $.get(
+            "command/core/get-csrf-token",
+            {},
+            function(response) {
+                CSRFUtil._token = response['token'];
+                CSRFUtil._fetchedOn = new Date();
+                onCSRF(CSRFUtil._token);
+            },
+            "json"
+        );
+    }
 };
 
 // Performs a POST request where an additional CSRF token


### PR DESCRIPTION
Our CSRF tokens are valid for an hour, so it is not necessary to get a fresh token before every time we call a CSRF-protected command. This adds the necessary logic to remeber such tokens and invalidate them well before they expire. This saves a few HTTP requests.