### PR TITLE
ci: Silence spurious Javadoc warnings

### DIFF
--- a/.github/workflows/pull_request_server.yml
+++ b/.github/workflows/pull_request_server.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Check Java linting
         id: java_linting
         run: |
-          mvn -B compile test-compile formatter:validate impsort:check javadoc:javadoc -Ddoclint=all
+          mvn -B compile test-compile formatter:validate impsort:check javadoc:javadoc -Ddoclint=html,syntax,accessibility,reference
 
       - name: Configure connections to databases
         id: configure_db_connections


### PR DESCRIPTION
As `doclint=all` includes a lot of warnings for missing elements which are actually reasonable to omit,
see https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html.

Examples of the warnings silenced:
```
[WARNING] extensions/wikibase/src/org/openrefine/wikibase/utils/EntityCache.java:93: warning: no description for @param
[WARNING] * @param mediaWikiApiEndpoint
[WARNING] ^
[WARNING] extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/EnglishDescriptionScrutinizer.java:46: warning: no comment
[WARNING] protected void checkUppercase(LabeledStatementEntityEdit update, String descText) {
[WARNING] ^
```
