### PR TITLE
grel: Translate expressions after a column rename

### DIFF
--- a/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
+++ b/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
@@ -91,16 +91,19 @@ public interface Evaluable {
     }
 
     /**
-     * Translates this expression by simultaneously substituting column names, as specified by the supplied map.
+     * Translates this expression by simultaneously substituting column names, as specified by the supplied map. This
+     * transformation is done on a best-effort basis. For instance, in cases where column dependencies cannot be
+     * isolated, the resulting expression could still rely on columns via their old names. The goal of this method is to
+     * rename as many references as possible. As such, it is always appropriate to return the original expression as a
+     * fall-back.
      *
      * @param substitutions
      *            a map specifying new names for some columns. Keys of the map are old column names, values are the new
      *            names for those columns. If a column name is not present in the map, the column is not renamed.
-     * @return a new expression with updated column names. If this renaming isn't supported, {@link Optional#empty()}
-     *         should be returned.
+     * @return a new expression with updated column names
      */
-    public default Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
-        return Optional.empty();
+    public default Evaluable renameColumnDependencies(Map<String, String> substitutions) {
+        return this;
     }
 
 }

--- a/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
+++ b/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.expr;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -86,6 +87,19 @@ public interface Evaluable {
      *         the expression is constant.
      */
     public default Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
+        return Optional.empty();
+    }
+
+    /**
+     * Translates this expression by simultaneously substituting column names, as specified by the supplied map.
+     *
+     * @param substitutions
+     *            a map specifying new names for some columns. Keys of the map are old column names, values are the new
+     *            names for those columns. If a column name is not present in the map, the column is not renamed.
+     * @return a new expression with updated column names. If this renaming isn't supported, {@link Optional#empty()}
+     *         should be returned.
+     */
+    public default Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
         return Optional.empty();
     }
 

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/ArrayExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/ArrayExpr.java
@@ -2,7 +2,6 @@
 package com.google.refine.grel.ast;
 
 import java.util.Map;
-import java.util.Optional;
 
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.functions.arrays.ArgsToArray;
@@ -25,17 +24,12 @@ public class ArrayExpr extends FunctionCallExpr {
     }
 
     @Override
