### PR TITLE
chore: Remove printStackTrace in Command

### DIFF
--- a/modules/core/src/main/java/com/google/refine/commands/Command.java
+++ b/modules/core/src/main/java/com/google/refine/commands/Command.java
@@ -410,7 +410,6 @@ public abstract class Command {
             throws IOException, ServletException {
 
         logger.warn("Exception caught", e);
-        e.printStackTrace();
 
         if (response == null) {
             throw new ServletException("Response object can't be null");


### PR DESCRIPTION
The logging statement before already shows the stack trace in the logs, so this printStackTrace() call duplicates it and has the downside of bypassing the logging framework.
