### PR TITLE
core: Introduce getSource() and getLanguagePrefix() on Evaluable

### DIFF
--- a/extensions/jython/tests/src/com/google/refine/jython/JythonEvaluableTest.java
+++ b/extensions/jython/tests/src/com/google/refine/jython/JythonEvaluableTest.java
@@ -1,6 +1,8 @@
 
 package com.google.refine.jython;
 
+import static org.testng.Assert.assertEquals;
+
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Properties;
@@ -132,5 +134,13 @@ public class JythonEvaluableTest {
         result = evaluable.evaluate(bindings);
         Assert.assertEquals(result, "foo");
 
+    }
+
+    @Test
+    public void testGetters() {
+        Evaluable evaluable = new JythonEvaluable("return (1,2)");
+
+        assertEquals(evaluable.getSource(), "return (1,2)");
+        assertEquals(evaluable.getLanguagePrefix(), "jython");
     }
 }

--- a/main/src/com/google/refine/expr/ClojureParser.java
+++ b/main/src/com/google/refine/expr/ClojureParser.java
@@ -45,12 +45,12 @@ import clojure.lang.RT;
 public class ClojureParser implements LanguageSpecificParser {
 
     @Override
-    public Evaluable parse(String s) throws ParsingException {
+    public Evaluable parse(String source, String languagePrefix) throws ParsingException {
         try {
 //                    RT.load("clojure/core"); // Make sure RT is initialized
             Object foo = RT.CURRENT_NS; // Make sure RT is initialized
             IFn fn = (IFn) clojure.lang.Compiler.load(new StringReader(
-                    "(fn [value cell cells row rowIndex] " + s + ")"));
+                    "(fn [value cell cells row rowIndex] " + source + ")"));
 
             // TODO: We should to switch from using Compiler.load
             // because it's technically an internal interface
@@ -79,6 +79,16 @@ public class ClojureParser implements LanguageSpecificParser {
                     } catch (Exception e) {
                         return new EvalError(e.getMessage());
                     }
+                }
+
+                @Override
+                public String getSource() {
+                    return source;
+                }
+
+                @Override
+                public String getLanguagePrefix() {
+                    return languagePrefix;
                 }
             }.init(fn);
         } catch (Exception e) {

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/TextSearchFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/TextSearchFacet.java
@@ -45,6 +45,7 @@ import com.google.refine.browsing.RowFilter;
 import com.google.refine.browsing.filters.AnyRowRecordFilter;
 import com.google.refine.browsing.filters.ExpressionStringComparisonRowFilter;
 import com.google.refine.expr.Evaluable;
+import com.google.refine.expr.MetaParser;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
 import com.google.refine.util.PatternSyntaxExceptionParser;
@@ -161,6 +162,16 @@ public class TextSearchFacet implements Facet {
             @Override
             public Object evaluate(Properties bindings) {
                 return bindings.get("value");
+            }
+
+            @Override
+            public String getSource() {
+                return "value";
+            }
+
+            @Override
+            public String getLanguagePrefix() {
+                return MetaParser.GREL_LANGUAGE_CODE;
             }
 
         };

--- a/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
+++ b/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
@@ -43,6 +43,17 @@ import java.util.Set;
 public interface Evaluable {
 
     /**
+     * The source string which generated this expression. This does not include the language prefix, which can be
+     * obtained by {@link #getLanguagePrefix()}.
+     */
+    public String getSource();
+
+    /**
+     * The language prefix used to generate this evaluable (without final colon).
+     */
+    public String getLanguagePrefix();
+
+    /**
      * Evaluate this expression in the given environment (bindings).
      * 
      * @param bindings

--- a/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
+++ b/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
@@ -37,6 +37,8 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
+import com.google.refine.util.NotImplementedException;
+
 /**
  * Interface for evaluable expressions in any arbitrary language.
  */
@@ -45,13 +47,23 @@ public interface Evaluable {
     /**
      * The source string which generated this expression. This does not include the language prefix, which can be
      * obtained by {@link #getLanguagePrefix()}.
+     * 
+     * @throws NotImplementedException
+     *             by default (for compatibility with older extensions)
      */
-    public String getSource();
+    public default String getSource() {
+        throw new NotImplementedException();
+    }
 
     /**
      * The language prefix used to generate this evaluable (without final colon).
+     * 
+     * @throws NotImplementedException
+     *             by default (for compatibility with older extensions)
      */
-    public String getLanguagePrefix();
+    public default String getLanguagePrefix() {
+        throw new NotImplementedException();
+    }
 
     /**
      * Evaluate this expression in the given environment (bindings).

--- a/modules/core/src/main/java/com/google/refine/expr/LanguageSpecificParser.java
+++ b/modules/core/src/main/java/com/google/refine/expr/LanguageSpecificParser.java
@@ -33,7 +33,34 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.expr;
 
+import org.apache.commons.lang3.NotImplementedException;
+
+/**
+ * A parser for an expression language. It is registered in {@link MetaParser} with a language prefix to identify it.
+ */
 public interface LanguageSpecificParser {
 
-    public Evaluable parse(String s) throws ParsingException;
+    /**
+     * @deprecated in favor of {@link #parse(String, String)}, which is the one implementations should override
+     */
+    @Deprecated(since = "3.9")
+    public default Evaluable parse(String source) throws ParsingException {
+        throw new NotImplementedException("The method parse(String source, String languagePrefix) should be overridden");
+    }
+
+    /**
+     * Parse an expression.
+     * 
+     * @param source
+     *            the source to be parsed
+     * @param languagePrefix
+     *            the prefix which identifies the language (which is the identifier with which this
+     *            {@link LanguageSpecificParser} was registered)
+     * @return a parsed expression
+     * @throws ParsingException
+     *             when the source contains any syntax error
+     */
+    default public Evaluable parse(String source, String languagePrefix) throws ParsingException {
+        return parse(source);
+    }
 }

--- a/modules/core/src/main/java/com/google/refine/expr/MetaParser.java
+++ b/modules/core/src/main/java/com/google/refine/expr/MetaParser.java
@@ -58,6 +58,7 @@ abstract public class MetaParser {
         }
     }
 
+    static final public String GREL_LANGUAGE_CODE = "grel";
     static final protected Map<String, LanguageInfo> s_languages = new HashMap<String, LanguageInfo>();
 
     /**
@@ -106,23 +107,24 @@ abstract public class MetaParser {
         if (colon >= 0) {
             language = s.substring(0, colon).toLowerCase();
             if ("gel".equals(language)) {
-                language = "grel";
+                language = GREL_LANGUAGE_CODE;
             }
         }
 
-        LanguageInfo info = s_languages.get(language.toLowerCase());
+        language = language.toLowerCase();
+        LanguageInfo info = s_languages.get(language);
         if (info != null) {
-            return info.parser.parse(s.substring(colon + 1));
+            return info.parser.parse(s.substring(colon + 1), language);
         } else {
             return parseGREL(s);
         }
     }
 
     static protected Evaluable parseGREL(String s) throws ParsingException {
-        LanguageInfo info = s_languages.get("grel");
+        LanguageInfo info = s_languages.get(GREL_LANGUAGE_CODE);
         if (info == null) {
             throw new ParsingException("Default language GREL is not available");
         }
-        return info.parser.parse(s);
+        return info.parser.parse(s, GREL_LANGUAGE_CODE);
     }
 }

--- a/modules/core/src/test/java/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
+++ b/modules/core/src/test/java/com/google/refine/browsing/util/ExpressionNominalValueGrouperTests.java
@@ -72,6 +72,16 @@ public class ExpressionNominalValueGrouperTests extends RefineTest {
             return bindings.get("value");
         }
 
+        @Override
+        public String getSource() {
+            return "value";
+        }
+
+        @Override
+        public String getLanguagePrefix() {
+            return "grel";
+        }
+
     };
     private static final int cellIndex = 0;
     private static final String columnName = "Col1";

--- a/modules/grel/src/main/java/com/google/refine/grel/Parser.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/Parser.java
@@ -57,7 +57,7 @@ public class Parser {
     static public LanguageSpecificParser grelParser = new LanguageSpecificParser() {
 
         @Override
-        public Evaluable parse(String source) throws ParsingException {
+        public Evaluable parse(String source, String languagePrefix) throws ParsingException {
             Parser parser = new Parser(source);
             return parser.getExpression();
         }

--- a/modules/grel/src/main/java/com/google/refine/grel/Parser.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/Parser.java
@@ -40,11 +40,12 @@ import java.util.regex.Pattern;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.LanguageSpecificParser;
 import com.google.refine.expr.ParsingException;
-import com.google.refine.expr.functions.arrays.ArgsToArray;
 import com.google.refine.grel.Scanner.NumberToken;
 import com.google.refine.grel.Scanner.RegexToken;
 import com.google.refine.grel.Scanner.Token;
 import com.google.refine.grel.Scanner.TokenType;
+import com.google.refine.grel.ast.ArrayExpr;
+import com.google.refine.grel.ast.BracketedExpr;
 import com.google.refine.grel.ast.ControlCallExpr;
 import com.google.refine.grel.ast.FieldAccessorExpr;
 import com.google.refine.grel.ast.FunctionCallExpr;
@@ -233,15 +234,15 @@ public class Parser {
                     if (errorMessage != null) {
                         throw makeException(errorMessage);
                     }
-                    eval = new ControlCallExpr(argsA, c);
+                    eval = new ControlCallExpr(argsA, c, text);
                 } else {
-                    eval = new FunctionCallExpr(makeArray(args), f);
+                    eval = new FunctionCallExpr(makeArray(args), f, text, false);
                 }
             }
         } else if (_token.type == TokenType.Delimiter && _token.text.equals("(")) {
             next(true);
 
-            eval = parseExpression();
+            eval = new BracketedExpr(parseExpression());
 
             if (_token != null && _token.type == TokenType.Delimiter && _token.text.equals(")")) {
                 next(false);
@@ -253,7 +254,7 @@ public class Parser {
 
             List<Evaluable> args = parseExpressionList("]");
 
-            eval = new FunctionCallExpr(makeArray(args), new ArgsToArray());
+            eval = new ArrayExpr(makeArray(args));
         } else {
             throw makeException("Missing number, string, identifier, regex, or parenthesized expression");
         }
@@ -282,7 +283,7 @@ public class Parser {
                     List<Evaluable> args = parseExpressionList(")");
                     args.add(0, eval);
 
-                    eval = new FunctionCallExpr(makeArray(args), f);
+                    eval = new FunctionCallExpr(makeArray(args), f, identifier, true);
                 } else {
                     eval = new FieldAccessorExpr(eval, identifier);
                 }
@@ -292,7 +293,7 @@ public class Parser {
                 List<Evaluable> args = parseExpressionList("]");
                 args.add(0, eval);
 
-                eval = new FunctionCallExpr(makeArray(args), ControlFunctionRegistry.getFunction("get"));
+                eval = new FunctionCallExpr(makeArray(args), ControlFunctionRegistry.getFunction("get"), "get", true);
             } else {
                 break;
             }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/ArrayExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/ArrayExpr.java
@@ -1,0 +1,47 @@
+
+package com.google.refine.grel.ast;
+
+import com.google.refine.expr.Evaluable;
+import com.google.refine.expr.functions.arrays.ArgsToArray;
+import com.google.refine.grel.Function;
+
+/**
+ * Node for an expression which introduces an array explicitly, with square brackets.
+ */
+public class ArrayExpr extends FunctionCallExpr {
+
+    private final static Function argsToArray = new ArgsToArray();
+
+    /**
+     * @param elements
+     *            the elements of the array
+     */
+    public ArrayExpr(Evaluable[] elements) {
+        super(elements, argsToArray, "argsToArray", false);
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+
+        for (Evaluable ev : _args) {
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+            sb.append(ev.toString());
+        }
+
+        return "[" + sb.toString() + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj) && obj instanceof ArrayExpr;
+    }
+
+}

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/BracketedExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/BracketedExpr.java
@@ -1,0 +1,59 @@
+
+package com.google.refine.grel.ast;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+import com.google.refine.expr.Evaluable;
+
+/**
+ * An AST node which represents a bracketed expression. This is introduced to enable faithful printing of a parsed
+ * expression, avoiding operator precedence issues for instance.
+ */
+public class BracketedExpr extends GrelExpr {
+
+    protected final Evaluable inner;
+
+    /**
+     * @param inner
+     *            the expression inside the brackets
+     */
+    public BracketedExpr(Evaluable inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public Object evaluate(Properties bindings) {
+        return inner.evaluate(bindings);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
+        return inner.getColumnDependencies(baseColumn);
+    }
+
+    @Override
+    public String toString() {
+        return "(" + inner + ")";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(inner);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        BracketedExpr other = (BracketedExpr) obj;
+        return Objects.equals(inner, other.inner);
+    }
+
+}

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
@@ -45,7 +45,7 @@ import com.google.refine.grel.Control;
 /**
  * An abstract syntax tree node encapsulating a control call, such as "if".
  */
-public class ControlCallExpr implements Evaluable {
+public class ControlCallExpr extends GrelExpr {
 
     final protected Evaluable[] _args;
     final protected Control _control;
@@ -90,4 +90,5 @@ public class ControlCallExpr implements Evaluable {
 
         return _control.getClass().getSimpleName() + "(" + sb.toString() + ")";
     }
+
 }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
@@ -33,7 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.grel.ast;
 
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -49,10 +51,30 @@ public class ControlCallExpr extends GrelExpr {
 
     final protected Evaluable[] _args;
     final protected Control _control;
+    final protected String _controlName;
 
+    /**
+     * @deprecated use the version that supplies the name under which the control was invoked
+     */
+    @Deprecated
     public ControlCallExpr(Evaluable[] args, Control c) {
         _args = args;
         _control = c;
+        _controlName = _control.getClass().getSimpleName();
+    }
+
+    /**
+     * @param args
+     *            the arguments of the control
+     * @param c
+     *            the control itself
+     * @param controlName
+     *            the name with which the control was referred to
+     */
+    public ControlCallExpr(Evaluable[] args, Control c, String controlName) {
+        _args = args;
+        _control = c;
+        _controlName = controlName;
     }
 
     @Override
@@ -88,7 +110,29 @@ public class ControlCallExpr extends GrelExpr {
             sb.append(ev.toString());
         }
 
-        return _control.getClass().getSimpleName() + "(" + sb.toString() + ")";
+        return _controlName + "(" + sb.toString() + ")";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(_args);
+        result = prime * result + Objects.hash(_control, _controlName);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ControlCallExpr other = (ControlCallExpr) obj;
+        return Arrays.equals(_args, other._args) && Objects.equals(_control, other._control)
+                && Objects.equals(_controlName, other._controlName);
     }
 
 }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.grel.ast;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -96,6 +97,23 @@ public class FieldAccessorExpr extends GrelExpr {
     @Override
     public String toString() {
         return _inner.toString() + "." + _fieldName;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_fieldName, _inner);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        FieldAccessorExpr other = (FieldAccessorExpr) obj;
+        return Objects.equals(_fieldName, other._fieldName) && Objects.equals(_inner, other._inner);
     }
 
 }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
@@ -50,7 +50,7 @@ import com.google.refine.expr.util.JsonValueConverter;
  * An abstract syntax tree node encapsulating a field accessor, e.g., "cell.value" is accessing the field named "value"
  * on the variable called "cell".
  */
-public class FieldAccessorExpr implements Evaluable {
+public class FieldAccessorExpr extends GrelExpr {
 
     final protected Evaluable _inner;
     final protected String _fieldName;
@@ -97,4 +97,5 @@ public class FieldAccessorExpr implements Evaluable {
     public String toString() {
         return _inner.toString() + "." + _fieldName;
     }
+
 }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FunctionCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FunctionCallExpr.java
@@ -50,7 +50,7 @@ import com.google.refine.grel.Function;
  * before the function is applied. If any argument is an error, the function is not applied, and the error is the result
  * of the expression.
  */
-public class FunctionCallExpr implements Evaluable {
+public class FunctionCallExpr extends GrelExpr {
 
     final protected Evaluable[] _args;
     final protected Function _function;
@@ -111,4 +111,5 @@ public class FunctionCallExpr implements Evaluable {
 
         return _function.getClass().getSimpleName() + "(" + sb.toString() + ")";
     }
+
 }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/GrelExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/GrelExpr.java
@@ -1,0 +1,18 @@
+
+package com.google.refine.grel.ast;
+
+import com.google.refine.expr.Evaluable;
+import com.google.refine.expr.MetaParser;
+
+abstract class GrelExpr implements Evaluable {
+
+    @Override
+    public String getSource() {
+        return toString();
+    }
+
+    @Override
+    public String getLanguagePrefix() {
+        return MetaParser.GREL_LANGUAGE_CODE;
+    }
+}

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
@@ -40,12 +40,10 @@ import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 
-import com.google.refine.expr.Evaluable;
-
 /**
  * An abstract syntax tree node encapsulating a literal value.
  */
-public class LiteralExpr implements Evaluable {
+public class LiteralExpr extends GrelExpr {
 
     final protected Object _value;
 

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.grel.ast;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -64,5 +65,22 @@ public class LiteralExpr extends GrelExpr {
     @Override
     public String toString() {
         return _value instanceof String ? new TextNode((String) _value).toString() : _value.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(_value);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        LiteralExpr other = (LiteralExpr) obj;
+        return Objects.equals(_value, other._value);
     }
 }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
@@ -34,7 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.grel.ast;
 
 import java.text.Collator;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -235,5 +237,26 @@ public class OperatorCallExpr extends GrelExpr {
 
     private boolean isIntegral(Object n) {
         return n instanceof Long || n instanceof Integer;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Arrays.hashCode(_args);
+        result = prime * result + Objects.hash(_op);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        OperatorCallExpr other = (OperatorCallExpr) obj;
+        return Arrays.equals(_args, other._args) && Objects.equals(_op, other._op);
     }
 }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
@@ -45,7 +45,7 @@ import com.google.refine.expr.ExpressionUtils;
 /**
  * An abstract syntax tree node encapsulating an operator call, such as "+".
  */
-public class OperatorCallExpr implements Evaluable {
+public class OperatorCallExpr extends GrelExpr {
 
     final protected Evaluable[] _args;
     final protected String _op;

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/VariableExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/VariableExpr.java
@@ -38,12 +38,10 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
-import com.google.refine.expr.Evaluable;
-
 /**
  * An abstract syntax tree node encapsulating the retrieval of a variable's content.
  */
-public class VariableExpr implements Evaluable {
+public class VariableExpr extends GrelExpr {
 
     final protected String _name;
 
@@ -88,4 +86,5 @@ public class VariableExpr implements Evaluable {
     public int hashCode() {
         return _name.hashCode();
     }
+
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
@@ -273,4 +273,12 @@ public class GrelTests extends GrelTestBase {
                     "Parsing error at offset 14: Missing number, string, identifier, regex, or parenthesized expression");
         }
     }
+
+    @Test
+    public void testGetters() throws ParsingException {
+        Evaluable evaluable = MetaParser.parse("grel:value + \" foo\"");
+
+        Assert.assertEquals(evaluable.getSource(), "value + \" foo\"");
+        Assert.assertEquals(evaluable.getLanguagePrefix(), "grel");
+    }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
@@ -261,6 +261,34 @@ public class GrelTests extends GrelTestBase {
         }
     }
 
+    @Test
+    public void testGetSource() throws ParsingException {
+        // integration test for getSource()
+        String tests[][] = {
+                { "value", "value" },
+                { "cell.recon.match.id", "cell.recon.match.id" },
+                { "value + 'a'", "value + \"a\"" },
+                { "\"foo\"", "\"foo\"" },
+                { "'\"'", "\"\\\"\"" }, // TODO we could print the string with the original quotes to avoid the escaping
+                { "1", "1" },
+                { "4 * (5 + 6)", "4 * (5 + 6)" },
+                { "cells.foo", "cells.foo" },
+                { "value + ' ' + cells.foo.value", "value + \" \" + cells.foo.value" },
+                { "cells[\"foo\"].value", "cells.get(\"foo\").value" }, // TODO this could be more faithful
+                { "toDate( value+4 )", "toDate(value + 4)" },
+                { "(value + 4).toDate()", "(value + 4).toDate()" },
+                { "forEach([3, 4,8,7], v, mod(v,2))", "forEach([3, 4, 8, 7], v, mod(v, 2))" },
+        };
+        for (String[] test : tests) {
+            Evaluable eval = MetaParser.parse("grel:" + test[0]);
+            Assert.assertEquals(eval.getSource(), test[1], "for expression: " + test[0]);
+
+            // check that the produced source can still be parsed
+            Evaluable reparsed = MetaParser.parse(eval.getSource());
+            Assert.assertEquals(reparsed, eval);
+        }
+    }
+
     // Test for /\ throwing Internal Error
     @Test
     public void testRegex() {

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ArrayExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ArrayExprTest.java
@@ -1,0 +1,28 @@
+
+package com.google.refine.grel.ast;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.Evaluable;
+
+public class ArrayExprTest extends ExprTestBase {
+
+    @Test
+    public void testSource() {
+        Evaluable ev = new ArrayExpr(new Evaluable[] { constant, currentColumn, twoColumns });
+        when(constant.toString()).thenReturn("a");
+        when(currentColumn.toString()).thenReturn("b");
+        when(twoColumns.toString()).thenReturn("c");
+
+        assertEquals(ev.getSource(), "[a, b, c]");
+    }
+
+    @Test
+    public void testColumnDependencies() {
+        Evaluable ev = new ArrayExpr(new Evaluable[] { constant, currentColumn, twoColumns });
+        assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
+    }
+}

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/BracketedExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/BracketedExprTest.java
@@ -1,0 +1,26 @@
+
+package com.google.refine.grel.ast;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+public class BracketedExprTest extends ExprTestBase {
+
+    @Test
+    public void testGetSource() {
+        when(constant.toString()).thenReturn("'foo'");
+        assertEquals(new BracketedExpr(constant).toString(), "('foo')");
+    }
+
+    @Test
+    public void testGetColumnDependencies() {
+        assertEquals(new BracketedExpr(constant).getColumnDependencies(baseColumn), Optional.of(Set.of()));
+        assertEquals(new BracketedExpr(currentColumn).getColumnDependencies(baseColumn), Optional.of(Set.of("baseColumn")));
+    }
+
+}

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ControlCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ControlCallExprTest.java
@@ -22,20 +22,26 @@ public class ControlCallExprTest extends ExprTestBase {
     }
 
     @Test
+    public void testSource() {
+        Evaluable e = new ControlCallExpr(new Evaluable[] {}, control, "myControl");
+        assertEquals(e.getSource(), "myControl()");
+    }
+
+    @Test
     public void testConstant() {
-        Evaluable c = new ControlCallExpr(new Evaluable[] { constant }, control);
+        Evaluable c = new ControlCallExpr(new Evaluable[] { constant }, control, "myControl");
         assertEquals(c.getColumnDependencies(baseColumn), set());
     }
 
     @Test
     public void testUnion() {
-        Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, currentColumn }, control);
+        Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, currentColumn }, control, "myControl");
         assertEquals(c.getColumnDependencies(baseColumn), set("a", "b", "baseColumn"));
     }
 
     @Test
     public void testUnanalyzable() {
-        Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, unanalyzable }, control);
+        Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, unanalyzable }, control, "myControl");
         assertEquals(c.getColumnDependencies(baseColumn), Optional.empty());
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/FunctionCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/FunctionCallExprTest.java
@@ -2,7 +2,9 @@
 package com.google.refine.grel.ast;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
 import java.util.Optional;
 
@@ -22,14 +24,39 @@ public class FunctionCallExprTest extends ExprTestBase {
     }
 
     @Test
+    public void testInvalidConstruct() {
+        assertThrows(IllegalArgumentException.class, () -> new FunctionCallExpr(new Evaluable[] {}, function, "fun", true));
+    }
+
+    @Test
+    public void testSource() {
+        Evaluable ev = new FunctionCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, function, "fun", false);
+        when(constant.toString()).thenReturn("a");
+        when(currentColumn.toString()).thenReturn("b");
+        when(twoColumns.toString()).thenReturn("c");
+
+        assertEquals(ev.getSource(), "fun(a, b, c)");
+    }
+
+    @Test
+    public void testSourceInFluentStyle() {
+        Evaluable ev = new FunctionCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, function, "fun", true);
+        when(constant.toString()).thenReturn("a");
+        when(currentColumn.toString()).thenReturn("b");
+        when(twoColumns.toString()).thenReturn("c");
+
+        assertEquals(ev.getSource(), "a.fun(b, c)");
+    }
+
+    @Test
     public void testUnion() {
-        Evaluable ev = new FunctionCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, function);
+        Evaluable ev = new FunctionCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, function, "fun", false);
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
     }
 
     @Test
     public void testUnanalyzable() {
-        Evaluable ev = new FunctionCallExpr(new Evaluable[] { currentColumn, unanalyzable }, function);
+        Evaluable ev = new FunctionCallExpr(new Evaluable[] { currentColumn, unanalyzable }, function, "fun", false);
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/OperatorCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/OperatorCallExprTest.java
@@ -78,4 +78,14 @@ class MockEvaluable implements Evaluable {
     public Object evaluate(Properties bindings) {
         return value;
     }
+
+    @Override
+    public String getSource() {
+        return "src";
+    }
+
+    @Override
+    public String getLanguagePrefix() {
+        return "mock";
+    }
 }


### PR DESCRIPTION
As a preparation for introducing the ability to rewrite an `Evaluable` after a renaming of the columns it depends on, this introduces getters to enable representing the expression as text again after this rewrite.

This will in turn enable the rewrite of facet configurations and operations and their serialization in JSON (for instance for #133).