### PR TITLE
Assign different cascade layers to CSS from different modules

### DIFF
--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -693,11 +693,18 @@ function process(path, request, response) {
         for (var key in styles) {
           if (styles.hasOwnProperty(key)) {
             var qualifiedPath = styles[key];
-            styleInjection.push(
-                '<link type="text/css" rel="stylesheet" href="' + qualifiedPath.fullPath.substring(1) + '" />');
+            var styleSource;
+            if (qualifiedPath.fullPath.substring(1).startsWith("extension/")) {
+                styleSource = qualifiedPath.fullPath.split("/")[2];
+            } else {
+                styleSource = "core";
+            }
+
+
+            styleInjection.push('@import url(' + qualifiedPath.fullPath.substring(1) + ') layer(' + styleSource + ');');
           }
         }
-        context.styleInjection = styleInjection.join("\n");
+        context.styleInjection = '<style>@layer core;\n' + styleInjection.join("\n") + '</style>';
 
         if (bundle) {
           context.scriptInjection = '<script type="text/javascript" src="' + path + '-bundle.js"></script>';


### PR DESCRIPTION
This assigns CSS from each module into a different cascade layer while also ensuring that the "core" layer takes priority.

This makes it so that CSS from core got a higher priority than that of extensions. It does not eliminate extensions ability to write over core styles(they might use `!important`) and they can still change rules and defaults provided by the browser, but it makes it slightly harder accidentally break core styles.   