### PR TITLE
Fix flakyness for some Facet tests

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
@@ -12,7 +12,11 @@ const clickFacetAction = (facetType, text, action) => {
   cy.getFacetContainer(facetType)
     .contains(text)
     .parent()
-    .invoke('trigger', 'mouseenter') // include/exclude not visible until we mouse over
+    .invoke('trigger', 'mouseenter'); // include/exclude not visible until we mouse over
+  // start a new chain after the trigger
+  cy.getFacetContainer(facetType)
+    .contains(text)
+    .siblings()
     .get(".facet-choice-toggle")
     .contains(action)
     .should('have.css', 'visibility', 'visible') // partially occluded, so "be.visible" won't work

--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
@@ -12,12 +12,10 @@ const clickFacetAction = (facetType, text, action) => {
   cy.getFacetContainer(facetType)
     .contains(text)
     .parent()
-    // TODO: Ideally, we'd like to use the native event handlers rather than forcing things
-    // .trigger("mouseenter") // this doesn't appear to have any affect
+    .invoke('trigger', 'mouseenter') // include/exclude not visible until we mouse over
     .get(".facet-choice-toggle")
     .contains(action)
-    .invoke('css', 'visibility', 'visible') // force visibility
-    .should('have.css', 'visibility', 'visible')
+    .should('have.css', 'visibility', 'visible') // partially occluded, so "be.visible" won't work
     .click();
 };
 


### PR DESCRIPTION
Fixes #6940 
- Mimics correct user behavior with using mouse to hover over a facet choice and then edit|include appear
- Previous method used `invoke()` to forceably change css style, instead of correctly triggering jQuery list-facet.js events `mouseenter mouseleave` that will automatically handle visibility, as seen in our code snippet below.  So this improves testing the HTML as well as our JavaScript.
https://github.com/OpenRefine/OpenRefine/blob/dac141c2049e651ff63ac339639add5b7e02ba51/main/webapp/modules/core/scripts/facets/list-facet.js#L484-L490

 Reference: https://github.com/cypress-io/cypress-example-recipes/blob/a2e24d19ec70c3fa8ae6a4a47574a239fc32c3e7/examples/testing-dom__hover-hidden-elements/cypress/e2e/hover-hidden-elements-spec.cy.js#L68


