### PR TITLE
Allow uploading new file versions

### DIFF
--- a/extensions/wikibase/module/langs/translation-en.json
+++ b/extensions/wikibase/module/langs/translation-en.json
@@ -288,6 +288,8 @@
     "warnings-messages/duplicate-file-names-in-batch/body": "The file names provided for the new media files should all be distinct. Some file names, such as <span class=\"wb-issue-preformat\">{example_filename}</span>, are used for more than one file.",
     "warnings-messages/file-names-already-exist-on-wiki/title": "Naming conflict between new and existing files on the wiki",
     "warnings-messages/file-names-already-exist-on-wiki/body": "The file names provided for the new media files should be distinct from any existing file names on the wiki. This is not the case for <span class=\"wb-issue-preformat\">{example_filename}</span>.",
+    "warnings-messages/upload-new-file-version/title": "Uploading new file version",
+    "warnings-messages/upload-new-file-version/body": "Some files, such as <span class=\"wb-issue-preformat\">{example_filename}</span>, have been matched to existing files. This will upload new versions of those files.",
     "warnings-messages/invalid-characters-in-file-name/title": "Invalid characters in file names",
     "warnings-messages/invalid-characters-in-file-name/body": "Filenames such as <span class=\"wb-issue-preformat\">{example_filename}</span> contain the character <span class=\"wb-issue-preformat\">{invalid_character}</span> which cannot be part of file names in a wiki.",
     "warnings-messages/file-name-too-long/title": "File names exceeding the maximum length",

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
@@ -218,14 +218,19 @@ public class EditBatchProcessor {
                 // custom code for handling our custom updates to mediainfo, which cover editing more than Wikibase
                 if (entityUpdate instanceof FullMediaInfoUpdate) {
                     FullMediaInfoUpdate fullMediaInfoUpdate = (FullMediaInfoUpdate) entityUpdate;
+                    MediaFileUtils mediaFileUtils = new MediaFileUtils(connection);
+
+                    if (fullMediaInfoUpdate.getFilePath() != null) {
+                        ((MediaInfoEdit) update).uploadFile(mediaFileUtils, summary, tags, filePageWaitTime,
+                                filePageMaxWaitTime);
+                    }
+
                     if (fullMediaInfoUpdate.isOverridingWikitext() && fullMediaInfoUpdate.getWikitext() != null) {
-                        MediaFileUtils mediaFileUtils = new MediaFileUtils(connection);
                         long pageId = Long.parseLong(fullMediaInfoUpdate.getEntityId().getId().substring(1));
                         long revisionId = mediaFileUtils.editPage(pageId, fullMediaInfoUpdate.getWikitext(), summary, tags);
                         lastRevisionId = OptionalLong.of(revisionId);
                     } else {
                         // manually purge the wikitext page associated with this mediainfo
-                        MediaFileUtils mediaFileUtils = new MediaFileUtils(connection);
                         mediaFileUtils.purgePage(Long.parseLong(entityUpdate.getEntityId().getId().substring(1)));
                     }
                 }

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
@@ -344,6 +344,14 @@ public class MediaFileUtils {
                     throw new IOException("The server did not return an 'upload' field in the JSON response.");
                 }
                 MediaUploadResponse response = ParsingUtilities.mapper.treeToValue(uploadNode, MediaUploadResponse.class);
+                if (response.hasAllowedWarnings()) {
+                    logger.info("Ignoring warnings: " + response.warnings);
+                    Map<String, String> ignoreWarningParameters = new HashMap<>();
+                    ignoreWarningParameters.putAll(parameters);
+                    ignoreWarningParameters.put("ignorewarnings", "1");
+                    return uploadFile(ignoreWarningParameters, files);
+                }
+
                 // todo check for errors which should be retried
                 return response;
             } catch (TokenErrorException e) {
@@ -444,6 +452,27 @@ public class MediaFileUtils {
                 }
             }
             return mid;
