### PR TITLE
core: Introduce @Internal annotation

### DIFF
--- a/modules/core/src/main/java/com/google/refine/annotations/Internal.java
+++ b/modules/core/src/main/java/com/google/refine/annotations/Internal.java
@@ -1,0 +1,19 @@
+
+package com.google.refine.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation signifying that the given class or method is only provided for internal use (inside OpenRefine itself) and
+ * should not be used by extensions, as it could change or be removed without notice.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE })
+public @interface Internal {
+
+    // the date or version number since this element has been marked as internal
+    public String since();
+}

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotDrawingRowVisitor.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotDrawingRowVisitor.java
@@ -43,6 +43,7 @@ import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
 
+import com.google.refine.annotations.Internal;
 import com.google.refine.browsing.RecordVisitor;
 import com.google.refine.browsing.RowVisitor;
 import com.google.refine.model.Cell;
@@ -50,6 +51,7 @@ import com.google.refine.model.Project;
 import com.google.refine.model.Record;
 import com.google.refine.model.Row;
 
+@Internal(since = "3.9")
 public class ScatterplotDrawingRowVisitor implements RowVisitor, RecordVisitor {
 
     int col_x;

--- a/modules/core/src/main/java/com/google/refine/browsing/util/ExpressionTimeValueBinner.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/util/ExpressionTimeValueBinner.java
@@ -37,6 +37,7 @@ import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.Properties;
 
+import com.google.refine.annotations.Internal;
 import com.google.refine.browsing.RecordVisitor;
 import com.google.refine.browsing.RowVisitor;
 import com.google.refine.expr.ExpressionUtils;
@@ -47,6 +48,7 @@ import com.google.refine.model.Row;
 /**
  * Visit matched rows or records and slot them into bins based on the date computed from a given expression.
  */
+@Internal(since = "3.9")
 public class ExpressionTimeValueBinner implements RowVisitor, RecordVisitor {
 
     /*

--- a/modules/core/src/main/java/com/google/refine/browsing/util/TimeBinIndex.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/util/TimeBinIndex.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
+import com.google.refine.annotations.Internal;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
@@ -51,6 +52,7 @@ import com.google.refine.model.Row;
  * This class processes all rows rather than just the filtered rows because it needs to compute the base bins of a
  * temporal range facet, which remain unchanged as the user interacts with the facet.
  */
+@Internal(since = "3.9")
 abstract public class TimeBinIndex {
 
     protected int _totalValueCount;

--- a/modules/core/src/main/java/com/google/refine/browsing/util/TimeBinRecordIndex.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/util/TimeBinRecordIndex.java
@@ -36,11 +36,13 @@ package com.google.refine.browsing.util;
 import java.util.List;
 import java.util.Properties;
 
+import com.google.refine.annotations.Internal;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Project;
 import com.google.refine.model.Record;
 import com.google.refine.model.Row;
 
+@Internal(since = "3.9")
 public class TimeBinRecordIndex extends TimeBinIndex {
 
     public TimeBinRecordIndex(Project project, RowEvaluable rowEvaluable) {

--- a/modules/core/src/main/java/com/google/refine/browsing/util/TimeBinRowIndex.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/util/TimeBinRowIndex.java
@@ -36,10 +36,12 @@ package com.google.refine.browsing.util;
 import java.util.List;
 import java.util.Properties;
 
+import com.google.refine.annotations.Internal;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 
+@Internal(since = "3.9")
 public class TimeBinRowIndex extends TimeBinIndex {
 
     public TimeBinRowIndex(Project project, RowEvaluable rowEvaluable) {


### PR DESCRIPTION
To mark things that are technically public but shouldn't be used outside of OpenRefine, in particular not by extensions, this PR proposes to use an annotation and adds it on a few classes to demonstrate how I would expect we use it. It's by no means exhaustive, and I expect marking a particular class as internal will often spark a debate.

It's meant to be sort of band-aid for the problem that Java encapsulation doesn't let us align class and method visibilities to match their expected stability, at least not without changing the package structure (as discussed in #6555 and #6899). It's meant to be similar to `@Deprecated`, except that it's only deprecated outside our code base. After an element has been marked as internal for a while, we should feel empowered to change it, remove it, or move it to a different package so that it can properly be package-private.

It would ideally be better to use a standard annotation for this (as it would make some sort of IDE support more likely), but I am not aware of any.