### PR TITLE
core: Change log level of "Skipping unnecessary workspace save" message

### DIFF
--- a/modules/core/src/main/java/com/google/refine/io/FileProjectManager.java
+++ b/modules/core/src/main/java/com/google/refine/io/FileProjectManager.java
@@ -279,7 +279,7 @@ public class FileProjectManager extends ProjectManager {
             List<Long> modified = getModifiedProjectIds();
             boolean saveNeeded = (modified.size() > 0) || _preferenceStore.isDirty() || projectRemoved;
             if (!saveNeeded) {
-                logger.info("Skipping unnecessary workspace save");
+                logger.debug("Skipping unnecessary workspace save");
                 return;
             }
             File tempFile = saveWorkspaceToTempFile();


### PR DESCRIPTION
So it doesn't spam the logs when OpenRefine is inactive:

```
10:45:14.353 [       FileProjectManager] Skipping unnecessary workspace save (300000ms)
10:50:14.354 [       FileProjectManager] Skipping unnecessary workspace save (300000ms)
10:55:14.354 [       FileProjectManager] Skipping unnecessary workspace save (300000ms)
11:00:14.355 [       FileProjectManager] Skipping unnecessary workspace save (300000ms)
11:05:14.356 [       FileProjectManager] Skipping unnecessary workspace save (300000ms)
11:10:14.356 [       FileProjectManager] Skipping unnecessary workspace save (300000ms)
11:15:14.357 [       FileProjectManager] Skipping unnecessary workspace save (300000ms)
```
