### PR TITLE
database: Improve exception reporting, to debug flaky tests

### DIFF
--- a/extensions/database/src/com/google/refine/extension/database/DatabaseServiceException.java
+++ b/extensions/database/src/com/google/refine/extension/database/DatabaseServiceException.java
@@ -43,12 +43,19 @@ public class DatabaseServiceException extends Exception {
         super(exception);
     }
 
+    public DatabaseServiceException(SQLException e) {
+        super(e);
+        this.sqlException = true;
+        this.sqlState = e.getSQLState();
+        this.sqlCode = e.getErrorCode();
+    }
+
+    @Deprecated(since = "3.9")
     public DatabaseServiceException(boolean sqlException, String sqlState, int sqlCode, String message) {
         super(message);
         this.sqlException = sqlException;
         this.sqlState = sqlState;
         this.sqlCode = sqlCode;
-
     }
 
     public boolean isSqlException() {

--- a/extensions/database/src/com/google/refine/extension/database/mariadb/MariaDBConnectionManager.java
+++ b/extensions/database/src/com/google/refine/extension/database/mariadb/MariaDBConnectionManager.java
@@ -105,7 +105,7 @@ public class MariaDBConnectionManager {
 
         } catch (SQLException e) {
             logger.error("Test connection Failed!", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
 
     }
@@ -149,7 +149,7 @@ public class MariaDBConnectionManager {
             throw new DatabaseServiceException(e.getMessage());
         } catch (SQLException e) {
             logger.error("SQLException::Couldn't get a Connection!", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 

--- a/extensions/database/src/com/google/refine/extension/database/mariadb/MariaDBDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/mariadb/MariaDBDatabaseService.java
@@ -115,7 +115,7 @@ public class MariaDBDatabaseService extends DatabaseService {
             return dbInfo;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         } finally {
             MariaDBConnectionManager.getInstance().shutdown();
         }
@@ -144,7 +144,7 @@ public class MariaDBDatabaseService extends DatabaseService {
             }
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
 
         return null;
@@ -166,7 +166,7 @@ public class MariaDBDatabaseService extends DatabaseService {
             return columns;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 
@@ -194,7 +194,7 @@ public class MariaDBDatabaseService extends DatabaseService {
             return rows;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 
@@ -225,7 +225,7 @@ public class MariaDBDatabaseService extends DatabaseService {
             return dbInfo;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         } finally {
             try {
                 if (queryResult != null) {

--- a/extensions/database/src/com/google/refine/extension/database/mysql/MySQLConnectionManager.java
+++ b/extensions/database/src/com/google/refine/extension/database/mysql/MySQLConnectionManager.java
@@ -105,7 +105,7 @@ public class MySQLConnectionManager {
 
         } catch (SQLException e) {
             logger.error("Test connection Failed!", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
 
     }
@@ -150,7 +150,7 @@ public class MySQLConnectionManager {
             throw new DatabaseServiceException(e.getMessage());
         } catch (SQLException e) {
             logger.error("SQLException::Couldn't get a Connection!", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 

--- a/extensions/database/src/com/google/refine/extension/database/mysql/MySQLDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/mysql/MySQLDatabaseService.java
@@ -119,7 +119,7 @@ public class MySQLDatabaseService extends DatabaseService {
             return dbInfo;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         } finally {
             MySQLConnectionManager.getInstance().shutdown();
         }
@@ -149,7 +149,7 @@ public class MySQLDatabaseService extends DatabaseService {
             }
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
         return null;
     }
@@ -170,7 +170,7 @@ public class MySQLDatabaseService extends DatabaseService {
             return columns;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 
@@ -202,7 +202,7 @@ public class MySQLDatabaseService extends DatabaseService {
             return rows;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         } finally {
             try {
                 if (queryResult != null) {
@@ -245,7 +245,7 @@ public class MySQLDatabaseService extends DatabaseService {
             return dbInfo;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         } finally {
             try {
                 if (queryResult != null) {

--- a/extensions/database/src/com/google/refine/extension/database/pgsql/PgSQLConnectionManager.java
+++ b/extensions/database/src/com/google/refine/extension/database/pgsql/PgSQLConnectionManager.java
@@ -108,7 +108,7 @@ public class PgSQLConnectionManager {
 
         } catch (SQLException e) {
             logger.error("Test connection Failed!", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
 
     }
@@ -149,7 +149,7 @@ public class PgSQLConnectionManager {
             throw new DatabaseServiceException(e.getMessage());
         } catch (SQLException e) {
             logger.error("SQLException::Couldn't get a Connection!", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 

--- a/extensions/database/src/com/google/refine/extension/database/pgsql/PgSQLDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/pgsql/PgSQLDatabaseService.java
@@ -116,7 +116,7 @@ public class PgSQLDatabaseService extends DatabaseService {
             return dbInfo;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         } finally {
             PgSQLConnectionManager.getInstance().shutdown();
         }
@@ -145,7 +145,7 @@ public class PgSQLDatabaseService extends DatabaseService {
             }
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
         return null;
     }
@@ -166,7 +166,7 @@ public class PgSQLDatabaseService extends DatabaseService {
             return columns;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 
@@ -198,7 +198,7 @@ public class PgSQLDatabaseService extends DatabaseService {
             return rows;
         } catch (SQLException e) {
             logger.error("SQLException::{}::{}", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         } finally {
             try {
                 if (queryResult != null) {
@@ -240,7 +240,7 @@ public class PgSQLDatabaseService extends DatabaseService {
             return dbInfo;
         } catch (SQLException e) {
             logger.error("SQLException::", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         } finally {
             try {
                 if (queryResult != null) {

--- a/extensions/database/src/com/google/refine/extension/database/sqlite/SQLiteConnectionManager.java
+++ b/extensions/database/src/com/google/refine/extension/database/sqlite/SQLiteConnectionManager.java
@@ -119,7 +119,7 @@ public class SQLiteConnectionManager {
             return connResult;
         } catch (SQLException e) {
             logger.error("Test connection Failed!", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 
@@ -146,7 +146,7 @@ public class SQLiteConnectionManager {
             throw new DatabaseServiceException(e.getMessage());
         } catch (SQLException e) {
             logger.error("SQLException::Couldn't get a Connection!", e);
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 

--- a/extensions/database/src/com/google/refine/extension/database/sqlite/SQLiteDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/sqlite/SQLiteDatabaseService.java
@@ -108,7 +108,7 @@ public class SQLiteDatabaseService extends DatabaseService {
                 return dbInfo;
             }
         } catch (SQLException e) {
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
         return null;
     }
@@ -145,7 +145,7 @@ public class SQLiteDatabaseService extends DatabaseService {
             dbInfo.setRows(rows);
             return dbInfo;
         } catch (SQLException e) {
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 
@@ -156,7 +156,7 @@ public class SQLiteDatabaseService extends DatabaseService {
                 ResultSet queryResult = statement.executeQuery(query)) {
             return new DatabaseInfo();
         } catch (SQLException e) {
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 
@@ -177,7 +177,7 @@ public class SQLiteDatabaseService extends DatabaseService {
             }
             return columns;
         } catch (SQLException e) {
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 
@@ -203,7 +203,7 @@ public class SQLiteDatabaseService extends DatabaseService {
             }
             return rows;
         } catch (SQLException e) {
-            throw new DatabaseServiceException(true, e.getSQLState(), e.getErrorCode(), e.getMessage());
+            throw new DatabaseServiceException(e);
         }
     }
 }


### PR DESCRIPTION
We currently have some flaky tests in the database extension:
```
 Error:  com.google.refine.extension.database.sqlite.SQLiteDatabaseServiceTest.testGetRows -- Time elapsed: 0.016 s <<< FAILURE!
com.google.refine.extension.database.DatabaseServiceException: stmt pointer is closed
	at com.google.refine.extension.database.sqlite.SQLiteDatabaseService.getRows(SQLiteDatabaseService.java:206)
	at com.google.refine.extension.database.sqlite.SQLiteDatabaseServiceTest.testGetRows(SQLiteDatabaseServiceTest.java:163)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.testng.internal.invokers.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:141)
```

To help debug this, it would be useful if `DatabaseServiceException` had a `cause` set (so that we can see the original stack trace). Because `DatabaseServiceException` is always wrapping a `SQLException` under the hood, this introduces a constructor that properly sets the original exception as the cause and updates all places where the exception is constructed.

It doesn't fix the flakiness issue as is, but should make it easier to investigate it next time it happens.