### PR TITLE
ui: Fix CSRF token fetching utility (and Wikibase login)

### DIFF
--- a/main/webapp/modules/core/scripts/util/csrf.js
+++ b/main/webapp/modules/core/scripts/util/csrf.js
@@ -20,11 +20,7 @@ CSRFUtil.postCSRF = function(url, data, success, dataType, failCallback) {
     return CSRFUtil.wrapCSRF(function(token) {
         var fullData = data || {};
         if (typeof fullData == 'string') {
-            if (fullData.includes('?')) {
-              fullData = fullData + "&" + $.param({csrf_token: token});
-            } else {
-              fullData = fullData + "?" + $.param({csrf_token: token});
-            }
+            fullData = fullData + "&" + $.param({csrf_token: token});
         } else {
             fullData['csrf_token'] = token;
         }


### PR DESCRIPTION
Fixes #6941

When adding CSRF protection to various new commands (for [GHSA-3jm4-c6qf-jrh3](https://github.com/OpenRefine/OpenRefine/security/advisories/GHSA-3jm4-c6qf-jrh3)), I set up the token passing by GET or POST parameter depending on the situation. Somehow this has led me to believe that the `postCSRF` utility should be adapted to append the CSRF token at the end of a URL with a `?` separator if it does not have any GET parameters yet. But in fact this method is exclusively used with POST and the string in question is never a full URL but the contents of the POST body, where no `?` is expected, so this was a mistake. The passing of CSRF tokens by GET is done by using `wrapCSRF` directly.