### PR TITLE
Add jquery-ui@1.12.1 to be loaded via npm

### DIFF
--- a/main/webapp/README.md
+++ b/main/webapp/README.md
@@ -8,8 +8,7 @@ Dependencies available in the npm registry are added to package.json.
 
 A few of the dependencies are not available in npm.
 
-* jquery-ui: packages are generated from jquery-ui website (https://jqueryui.com/download/#!version=1.12.1).
-* imgAreaSelect: cannot find 0.9.2 version in npm, found 0.9.11-rc.1 on GitHub (https://github.com/odyniec/imgareaselect).
+* imgAreaSelect: cannot find 0.9.2 version in npm, found 0.9.11-rc.1 on GitHub [@odyniec/imgareaselect](https://github.com/odyniec/imgareaselect).
 * suggest (4.3a): not in npm, contains fixes from Google Code SVN.
 
 These dependencies are located under `webapp/modules/core/externals`.

--- a/main/webapp/package-lock.json
+++ b/main/webapp/package-lock.json
@@ -10,6 +10,7 @@
         "@wikimedia/jquery.i18n": "1.0.9",
         "jquery": "3.7.1",
         "jquery-migrate": "3.5.2",
+        "jquery-ui": "^1.12.1",
         "js-cookie": "3.0.5",
         "select2": "4.1.0-rc.0",
         "tablesorter": "2.32.0",
@@ -39,6 +40,12 @@
       "peerDependencies": {
         "jquery": ">=3 <4"
       }
+    },
+    "node_modules/jquery-ui": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "integrity": "sha512-K/kDBMXkTky5LH+gqbMvttU1ipqCTaecKyAFjwHjUnPTVfm5I5PZC7We31iNR3yWtAHNqoxkLoit06lR/gKVlA==",
+      "license": "MIT"
     },
     "node_modules/js-cookie": {
       "version": "3.0.5",
@@ -83,6 +90,11 @@
       "resolved": "https://registry.npmjs.org/jquery-migrate/-/jquery-migrate-3.5.2.tgz",
       "integrity": "sha512-GGvcVWK3aei2/98r7pA4UkOYvs4xVeCGvquNXADFUp9+Sr6VeOw0ktlQ9z4YlBbEFpsXBlRioAgpH/fLWinj4Q==",
       "requires": {}
+    },
+    "jquery-ui": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/jquery-ui/-/jquery-ui-1.12.1.tgz",
+      "integrity": "sha512-K/kDBMXkTky5LH+gqbMvttU1ipqCTaecKyAFjwHjUnPTVfm5I5PZC7We31iNR3yWtAHNqoxkLoit06lR/gKVlA=="
     },
     "js-cookie": {
       "version": "3.0.5",

--- a/main/webapp/package.json
+++ b/main/webapp/package.json
@@ -1,7 +1,7 @@
 {
   "engines": {
     "node": ">=14.0.0",
-    "npm":  ">=8.11.0",
+    "npm": ">=8.11.0",
     "yarn": ">=1.22.15"
   },
   "scripts": {
@@ -13,10 +13,10 @@
     "@wikimedia/jquery.i18n": "1.0.9",
     "jquery": "3.7.1",
     "jquery-migrate": "3.5.2",
+    "jquery-ui": "^1.12.1",
     "js-cookie": "3.0.5",
     "select2": "4.1.0-rc.0",
     "tablesorter": "2.32.0",
     "underscore": "1.13.7"
-  },
-  "devDependencies": {}
+  }
 }


### PR DESCRIPTION
Fixes #6909

Changes proposed in this pull request:
- Add `jquery-ui` to be downloaded via `npm`
- Remove `jquery-ui` mention for `postinstall`
- [NITS] Add text for https://github.com/odyniec/imgareaselect as [@odyniec/imgareaselect](https://github.com/odyniec/imgareaselect) (no-bare-urls practice)
