### PR TITLE
operations: Implement validate() method for a first batch of classes

### DIFF
--- a/main/src/com/google/refine/operations/cell/KeyValueColumnizeOperation.java
+++ b/main/src/com/google/refine/operations/cell/KeyValueColumnizeOperation.java
@@ -40,6 +40,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.history.HistoryEntry;
@@ -65,6 +66,13 @@ public class KeyValueColumnizeOperation extends AbstractOperation {
         _keyColumnName = keyColumnName;
         _valueColumnName = valueColumnName;
         _noteColumnName = noteColumnName;
+    }
+
+    @Override
+    public void validate() {
+        Validate.notNull(_keyColumnName, "Missing key column name");
+        Validate.notNull(_valueColumnName, "Missing value column name");
+        // _noteColumnName can be null
     }
 
     @JsonProperty("keyColumnName")

--- a/main/src/com/google/refine/operations/cell/MassEditOperation.java
+++ b/main/src/com/google/refine/operations/cell/MassEditOperation.java
@@ -42,12 +42,14 @@ import java.util.Properties;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.RowVisitor;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.MetaParser;
+import com.google.refine.expr.ParsingException;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
@@ -110,6 +112,17 @@ public class MassEditOperation extends EngineDependentMassCellOperation {
         super(engineConfig, columnName, true);
         _expression = expression;
         _edits = edits;
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+        try {
+            MetaParser.parse(_expression);
+        } catch (ParsingException e) {
+            throw new IllegalArgumentException(e);
+        }
+        Validate.notNull(_edits, "Missing edits");
     }
 
     @JsonProperty("expression")

--- a/main/src/com/google/refine/operations/cell/MultiValuedCellJoinOperation.java
+++ b/main/src/com/google/refine/operations/cell/MultiValuedCellJoinOperation.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.history.HistoryEntry;
@@ -63,6 +64,13 @@ public class MultiValuedCellJoinOperation extends AbstractOperation {
         _columnName = columnName;
         _keyColumnName = keyColumnName;
         _separator = separator;
+    }
+
+    @Override
+    public void validate() {
+        Validate.notNull(_columnName, "Missing column name");
+        Validate.notNull(_keyColumnName, "Missing key column name");
+        Validate.notNull(_separator, "Missing separator");
     }
 
     @JsonProperty("columnName")

--- a/main/src/com/google/refine/operations/cell/MultiValuedCellSplitOperation.java
+++ b/main/src/com/google/refine/operations/cell/MultiValuedCellSplitOperation.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.refine.history.HistoryEntry;
@@ -123,6 +124,17 @@ public class MultiValuedCellSplitOperation extends AbstractOperation {
             }
         }
         _fieldLengths = fieldLengths;
+    }
+
+    @Override
+    public void validate() {
+        Validate.notNull(_columnName, "Missing column name");
+        Validate.notNull(_keyColumnName, "Missing key column name");
+        if ("separator".equals(_mode)) {
+            Validate.notNull(_separator, "Missing separator");
+            // pattern already compiled in the constructor
+        }
+        // field lengths already validated in the constructor
     }
 
     @JsonProperty("columnName")

--- a/main/src/com/google/refine/operations/cell/TextTransformOperation.java
+++ b/main/src/com/google/refine/operations/cell/TextTransformOperation.java
@@ -45,6 +45,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.MetaParser;
+import com.google.refine.expr.ParsingException;
 import com.google.refine.expr.WrappedCell;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
