### PR TITLE
csrf: Fix callback wiring-up for templating exporter

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/templating-exporter-dialog.js
@@ -144,12 +144,13 @@ TemplatingExporterDialog.prototype._updatePreview = function() {
         function (data) {
             self._elmts.previewTextarea[0].value = data;
         },
-        "text"
-    ).fail(function (jqXhr, textStatus, errorMessage) {
-        if (jqXhr.status === 500) {
+        "text",
+        function (jqXhr, textStatus, errorMessage) {
+          if (jqXhr.status === 500) {
             self._elmts.previewTextarea[0].value = $.i18n('core-dialogs/missing-bad-template');
+          }
         }
-    });
+    );
 };
 
 TemplatingExporterDialog.prototype._export = function(csrfToken) {

--- a/main/webapp/modules/core/scripts/util/csrf.js
+++ b/main/webapp/modules/core/scripts/util/csrf.js
@@ -3,7 +3,7 @@ CSRFUtil = {};
 // Requests a CSRF token and calls the supplied callback
 // with the token
 CSRFUtil.wrapCSRF = function(onCSRF) {
-    return $.get(
+    $.get(
         "command/core/get-csrf-token",
         {},
         function(response) {
@@ -17,7 +17,7 @@ CSRFUtil.wrapCSRF = function(onCSRF) {
 // is supplied in the POST data. The arguments match those
 // of $.post().
 CSRFUtil.postCSRF = function(url, data, success, dataType, failCallback) {
-    return CSRFUtil.wrapCSRF(function(token) {
+    CSRFUtil.wrapCSRF(function(token) {
         var fullData = data || {};
         if (typeof fullData == 'string') {
             if (fullData.includes('?')) {


### PR DESCRIPTION
Follow-up to 090924c.

When writing 090924c, I thought it could be useful to return the jQuery request object created in the `wrapCSRF` utility so that it could be used for further chaining, such as adding error handling with the `.fail(…)` method.
That was a bad idea since this would bind the failure callback to the request that fetches a new CSRF token, not the one that actually does the POST request for which the token is fetched. Instead, the failure callback should be passed to the `postCSRF` / `wrapCSRF` method as last argument. I have reviewed all the places where those are used and made sure we don't rely on the return value.