### PR TITLE
Make it possibly for users to quickly copy system and version information

### DIFF
--- a/main/webapp/modules/core/index.vt
+++ b/main/webapp/modules/core/index.vt
@@ -56,7 +56,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <div id="project-links">
       <div id="logo-container">
         <img alt="OpenRefine" src="images/logo-gem-126.svg" height="65" />
-        <div id="openrefine-version"></div>
+        <div id="openrefine-version" role="button" tabindex="0" title="">
+          <svg xmlns="http://www.w3.org/2000/svg"width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><g><path d="M3 3h8v2h2V3c0-1.1-.895-2-2-2H3c-1.1 0-2 .895-2 2v8c0 1.1.895 2 2 2h2v-2H3z"></path><path d="M9 9h8v8H9zm0-2c-1.1 0-2 .895-2 2v8c0 1.1.895 2 2 2h8c1.1 0 2-.895 2-2V9c0-1.1-.895-2-2-2z"></path></g></svg>
+        </div>
       </div>
       <ul>
         <li><a href="preferences" id="or-index-pref"></a></li>

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -10,6 +10,8 @@
     "core-index/version": "Version",
     "core-index/new-version": "New Version",
     "core-index/refine-version": "Version $1",
+    "core-index/refine-version-copied": "Copied version information to your clipboard!",
+    "core-index/refine-version-copy-to-clipboard": "Copy version information to your clipboard",
     "core-index/refine-extensions": "Extensions: $1",
     "core-index/new-version-available": "Download OpenRefine $1 now.",
     "core-index/notification-opt-in": "Do you want to be notified of new OpenRefine releases and events?",

--- a/main/webapp/modules/core/scripts/index.js
+++ b/main/webapp/modules/core/scripts/index.js
@@ -87,14 +87,15 @@ $(function() {
         "command/core/get-version",
         null,
         function(data) {
-          OpenRefineVersion = data;
+          var OpenRefineVersion = data;
 
-          $("#openrefine-version").text($.i18n('core-index/refine-version', OpenRefineVersion.full_version));
+          $("#openrefine-version").prepend($.i18n('core-index/refine-version', OpenRefineVersion.full_version));
           $("#openrefine-extensions").text($.i18n('core-index/refine-extensions', OpenRefineVersion.module_names.join(", ")));
           $("#java-runtime-version").text(OpenRefineVersion.java_runtime_name + " " + OpenRefineVersion.java_runtime_version);
           if (OpenRefineVersion.display_new_version_notice === "true") {
             showNotifications();
           }
+          buildClipBoardInformation(OpenRefineVersion);
         }
     );
   };
@@ -205,6 +206,25 @@ $(function() {
     );
   };
 
+  var buildClipBoardInformation = function(versionData) {
+    const clipboardData = `${versionData.full_version}
+${versionData.java_runtime_name} ${versionData.java_runtime_version}
+${versionData.java_vm_name} ${versionData.java_vm_version}
+Modules: ${versionData.module_names.join(", ")}
+Client user-agent: ${navigator.userAgent}`;
+
+    $("#openrefine-version").on('click', function() {
+      navigator.clipboard.writeText(clipboardData).then(function() {
+        // show notification that the text has been copied to clipboard
+        const container = $('<div id="notification-container">').appendTo(document.body);
+        $('<div id="notification">').text($.i18n('core-index/refine-version-copied')).appendTo(container);
+        setTimeout(function() {
+          container.remove();
+        }, 2000);
+      });
+    });
+  }
+
   var resize = function() {
     for (var i = 0; i < Refine.actionAreas.length; i++) {
       if (Refine.actionAreas[i].ui.resize) {
@@ -262,6 +282,7 @@ $(function() {
   $("#or-index-noProj").text($.i18n('core-index/no-proj')+".");
   $("#or-index-try").text($.i18n('core-index/try-these'));
   $("#or-index-sample").text($.i18n('core-index/sample-data'));
+  $("#openrefine-version").attr('title', $.i18n('core-index/refine-version-copy-to-clipboard'));
 
   maybeShowNotifications();
 

--- a/main/webapp/modules/core/styles/index.css
+++ b/main/webapp/modules/core/styles/index.css
@@ -109,6 +109,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   margin: var(--padding-normal) 0 0 0;
   color: var(--text-tertiary);
   font-size: 80%;
+  cursor: pointer;
+}
+
+#openrefine-version svg {
+  height: 16px;
+  width: 16px;
+  margin-left: var(--padding-tight);
+  fill: var(--text-tertiary);
+  position: relative;
+  top: 3px;
 }
 
 #right-panel {


### PR DESCRIPTION
This change makes it possibly for users to copy detailed version and system information by clicking the version on the index page.

Example clipboard contents:

```
3.9-SNAPSHOT [TRUNK]
OpenJDK Runtime Environment 21.0.4+7
OpenJDK 64-Bit Server VM 21.0.4+7
Modules: command-palette, core, database, jython, module, pc-axis, wikidata
Client user-agent: Mozilla/5.0 (X11; Linux x86_64; rv:131.0) Gecko/20100101 Firefox/131.0
``` 
