### PR TITLE
Antonin leaving the advisory committee

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -94,7 +94,6 @@ In the event of any conflict of interest (a Committee Member, their family membe
 
 #### Current list of Advisory Committee members
 * Jan Ainali
-* Antonin Delpeuch
 * Julie Faure-Lacroix
 * Esther Jackson
 


### PR DESCRIPTION
As mentioned [on the forum](https://forum.openrefine.org/t/transitioning-out-of-the-project/1879), I am in the process of reducing my involvement in OpenRefine. Leaving the advisory committee is one step of that process. I intend to continue development and other activities until the end of March, but I don't need to be in the committee for that.

Perhaps it would be worth thinking about onboarding new members on the advisory committee.

Documents to update
- [x] Update [Project Advisory Committee Table](https://docs.google.com/document/d/1ME9IaMzsu6-fTGdW1BXpH_JmAZlsWoFNP3qkminIj_4/edit) and approval by the Advisory Committee Chair
- [ ] Blogpost announcement
- [x] Update the Governance.md file (this PR)
- [x] Removing from [OpenRefine - CS&S Shared Drive](https://drive.google.com/drive/folders/0ACElu6YXQH0GUk9PVA) 
- [x] Remove from [advisory.committee@openrefine.org](mailto:advisory.committee@openrefine.org)