### PR TITLE
core: Introduce an @ExtensionAPI annotation

### DIFF
--- a/modules/core/src/main/java/com/google/refine/annotations/ExtensionAPI.java
+++ b/modules/core/src/main/java/com/google/refine/annotations/ExtensionAPI.java
@@ -1,0 +1,15 @@
+
+package com.google.refine.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation signifying that a given class or method can be relied on when building OpenRefine extensions.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE })
+public @interface ExtensionAPI {
+}

--- a/modules/core/src/main/java/com/google/refine/model/AbstractOperation.java
+++ b/modules/core/src/main/java/com/google/refine/model/AbstractOperation.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.operations.OperationRegistry;
 import com.google.refine.operations.OperationResolver;
@@ -60,6 +61,7 @@ import com.google.refine.process.QuickHistoryEntryProcess;
                                                                                                                  // own
                                                                                                                  // id
 @JsonTypeIdResolver(OperationResolver.class)
+@ExtensionAPI
 abstract public class AbstractOperation {
 
     public Process createProcess(Project project, Properties options) throws Exception {

--- a/modules/core/src/main/java/com/google/refine/model/Cell.java
+++ b/modules/core/src/main/java/com/google/refine/model/Cell.java
@@ -53,6 +53,7 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.HasFields;
@@ -60,6 +61,7 @@ import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.Pool;
 import com.google.refine.util.StringUtils;
 
+@ExtensionAPI
 public class Cell implements HasFields, Serializable {
 
     private static final long serialVersionUID = 7456683757764146620L;

--- a/modules/core/src/main/java/com/google/refine/model/Column.java
+++ b/modules/core/src/main/java/com/google/refine/model/Column.java
@@ -43,9 +43,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.model.recon.ReconConfig;
 import com.google.refine.util.ParsingUtilities;
 
+@ExtensionAPI
 public class Column {
 
     final private int _cellIndex;

--- a/modules/core/src/main/java/com/google/refine/model/ColumnGroup.java
+++ b/modules/core/src/main/java/com/google/refine/model/ColumnGroup.java
@@ -44,9 +44,11 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.util.JsonViews;
 import com.google.refine.util.ParsingUtilities;
 
+@ExtensionAPI
 public class ColumnGroup {
 
     final public int startColumnIndex;

--- a/modules/core/src/main/java/com/google/refine/model/ColumnModel.java
+++ b/modules/core/src/main/java/com/google/refine/model/ColumnModel.java
@@ -50,6 +50,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
+
+@ExtensionAPI
 public class ColumnModel {
 
     @JsonProperty("columns")

--- a/modules/core/src/main/java/com/google/refine/model/ModelException.java
+++ b/modules/core/src/main/java/com/google/refine/model/ModelException.java
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.model;
 
+import com.google.refine.annotations.ExtensionAPI;
+
+@ExtensionAPI
 public class ModelException extends Exception {
 
     private static final long serialVersionUID = -168448967638065467L;

--- a/modules/core/src/main/java/com/google/refine/model/OverlayModel.java
+++ b/modules/core/src/main/java/com/google/refine/model/OverlayModel.java
@@ -33,11 +33,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.model;
 
+import com.google.refine.annotations.ExtensionAPI;
+
 /**
  * Overlay models must be serializable and deserializable with Jackson. It is possible to have access to the project at
  * deserialization time by adding the corresponding parameter to the JSON creator with @JacksonInject("project").
  *
  */
+@ExtensionAPI
 public interface OverlayModel {
 
     public void onBeforeSave(Project project);

--- a/modules/core/src/main/java/com/google/refine/model/Project.java
+++ b/modules/core/src/main/java/com/google/refine/model/Project.java
@@ -56,6 +56,7 @@ import org.slf4j.LoggerFactory;
 import com.google.refine.ProjectManager;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.RefineServlet;
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.history.History;
 import com.google.refine.process.ProcessManager;
 import com.google.refine.util.ParsingUtilities;
@@ -64,6 +65,7 @@ import com.google.refine.util.Pool;
 /**
  * Project with all its associated metadata and data
  */
+@ExtensionAPI
 public class Project {
 
     final static protected Map<String, Class<? extends OverlayModel>> s_overlayModelClasses = new HashMap<String, Class<? extends OverlayModel>>();

--- a/modules/core/src/main/java/com/google/refine/model/Recon.java
+++ b/modules/core/src/main/java/com/google/refine/model/Recon.java
@@ -51,10 +51,12 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.expr.HasFields;
 import com.google.refine.util.JsonViews;
 import com.google.refine.util.ParsingUtilities;
 
+@ExtensionAPI
 @JsonFilter("reconCandidateFilter")
 public class Recon implements HasFields {
 

--- a/modules/core/src/main/java/com/google/refine/model/ReconCandidate.java
+++ b/modules/core/src/main/java/com/google/refine/model/ReconCandidate.java
@@ -45,9 +45,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.expr.HasFields;
 import com.google.refine.util.ParsingUtilities;
 
+@ExtensionAPI
 public class ReconCandidate implements HasFields {
 
     @JsonProperty("id")

--- a/modules/core/src/main/java/com/google/refine/model/ReconStats.java
+++ b/modules/core/src/main/java/com/google/refine/model/ReconStats.java
@@ -39,10 +39,12 @@ import java.io.Writer;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Recon.Judgment;
 import com.google.refine.util.ParsingUtilities;
 
+@ExtensionAPI
 public class ReconStats {
 
     @JsonProperty("nonBlanks")

--- a/modules/core/src/main/java/com/google/refine/model/ReconType.java
+++ b/modules/core/src/main/java/com/google/refine/model/ReconType.java
@@ -38,12 +38,14 @@ import java.io.IOException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.util.ParsingUtilities;
 
 /**
  * This represents a type from the reconciliation service. It is used when extending data to store the (expected) types
  * of new columns.
  */
+@ExtensionAPI
 public class ReconType {
 
     @JsonProperty("id")

--- a/modules/core/src/main/java/com/google/refine/model/Record.java
+++ b/modules/core/src/main/java/com/google/refine/model/Record.java
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.model;
 
+import com.google.refine.annotations.ExtensionAPI;
+
+@ExtensionAPI
 public class Record {
 
     final public int fromRowIndex;

--- a/modules/core/src/main/java/com/google/refine/model/RecordModel.java
+++ b/modules/core/src/main/java/com/google/refine/model/RecordModel.java
@@ -44,8 +44,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.expr.ExpressionUtils;
 
+@ExtensionAPI
 public class RecordModel {
 
     final static Logger logger = LoggerFactory.getLogger("RecordModel");

--- a/modules/core/src/main/java/com/google/refine/model/Row.java
+++ b/modules/core/src/main/java/com/google/refine/model/Row.java
@@ -45,6 +45,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.google.common.base.CharMatcher;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.expr.CellTuple;
 import com.google.refine.expr.HasFields;
 import com.google.refine.util.ParsingUtilities;
@@ -54,6 +55,7 @@ import com.google.refine.util.Pool;
  * Class representing a single Row which contains a list of {@link Cell}s. There may be multiple rows in a
  * {@link Record}.
  */
+@ExtensionAPI
 public class Row implements HasFields {
 
     public boolean flagged;

--- a/modules/core/src/main/java/com/google/refine/model/recon/ReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/ReconConfig.java
@@ -47,12 +47,14 @@ import edu.mit.simile.butterfly.ButterflyModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Row;
 import com.google.refine.util.ParsingUtilities;
 
+@ExtensionAPI
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = JsonTypeInfo.As.PROPERTY, property = "mode")
 @JsonTypeIdResolver(ReconConfigResolver.class)
 abstract public class ReconConfig {

--- a/modules/core/src/main/java/com/google/refine/model/recon/ReconJob.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/ReconJob.java
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.model.recon;
 
+import com.google.refine.annotations.ExtensionAPI;
+
+@ExtensionAPI
 abstract public class ReconJob {
 
     public int getKey() {

--- a/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
@@ -60,6 +60,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
@@ -72,6 +73,7 @@ import com.google.refine.model.Row;
 import com.google.refine.util.HttpClient;
 import com.google.refine.util.ParsingUtilities;
 
+@ExtensionAPI
 public class StandardReconConfig extends ReconConfig {
 
     final static Logger logger = LoggerFactory.getLogger("refine-standard-recon");

--- a/modules/core/src/main/java/com/google/refine/operations/EngineDependentMassCellOperation.java
+++ b/modules/core/src/main/java/com/google/refine/operations/EngineDependentMassCellOperation.java
@@ -39,6 +39,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.FilteredRows;
@@ -50,6 +51,7 @@ import com.google.refine.model.Project;
 import com.google.refine.model.changes.CellChange;
 import com.google.refine.model.changes.MassCellChange;
 
+@ExtensionAPI
 abstract public class EngineDependentMassCellOperation extends EngineDependentOperation {
 
     @JsonIgnore

--- a/modules/core/src/main/java/com/google/refine/operations/EngineDependentOperation.java
+++ b/modules/core/src/main/java/com/google/refine/operations/EngineDependentOperation.java
@@ -35,11 +35,13 @@ package com.google.refine.operations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 
+@ExtensionAPI
 abstract public class EngineDependentOperation extends AbstractOperation {
 
     transient protected EngineConfig _engineConfig;

--- a/modules/core/src/main/java/com/google/refine/operations/OnError.java
+++ b/modules/core/src/main/java/com/google/refine/operations/OnError.java
@@ -35,6 +35,9 @@ package com.google.refine.operations;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
+
+@ExtensionAPI
 public enum OnError {
     @JsonProperty("keep-original")
     KeepOriginal, @JsonProperty("set-to-blank")

--- a/modules/core/src/main/java/com/google/refine/operations/OperationRegistry.java
+++ b/modules/core/src/main/java/com/google/refine/operations/OperationRegistry.java
@@ -40,8 +40,10 @@ import java.util.Map;
 
 import edu.mit.simile.butterfly.ButterflyModule;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.model.AbstractOperation;
 
+@ExtensionAPI
 public abstract class OperationRegistry {
 
     static final public Map<String, List<Class<? extends AbstractOperation>>> s_opNameToClass = new HashMap<String, List<Class<? extends AbstractOperation>>>();

--- a/modules/core/src/main/java/com/google/refine/preference/PreferenceStore.java
+++ b/modules/core/src/main/java/com/google/refine/preference/PreferenceStore.java
@@ -46,8 +46,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.util.ParsingUtilities;
 
+@ExtensionAPI
 public class PreferenceStore {
 
     public static final String USER_METADATA_KEY = "userMetadata";

--- a/modules/core/src/main/java/com/google/refine/preference/PreferenceValue.java
+++ b/modules/core/src/main/java/com/google/refine/preference/PreferenceValue.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 
 import com.google.refine.ClassResolver;
+import com.google.refine.annotations.ExtensionAPI;
 
 /**
  * Interface to be extended by all objects stored in the preferences. This ensures that their full class name is
@@ -39,7 +40,7 @@ import com.google.refine.ClassResolver;
  * 
  * @author Antonin Delpeuch
  */
-
+@ExtensionAPI
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "class")
 @JsonTypeIdResolver(ClassResolver.class)
 public interface PreferenceValue {

--- a/modules/core/src/main/java/com/google/refine/preference/TopList.java
+++ b/modules/core/src/main/java/com/google/refine/preference/TopList.java
@@ -42,6 +42,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
+
+@ExtensionAPI
 public class TopList implements Iterable<String>, PreferenceValue {
 
     @JsonProperty("top")

--- a/modules/core/src/main/java/com/google/refine/process/LongRunningProcess.java
+++ b/modules/core/src/main/java/com/google/refine/process/LongRunningProcess.java
@@ -36,8 +36,10 @@ package com.google.refine.process;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.history.HistoryEntry;
 
+@ExtensionAPI
 abstract public class LongRunningProcess extends Process {
 
     @JsonProperty("description")

--- a/modules/core/src/main/java/com/google/refine/process/Process.java
+++ b/modules/core/src/main/java/com/google/refine/process/Process.java
@@ -36,8 +36,10 @@ package com.google.refine.process;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.history.HistoryEntry;
 
+@ExtensionAPI
 public abstract class Process {
 
     @JsonProperty("immediate")

--- a/modules/core/src/main/java/com/google/refine/process/ProcessManager.java
+++ b/modules/core/src/main/java/com/google/refine/process/ProcessManager.java
@@ -43,9 +43,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.history.HistoryProcess;
 
+@ExtensionAPI
 public class ProcessManager {
 
     @JsonProperty("processes")

--- a/modules/core/src/main/java/com/google/refine/process/QuickHistoryEntryProcess.java
+++ b/modules/core/src/main/java/com/google/refine/process/QuickHistoryEntryProcess.java
@@ -35,9 +35,11 @@ package com.google.refine.process;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.google.refine.annotations.ExtensionAPI;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.Project;
 
+@ExtensionAPI
 abstract public class QuickHistoryEntryProcess extends Process {
 
     final protected Project _project;


### PR DESCRIPTION
To identify things that can be relied on by extensions, the rest being assumed to be internal. The initial annotations are just a sample, more would be needed.

I went for the `@ExtensionAPI` to clarify the expected use (not as a library) and better distinguish the annotation from `public` visibility.

Alternative to #6928.

I can see pros and cons to both:
* `@Internal` seems more effective to warn extension developers against using something internal
* `@ExtensionAPI` seems more effective to warn core developers against making changes to the extension API

In terms of annotation scale, I have the feeling that `@Internal` would actually be a bit parsimonious than `@ExtensionAPI` as far as the `core` module is concerned. This is because this module is already designed to contain mostly public things.
If we also want to annotate other Maven modules (such as `main`) then of course it would all get annotated by `@Internal`, so `@ExtensionAPI` would be more parsimonious. But I think it's not worth annotating that module, as we could simply discourage extension authors from adding `main` as a dependency in the first place. This is all assuming that we keep this separation into Maven modules, as @tfmorris would like to revert it.