### PR TITLE
database: Re-enable test that fails in the CI

### DIFF
--- a/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
@@ -195,7 +195,7 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
         ObjectNode json = ParsingUtilities.mapper.readValue(result, ObjectNode.class);
 
         String status = json.get("status").asText();
-        System.out.println("response: " + json);
+        // System.out.println("json::" + json);
         Assert.assertEquals(status, "ok");
     }
 

--- a/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
@@ -161,8 +161,7 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
         Assert.assertEquals(status, "ok");
     }
 
-    // 2024-10-24 disabled for now as it fails in the CI (but not locally)
-    @Test(enabled = false)
+    @Test
     public void testDoPostParsePreview() throws IOException, ServletException {
 
         StringWriter sw = new StringWriter();

--- a/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/DatabaseImportControllerTest.java
@@ -195,7 +195,7 @@ public class DatabaseImportControllerTest extends DBExtensionTests {
         ObjectNode json = ParsingUtilities.mapper.readValue(result, ObjectNode.class);
 
         String status = json.get("status").asText();
-        // System.out.println("json::" + json);
+        System.out.println("response: " + json);
         Assert.assertEquals(status, "ok");
     }
 


### PR DESCRIPTION
This is a draft PR to debug the CI failure.

Eventually fixes #6935
