### PR TITLE
facets: Add column dependency extraction

### DIFF
--- a/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java
@@ -27,11 +27,15 @@
 
 package com.google.refine.browsing.facets;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -57,6 +61,19 @@ public class ListFacetTests extends RefineTest {
             + "\"name\":\"facet A\","
             + "\"columnName\":\"Column A\","
             + "\"expression\":\"value+\\\"bar\\\"\","
+            + "\"omitBlank\":false,"
+            + "\"omitError\":false,"
+            + "\"selection\":[{\"v\":{\"v\":\"foobar\",\"l\":\"true\"}}],"
+            + "\"selectBlank\":false,"
+            + "\"selectError\":false,"
+            + "\"invert\":false"
+            + "}";
+
+    private static String jsonConfigParseError = "{"
+            + "\"type\":\"list\","
+            + "\"name\":\"facet A\","
+            + "\"columnName\":\"Column A\","
+            + "\"expression\":\"foo(\","
             + "\"omitBlank\":false,"
             + "\"omitError\":false,"
             + "\"selection\":[{\"v\":{\"v\":\"foobar\",\"l\":\"true\"}}],"
@@ -109,6 +126,18 @@ public class ListFacetTests extends RefineTest {
     public void serializeListFacetConfig() throws JsonParseException, JsonMappingException, IOException {
         ListFacetConfig facetConfig = ParsingUtilities.mapper.readValue(jsonConfig, ListFacetConfig.class);
         TestUtils.isSerializedTo(facetConfig, jsonConfig);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        ListFacetConfig facetConfig = ParsingUtilities.mapper.readValue(jsonConfig, ListFacetConfig.class);
+        assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.singleton("Column A")));
+    }
+
+    @Test
+    public void testColumnDependenciesWithError() throws Exception {
+        ListFacetConfig facetConfig = ParsingUtilities.mapper.readValue(jsonConfigParseError, ListFacetConfig.class);
+        assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.emptySet()));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/browsing/facets/RangeFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/RangeFacetTests.java
@@ -27,8 +27,12 @@
 
 package com.google.refine.browsing.facets;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -50,6 +54,19 @@ public class RangeFacetTests extends RefineTest {
     public static String configJson = "{\n" +
             "          \"selectNumeric\": true,\n" +
             "          \"expression\": \"value\",\n" +
+            "          \"selectBlank\": true,\n" +
+            "          \"selectNonNumeric\": true,\n" +
+            "          \"selectError\": true,\n" +
+            "          \"name\": \"my column\",\n" +
+            "          \"from\": -30,\n" +
+            "          \"to\": 90,\n" +
+            "          \"type\": \"range\",\n" +
+            "          \"columnName\": \"my column\"\n" +
+            "        }";
+
+    public static String configJsonWithParseError = "{\n" +
+            "          \"selectNumeric\": true,\n" +
+            "          \"expression\": \"foo(\",\n" +
             "          \"selectBlank\": true,\n" +
             "          \"selectNonNumeric\": true,\n" +
             "          \"selectError\": true,\n" +
@@ -111,5 +128,17 @@ public class RangeFacetTests extends RefineTest {
         RangeFacet facet = config.apply(project);
         facet.computeChoices(project, engine.getAllFilteredRows());
         TestUtils.isSerializedTo(facet, facetJson);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        RangeFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJson, RangeFacetConfig.class);
+        assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.singleton("my column")));
+    }
+
+    @Test
+    public void testColumnDependenciesWithError() throws Exception {
+        RangeFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJsonWithParseError, RangeFacetConfig.class);
+        assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.emptySet()));
     }
 }

