### PR TITLE
chore: Deprecate EngineConfig::reconstruct

### DIFF
--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/operations/PerformWikibaseEditsOperationTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/operations/PerformWikibaseEditsOperationTest.java
@@ -62,13 +62,13 @@ public class PerformWikibaseEditsOperationTest extends OperationTest {
 
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testConstructor() {
-        new PerformWikibaseEditsOperation(EngineConfig.reconstruct("{}"), "", 5, "", 60, "tag", "editing results");
+        new PerformWikibaseEditsOperation(EngineConfig.defaultRowBased(), "", 5, "", 60, "tag", "editing results");
     }
 
     @Test
     public void testGetTagCandidates() {
         PerformWikibaseEditsOperation operation = new PerformWikibaseEditsOperation(
-                EngineConfig.reconstruct("{}"), "my summary", 5, "", 60, "openrefine-${version}", null);
+                EngineConfig.defaultRowBased(), "my summary", 5, "", 60, "openrefine-${version}", null);
         List<String> candidates = operation.getTagCandidates("3.4");
 
         assertEquals(candidates, Arrays.asList("openrefine-3.4", "openrefine"));

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WikibaseSchemaTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/schema/WikibaseSchemaTest.java
@@ -209,7 +209,7 @@ public class WikibaseSchemaTest extends WikidataRefineTest {
         assertTrue(validation.getValidationErrors().isEmpty());
 
         Engine engine = new Engine(project);
-        EngineConfig engineConfig = EngineConfig.reconstruct("{\n"
+        EngineConfig engineConfig = EngineConfig.deserialize("{\n"
                 + "      \"mode\": \"row-based\",\n"
                 + "      \"facets\": [\n"
                 + "        {\n"

--- a/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
@@ -137,7 +137,7 @@ public class BlankDownTests extends RefineTest {
 
     @Test
     public void testBlankDownRecordsNoFacets() throws Exception {
-        BlankDownOperation operation = new BlankDownOperation(EngineConfig.reconstruct("{\"mode\":\"record-based\",\"facets\":[]}"), "bar");
+        BlankDownOperation operation = new BlankDownOperation(EngineConfig.deserialize("{\"mode\":\"record-based\",\"facets\":[]}"), "bar");
 
         runOperation(operation, projectToBlankDown);
 
@@ -155,7 +155,7 @@ public class BlankDownTests extends RefineTest {
 
     @Test
     public void testBlankDownRowsNoFacets() throws Exception {
-        BlankDownOperation operation = new BlankDownOperation(EngineConfig.reconstruct("{\"mode\":\"row-based\",\"facets\":[]}"), "bar");
+        BlankDownOperation operation = new BlankDownOperation(EngineConfig.defaultRowBased(), "bar");
 
         runOperation(operation, projectToBlankDown);
 
@@ -186,7 +186,7 @@ public class BlankDownTests extends RefineTest {
         project.columnModel.update();
 
         AbstractOperation op = new BlankDownOperation(
-                EngineConfig.reconstruct("{\"mode\":\"record-based\",\"facets\":[]}"),
+                EngineConfig.deserialize("{\"mode\":\"record-based\",\"facets\":[]}"),
                 "second");
 
         runOperation(op, project);
@@ -248,7 +248,7 @@ public class BlankDownTests extends RefineTest {
 
     @Test
     public void testBlankDownRecordKey() throws Exception {
-        BlankDownOperation operation = new BlankDownOperation(EngineConfig.reconstruct("{\"mode\":\"row-based\",\"facets\":[]}"), "foo");
+        BlankDownOperation operation = new BlankDownOperation(EngineConfig.deserialize("{\"mode\":\"row-based\",\"facets\":[]}"), "foo");
 
         runOperation(operation, projectForRecordKey);
 

--- a/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
@@ -125,7 +125,7 @@ public class FillDownTests extends RefineTest {
     @Test
     public void testFillDownRecordKey() throws Exception {
         AbstractOperation op = new FillDownOperation(
-                EngineConfig.reconstruct("{\"mode\":\"record-based\",\"facets\":[]}"),
+                EngineConfig.deserialize("{\"mode\":\"record-based\",\"facets\":[]}"),
                 "key");
 
         runOperation(op, project);
@@ -145,7 +145,7 @@ public class FillDownTests extends RefineTest {
     // https://github.com/OpenRefine/OpenRefine/issues/742
     @Test
     public void testFillDownRecordsNoFacets() throws Exception {
-        FillDownOperation operation = new FillDownOperation(EngineConfig.reconstruct("{\"mode\":\"record-based\",\"facets\":[]}"), "bar");
+        FillDownOperation operation = new FillDownOperation(EngineConfig.deserialize("{\"mode\":\"record-based\",\"facets\":[]}"), "bar");
 
         runOperation(operation, toFillDown);
 
@@ -165,7 +165,7 @@ public class FillDownTests extends RefineTest {
     // https://github.com/OpenRefine/OpenRefine/issues/742
     @Test
     public void testFillDownRowsNoFacets() throws Exception {
-        FillDownOperation operation = new FillDownOperation(EngineConfig.reconstruct("{\"mode\":\"row-based\",\"facets\":[]}"), "bar");
+        FillDownOperation operation = new FillDownOperation(EngineConfig.defaultRowBased(), "bar");
 
         runOperation(operation, toFillDown);
 
@@ -196,7 +196,7 @@ public class FillDownTests extends RefineTest {
         project.columnModel.update();
 
         AbstractOperation op = new FillDownOperation(
-                EngineConfig.reconstruct("{\"mode\":\"record-based\",\"facets\":[]}"),
+                EngineConfig.deserialize("{\"mode\":\"record-based\",\"facets\":[]}"),
                 "second");
 
         runOperation(op, project);
@@ -257,7 +257,7 @@ public class FillDownTests extends RefineTest {
 
     @Test
     public void testFillDownRowsKeyColumn() throws Exception {
-        FillDownOperation operation = new FillDownOperation(EngineConfig.reconstruct("{\"mode\":\"row-based\",\"facets\":[]}"), "foo");
+        FillDownOperation operation = new FillDownOperation(EngineConfig.defaultRowBased(), "foo");
 
         runOperation(operation, toFillDown);
 

--- a/main/tests/server/src/com/google/refine/operations/cell/TextTransformOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TextTransformOperationTests.java
@@ -93,7 +93,7 @@ public class TextTransformOperationTests extends RefineTest {
     @Test
     public void testTransformColumnInRowsMode() throws Exception {
         TextTransformOperation operation = new TextTransformOperation(
-                EngineConfig.reconstruct("{\"mode\":\"row-based\",\"facets\":[]}"),
+                EngineConfig.defaultRowBased(),
                 "bar",
                 "grel:cells[\"foo\"].value+'_'+value",
                 OnError.SetToBlank,
@@ -117,7 +117,7 @@ public class TextTransformOperationTests extends RefineTest {
     @Test
     public void testTransformIdentity() throws Exception {
         TextTransformOperation operation = new TextTransformOperation(
-                EngineConfig.reconstruct("{\"mode\":\"row-based\",\"facets\":[]}"),
+                EngineConfig.defaultRowBased(),
                 "bar",
                 "grel:value",
                 OnError.SetToBlank,
@@ -140,7 +140,7 @@ public class TextTransformOperationTests extends RefineTest {
     @Test
     public void testTransformNull() throws Exception {
         TextTransformOperation operation = new TextTransformOperation(
-                EngineConfig.reconstruct("{\"mode\":\"row-based\",\"facets\":[]}"),
+                EngineConfig.defaultRowBased(),
                 "bar",
                 "grel:null",
                 OnError.SetToBlank,
@@ -164,7 +164,7 @@ public class TextTransformOperationTests extends RefineTest {
     @Test
     public void testTransformColumnInRecordsMode() throws Exception {
         TextTransformOperation operation = new TextTransformOperation(
-                EngineConfig.reconstruct("{\"mode\":\"record-based\",\"facets\":[]}"),
+                EngineConfig.deserialize("{\"mode\":\"record-based\",\"facets\":[]}"),
                 "bar",
                 "grel:cells[\"foo\"].value+'_'+row.record.rowCount",
                 OnError.SetToBlank,
@@ -188,7 +188,7 @@ public class TextTransformOperationTests extends RefineTest {
     @Test
     public void testTransformColumnNonLocalOperationInRowsMode() throws Exception {
         TextTransformOperation operation = new TextTransformOperation(
-                EngineConfig.reconstruct("{\"mode\":\"record-based\",\"facets\":[]}"),
+                EngineConfig.deserialize("{\"mode\":\"record-based\",\"facets\":[]}"),
                 "bar",
                 "grel:value + '_' + facetCount(value, 'value', 'bar')",
                 OnError.SetToBlank,

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -123,7 +123,7 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
 
     // dependencies
     private Project project;
-    private EngineConfig engine_config = EngineConfig.reconstruct(ENGINE_JSON_URLS);
+    private EngineConfig engine_config = EngineConfig.deserialize(ENGINE_JSON_URLS);
 
     @BeforeMethod
     public void SetUp() throws IOException, ModelException {

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionOperationTests.java
@@ -95,7 +95,7 @@ public class ColumnAdditionOperationTests extends RefineTest {
     @Test
     public void testAddColumnRowsMode() throws Exception {
         ColumnAdditionOperation operation = new ColumnAdditionOperation(
-                EngineConfig.reconstruct("{\"mode\":\"row-based\",\"facets\":[]}"),
+                EngineConfig.deserialize("{\"mode\":\"row-based\",\"facets\":[]}"),
                 "bar",
                 "grel:cells[\"foo\"].value+'_'+value",
                 OnError.SetToBlank,
@@ -151,7 +151,7 @@ public class ColumnAdditionOperationTests extends RefineTest {
     @Test
     public void testAddColumnRecordsMode() throws Exception {
         ColumnAdditionOperation operation = new ColumnAdditionOperation(
-                EngineConfig.reconstruct("{\"mode\":\"record-based\",\"facets\":[]}"),
+                EngineConfig.deserialize("{\"mode\":\"record-based\",\"facets\":[]}"),
                 "bar",
                 "grel:length(row.record.cells['hello'])",
                 OnError.SetToBlank,

--- a/main/tests/server/src/com/google/refine/operations/recon/ExtendDataOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ExtendDataOperationTests.java
@@ -163,7 +163,7 @@ public class ExtendDataOperationTests extends RefineTest {
 
         options = mock(Properties.class);
         engine = new Engine(project);
-        engine_config = EngineConfig.reconstruct(ENGINE_JSON_URLS);
+        engine_config = EngineConfig.deserialize(ENGINE_JSON_URLS);
         engine.initializeFromConfig(engine_config);
         engine.setMode(Engine.Mode.RowBased);
 

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsOperationTests.java
@@ -56,7 +56,7 @@ import com.google.refine.util.TestUtils;
 
 public class ReconJudgeSimilarCellsOperationTests extends RefineTest {
 
-    static final EngineConfig ENGINE_CONFIG = EngineConfig.reconstruct("{\"mode\":\"row-based\"}}");
+    static final EngineConfig ENGINE_CONFIG = EngineConfig.defaultRowBased();
 
     Project project;
     ReconConfig reconConfig;

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
@@ -207,7 +207,7 @@ public class ReconOperationTests extends RefineTest {
 
     @Test
     public void testWorkingRecon() throws Exception {
-        ReconOperation operation = new ReconOperation(EngineConfig.reconstruct("{}"), "column", reconConfig);
+        ReconOperation operation = new ReconOperation(EngineConfig.defaultRowBased(), "column", reconConfig);
 
         runOperation(operation, project);
 
@@ -241,7 +241,7 @@ public class ReconOperationTests extends RefineTest {
         when(reconConfig.createJob(Mockito.eq(project), Mockito.anyInt(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(reconJob);
 
-        ReconOperation op = new ReconOperation(EngineConfig.reconstruct("{}"), "column", reconConfig);
+        ReconOperation op = new ReconOperation(EngineConfig.defaultRowBased(), "column", reconConfig);
 
         runOperation(op, project, 1000);
 
@@ -298,7 +298,7 @@ public class ReconOperationTests extends RefineTest {
                     "           }\n" +
                     "        ]}";
             StandardReconConfig config = StandardReconConfig.reconstruct(configJson);
-            ReconOperation op = new ReconOperation(EngineConfig.reconstruct(null), "director", config);
+            ReconOperation op = new ReconOperation(EngineConfig.defaultRowBased(), "director", config);
             Process process = op.createProcess(project, new Properties());
             ProcessManager pm = project.getProcessManager();
             process.startPerforming(pm);
@@ -404,7 +404,7 @@ public class ReconOperationTests extends RefineTest {
                     "           }\n" +
                     "        ]}";
             StandardReconConfig config = StandardReconConfig.reconstruct(configJson);
-            ReconOperation op = new ReconOperation(EngineConfig.reconstruct(null), "director", config);
+            ReconOperation op = new ReconOperation(EngineConfig.defaultRowBased(), "director", config);
             Process process = op.createProcess(project, new Properties());
             ProcessManager pm = project.getProcessManager();
             process.startPerforming(pm);

--- a/main/tests/server/src/com/google/refine/operations/row/RowRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowRemovalOperationTests.java
@@ -109,7 +109,7 @@ public class RowRemovalOperationTests extends RefineTest {
                 });
 
         engine = new Engine(projectIssue567);
-        engine_config = EngineConfig.reconstruct(ENGINE_JSON_DUPLICATES);
+        engine_config = EngineConfig.deserialize(ENGINE_JSON_DUPLICATES);
         engine.initializeFromConfig(engine_config);
         engine.setMode(Engine.Mode.RowBased);
 

--- a/modules/core/src/main/java/com/google/refine/commands/Command.java
+++ b/modules/core/src/main/java/com/google/refine/commands/Command.java
@@ -126,7 +126,14 @@ public abstract class Command {
         }
 
         String json = request.getParameter("engine");
-        return (json == null) ? null : EngineConfig.reconstruct(json);
+        if (json == null) {
+            return null; // TODO returning a default value or throwing an exception would be better
+        }
+        try {
+            return EngineConfig.deserialize(json);
+        } catch (IllegalArgumentException e) {
+            return null; // TODO throwing an exception would be better
+        }
     }
 
     /**

--- a/modules/core/src/test/java/com/google/refine/browsing/EngineConfigTests.java
+++ b/modules/core/src/test/java/com/google/refine/browsing/EngineConfigTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.browsing;
 
+import static org.testng.Assert.assertThrows;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -59,13 +61,13 @@ public class EngineConfigTests {
 
     @Test
     public void serializeEngineConfig() {
-        EngineConfig ec = EngineConfig.reconstruct(engineConfigJson);
+        EngineConfig ec = EngineConfig.deserialize(engineConfigJson);
         TestUtils.isSerializedTo(ec, engineConfigJson);
     }
 
     @Test
     public void serializeEngineConfigRecordMode() {
-        EngineConfig ec = EngineConfig.reconstruct(engineConfigRecordModeJson);
+        EngineConfig ec = EngineConfig.deserialize(engineConfigRecordModeJson);
         TestUtils.isSerializedTo(ec, engineConfigRecordModeJson);
     }
 
@@ -79,6 +81,25 @@ public class EngineConfigTests {
     @Test
     public void reconstructNoFacetsProvided() {
         EngineConfig ec = EngineConfig.reconstruct(noFacetProvided);
+        Assert.assertEquals(ec.getMode(), Mode.RowBased);
+        Assert.assertTrue(ec.getFacetConfigs().isEmpty());
+    }
+
+    @Test
+    public void deserializeNullEngineConfig() {
+        assertThrows(IllegalArgumentException.class, () -> EngineConfig.deserialize(null));
+    }
+
+    @Test
+    public void deserializeNoFacetsProvided() {
+        EngineConfig ec = EngineConfig.deserialize(noFacetProvided);
+        Assert.assertEquals(ec.getMode(), Mode.RowBased);
+        Assert.assertTrue(ec.getFacetConfigs().isEmpty());
+    }
+
+    @Test
+    public void defaultRowBased() {
+        EngineConfig ec = EngineConfig.defaultRowBased();
         Assert.assertEquals(ec.getMode(), Mode.RowBased);
         Assert.assertTrue(ec.getFacetConfigs().isEmpty());
     }


### PR DESCRIPTION
This method returns null when supplied with an invalid argument, which is bad practice. Instead of swallowing the exception and printing its stack trace, it should rather let the exception flow to the caller. Because fixing this behaviour would be a breaking change, I have deprecated the method and introduced a new one with the better behaviour. I have also introduced EngineConfig::defaultRowBased, as the reconstruct was overwhelmingly being used to build a default row-based engine configuration.