-    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+    public Evaluable renameColumnDependencies(Map<String, String> substitutions) {
         Evaluable[] translatedArgs = new Evaluable[_args.length];
         for (int i = 0; i != _args.length; i++) {
-            Optional<Evaluable> translatedArg = _args[i].renameColumnDependencies(substitutions);
-            if (translatedArg.isEmpty()) {
-                return Optional.empty();
-            } else {
-                translatedArgs[i] = translatedArg.get();
-            }
+            translatedArgs[i] = _args[i].renameColumnDependencies(substitutions);
         }
-        return Optional.of(new ArrayExpr(translatedArgs));
+        return new ArrayExpr(translatedArgs);
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/ArrayExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/ArrayExpr.java
@@ -1,6 +1,9 @@
 
 package com.google.refine.grel.ast;
 
+import java.util.Map;
+import java.util.Optional;
+
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.functions.arrays.ArgsToArray;
 import com.google.refine.grel.Function;
@@ -8,6 +11,7 @@ import com.google.refine.grel.Function;
 /**
  * Node for an expression which introduces an array explicitly, with square brackets.
  */
+
 public class ArrayExpr extends FunctionCallExpr {
 
     private final static Function argsToArray = new ArgsToArray();
@@ -18,6 +22,20 @@ public class ArrayExpr extends FunctionCallExpr {
      */
     public ArrayExpr(Evaluable[] elements) {
         super(elements, argsToArray, "argsToArray", false);
+    }
+
+    @Override
+    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+        Evaluable[] translatedArgs = new Evaluable[_args.length];
+        for (int i = 0; i != _args.length; i++) {
+            Optional<Evaluable> translatedArg = _args[i].renameColumnDependencies(substitutions);
+            if (translatedArg.isEmpty()) {
+                return Optional.empty();
+            } else {
+                translatedArgs[i] = translatedArg.get();
+            }
+        }
+        return Optional.of(new ArrayExpr(translatedArgs));
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/BracketedExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/BracketedExpr.java
@@ -1,6 +1,7 @@
 
 package com.google.refine.grel.ast;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -32,6 +33,11 @@ public class BracketedExpr extends GrelExpr {
     @Override
     public Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
         return inner.getColumnDependencies(baseColumn);
+    }
+
+    @Override
+    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+        return inner.renameColumnDependencies(substitutions).map(renamed -> new BracketedExpr(renamed));
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/BracketedExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/BracketedExpr.java
@@ -36,8 +36,8 @@ public class BracketedExpr extends GrelExpr {
     }
 
     @Override
-    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
-        return inner.renameColumnDependencies(substitutions).map(renamed -> new BracketedExpr(renamed));
+    public Evaluable renameColumnDependencies(Map<String, String> substitutions) {
+        return new BracketedExpr(inner.renameColumnDependencies(substitutions));
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
@@ -101,17 +101,12 @@ public class ControlCallExpr extends GrelExpr {
     }
 
     @Override
-    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+    public Evaluable renameColumnDependencies(Map<String, String> substitutions) {
         Evaluable[] translatedArgs = new Evaluable[_args.length];
         for (int i = 0; i != _args.length; i++) {
-            Optional<Evaluable> translatedArg = _args[i].renameColumnDependencies(substitutions);
-            if (translatedArg.isEmpty()) {
-                return Optional.empty();
-            } else {
-                translatedArgs[i] = translatedArg.get();
-            }
+            translatedArgs[i] = _args[i].renameColumnDependencies(substitutions);
         }
-        return Optional.of(new ControlCallExpr(translatedArgs, _control, _controlName));
+        return new ControlCallExpr(translatedArgs, _control, _controlName);
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/ControlCallExpr.java
@@ -35,6 +35,7 @@ package com.google.refine.grel.ast;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -97,6 +98,20 @@ public class ControlCallExpr extends GrelExpr {
             dependencies.addAll(deps.get());
         }
         return Optional.of(dependencies);
+    }
+
+    @Override
+    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+        Evaluable[] translatedArgs = new Evaluable[_args.length];
+        for (int i = 0; i != _args.length; i++) {
+            Optional<Evaluable> translatedArg = _args[i].renameColumnDependencies(substitutions);
+            if (translatedArg.isEmpty()) {
+                return Optional.empty();
+            } else {
+                translatedArgs[i] = translatedArg.get();
+            }
+        }
+        return Optional.of(new ControlCallExpr(translatedArgs, _control, _controlName));
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.grel.ast;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -90,6 +91,22 @@ public class FieldAccessorExpr extends GrelExpr {
             }
             // TODO add support for starred, flagged, rowIndex, which are not real columns
             // but whose dependency could also be analyzed.
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+        Optional<Evaluable> innerTranslated = _inner.renameColumnDependencies(substitutions);
+        if (innerTranslated.isPresent()) {
+            return Optional.of(new FieldAccessorExpr(innerTranslated.get(), _fieldName));
+        } else {
+            String innerStr = _inner.toString();
+            if ("cells".equals(innerStr) || "row.cells".equals(innerStr)) {
+                String newColumnName = substitutions.getOrDefault(_fieldName, _fieldName);
+                return Optional.of(new FieldAccessorExpr(_inner, newColumnName));
+            }
+            // TODO add support for starred, flagged, rowIndex
             return Optional.empty();
         }
     }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FieldAccessorExpr.java
@@ -96,19 +96,14 @@ public class FieldAccessorExpr extends GrelExpr {
     }
 
     @Override
-    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
-        Optional<Evaluable> innerTranslated = _inner.renameColumnDependencies(substitutions);
-        if (innerTranslated.isPresent()) {
-            return Optional.of(new FieldAccessorExpr(innerTranslated.get(), _fieldName));
-        } else {
-            String innerStr = _inner.toString();
-            if ("cells".equals(innerStr) || "row.cells".equals(innerStr)) {
-                String newColumnName = substitutions.getOrDefault(_fieldName, _fieldName);
-                return Optional.of(new FieldAccessorExpr(_inner, newColumnName));
-            }
-            // TODO add support for starred, flagged, rowIndex
-            return Optional.empty();
+    public Evaluable renameColumnDependencies(Map<String, String> substitutions) {
+        String innerStr = _inner.toString();
+        if ("cells".equals(innerStr) || "row.cells".equals(innerStr)) {
+            String newColumnName = substitutions.getOrDefault(_fieldName, _fieldName);
+            return new FieldAccessorExpr(_inner, newColumnName);
         }
+        // TODO add support for starred, flagged, rowIndex
+        return new FieldAccessorExpr(_inner.renameColumnDependencies(substitutions), _fieldName);
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FunctionCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FunctionCallExpr.java
@@ -162,26 +162,21 @@ public class FunctionCallExpr extends GrelExpr {
     }
 
     @Override
-    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+    public Evaluable renameColumnDependencies(Map<String, String> substitutions) {
         if (_function instanceof Get && _args.length == 2 && (new VariableExpr("cells")).equals(_args[0]) &&
                 _args[1] != null && _args[1] instanceof LiteralExpr) {
             String columnName = Objects.toString(((LiteralExpr) _args[1]).getValue());
             String newColumnName = substitutions.getOrDefault(columnName, columnName);
-            return Optional.of(new FunctionCallExpr(new Evaluable[] {
+            return new FunctionCallExpr(new Evaluable[] {
                     _args[0],
                     new LiteralExpr(newColumnName)
-            }, _function, _functionName, _fluentStyle));
+            }, _function, _functionName, _fluentStyle);
         } else {
             Evaluable[] translatedArgs = new Evaluable[_args.length];
             for (int i = 0; i != _args.length; i++) {
-                Optional<Evaluable> translatedArg = _args[i].renameColumnDependencies(substitutions);
-                if (translatedArg.isEmpty()) {
-                    return Optional.empty();
-                } else {
-                    translatedArgs[i] = translatedArg.get();
-                }
+                translatedArgs[i] = _args[i].renameColumnDependencies(substitutions);
             }
-            return Optional.of(new FunctionCallExpr(translatedArgs, _function, _functionName, _fluentStyle));
+            return new FunctionCallExpr(translatedArgs, _function, _functionName, _fluentStyle);
         }
     }
 

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FunctionCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FunctionCallExpr.java
@@ -36,6 +36,7 @@ package com.google.refine.grel.ast;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -64,6 +65,7 @@ public class FunctionCallExpr extends GrelExpr {
     /**
      * @deprecated use the other constructor supplying the name under which the function was invoked
      */
+
     @Deprecated
     public FunctionCallExpr(Evaluable[] args, Function f) {
         _args = args;
@@ -160,6 +162,30 @@ public class FunctionCallExpr extends GrelExpr {
     }
 
     @Override
+    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+        if (_function instanceof Get && _args.length == 2 && (new VariableExpr("cells")).equals(_args[0]) &&
+                _args[1] != null && _args[1] instanceof LiteralExpr) {
+            String columnName = Objects.toString(((LiteralExpr) _args[1]).getValue());
+            String newColumnName = substitutions.getOrDefault(columnName, columnName);
+            return Optional.of(new FunctionCallExpr(new Evaluable[] {
+                    _args[0],
+                    new LiteralExpr(newColumnName)
+            }, _function, _functionName, _fluentStyle));
+        } else {
+            Evaluable[] translatedArgs = new Evaluable[_args.length];
+            for (int i = 0; i != _args.length; i++) {
+                Optional<Evaluable> translatedArg = _args[i].renameColumnDependencies(substitutions);
+                if (translatedArg.isEmpty()) {
+                    return Optional.empty();
+                } else {
+                    translatedArgs[i] = translatedArg.get();
+                }
+            }
+            return Optional.of(new FunctionCallExpr(translatedArgs, _function, _functionName, _fluentStyle));
+        }
+    }
+
+    @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
@@ -180,4 +206,5 @@ public class FunctionCallExpr extends GrelExpr {
         return Arrays.equals(_args, other._args) && Objects.equals(_function, other._function)
                 && Objects.equals(_functionName, other._functionName) && _fluentStyle == other._fluentStyle;
     }
+
 }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/GrelExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/GrelExpr.java
@@ -2,7 +2,6 @@
 package com.google.refine.grel.ast;
 
 import java.util.Map;
-import java.util.Optional;
 
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.MetaParser;
@@ -21,5 +20,5 @@ abstract class GrelExpr implements Evaluable {
 
     // make sure all subclasses implement this method
     @Override
-    public abstract Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions);
+    public abstract Evaluable renameColumnDependencies(Map<String, String> substitutions);
 }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/GrelExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/GrelExpr.java
@@ -1,6 +1,9 @@
 
 package com.google.refine.grel.ast;
 
+import java.util.Map;
+import java.util.Optional;
+
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.MetaParser;
 
@@ -15,4 +18,8 @@ abstract class GrelExpr implements Evaluable {
     public String getLanguagePrefix() {
         return MetaParser.GREL_LANGUAGE_CODE;
     }
+
+    // make sure all subclasses implement this method
+    @Override
+    public abstract Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions);
 }

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
@@ -70,8 +70,8 @@ public class LiteralExpr extends GrelExpr {
     }
 
     @Override
-    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
-        return Optional.of(this);
+    public Evaluable renameColumnDependencies(Map<String, String> substitutions) {
+        return this;
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
@@ -34,12 +34,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.grel.ast;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
+
+import com.google.refine.expr.Evaluable;
 
 /**
  * An abstract syntax tree node encapsulating a literal value.
@@ -52,6 +55,10 @@ public class LiteralExpr extends GrelExpr {
         _value = value;
     }
 
+    protected Object getValue() {
+        return _value;
+    }
+
     @Override
     public Object evaluate(Properties bindings) {
         return _value;
@@ -60,6 +67,11 @@ public class LiteralExpr extends GrelExpr {
     @Override
     public Optional<Set<String>> getColumnDependencies(Optional<String> baseColumn) {
         return Optional.of(Collections.emptySet());
+    }
+
+    @Override
+    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+        return Optional.of(this);
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
@@ -221,16 +221,12 @@ public class OperatorCallExpr extends GrelExpr {
     }
 
     @Override
-    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+    public Evaluable renameColumnDependencies(Map<String, String> substitutions) {
         Evaluable[] translatedArgs = new Evaluable[_args.length];
         for (int i = 0; i != _args.length; i++) {
-            Optional<Evaluable> translatedArg = _args[i].renameColumnDependencies(substitutions);
-            if (translatedArg.isEmpty()) {
-                return Optional.empty();
-            }
-            translatedArgs[i] = translatedArg.get();
+            translatedArgs[i] = _args[i].renameColumnDependencies(substitutions);
         }
-        return Optional.of(new OperatorCallExpr(translatedArgs, _op));
+        return new OperatorCallExpr(translatedArgs, _op);
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/OperatorCallExpr.java
@@ -36,6 +36,7 @@ package com.google.refine.grel.ast;
 import java.text.Collator;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -217,6 +218,19 @@ public class OperatorCallExpr extends GrelExpr {
             dependencies.addAll(deps.get());
         }
         return Optional.of(dependencies);
+    }
+
+    @Override
+    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+        Evaluable[] translatedArgs = new Evaluable[_args.length];
+        for (int i = 0; i != _args.length; i++) {
+            Optional<Evaluable> translatedArg = _args[i].renameColumnDependencies(substitutions);
+            if (translatedArg.isEmpty()) {
+                return Optional.empty();
+            }
+            translatedArgs[i] = translatedArg.get();
+        }
+        return Optional.of(new OperatorCallExpr(translatedArgs, _op));
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/VariableExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/VariableExpr.java
@@ -72,12 +72,8 @@ public class VariableExpr extends GrelExpr {
     }
 
     @Override
-    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
-        if ("cells".equals(_name) || "row".equals(_name) || "record".equals(_name)) {
-            return Optional.empty();
-        } else {
-            return Optional.of(this);
-        }
+    public Evaluable renameColumnDependencies(Map<String, String> substitutions) {
+        return this;
     }
 
     @Override

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/VariableExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/VariableExpr.java
@@ -34,9 +34,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.grel.ast;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+
+import com.google.refine.expr.Evaluable;
 
 /**
  * An abstract syntax tree node encapsulating the retrieval of a variable's content.
@@ -66,6 +69,15 @@ public class VariableExpr extends GrelExpr {
             return Optional.empty();
         }
         return Optional.of(Collections.emptySet());
+    }
+
+    @Override
+    public Optional<Evaluable> renameColumnDependencies(Map<String, String> substitutions) {
+        if ("cells".equals(_name) || "row".equals(_name) || "record".equals(_name)) {
+            return Optional.empty();
+        } else {
+            return Optional.of(this);
+        }
     }
 
     @Override

--- a/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
@@ -305,13 +305,16 @@ public class GrelTests extends GrelTestBase {
                 { "value + ' ' + cells.foo.value", "value + ' ' + cells.bar.value" },
                 { "cells[\"foo\"].value+'_'+value", "cells[\"bar\"].value+'_'+value" },
                 { "parseHtml(value.trim())", "parseHtml(value.trim())" },
-                { "cells", null },
+                // when the dependencies cannot be isolated, we just return the original
+                { "cells", "cells" },
                 // this could be analyzed too, but we will never reach completeness anyway!
-                { "get(cells, 'foo'+'bar')", null },
+                { "get(cells, 'f'+'oo')", "get(cells, 'f'+'oo')" },
+                // When parts of the expression can be analyzed, those get renamed accordingly
+                { "get(cells, 'f'+'oo') + cells.foo", "get(cells, 'f'+'oo') + cells.bar" },
         };
         for (String[] test : tests) {
             Evaluable eval = MetaParser.parse("grel:" + test[0]);
-            Optional<Evaluable> expected = test[1] == null ? Optional.empty() : Optional.of(MetaParser.parse("grel:" + test[1]));
+            Evaluable expected = MetaParser.parse("grel:" + test[1]);
             Assert.assertEquals(eval.renameColumnDependencies(rename), expected, "for expression: " + test[0]);
         }
     }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ArrayExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ArrayExprTest.java
@@ -4,8 +4,6 @@ package com.google.refine.grel.ast;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
-import java.util.Optional;
-
 import org.testng.annotations.Test;
 
 import com.google.refine.expr.Evaluable;
@@ -27,6 +25,6 @@ public class ArrayExprTest extends ExprTestBase {
         Evaluable ev = new ArrayExpr(new Evaluable[] { constant, currentColumn, twoColumns });
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
         assertEquals(ev.renameColumnDependencies(sampleRename),
-                Optional.of(new ArrayExpr(new Evaluable[] { constant, currentColumnRenamed, twoColumnsRenamed })));
+                new ArrayExpr(new Evaluable[] { constant, currentColumnRenamed, twoColumnsRenamed }));
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ArrayExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ArrayExprTest.java
@@ -4,6 +4,8 @@ package com.google.refine.grel.ast;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
+import java.util.Optional;
+
 import org.testng.annotations.Test;
 
 import com.google.refine.expr.Evaluable;
@@ -24,5 +26,7 @@ public class ArrayExprTest extends ExprTestBase {
     public void testColumnDependencies() {
         Evaluable ev = new ArrayExpr(new Evaluable[] { constant, currentColumn, twoColumns });
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
+        assertEquals(ev.renameColumnDependencies(sampleRename),
+                Optional.of(new ArrayExpr(new Evaluable[] { constant, currentColumnRenamed, twoColumnsRenamed })));
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/BracketedExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/BracketedExprTest.java
@@ -26,8 +26,8 @@ public class BracketedExprTest extends ExprTestBase {
     @Test
     public void testRenameColumnDependencies() {
         GrelExpr bracketedConstant = new BracketedExpr(constant);
-        assertEquals(bracketedConstant.renameColumnDependencies(sampleRename), Optional.of(bracketedConstant));
+        assertEquals(bracketedConstant.renameColumnDependencies(sampleRename), bracketedConstant);
         GrelExpr bracketedVariable = new BracketedExpr(currentColumn);
-        assertEquals(bracketedVariable.renameColumnDependencies(sampleRename), Optional.of(new BracketedExpr(currentColumnRenamed)));
+        assertEquals(bracketedVariable.renameColumnDependencies(sampleRename), new BracketedExpr(currentColumnRenamed));
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/BracketedExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/BracketedExprTest.java
@@ -23,4 +23,11 @@ public class BracketedExprTest extends ExprTestBase {
         assertEquals(new BracketedExpr(currentColumn).getColumnDependencies(baseColumn), Optional.of(Set.of("baseColumn")));
     }
 
+    @Test
+    public void testRenameColumnDependencies() {
+        GrelExpr bracketedConstant = new BracketedExpr(constant);
+        assertEquals(bracketedConstant.renameColumnDependencies(sampleRename), Optional.of(bracketedConstant));
+        GrelExpr bracketedVariable = new BracketedExpr(currentColumn);
+        assertEquals(bracketedVariable.renameColumnDependencies(sampleRename), Optional.of(new BracketedExpr(currentColumnRenamed)));
+    }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ControlCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ControlCallExprTest.java
@@ -31,7 +31,7 @@ public class ControlCallExprTest extends ExprTestBase {
     public void testConstant() {
         Evaluable c = new ControlCallExpr(new Evaluable[] { constant }, control, "myControl");
         assertEquals(c.getColumnDependencies(baseColumn), set());
-        assertEquals(c.renameColumnDependencies(sampleRename), Optional.of(c));
+        assertEquals(c.renameColumnDependencies(sampleRename), c);
     }
 
     @Test
@@ -39,13 +39,14 @@ public class ControlCallExprTest extends ExprTestBase {
         Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, currentColumn }, control, "myControl");
         assertEquals(c.getColumnDependencies(baseColumn), set("a", "b", "baseColumn"));
         assertEquals(c.renameColumnDependencies(sampleRename),
-                Optional.of(new ControlCallExpr(new Evaluable[] { twoColumnsRenamed, currentColumnRenamed }, control, "myControl")));
+                new ControlCallExpr(new Evaluable[] { twoColumnsRenamed, currentColumnRenamed }, control, "myControl"));
     }
 
     @Test
     public void testUnanalyzable() {
         Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, unanalyzable }, control, "myControl");
         assertEquals(c.getColumnDependencies(baseColumn), Optional.empty());
-        assertEquals(c.renameColumnDependencies(sampleRename), Optional.empty());
+        assertEquals(c.renameColumnDependencies(sampleRename),
+                new ControlCallExpr(new Evaluable[] { twoColumnsRenamed, unanalyzable }, control, "myControl"));
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ControlCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ControlCallExprTest.java
@@ -31,17 +31,21 @@ public class ControlCallExprTest extends ExprTestBase {
     public void testConstant() {
         Evaluable c = new ControlCallExpr(new Evaluable[] { constant }, control, "myControl");
         assertEquals(c.getColumnDependencies(baseColumn), set());
+        assertEquals(c.renameColumnDependencies(sampleRename), Optional.of(c));
     }
 
     @Test
     public void testUnion() {
         Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, currentColumn }, control, "myControl");
         assertEquals(c.getColumnDependencies(baseColumn), set("a", "b", "baseColumn"));
+        assertEquals(c.renameColumnDependencies(sampleRename),
+                Optional.of(new ControlCallExpr(new Evaluable[] { twoColumnsRenamed, currentColumnRenamed }, control, "myControl")));
     }
 
     @Test
     public void testUnanalyzable() {
         Evaluable c = new ControlCallExpr(new Evaluable[] { twoColumns, unanalyzable }, control, "myControl");
         assertEquals(c.getColumnDependencies(baseColumn), Optional.empty());
+        assertEquals(c.renameColumnDependencies(sampleRename), Optional.empty());
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ExprTestBase.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ExprTestBase.java
@@ -1,10 +1,12 @@
 
 package com.google.refine.grel.ast;
 
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -26,6 +28,10 @@ public class ExprTestBase {
     protected Evaluable twoColumns;
     protected Evaluable constant;
 
+    protected Map<String, String> sampleRename = Map.of("baseColumn", "newBaseColumn", "a", "a2");
+    protected Evaluable currentColumnRenamed;
+    protected Evaluable twoColumnsRenamed;
+
     @BeforeMethod
     public void setUp() {
         currentColumn = mock(Evaluable.class);
@@ -33,14 +39,28 @@ public class ExprTestBase {
         twoColumns = mock(Evaluable.class);
         constant = mock(Evaluable.class);
 
+        currentColumnRenamed = mock(Evaluable.class);
+        twoColumnsRenamed = mock(Evaluable.class);
+
         when(currentColumn.getColumnDependencies(baseColumn))
                 .thenReturn(set("baseColumn"));
+        when(currentColumn.renameColumnDependencies(sampleRename))
+                .thenReturn(Optional.of(currentColumnRenamed));
+
         when(unanalyzable.getColumnDependencies(baseColumn))
                 .thenReturn(Optional.empty());
+        when(unanalyzable.renameColumnDependencies(any()))
+                .thenReturn(Optional.empty());
+
         when(twoColumns.getColumnDependencies(baseColumn))
                 .thenReturn(set("a", "b"));
+        when(twoColumns.renameColumnDependencies(sampleRename))
+                .thenReturn(Optional.of(twoColumnsRenamed));
+
         when(constant.getColumnDependencies(baseColumn))
                 .thenReturn(set());
+        when(constant.renameColumnDependencies(any()))
+                .thenReturn(Optional.of(constant));
     }
 
     protected Optional<Set<String>> set(String... strings) {

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/ExprTestBase.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/ExprTestBase.java
@@ -45,22 +45,22 @@ public class ExprTestBase {
         when(currentColumn.getColumnDependencies(baseColumn))
                 .thenReturn(set("baseColumn"));
         when(currentColumn.renameColumnDependencies(sampleRename))
-                .thenReturn(Optional.of(currentColumnRenamed));
+                .thenReturn(currentColumnRenamed);
 
         when(unanalyzable.getColumnDependencies(baseColumn))
                 .thenReturn(Optional.empty());
         when(unanalyzable.renameColumnDependencies(any()))
-                .thenReturn(Optional.empty());
+                .thenReturn(unanalyzable);
 
         when(twoColumns.getColumnDependencies(baseColumn))
                 .thenReturn(set("a", "b"));
         when(twoColumns.renameColumnDependencies(sampleRename))
-                .thenReturn(Optional.of(twoColumnsRenamed));
+                .thenReturn(twoColumnsRenamed);
 
         when(constant.getColumnDependencies(baseColumn))
                 .thenReturn(set());
         when(constant.renameColumnDependencies(any()))
-                .thenReturn(Optional.of(constant));
+                .thenReturn(constant);
     }
 
     protected Optional<Set<String>> set(String... strings) {

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/FieldAccessorExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/FieldAccessorExprTest.java
@@ -4,6 +4,7 @@ package com.google.refine.grel.ast;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.testng.annotations.Test;
@@ -16,10 +17,15 @@ public class FieldAccessorExprTest extends ExprTestBase {
     public void testInnerAnalyzable() {
         Evaluable ev = new FieldAccessorExpr(constant, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set());
+        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.of(ev));
+
         ev = new FieldAccessorExpr(currentColumn, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
+        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.of(new FieldAccessorExpr(currentColumnRenamed, "foo")));
+
         ev = new FieldAccessorExpr(twoColumns, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set("a", "b"));
+        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.of(new FieldAccessorExpr(twoColumnsRenamed, "foo")));
     }
 
     @Test
@@ -27,6 +33,7 @@ public class FieldAccessorExprTest extends ExprTestBase {
         when(unanalyzable.toString()).thenReturn("bar");
         Evaluable ev = new FieldAccessorExpr(unanalyzable, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
+        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.empty());
     }
 
     @Test
@@ -34,5 +41,6 @@ public class FieldAccessorExprTest extends ExprTestBase {
         when(unanalyzable.toString()).thenReturn("cells");
         Evaluable ev = new FieldAccessorExpr(unanalyzable, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set("foo"));
+        assertEquals(ev.renameColumnDependencies(Map.of("foo", "bar")), Optional.of(new FieldAccessorExpr(unanalyzable, "bar")));
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/FieldAccessorExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/FieldAccessorExprTest.java
@@ -17,15 +17,15 @@ public class FieldAccessorExprTest extends ExprTestBase {
     public void testInnerAnalyzable() {
         Evaluable ev = new FieldAccessorExpr(constant, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set());
-        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.of(ev));
+        assertEquals(ev.renameColumnDependencies(sampleRename), ev);
 
         ev = new FieldAccessorExpr(currentColumn, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
-        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.of(new FieldAccessorExpr(currentColumnRenamed, "foo")));
+        assertEquals(ev.renameColumnDependencies(sampleRename), new FieldAccessorExpr(currentColumnRenamed, "foo"));
 
         ev = new FieldAccessorExpr(twoColumns, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set("a", "b"));
-        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.of(new FieldAccessorExpr(twoColumnsRenamed, "foo")));
+        assertEquals(ev.renameColumnDependencies(sampleRename), new FieldAccessorExpr(twoColumnsRenamed, "foo"));
     }
 
     @Test
@@ -33,7 +33,7 @@ public class FieldAccessorExprTest extends ExprTestBase {
         when(unanalyzable.toString()).thenReturn("bar");
         Evaluable ev = new FieldAccessorExpr(unanalyzable, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
-        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.empty());
+        assertEquals(ev.renameColumnDependencies(sampleRename), ev);
     }
 
     @Test
@@ -41,6 +41,6 @@ public class FieldAccessorExprTest extends ExprTestBase {
         when(unanalyzable.toString()).thenReturn("cells");
         Evaluable ev = new FieldAccessorExpr(unanalyzable, "foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set("foo"));
-        assertEquals(ev.renameColumnDependencies(Map.of("foo", "bar")), Optional.of(new FieldAccessorExpr(unanalyzable, "bar")));
+        assertEquals(ev.renameColumnDependencies(Map.of("foo", "bar")), new FieldAccessorExpr(unanalyzable, "bar"));
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/FunctionCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/FunctionCallExprTest.java
@@ -52,11 +52,15 @@ public class FunctionCallExprTest extends ExprTestBase {
     public void testUnion() {
         Evaluable ev = new FunctionCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, function, "fun", false);
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
+        assertEquals(ev.renameColumnDependencies(sampleRename),
+                Optional.of(new FunctionCallExpr(new Evaluable[] { constant, currentColumnRenamed, twoColumnsRenamed }, function, "fun",
+                        false)));
     }
 
     @Test
     public void testUnanalyzable() {
         Evaluable ev = new FunctionCallExpr(new Evaluable[] { currentColumn, unanalyzable }, function, "fun", false);
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
+        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.empty());
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/FunctionCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/FunctionCallExprTest.java
@@ -53,14 +53,15 @@ public class FunctionCallExprTest extends ExprTestBase {
         Evaluable ev = new FunctionCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, function, "fun", false);
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
         assertEquals(ev.renameColumnDependencies(sampleRename),
-                Optional.of(new FunctionCallExpr(new Evaluable[] { constant, currentColumnRenamed, twoColumnsRenamed }, function, "fun",
-                        false)));
+                new FunctionCallExpr(new Evaluable[] { constant, currentColumnRenamed, twoColumnsRenamed }, function, "fun",
+                        false));
     }
 
     @Test
     public void testUnanalyzable() {
         Evaluable ev = new FunctionCallExpr(new Evaluable[] { currentColumn, unanalyzable }, function, "fun", false);
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
-        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.empty());
+        assertEquals(ev.renameColumnDependencies(sampleRename),
+                new FunctionCallExpr(new Evaluable[] { currentColumnRenamed, unanalyzable }, function, "fun", false));
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/LiteralExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/LiteralExprTest.java
@@ -47,11 +47,11 @@ public class LiteralExprTest {
     public void columnDependencies() {
         LiteralExpr expr = new LiteralExpr(34);
         assertEquals(expr.getColumnDependencies(Optional.of("column")), Optional.of(Collections.emptySet()));
-        assertEquals(expr.renameColumnDependencies(Map.of("foo", "bar")), Optional.of(expr));
+        assertEquals(expr.renameColumnDependencies(Map.of("foo", "bar")), expr);
 
         LiteralExpr string = new LiteralExpr("foo");
         assertEquals(string.getColumnDependencies(Optional.of("foo")), Optional.of(Collections.emptySet()));
-        assertEquals(string.renameColumnDependencies(Map.of("foo", "bar")), Optional.of(string));
+        assertEquals(string.renameColumnDependencies(Map.of("foo", "bar")), string);
     }
 
     @Test

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/LiteralExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/LiteralExprTest.java
@@ -30,6 +30,7 @@ package com.google.refine.grel.ast;
 import static org.testng.Assert.assertEquals;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 import org.testng.annotations.Test;
@@ -46,8 +47,11 @@ public class LiteralExprTest {
     public void columnDependencies() {
         LiteralExpr expr = new LiteralExpr(34);
         assertEquals(expr.getColumnDependencies(Optional.of("column")), Optional.of(Collections.emptySet()));
+        assertEquals(expr.renameColumnDependencies(Map.of("foo", "bar")), Optional.of(expr));
+
         LiteralExpr string = new LiteralExpr("foo");
         assertEquals(string.getColumnDependencies(Optional.of("foo")), Optional.of(Collections.emptySet()));
+        assertEquals(string.renameColumnDependencies(Map.of("foo", "bar")), Optional.of(string));
     }
 
     @Test

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/OperatorCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/OperatorCallExprTest.java
@@ -57,8 +57,8 @@ public class OperatorCallExprTest extends ExprTestBase {
     public void testUnion() {
         Evaluable ev = new OperatorCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, "+");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
-        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.of(
-                new OperatorCallExpr(new Evaluable[] { constant, currentColumnRenamed, twoColumnsRenamed }, "+")));
+        assertEquals(ev.renameColumnDependencies(sampleRename),
+                new OperatorCallExpr(new Evaluable[] { constant, currentColumnRenamed, twoColumnsRenamed }, "+"));
     }
 
     @Test

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/OperatorCallExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/OperatorCallExprTest.java
@@ -57,6 +57,8 @@ public class OperatorCallExprTest extends ExprTestBase {
     public void testUnion() {
         Evaluable ev = new OperatorCallExpr(new Evaluable[] { constant, currentColumn, twoColumns }, "+");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn", "a", "b"));
+        assertEquals(ev.renameColumnDependencies(sampleRename), Optional.of(
+                new OperatorCallExpr(new Evaluable[] { constant, currentColumnRenamed, twoColumnsRenamed }, "+")));
     }
 
     @Test

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/VariableExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/VariableExprTest.java
@@ -3,6 +3,7 @@ package com.google.refine.grel.ast;
 
 import static org.testng.Assert.assertEquals;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.testng.annotations.Test;
@@ -15,25 +16,36 @@ public class VariableExprTest extends ExprTestBase {
     public void testBaseColumn() {
         Evaluable ev = new VariableExpr("value");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.of(ev));
+
         ev = new VariableExpr("cell");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.of(ev));
+
         ev = new VariableExpr("recon");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.of(ev));
     }
 
     @Test
     public void testUnanalyzable() {
         Evaluable ev = new VariableExpr("cells");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.empty());
+
         ev = new VariableExpr("row");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.empty());
+
         ev = new VariableExpr("record");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.empty());
     }
 
     @Test
     public void testSingleton() {
         Evaluable ev = new VariableExpr("foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set());
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.of(ev));
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/VariableExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/VariableExprTest.java
@@ -16,36 +16,36 @@ public class VariableExprTest extends ExprTestBase {
     public void testBaseColumn() {
         Evaluable ev = new VariableExpr("value");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
-        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.of(ev));
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), ev);
 
         ev = new VariableExpr("cell");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
-        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.of(ev));
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), ev);
 
         ev = new VariableExpr("recon");
         assertEquals(ev.getColumnDependencies(baseColumn), set("baseColumn"));
-        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.of(ev));
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), ev);
     }
 
     @Test
     public void testUnanalyzable() {
         Evaluable ev = new VariableExpr("cells");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
-        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.empty());
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), ev);
 
         ev = new VariableExpr("row");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
-        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.empty());
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), ev);
 
         ev = new VariableExpr("record");
         assertEquals(ev.getColumnDependencies(baseColumn), Optional.empty());
-        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.empty());
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), ev);
     }
 
     @Test
     public void testSingleton() {
         Evaluable ev = new VariableExpr("foo");
         assertEquals(ev.getColumnDependencies(baseColumn), set());
-        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), Optional.of(ev));
+        assertEquals(ev.renameColumnDependencies(Map.of("someColumn", "newColumn")), ev);
     }
 }


### PR DESCRIPTION
This adds support for transforming GREL expressions to adapt them after a column rename.
This interface is also made available to other expression languages, in a backwards compatible way thanks to a default implementation which treats all expressions as un-analyzable by default.

The goal is to make it possible to reliably adapt an history recipe to a new project when column names are different. Similar translation methods would be introduced on operation classes. It could also be useful to solve #133.