--- a/main/tests/server/src/com/google/refine/browsing/facets/ScatterplotFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/ScatterplotFacetTests.java
@@ -27,11 +27,15 @@
 
 package com.google.refine.browsing.facets;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -63,6 +67,23 @@ public class ScatterplotFacetTests extends RefineTest {
             "          \"ex\": \"value\",\n" +
             "          \"dim_x\": \"lin\",\n" +
             "          \"ey\": \"value\",\n" +
+            "          \"cx\": \"my column\",\n" +
+            "          \"cy\": \"e\",\n" +
+            "          \"name\": \"my column (x) vs. e (y)\"\n" +
+            "        }";
+
+    public static String configJsonWithParseError = "{\n" +
+            "          \"to_x\": 1,\n" +
+            "          \"to_y\": 1,\n" +
+            "          \"dot\": 1,\n" +
+            "          \"from_x\": 0.21333333333333335,\n" +
+            "          \"l\": 150,\n" +
+            "          \"type\": \"scatterplot\",\n" +
+            "          \"from_y\": 0.26666666666666666,\n" +
+            "          \"dim_y\": \"lin\",\n" +
+            "          \"ex\": \"value\",\n" +
+            "          \"dim_x\": \"lin\",\n" +
+            "          \"ey\": \"foo(\",\n" +
             "          \"cx\": \"my column\",\n" +
             "          \"cy\": \"e\",\n" +
             "          \"name\": \"my column (x) vs. e (y)\"\n" +
@@ -124,5 +145,17 @@ public class ScatterplotFacetTests extends RefineTest {
         assertTrue(filter.filterRow(project, 0, project.rows.get(0)));
         assertFalse(filter.filterRow(project, 1, project.rows.get(1)));
         assertTrue(filter.filterRow(project, 3, project.rows.get(3)));
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        ScatterplotFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJson, ScatterplotFacetConfig.class);
+        assertEquals(facetConfig.getColumnDependencies(), Optional.of(Set.of("my column", "e")));
+    }
+
+    @Test
+    public void testColumnDependenciesWithError() throws Exception {
+        ScatterplotFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJsonWithParseError, ScatterplotFacetConfig.class);
+        assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.emptySet()));
     }
 }

--- a/main/tests/server/src/com/google/refine/browsing/facets/TextSearchFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/TextSearchFacetTests.java
@@ -33,8 +33,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.browsing.facets;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -206,5 +210,11 @@ public class TextSearchFacetTests extends RefineTest {
         TextSearchFacetConfig config = ParsingUtilities.mapper.readValue(sensitiveConfigJson, TextSearchFacetConfig.class);
         TextSearchFacet facet = config.apply(project);
         TestUtils.isSerializedTo(facet, sensitiveFacetJson);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        TextSearchFacetConfig facetConfig = ParsingUtilities.mapper.readValue(sensitiveConfigJson, TextSearchFacetConfig.class);
+        assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.singleton("Value")));
     }
 }

--- a/main/tests/server/src/com/google/refine/browsing/facets/TimeRangeFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/TimeRangeFacetTests.java
@@ -27,9 +27,13 @@
 
 package com.google.refine.browsing.facets;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -81,6 +85,19 @@ public class TimeRangeFacetTests extends RefineTest {
             "          \"columnName\": \"my column\"\n" +
             "        }";
 
+    public static String configJsonWithParseError = "{\n" +
+            "          \"selectNonTime\": true,\n" +
+            "          \"expression\": \"foo(\",\n" +
+            "          \"selectBlank\": true,\n" +
+            "          \"selectError\": true,\n" +
+            "          \"selectTime\": true,\n" +
+            "          \"name\": \"my column\",\n" +
+            "          \"from\": 1262443349000,\n" +
+            "          \"to\": 1514966950000,\n" +
+            "          \"type\": \"timerange\",\n" +
+            "          \"columnName\": \"my column\"\n" +
+            "        }";
+
     @BeforeMethod
     public void registerGRELParser() {
         MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
@@ -113,5 +130,17 @@ public class TimeRangeFacetTests extends RefineTest {
         TimeRangeFacet facet = config.apply(project);
         facet.computeChoices(project, engine.getAllFilteredRows());
         TestUtils.isSerializedTo(facet, facetJson);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        TimeRangeFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJson, TimeRangeFacetConfig.class);
+        assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.singleton("my column")));
+    }
+
+    @Test
+    public void testColumnDependenciesWithError() throws Exception {
+        TimeRangeFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJsonWithParseError, TimeRangeFacetConfig.class);
+        assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.emptySet()));
     }
 }

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/FacetConfig.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/FacetConfig.java
@@ -27,6 +27,9 @@
 
 package com.google.refine.browsing.facets;
 
+import java.util.Optional;
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
@@ -75,4 +78,17 @@ public interface FacetConfig {
     public default void validate() {
     }
 
+    /**
+     * Returns an approximation of the names of the columns this facet depends on. This approximation is designed to be
+     * safe: if a set of column names is returned, then the expression does not read any other column than the ones
+     * mentioned, regardless of the data it is executed on.
+     *
+     * @return {@link Optional#empty()} if the columns could not be isolated: in this case, the facet might depend on
+     *         all columns in the project. Note that this is different from returning an empty set, which means that the
+     *         facet's evaluation does not depend on any column.
+     */
+    @JsonIgnore
+    public default Optional<Set<String>> getColumnDependencies() {
+        return Optional.empty();
+    }
 }

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ListFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ListFacet.java
@@ -33,8 +33,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.browsing.facets;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -139,6 +142,17 @@ public class ListFacet implements Facet {
                 throw new IllegalArgumentException(e);
             }
         }
