### PR TITLE
Fix inclusion of CSRF token in QuickStatements export

### DIFF
--- a/extensions/wikibase/module/scripts/menu-bar-extension.js
+++ b/extensions/wikibase/module/scripts/menu-bar-extension.js
@@ -36,9 +36,6 @@ WikibaseExporterMenuBar.exportTo = function (format) {
   $(form).css("display", "none")
       .attr("method", "post")
       .attr("target", "openrefine-export-" + format);
-  Refine.wrapCSRF(function(csrfToken) {
-    $(form).attr("action", "command/core/export-rows/" + targetUrl + "?" + $.attr({csrf_token: csrfToken}))
-  });
   $('<input />')
       .attr("name", "engine")
       .val(JSON.stringify(ui.browsingEngine.getJSON()))
@@ -52,12 +49,15 @@ WikibaseExporterMenuBar.exportTo = function (format) {
       .val(format)
       .appendTo(form);
 
-  document.body.appendChild(form);
+  Refine.wrapCSRF(function(csrfToken) {
+    $(form).attr("action", "command/core/export-rows/" + targetUrl + "?" + $.attr({csrf_token: csrfToken}))
+    document.body.appendChild(form);
 
-  window.open("about:blank", "openrefine-export");
-  form.submit();
+    window.open("about:blank", "openrefine-export");
+    form.submit();
 
-  document.body.removeChild(form);
+    document.body.removeChild(form);
+  });
 };
 
 WikibaseExporterMenuBar.checkSchemaAndExport = function (format) {


### PR DESCRIPTION
Fixes #6977.

The problem was a race between the addition of the CSRF token to the form and its submission (I didn't realize this form was submitted immediately when I made the change).

It could be worth backporting this to 3.8 and releasing this as a 3.8.6, which would benefit from the Apple signing fix too.