### PR TITLE
Inadequate rate-limiting when editing Wikimedia Commons

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/EditBatchProcessor.java
@@ -119,6 +119,10 @@ public class EditBatchProcessor {
         editor.setAverageTimePerEdit(maxEditsPerMinute <= 0 ? 0 : (int) (1000 * (maxEditsPerMinute / 60.)));
         // set maxlag based on preference store
         editor.setMaxLag(maxLag);
+        // configure retry limit, backoff settings
+        editor.setMaxLagMaxRetries(3);
+        editor.setMaxLagFirstWaitTime(1000);
+        editor.setMaxLagBackOffFactor(2.0);
 
         this.library = library;
         this.summary = summary;

--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
@@ -78,7 +78,19 @@ public class MediaFileUtils {
         parameters.put("action", "purge");
         parameters.put("pageids", Long.toString(pageid));
 
-        apiConnection.sendJsonRequest("POST", parameters);
+        int retries = 3;
+        MediaWikiApiErrorException lastException = null;
+        while (retries > 0) {
+            try {
+                JsonNode response = apiConnection.sendJsonRequest("POST", parameters);
+            } catch (MediaWikiApiErrorException e) {
+                lastException = e;
+            }
+            retries--;
+        }
+        if (retries <= 0 && lastException != null) {
+            throw lastException;
+        }
     }
 
     /**

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/MediaFileUtilsTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/MediaFileUtilsTest.java
@@ -83,7 +83,7 @@ public class MediaFileUtilsTest {
         Map<String, String> params = new HashMap<>();
         params.put("action", "purge");
         params.put("pageids", "12345");
-        verify(connection, times(1)).sendJsonRequest("POST", params);
+        verify(connection, times(3)).sendJsonRequest("POST", params);
     }
 
     @Test


### PR DESCRIPTION
Added retry & backoff settings in Wiki data add / update / delete flows

Fixes #6055 

Changes proposed in this pull request:
- Add / Update flows - added retry and exponential backoff settings on WikibaseDataEditor
- MediaFileUtils - added retry support in purgePage flow 
- Updated purge test case to reflect retry support