+
+        @Override
+        public Optional<Set<String>> getColumnDependencies() {
+            try {
+                return MetaParser.parse(expression)
+                        .getColumnDependencies(Optional.of(columnName));
+            } catch (ParsingException e) {
+                return Optional.of(Collections.emptySet());
+            }
+        }
+
     }
 
     /**

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/RangeFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/RangeFacet.java
@@ -33,6 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.browsing.facets;
 
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -132,6 +136,16 @@ public class RangeFacet implements Facet {
                 MetaParser.parse(_expression);
             } catch (ParsingException e) {
                 throw new IllegalArgumentException(e);
+            }
+        }
+
+        @Override
+        public Optional<Set<String>> getColumnDependencies() {
+            try {
+                return MetaParser.parse(_expression)
+                        .getColumnDependencies(Optional.of(_columnName));
+            } catch (ParsingException e) {
+                return Optional.of(Collections.emptySet());
             }
         }
     }

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
@@ -40,6 +40,10 @@ import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 
 import javax.imageio.ImageIO;
 
@@ -176,6 +180,25 @@ public class ScatterplotFacet implements Facet {
                 MetaParser.parse(expression_y);
             } catch (ParsingException e) {
                 throw new IllegalArgumentException(e);
+            }
+        }
+
+        @Override
+        public Optional<Set<String>> getColumnDependencies() {
+            try {
+                Optional<Set<String>> depsX = MetaParser.parse(expression_x)
+                        .getColumnDependencies(Optional.of(columnName_x));
+                Optional<Set<String>> depsY = MetaParser.parse(expression_y)
+                        .getColumnDependencies(Optional.of(columnName_y));
+                if (depsX.isPresent() && depsY.isPresent()) {
+                    Set<String> union = new HashSet<>(depsX.get());
+                    union.addAll(depsY.get());
+                    return Optional.of(union);
+                } else {
+                    return Optional.empty();
+                }
+            } catch (ParsingException e) {
+                return Optional.of(Collections.emptySet());
             }
         }
     }

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/TextSearchFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/TextSearchFacet.java
@@ -33,7 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.browsing.facets;
 
+import java.util.Collections;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -93,6 +96,11 @@ public class TextSearchFacet implements Facet {
                     throw new IllegalArgumentException(e);
                 }
             }
+        }
+
+        @Override
+        public Optional<Set<String>> getColumnDependencies() {
+            return Optional.of(Collections.singleton(_columnName));
         }
     }
 

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/TimeRangeFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/TimeRangeFacet.java
@@ -33,6 +33,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.browsing.facets;
 
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -109,6 +113,16 @@ public class TimeRangeFacet implements Facet {
                 MetaParser.parse(_expression);
             } catch (ParsingException e) {
                 throw new IllegalArgumentException(e);
+            }
+        }
+
+        @Override
+        public Optional<Set<String>> getColumnDependencies() {
+            try {
+                return MetaParser.parse(_expression)
+                        .getColumnDependencies(Optional.of(_columnName));
+            } catch (ParsingException e) {
+                return Optional.of(Collections.emptySet());
             }
         }
     }

--- a/modules/core/src/test/java/com/google/refine/browsing/EngineConfigTests.java
+++ b/modules/core/src/test/java/com/google/refine/browsing/EngineConfigTests.java
@@ -29,6 +29,9 @@ package com.google.refine.browsing;
 
 import static org.testng.Assert.assertThrows;
 
+import java.util.Optional;
+import java.util.Set;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -69,6 +72,12 @@ public class EngineConfigTests {
     public void serializeEngineConfigRecordMode() {
         EngineConfig ec = EngineConfig.deserialize(engineConfigRecordModeJson);
         TestUtils.isSerializedTo(ec, engineConfigRecordModeJson);
+    }
+
+    @Test
+    public void columnDependencies() {
+        EngineConfig ec = EngineConfig.reconstruct(engineConfigJson);
+        Assert.assertEquals(ec.getColumnDependencies(), Optional.of(Set.of("reference")));
     }
 
     @Test


### PR DESCRIPTION
This adds a method of `FacetConfig` to extract column dependencies from a facet, and to `EngineConfig` to get the set of all columns referenced by facets.

This will then be used to expose a similar method on operation classes.

For #133. Follow-up to #6740.