@@ -99,6 +100,16 @@ public class TextTransformOperation extends EngineDependentMassCellOperation {
         _onError = onError;
         _repeat = repeat;
         _repeatCount = repeatCount;
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+        try {
+            MetaParser.parse(_expression);
+        } catch (ParsingException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperation.java
+++ b/main/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperation.java
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.history.HistoryEntry;
@@ -154,6 +155,15 @@ public class TransposeColumnsIntoRowsOperation extends AbstractOperation {
 
         _keyColumnName = keyColumnName;
         _valueColumnName = valueColumnName;
+    }
+
+    @Override
+    public void validate() {
+        Validate.notNull(_startColumnName, "Missing name of the start column");
+        if (_combinedColumnName == null) {
+            Validate.notNull(_keyColumnName, "Missing name of the key column");
+            Validate.notNull(_valueColumnName, "Missing name of the value column");
+        }
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperation.java
+++ b/main/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperation.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
@@ -59,6 +60,11 @@ public class TransposeRowsIntoColumnsOperation extends AbstractOperation {
             @JsonProperty("rowCount") int rowCount) {
         _columnName = columnName;
         _rowCount = rowCount;
+    }
+
+    @Override
+    public void validate() {
+        Validate.notNull(_columnName, "Missing column name");
     }
 
     @JsonProperty("rowCount")

--- a/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -125,6 +127,12 @@ public class BlankDownTests extends RefineTest {
                 + "\"columnName\":\"my column\"}";
         AbstractOperation op = ParsingUtilities.mapper.readValue(json, BlankDownOperation.class);
         TestUtils.isSerializedTo(op, json);
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class, () -> new BlankDownOperation(invalidEngineConfig, "bar").validate());
+        assertThrows(IllegalArgumentException.class, () -> new BlankDownOperation(defaultEngineConfig, null).validate());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -112,6 +114,12 @@ public class FillDownTests extends RefineTest {
                 + "\"engineConfig\":{\"mode\":\"record-based\",\"facets\":[]},"
                 + "\"columnName\":\"my key\"}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, FillDownOperation.class), json);
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class, () -> new FillDownOperation(invalidEngineConfig, "bar").validate());
+        assertThrows(IllegalArgumentException.class, () -> new FillDownOperation(defaultEngineConfig, null).validate());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -110,6 +112,12 @@ public class KeyValueColumnizeTests extends RefineTest {
                 + "\"valueColumnName\":\"value column\","
                 + "\"noteColumnName\":\"note column\"}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(jsonFull, KeyValueColumnizeOperation.class), jsonFull);
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class, () -> new KeyValueColumnizeOperation(null, "foo", "bar").validate());
+        assertThrows(IllegalArgumentException.class, () -> new KeyValueColumnizeOperation("foo", null, "bar").validate());
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/operations/cell/MassOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MassOperationTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -166,6 +168,18 @@ public class MassOperationTests extends RefineTest {
         Assert.assertTrue(editList.get(0).fromBlank);
         Assert.assertFalse(editList.get(0).fromError);
 
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new MassEditOperation(invalidEngineConfig, "foo", "grel:value", editsWithFromBlank).validate());
+        assertThrows(IllegalArgumentException.class,
+                () -> new MassEditOperation(defaultEngineConfig, null, "grel:value", editsWithFromBlank).validate());
+        assertThrows(IllegalArgumentException.class,
+                () -> new MassEditOperation(defaultEngineConfig, "foo", "grel:invalid(", editsWithFromBlank).validate());
+        assertThrows(IllegalArgumentException.class,
+                () -> new MassEditOperation(defaultEngineConfig, "foo", "grel:value", null).validate());
     }
 
     // Not yet testing for mass edit from OR Error

--- a/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellJoinOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellJoinOperationTests.java
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 
 import org.slf4j.LoggerFactory;
@@ -93,6 +95,13 @@ public class MultiValuedCellJoinOperationTests extends RefineTest {
                 + "\"keyColumnName\":\"key column\","
                 + "\"separator\":\",\"}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, MultiValuedCellJoinOperation.class), json);
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellJoinOperation(null, "key", "sep").validate());
+        assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellJoinOperation("value", null, "sep").validate());
+        assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellJoinOperation("value", "key", null).validate());
     }
 
     /*

--- a/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellSplitOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellSplitOperationTests.java
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 
 import org.slf4j.LoggerFactory;
@@ -100,6 +102,13 @@ public class MultiValuedCellSplitOperationTests extends RefineTest {
                 + "\"mode\":\"lengths\","
                 + "\"fieldLengths\":[1,1]}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, MultiValuedCellSplitOperation.class), json);
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellSplitOperation(null, "key", "sep", false).validate());
+        assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellSplitOperation("value", null, "sep", false).validate());
+        assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellSplitOperation("value", "key", null, false).validate());
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/operations/cell/TextTransformOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TextTransformOperationTests.java
@@ -1,6 +1,8 @@
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 
 import org.testng.annotations.AfterMethod;
@@ -64,6 +66,28 @@ public class TextTransformOperationTests extends RefineTest {
                 + "   \"repeatCount\": 0"
                 + "}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, TextTransformOperation.class), json);
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class, () -> new TextTransformOperation(
+                invalidEngineConfig,
+                "bar",
+                "grel:cells[\"foo\"].value+'_'+value",
+                OnError.SetToBlank,
+                false, 0).validate());
+        assertThrows(IllegalArgumentException.class, () -> new TextTransformOperation(
+                defaultEngineConfig,
+                null,
+                "grel:cells[\"foo\"].value+'_'+value",
+                OnError.SetToBlank,
+                false, 0).validate());
+        assertThrows(IllegalArgumentException.class, () -> new TextTransformOperation(
+                defaultEngineConfig,
+                "bar",
+                "grel:foo(",
+                OnError.SetToBlank,
+                false, 0).validate());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperationTest.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperationTest.java
@@ -1,6 +1,8 @@
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 
 import org.testng.annotations.BeforeSuite;
@@ -36,6 +38,16 @@ public class TransposeColumnsIntoRowsOperationTest extends RefineTest {
                 "}";
         TestUtils.isSerializedTo(new TransposeColumnsIntoRowsOperation(
                 "b 1", 2, true, false, "b", false, null), json);
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new TransposeColumnsIntoRowsOperation(null, -1, true, false, "a", true, ":").validate());
+        assertThrows(IllegalArgumentException.class, () -> new TransposeColumnsIntoRowsOperation(
+                "b 1", 2, true, false, null, "value").validate());
+        assertThrows(IllegalArgumentException.class, () -> new TransposeColumnsIntoRowsOperation(
+                "b 1", 2, true, false, "key", null).validate());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperationTests.java
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 
 import org.slf4j.LoggerFactory;
@@ -76,6 +78,11 @@ public class TransposeRowsIntoColumnsOperationTests extends RefineTest {
                 + "\"columnName\":\"start column\","
                 + "\"rowCount\":3}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, TransposeRowsIntoColumnsOperation.class), json);
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class, () -> new TransposeRowsIntoColumnsOperation(null, 2).validate());
     }
 
     @Test

--- a/modules/core/src/main/java/com/google/refine/browsing/EngineConfig.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/EngineConfig.java
@@ -61,6 +61,17 @@ public class EngineConfig {
         return _facets;
     }
 
+    /**
+     * Checks that all facets in this engine config are valid (rely on syntactically correct expressions, don't contain
+     * contradictory options).
+     * 
+     * @throws IllegalArgumentException
+     *             if not
+     */
+    public void validate() {
+        _facets.stream().forEach(facetConfig -> facetConfig.validate());
+    }
+
     public static EngineConfig reconstruct(String json) {
         if (json == null) {
             return new EngineConfig(Collections.emptyList(), Mode.RowBased);

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/FacetConfig.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/FacetConfig.java
@@ -63,4 +63,16 @@ public interface FacetConfig {
      */
     @JsonIgnore // already included by @JsonTypeInfo
     public String getJsonType();
+
+    /**
+     * Checks that this facet is correctly configured (such as that expressions are syntactically correct and that
+     * options are not contradictory). This should not be done in the constructor, as it would endanger the
+     * deserialization.
+     * 
+     * @throws IllegalArgumentException
+     *             if any parameter is missing or inconsistent
+     */
+    public default void validate() {
+    }
+
 }

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ListFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ListFacet.java
@@ -130,6 +130,15 @@ public class ListFacet implements Facet {
         public String getJsonType() {
             return "list";
         }
+
+        @Override
+        public void validate() {
+            try {
+                MetaParser.parse(expression);
+            } catch (ParsingException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
     }
 
     /**

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/RangeFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/RangeFacet.java
@@ -125,6 +125,15 @@ public class RangeFacet implements Facet {
         public String getJsonType() {
             return "range";
         }
+
+        @Override
+        public void validate() {
+            try {
+                MetaParser.parse(_expression);
+            } catch (ParsingException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
     }
 
     RangeFacetConfig _config = null;

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
@@ -164,6 +164,20 @@ public class ScatterplotFacet implements Facet {
         public String getJsonType() {
             return "scatterplot";
         }
+
+        @Override
+        public void validate() {
+            try {
+                MetaParser.parse(expression_x);
+            } catch (ParsingException e) {
+                throw new IllegalArgumentException(e);
+            }
+            try {
+                MetaParser.parse(expression_y);
+            } catch (ParsingException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
     }
 
     ScatterplotFacetConfig config;

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/TextSearchFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/TextSearchFacet.java
@@ -80,6 +80,19 @@ public class TextSearchFacet implements Facet {
         public String getJsonType() {
             return "text";
         }
+
+        @Override
+        public void validate() {
+            if ("regex".equals(_mode)) {
+                try {
+                    Pattern.compile(
+                            _query,
+                            _caseSensitive ? 0 : Pattern.CASE_INSENSITIVE);
+                } catch (java.util.regex.PatternSyntaxException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            }
+        }
     }
 
     TextSearchFacetConfig _config = new TextSearchFacetConfig();

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/TimeRangeFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/TimeRangeFacet.java
@@ -102,6 +102,15 @@ public class TimeRangeFacet implements Facet {
         public String getJsonType() {
             return "timerange";
         }
+
+        @Override
+        public void validate() {
+            try {
+                MetaParser.parse(_expression);
+            } catch (ParsingException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
     }
 
     protected TimeRangeFacetConfig _config;

--- a/modules/core/src/main/java/com/google/refine/operations/EngineDependentMassCellOperation.java
+++ b/modules/core/src/main/java/com/google/refine/operations/EngineDependentMassCellOperation.java
@@ -38,6 +38,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.EngineConfig;
@@ -62,6 +63,12 @@ abstract public class EngineDependentMassCellOperation extends EngineDependentOp
         super(engineConfig);
         _columnName = columnName;
         _updateRowContextDependencies = updateRowContextDependencies;
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+        Validate.notNull(_columnName, "Missing column name");
     }
 
     @Override

--- a/modules/core/src/main/java/com/google/refine/operations/EngineDependentOperation.java
+++ b/modules/core/src/main/java/com/google/refine/operations/EngineDependentOperation.java
@@ -48,6 +48,11 @@ abstract public class EngineDependentOperation extends AbstractOperation {
         _engineConfig = engineConfig;
     }
 
+    @Override
+    public void validate() {
+        _engineConfig.validate();
+    }
+
     protected Engine createEngine(Project project) throws Exception {
         Engine engine = new Engine(project);
         engine.initializeFromConfig(getEngineConfig());


### PR DESCRIPTION
This adds validate() methods for operations in the `com.google.refine.operations.cell` package.
It also introduces the required methods on `EngineConfig` and `FacetConfig` to do the validation there too.