### PR TITLE
wikibase: Only ignore file upload warnings for matched cells

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/editing/MediaFileUtils.java
@@ -124,17 +124,21 @@ public class MediaFileUtils {
      *            the edit summary associated with the upload
      * @param tags
      *            tags to apply to the edit
+     * @param shouldChunk
+     *            whether the file should be uploaded in chunks
+     * @param newVersion
+     *            true when we expect the file to already exist, in which case we want to upload a new version
      * @return
      * @throws IOException
      * @throws MediaWikiApiErrorException
      */
     public MediaUploadResponse uploadLocalFile(File path, String fileName, String wikitext, String summary, List<String> tags,
-            boolean shouldChunk)
+            boolean shouldChunk, boolean newVersion)
             throws IOException, MediaWikiApiErrorException {
         if (shouldChunk) {
             try (ChunkedFile chunkedFile = new ChunkedFile(path)) {
                 logger.info("Uploading large file in chunks.");
-                return uploadLocalFileChunked(chunkedFile, fileName, wikitext, summary, tags);
+                return uploadLocalFileChunked(chunkedFile, fileName, wikitext, summary, tags, newVersion);
             }
         }
 
@@ -148,7 +152,7 @@ public class MediaFileUtils {
         Map<String, ImmutablePair<String, java.io.File>> files = new HashMap<>();
         files.put("file", new ImmutablePair<String, File>(fileName, path));
 
-        return uploadFile(parameters, files);
+        return uploadFile(parameters, files, newVersion);
     }
 
     /**
@@ -169,7 +173,7 @@ public class MediaFileUtils {
      * @throws MediaWikiApiErrorException
      */
     protected MediaUploadResponse uploadLocalFileChunked(ChunkedFile path, String fileName, String wikitext, String summary,
-            List<String> tags)
+            List<String> tags, boolean newVersion)
             throws IOException, MediaWikiApiErrorException {
         MediaUploadResponse response = null;
         int i = 1;
@@ -192,7 +196,7 @@ public class MediaFileUtils {
             Map<String, ImmutablePair<String, java.io.File>> files = new HashMap<>();
             String chunkName = "chunk-" + i + path.getExtension();
             files.put("chunk", new ImmutablePair<String, File>(chunkName, chunk));
-            response = uploadFile(parameters, files);
+            response = uploadFile(parameters, files, newVersion);
             chunk.delete();
             response.checkForErrors();
             double percent = (double) i / totalChunks * 100.0;
@@ -211,7 +215,7 @@ public class MediaFileUtils {
         parameters.put("text", wikitext);
         logger.info("Chunked upload committed.");
 
-        return uploadFile(parameters, null);
+        return uploadFile(parameters, null, newVersion);
     }
 
     /**
@@ -228,11 +232,14 @@ public class MediaFileUtils {
      *            the edit summary associated with the upload
      * @param tags
      *            tags to apply to the edit
+     * @param newVersion
+     *            true when we expect the file to exist already, in which case we want to upload a new version
      * @return
      * @throws IOException
      * @throws MediaWikiApiErrorException
      */
-    public MediaUploadResponse uploadRemoteFile(URL url, String fileName, String wikitext, String summary, List<String> tags)
+    public MediaUploadResponse uploadRemoteFile(URL url, String fileName, String wikitext, String summary, List<String> tags,
+            boolean newVersion)
             throws IOException, MediaWikiApiErrorException {
         Map<String, String> parameters = new HashMap<>();
         parameters.put("action", "upload");
@@ -244,7 +251,7 @@ public class MediaFileUtils {
         parameters.put("url", url.toExternalForm());
         Map<String, ImmutablePair<String, java.io.File>> files = Collections.emptyMap();
 
-        return uploadFile(parameters, files);
+        return uploadFile(parameters, files, newVersion);
     }
 
     /**
@@ -331,7 +338,8 @@ public class MediaFileUtils {
      * @throws IOException
      * @throws MediaWikiApiErrorException
      */
-    protected MediaUploadResponse uploadFile(Map<String, String> parameters, Map<String, ImmutablePair<String, java.io.File>> files)
+    protected MediaUploadResponse uploadFile(Map<String, String> parameters, Map<String, ImmutablePair<String, java.io.File>> files,
+            boolean newVersion)
             throws IOException, MediaWikiApiErrorException {
         int retries = 3;
         long backOffTime = maxLagWaitTime;
@@ -344,14 +352,14 @@ public class MediaFileUtils {
                     throw new IOException("The server did not return an 'upload' field in the JSON response.");
                 }
                 MediaUploadResponse response = ParsingUtilities.mapper.treeToValue(uploadNode, MediaUploadResponse.class);
-                if (response.hasAllowedWarnings()) {
+                if (response.hasAllowedWarnings() && newVersion) {
                     logger.info("Ignoring warnings: " + response.warnings);
                     Map<String, String> ignoreWarningsParameters = new HashMap<>();
                     ignoreWarningsParameters.putAll(parameters);
                     ignoreWarningsParameters.put("ignorewarnings", "1");
                     ignoreWarningsParameters.remove("url");
                     ignoreWarningsParameters.put("filekey", response.filekey);
-                    return uploadFile(ignoreWarningsParameters, null);
+                    return uploadFile(ignoreWarningsParameters, null, newVersion);
                 }
 
                 // todo check for errors which should be retried

--- a/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/updates/MediaInfoEdit.java
@@ -282,10 +282,10 @@ public class MediaInfoEdit extends LabeledStatementEntityEdit {
         MediaFileUtils.MediaUploadResponse response;
         File path = new File(filePath);
         if (path.exists()) {
-            response = mediaFileUtils.uploadLocalFile(path, fileName, wikitext, summary, tags, shouldUploadInChunks());
+            response = mediaFileUtils.uploadLocalFile(path, fileName, wikitext, summary, tags, shouldUploadInChunks(), !isNew());
         } else {
             URL url = new URL(filePath);
-            response = mediaFileUtils.uploadRemoteFile(url, fileName, wikitext, summary, tags);
+            response = mediaFileUtils.uploadRemoteFile(url, fileName, wikitext, summary, tags, !isNew());
         }
 
         response.checkForErrors();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/MediaFileUtilsTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/MediaFileUtilsTest.java
@@ -115,7 +115,7 @@ public class MediaFileUtilsTest {
         MediaFileUtils mediaFileUtils = new MediaFileUtils(connection);
         File path = new File("/tmp/image.png");
         MediaUploadResponse response = mediaFileUtils.uploadLocalFile(path, "My_test_file.png", "my wikitext", "my summary",
-                Collections.emptyList(), false);
+                Collections.emptyList(), false, false);
         assertEquals(response.filename, "My_test_file.png");
         assertEquals(response.pageid, 12345L);
         assertEquals(response.getMid(connection, Datamodel.SITE_WIKIMEDIA_COMMONS),
@@ -141,7 +141,7 @@ public class MediaFileUtilsTest {
         mediaFileUtils.fetchCsrfToken();
 
         MediaUploadResponse response = mediaFileUtils.uploadRemoteFile(new URL(url), "My_test_file.png", "my wikitext", "my summary",
-                Collections.emptyList());
+                Collections.emptyList(), false);
 
         assertEquals(response.filename, "My_test_file.png");
         assertEquals(response.pageid, 12345L);
@@ -180,7 +180,7 @@ public class MediaFileUtilsTest {
         mediaFileUtils.csrfToken = "invalid_token";
 
         MediaUploadResponse response = mediaFileUtils.uploadRemoteFile(new URL(url), "My_test_file.png", "my wikitext", "my summary",
-                Collections.emptyList());
+                Collections.emptyList(), false);
 
         // the request still succeeds because we retry with a fresh CSRF
         assertEquals(response.filename, "My_test_file.png");
@@ -206,7 +206,7 @@ public class MediaFileUtilsTest {
         MediaFileUtils mediaFileUtils = new MediaFileUtils(connection);
         mediaFileUtils.setMaxLagWaitTime(10);
 
-        mediaFileUtils.uploadRemoteFile(new URL(url), "My_test_file.png", "my wikitext", "my summary", Collections.emptyList());
+        mediaFileUtils.uploadRemoteFile(new URL(url), "My_test_file.png", "my wikitext", "my summary", Collections.emptyList(), false);
     }
 
     @Test
@@ -405,7 +405,7 @@ public class MediaFileUtilsTest {
 
         MediaFileUtils mediaFileUtils = new MediaFileUtils(connection);
         MediaUploadResponse response = mediaFileUtils.uploadLocalFileChunked(chunkedFile, "My_test_file.png", "my wikitext", "my summary",
-                Collections.emptyList());
+                Collections.emptyList(), false);
 
         InOrder inOrder = inOrder(connection);
         inOrder.verify(connection).sendJsonRequest(eq("POST"), eq(firstParams), eq(firstFiles));
@@ -517,7 +517,7 @@ public class MediaFileUtilsTest {
         MediaFileUtils mediaFileUtils = new MediaFileUtils(connection);
         MediaUploadResponse response = mediaFileUtils.uploadRemoteFile(new URL("https://foo.com/file.png"), "My_test_file.png",
                 "my wikitext", "my summary",
-                Collections.emptyList());
+                Collections.emptyList(), true);
         assertEquals(response.filename, "My_test_file.png");
         assertEquals(response.pageid, 12345L);
         assertEquals(response.getMid(connection, Datamodel.SITE_WIKIMEDIA_COMMONS),

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/MediaInfoEditTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/MediaInfoEditTest.java
@@ -157,7 +157,7 @@ public class MediaInfoEditTest {
         when(response.getMid(any(), any()))
                 .thenReturn(mid);
         when(mediaFileUtils.uploadRemoteFile(new URL(url), "Foo.png", "{{wikitext}}\n[[Category:Uploaded with OpenRefine]]", "summary",
-                Collections.emptyList()))
+                Collections.emptyList(), false))
                         .thenReturn(response);
         when(mediaFileUtils.checkIfPageNamesExist(anyList()))
                 .thenReturn(Collections.singleton("File:Foo.png"));
@@ -186,7 +186,7 @@ public class MediaInfoEditTest {
         when(response.getMid(any(), any()))
                 .thenReturn(mid);
         when(mediaFileUtils.uploadRemoteFile(new URL(url), "Foo.png", "{{wikitext}}\n[[Category:Uploaded with OpenRefine]]", "summary",
-                Collections.emptyList()))
+                Collections.emptyList(), false))
                         .thenReturn(response);
         when(mediaFileUtils.checkIfPageNamesExist(anyList()))
                 .thenReturn(Collections.emptySet())


### PR DESCRIPTION
This can be useful in scenarios where a file was uploaded just before us, meaning that the file name clash was not caught by FileNameScrutinizer.

Follow-up to #6967.