+        }
+
+        /**
+         * Checks if warnings are allowed for the purpose of uploading a new version of the file. If there are any
+         * warnings they must all be allowed.
+         *
+         * @return
+         */
+        public boolean hasAllowedWarnings() {
+
+            if ("Success".equals(result)) {
+                return false;
+            }
+
+            if (warnings == null) {
+                return false;
+            }
+
+            Set<String> warningCodes = warnings.keySet();
+            Set<String> allowedWarnings = Set.of("exists", "duplicateversions");
+            return allowedWarnings.containsAll(warningCodes);
         }
     }
 

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
@@ -346,10 +346,12 @@ public class MediaFileUtils {
                 MediaUploadResponse response = ParsingUtilities.mapper.treeToValue(uploadNode, MediaUploadResponse.class);
                 if (response.hasAllowedWarnings()) {
                     logger.info("Ignoring warnings: " + response.warnings);
-                    Map<String, String> ignoreWarningParameters = new HashMap<>();
-                    ignoreWarningParameters.putAll(parameters);
-                    ignoreWarningParameters.put("ignorewarnings", "1");
-                    return uploadFile(ignoreWarningParameters, files);
+                    Map<String, String> ignoreWarningsParameters = new HashMap<>();
+                    ignoreWarningsParameters.putAll(parameters);
+                    ignoreWarningsParameters.put("ignorewarnings", "1");
+                    ignoreWarningsParameters.remove("url");
+                    ignoreWarningsParameters.put("filekey", response.filekey);
+                    return uploadFile(ignoreWarningsParameters, null);
                 }
 
                 // todo check for errors which should be retried

--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
@@ -26,12 +26,14 @@ public class FileNameScrutinizer extends EditScrutinizer {
 
     public static final String duplicateFileNamesInBatchType = "duplicate-file-names-in-batch";
     public static final String fileNamesAlreadyExistOnWikiType = "file-names-already-exist-on-wiki";
+    public static final String uploadNewFileVersionType = "upload-new-file-version";
     public static final String invalidCharactersInFileNameType = "invalid-characters-in-file-name";
     public static final String fileNameTooLongType = "file-name-too-long";
     public static final String missingFileNameExtensionType = "missing-file-name-extension";
     public static final String inconsistentFileNameAndPathExtensionType = "inconsistent-file-name-and-path-extension";
 
     protected Set<String> seenFileNames;
+    protected Set<String> matchedFileNames;
 
     @Override
     public boolean prepareDependencies() {
@@ -46,6 +48,7 @@ public class FileNameScrutinizer extends EditScrutinizer {
     @Override
     public void batchIsBeginning() {
         seenFileNames = new HashSet<>();
+        matchedFileNames = new HashSet<>();
     }
 
     /**
@@ -65,6 +68,16 @@ public class FileNameScrutinizer extends EditScrutinizer {
         if (fileName == null || fileName.isEmpty()) {
             // empty file names for new items are handled in NewEntityScrutinizer
             return;
+        }
+
+        if (edit.isMatched() && !edit.getFilePath().isEmpty()) {
+            String normalizedFileName = normalizeFileNameSpaces(fileName);
+            matchedFileNames.add(normalizedFileName);
+            QAWarning issue = new QAWarning(uploadNewFileVersionType, null,
+                    QAWarning.Severity.INFO, matchedFileNames.size());
+            issue.setProperty("example_filename", matchedFileNames.stream().findFirst().get());
+            issue.setFacetable(false);
+            addIssue(issue);
         }
 
         if (edit.isNew()) {

--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
@@ -76,7 +76,6 @@ public class FileNameScrutinizer extends EditScrutinizer {
             QAWarning issue = new QAWarning(uploadNewFileVersionType, null,
                     QAWarning.Severity.INFO, matchedFileNames.size());
             issue.setProperty("example_filename", matchedFileNames.stream().findFirst().get());
-            issue.setFacetable(false);
             addIssue(issue);
         }
 

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
@@ -303,10 +303,6 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
      *            the edit summary
      * @param tags
      *            the tags to apply to both edits
-     * @param filePageWaitTime
-     *            initial time to wait between checking if the page exists
-     * @param filePageMaxWaitTime
-     *            maximum time to wait between checking if the page exists
      * @return the id of the created entity
      * @throws MediaWikiApiErrorException
      * @throws IOException

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jsoup.helper.Validate;
 import org.slf4j.Logger;
@@ -237,6 +238,40 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
             int filePageWaitTime, int filePageMaxWaitTime)
             throws MediaWikiApiErrorException, IOException, InterruptedException {
         Validate.isTrue(isNew());
+        MediaUploadResponse response = uploadFile(mediaFileUtils, summary, tags, filePageWaitTime, filePageMaxWaitTime);
+        List<String> filenames = Collections.singletonList(fileName);
+        logger.info("Checking if file page has been created.");
+        int waitTime = filePageWaitTime;
+        while (mediaFileUtils.checkIfPageNamesExist(filenames).isEmpty()) {
+            logger.debug("No file page yet, waiting " + waitTime / 1000.0 + " s to check again");
+            Thread.sleep(waitTime);
+            waitTime = Math.min(waitTime + filePageWaitTime, filePageMaxWaitTime);
+        }
+        MediaInfoIdValue mid = uploadSdc(editor, mediaFileUtils, summary, tags, response);
+
+        return mid;
+    }
+
+    /**
+     * Upload a file.
+     * 
+     * @param mediaFileUtils
+     *            the {@link MediaFileUtils} to use
+     * @param summary
+     *            the edit summary
+     * @param tags
+     *            the tags to apply to both edits
+     * @param filePageWaitTime
+     *            initial time to wait between checking if the page exists
+     * @param filePageMaxWaitTime
+     *            maximum time to wait between checking if the page exists
+     * @return response from the upload request
+     * @throws MediaWikiApiErrorException
+     * @throws IOException
+     */
+    public MediaUploadResponse uploadFile(MediaFileUtils mediaFileUtils, String summary, List<String> tags,
+            int filePageWaitTime, int filePageMaxWaitTime)
+            throws MediaWikiApiErrorException, IOException {
         // Temporary addition of the category (should be configurable)
         String wikitext = this.wikitext;
         if (!wikitext.contains("[[Category:Uploaded with OpenRefine]]")) {
@@ -254,16 +289,30 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
         }
 
         response.checkForErrors();
+        return response;
+    }
 
-        List<String> filenames = Collections.singletonList(fileName);
-        logger.info("Checking if file page has been created.");
-        int waitTime = filePageWaitTime;
-        while (mediaFileUtils.checkIfPageNamesExist(filenames).isEmpty()) {
-            logger.debug("No file page yet, waiting " + waitTime / 1000.0 + " s to check again");
-            Thread.sleep(waitTime);
-            waitTime = Math.min(waitTime + filePageWaitTime, filePageMaxWaitTime);
-        }
-
+    /**
+     * Upload file metadata.
+     * 
+     * @param editor
+     *            the {@link WikibaseDataEditor} to use
+     * @param mediaFileUtils
+     *            the {@link MediaFileUtils} to use
+     * @param summary
+     *            the edit summary
+     * @param tags
+     *            the tags to apply to both edits
+     * @param filePageWaitTime
+     *            initial time to wait between checking if the page exists
+     * @param filePageMaxWaitTime
+     *            maximum time to wait between checking if the page exists
+     * @return the id of the created entity
+     * @throws MediaWikiApiErrorException
+     * @throws IOException
+     */
+    protected MediaInfoIdValue uploadSdc(WikibaseDataEditor editor, MediaFileUtils mediaFileUtils, String summary, List<String> tags,
+            MediaUploadResponse response) throws IOException, MediaWikiApiErrorException {
         // Upload the structured data
         logger.info("Uploading SDC.");
         ReconEntityIdValue reconEntityIdValue = (ReconEntityIdValue) id;
@@ -317,6 +366,15 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
     public boolean shouldUploadInChunks() {
         File file = new File(filePath);
         return file.length() > 100000000; // 100 MB
+    }
+
+    @JsonIgnore
+    public boolean isMatched() {
+        if (!(id instanceof ReconEntityIdValue)) {
+            return false;
+        }
+
+        return ((ReconEntityIdValue) id).isMatched();
     }
 
     @Override

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
@@ -498,6 +498,57 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         verify(connection, times(1)).sendJsonRequest("POST", editParams);
     }
 
+    @Test
+    public void testNewFileVersion()
+            throws InterruptedException, MediaWikiApiErrorException, IOException {
+        MediaInfoIdValue mid = Datamodel.makeWikimediaCommonsMediaInfoIdValue("M12345");
+        MediaInfoEdit edit = new MediaInfoEditBuilder(mid)
+                .addWikitext("my new wikitext [[Category:Uploaded with OpenRefine]]")
+                .addFileName("File:My_test_file.png")
+                .addFilePath("https://my.site.com/file.png")
+                .addContributingRowId(123)
+                .build();
+        List<EntityEdit> batch = Collections.singletonList(edit);
+
+        // Plan expected edits
+        ItemDocument existingItem = ItemDocumentBuilder
+                .forItemId(TestingData.existingId)
+                .build();
+        when(fetcher.getEntityDocuments(Collections.singletonList(TestingData.existingId.getId())))
+                .thenReturn(Collections.singletonMap(TestingData.existingId.getId(), existingItem));
+
+        // mock CSRF token fetching
+        String csrfToken = "9dd28471819";
+        Map<String, String> params = new HashMap<>();
+        params.put("action", "query");
+        params.put("meta", "tokens");
+        params.put("type", "csrf");
+        when(connection.sendJsonRequest("POST", params))
+                .thenReturn(ParsingUtilities.mapper.readTree("{\"batchcomplete\":\"\",\"query\":{\"tokens\":{"
+                        + "\"csrftoken\":\"9dd28471819\"}}}"));
+        String successfulUploadResponse = "{\"upload\":{\"result\":\"Success\",\"filename\":\"My_test_file.png\",\"pageid\":12345}}";
+
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put("action", "upload");
+        parameters.put("tags", "my-tag");
+        parameters.put("comment", summary);
+        parameters.put("filename", "File:My_test_file.png");
+        parameters.put("text", "my new wikitext [[Category:Uploaded with OpenRefine]]");
+        parameters.put("token", csrfToken);
+        parameters.put("url", "https://my.site.com/file.png");
+        when(connection.sendJsonRequest("POST", parameters, Collections.emptyMap()))
+                .thenReturn(ParsingUtilities.mapper.readTree(successfulUploadResponse));
+
+        EditBatchProcessor processor = new EditBatchProcessor(fetcher, editor, connection, batch, library, summary, maxlag, tags, 50, 60);
+        assertEquals(1, processor.remainingEdits());
+        assertEquals(0, processor.progress());
+        processor.performEdit();
+        assertEquals(0, processor.remainingEdits());
+        assertEquals(100, processor.progress());
+
+        verify(connection).sendJsonRequest("POST", parameters, Collections.emptyMap());
+    }
+
     private Map<String, EntityDocument> toMap(List<ItemDocument> docs) {
         return docs.stream().collect(Collectors.toMap(doc -> doc.getEntityId().getId(), doc -> doc));
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
@@ -534,7 +534,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
         parameters.put("filename", "File:My_test_file.png");
         parameters.put("text", "my new wikitext [[Category:Uploaded with OpenRefine]]");
         parameters.put("token", csrfToken);
-        
+
         Map<String, String> uploadParameters = new HashMap<>();
         uploadParameters.putAll(parameters);
         uploadParameters.put("url", "https://my.site.com/file.png");

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/MediaFileUtilsTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/MediaFileUtilsTest.java
@@ -502,7 +502,7 @@ public class MediaFileUtilsTest {
                 "    \"warnings\": {" +
                 "      \"exists\": \"My_test_file.png\"" +
                 "    }," +
-                "    \"filekey\": \"file.key.1.png\""+
+                "    \"filekey\": \"file.key.1.png\"" +
                 "  }" +
                 "}";
         JsonNode warningResponse = ParsingUtilities.mapper.readTree(warningResponseString);
@@ -515,7 +515,8 @@ public class MediaFileUtilsTest {
         when(connection.sendJsonRequest("POST", ignoreWarningParameters, null)).thenReturn(uploadJsonResponse);
 
         MediaFileUtils mediaFileUtils = new MediaFileUtils(connection);
-        MediaUploadResponse response = mediaFileUtils.uploadRemoteFile(new URL("https://foo.com/file.png"), "My_test_file.png", "my wikitext", "my summary",
+        MediaUploadResponse response = mediaFileUtils.uploadRemoteFile(new URL("https://foo.com/file.png"), "My_test_file.png",
+                "my wikitext", "my summary",
                 Collections.emptyList());
         assertEquals(response.filename, "My_test_file.png");
         assertEquals(response.pageid, 12345L);

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
@@ -225,4 +225,20 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
         assertNoWarningRaised();
         verifyNoInteractions(connection);
     }
+
+    @Test
+    public void testAlreadyExistsOnWikiNewVersion() throws IOException, MediaWikiApiErrorException {
+        // mock API call to search for existing filenames
+        when(connection.sendJsonRequest(any(), any())).thenReturn(apiResponseFound);
+
+        MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.matchedMid)
+                .addFileName("Matched.png")
+                .addFilePath("/path/to/Matched.png")
+                .addContributingRowId(123)
+                .build();
+
+        scrutinize(edit);
+
+        assertWarningsRaised(FileNameScrutinizer.uploadNewFileVersionType);
+    }
 }


### PR DESCRIPTION
If there's a match for a file an upload request will be made. The response should contain warnings since the file would already exist. If the only warnings are "exists" and "duplicateversions" another request will be made with `ignorewarnings=1`. This will upload the file as a new version. Allowing these warnings means that you can upload a file with the same name as one that already exists even if the new file is that same as and older version.

An issue is shown when a new version is about to be uploaded to prevent this happening by mistake.

Fixes #5959