### PR TITLE
fix: Remove usage of org.json in ComputeClustersCommand

### DIFF
--- a/main/src/com/google/refine/commands/browsing/ComputeClustersCommand.java
+++ b/main/src/com/google/refine/commands/browsing/ComputeClustersCommand.java
@@ -39,7 +39,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,12 +73,12 @@ public class ComputeClustersCommand extends Command {
             Engine engine = getEngine(request, project);
             String clusterer_conf = request.getParameter("clusterer");
 
-            JSONObject jsonObject = new JSONObject(clusterer_conf);
-            JSONObject params = jsonObject.getJSONObject("params");
+            JsonNode jsonObject = ParsingUtilities.mapper.readTree(clusterer_conf);
+            JsonNode params = jsonObject.get("params");
 
-            if (params.has("expression")) {
-                String expression = params.getString("expression");
-                if ("UserDefinedKeyer".equals(jsonObject.getString("function"))) {
+            if (params != null && params.has("expression")) {
+                String expression = params.get("expression").asText();
+                if (jsonObject.has("function") && "UserDefinedKeyer".equals(jsonObject.get("function").asText())) {
                     KeyerFactory.put("userdefinedkeyer", new UserDefinedKeyer(expression));
                 } else {
                     DistanceFactory.put("userdefineddistance", new UserDefinedDistance(expression));

--- a/main/tests/server/src/com/google/refine/commands/browsing/ComputeClustersCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/browsing/ComputeClustersCommandTests.java
@@ -1,25 +1,73 @@
 
 package com.google.refine.commands.browsing;
 
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
 import java.io.IOException;
+import java.io.Serializable;
 
 import javax.servlet.ServletException;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.refine.commands.Command;
 import com.google.refine.commands.CommandTestBase;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
+import com.google.refine.model.Project;
+import com.google.refine.util.ParsingUtilities;
 
 public class ComputeClustersCommandTests extends CommandTestBase {
+
+    Project project;
 
     @BeforeMethod
     public void setUpCommand() {
         command = new ComputeClustersCommand();
+        project = createProject(new String[] { "foo", "bar " },
+                new Serializable[][] {
+                        { "ecole", "1" },
+                        { "école", "3" },
+                        { "École", "2" },
+                });
+    }
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
     }
 
     @Test
     public void testCSRFProtection() throws ServletException, IOException {
         command.doPost(request, response);
         assertCSRFCheckFailed();
+    }
+
+    @Test
+    public void testUserDefinedClustering() throws ServletException, IOException {
+        String clusteringConf = "{"
+                + "  \"type\": \"binning\","
+                + "  \"params\":{"
+                + "    \"expression\": \"value.fingerprint()\""
+                + "  },"
+                + "  \"function\": \"UserDefinedKeyer\""
+                + "}";
+        when(request.getParameter("project")).thenReturn(Long.toString(project.id));
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("clusterer")).thenReturn(clusteringConf);
+
+        command.doPost(request, response);
+
+        JsonNode results = ParsingUtilities.mapper.readTree(writer.toString());
+        assertEquals(results.get(0).size(), 3);
     }
 }


### PR DESCRIPTION
@tfmorris pointed out that we have this use of `org.json` creeping again in the codebase. We migrated out of org.json years ago to Jackson, so it makes sense to keep relying on that only.

The dependency to org.json was made possible because a new version of odftoolkit depends on it, and there isn't any isolation of dependencies. We originally migrated out of org.json for licensing reasons, but the author has in the meantime re-licensed it as public domain dedication, so a priori it's fine to have it as a transitive dependency again.