### PR TITLE
Make the client link clickable in terminals

### DIFF
--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -176,7 +176,7 @@ class RefineServer extends Server {
         logger.info("Java runtime version {} from java.home: {}", Runtime.version().toString(), System.getProperty("java.home", ""));
         logger.info("Java VM: {} {} {} {}", System.getProperty("java.vm.vendor", ""), System.getProperty("java.vm.name", ""),
                 System.getProperty("java.vm.version", ""), System.getProperty("java.vm.info", ""));
-        logger.info("Starting Server bound to '{}:{}'", iface, port);
+        logger.info("Starting Server bound to http://{}:{}", iface, port);
         logger.info("refine.memory size: {} JVM Max heap: {} MBytes", Configurations.get("refine.memory", "<default>"),
                 Runtime.getRuntime().maxMemory() / 1024 / 1024.0);
 


### PR DESCRIPTION
This change makes the client link printed to the terminal during startup clickable/selectable(in most terminals).

Most terminals(tested on a few Linux terminals) needs a protocol in front of links/ips to detect them.

No tested terminals supported a wildcard("//") protocol so this change assumes that one either serves OpenRefine over plain HTTP or that ones ones setup at least redirects plain HTTP calls.
