### PR TITLE
operations: Implement validate() method for c.g.r.o.column classes

### DIFF
--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -47,6 +47,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import org.apache.commons.lang.Validate;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.message.BasicHeader;
 
@@ -58,6 +59,7 @@ import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.MetaParser;
+import com.google.refine.expr.ParsingException;
 import com.google.refine.expr.WrappedCell;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.Cell;
@@ -139,6 +141,21 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
         httpHeaders = headers.toArray(httpHeaders);
         _httpClient = new HttpClient(_delay);
 
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+        Validate.notNull(_baseColumnName, "Missing base column name");
+        Validate.notNull(_urlExpression, "Missing URL expression");
+        try {
+            MetaParser.parse(_urlExpression);
+        } catch (ParsingException e) {
+            throw new IllegalArgumentException(e);
+        }
+        Validate.notNull(_onError, "Missing 'on error' behaviour");
+        Validate.notNull(_newColumnName, "Missing new column name");
+        Validate.isTrue(_columnInsertIndex >= 0, "Invalid column insert index");
     }
 
     @JsonProperty("newColumnName")

--- a/main/src/com/google/refine/operations/column/ColumnAdditionOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionOperation.java
@@ -40,6 +40,7 @@ import java.util.Properties;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.browsing.Engine;
 import com.google.refine.browsing.EngineConfig;
@@ -48,6 +49,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.MetaParser;
+import com.google.refine.expr.ParsingException;
 import com.google.refine.expr.WrappedCell;
 import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
@@ -86,6 +88,21 @@ public class ColumnAdditionOperation extends EngineDependentOperation {
 
         _newColumnName = newColumnName;
         _columnInsertIndex = columnInsertIndex;
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+        Validate.notNull(_baseColumnName, "Missing base column name");
+        Validate.notNull(_expression, "Missing expression");
+        try {
+            MetaParser.parse(_expression);
+        } catch (ParsingException e) {
+            throw new IllegalArgumentException(e);
+        }
+        Validate.notNull(_onError, "Missing 'on error' behaviour");
+        Validate.notNull(_newColumnName, "Missing new column name");
+        Validate.isTrue(_columnInsertIndex >= 0, "Invalid column insert index");
     }
 
     @JsonProperty("newColumnName")

--- a/main/src/com/google/refine/operations/column/ColumnMoveOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnMoveOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.column;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
@@ -54,6 +55,12 @@ public class ColumnMoveOperation extends AbstractOperation {
             @JsonProperty("index") int index) {
         _columnName = columnName;
         _index = index;
+    }
+
+    @Override
+    public void validate() {
+        Validate.notNull(_columnName, "Missing column name");
+        Validate.isTrue(_index >= 0, "Invalid column index");
     }
 
     @JsonProperty("columnName")

--- a/main/src/com/google/refine/operations/column/ColumnRemovalOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnRemovalOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.column;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
@@ -52,6 +53,11 @@ public class ColumnRemovalOperation extends AbstractOperation {
     public ColumnRemovalOperation(
             @JsonProperty("columnName") String columnName) {
         _columnName = columnName;
+    }
+
+    @Override
+    public void validate() {
+        Validate.notNull(_columnName, "Missing column name");
     }
 
     @JsonProperty("columnName")

--- a/main/src/com/google/refine/operations/column/ColumnRenameOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnRenameOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.column;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
@@ -54,6 +55,12 @@ public class ColumnRenameOperation extends AbstractOperation {
             @JsonProperty("newColumnName") String newColumnName) {
         _oldColumnName = oldColumnName;
         _newColumnName = newColumnName;
+    }
+
+    @Override
+    public void validate() {
+        Validate.notNull(_oldColumnName, "Missing old column name");
+        Validate.notNull(_newColumnName, "Missing new column name");
     }
 
     @JsonProperty("oldColumnName")

--- a/main/src/com/google/refine/operations/column/ColumnReorderOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnReorderOperation.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
@@ -52,6 +53,11 @@ public class ColumnReorderOperation extends AbstractOperation {
     public ColumnReorderOperation(
             @JsonProperty("columnNames") List<String> columnNames) {
         _columnNames = columnNames;
+    }
+
+    @Override
+    public void validate() {
+        Validate.notNull(_columnNames, "Missing column names");
     }
 
     @JsonProperty("columnNames")

--- a/main/src/com/google/refine/operations/column/ColumnSplitOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnSplitOperation.java
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.refine.browsing.Engine;
@@ -99,6 +100,15 @@ public class ColumnSplitOperation extends EngineDependentOperation {
                     guessCellType,
                     removeOriginalColumn,
                     fieldLengths);
+        }
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+        Validate.notNull(_columnName, "Missing column name");
+        if (!"separator".equals(_mode)) {
+            Validate.notNull(_fieldLengths, "Missing field lengths");
         }
     }
 

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.operations.column;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import java.io.IOException;
@@ -140,6 +141,50 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
         AbstractOperation op = ParsingUtilities.mapper.readValue(json, ColumnAdditionByFetchingURLsOperation.class);
         Process process = op.createProcess(project, new Properties());
         TestUtils.isSerializedTo(process, String.format(processJson, process.hashCode()));
+    }
+
+    @Test
+    public void testValidate() {
+        AbstractOperation withInvalidEngine = new ColumnAdditionByFetchingURLsOperation(invalidEngineConfig,
+                "fruits",
+                "\"https://foo.com/api?city=\"+value",
+                OnError.StoreError,
+                "rand",
+                1,
+                5,
+                true,
+                null);
+        assertThrows(IllegalArgumentException.class, () -> withInvalidEngine.validate());
+        AbstractOperation missingBaseColumn = new ColumnAdditionByFetchingURLsOperation(engine_config,
+                null,
+                "\"https://foo.com/api?city=\"+value",
+                OnError.StoreError,
+                "rand",
+                1,
+                5,
+                true,
+                null);
+        assertThrows(IllegalArgumentException.class, () -> missingBaseColumn.validate());
+        AbstractOperation missingNewColumn = new ColumnAdditionByFetchingURLsOperation(engine_config,
+                "fruits",
+                "\"https://foo.com/api?city=\"+value",
+                OnError.StoreError,
+                null,
+                1,
+                5,
+                true,
+                null);
+        assertThrows(IllegalArgumentException.class, () -> missingNewColumn.validate());
+        AbstractOperation missingExpression = new ColumnAdditionByFetchingURLsOperation(engine_config,
+                "fruits",
+                null,
+                OnError.StoreError,
+                "rand",
+                1,
+                5,
+                true,
+                null);
+        assertThrows(IllegalArgumentException.class, () -> missingExpression.validate());
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionOperationTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 import java.util.Collections;
 
@@ -90,6 +92,34 @@ public class ColumnAdditionOperationTests extends RefineTest {
                 + "   \"onError\":\"set-to-blank\""
                 + "}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ColumnAdditionOperation.class), json);
+    }
+
+    @Test
+    public void testValidate() {
+        ColumnAdditionOperation invalidEngine = new ColumnAdditionOperation(
+                invalidEngineConfig,
+                "bar",
+                "grel:cells[\"foo\"].value+'_'+value",
+                OnError.SetToBlank,
+                "newcolumn",
+                2);
+        assertThrows(IllegalArgumentException.class, () -> invalidEngine.validate());
+        ColumnAdditionOperation missingBaseColumn = new ColumnAdditionOperation(
+                EngineConfig.reconstruct("{}"),
+                null,
+                "grel:cells[\"foo\"].value+'_'+value",
+                OnError.SetToBlank,
+                "newcolumn",
+                2);
+        assertThrows(IllegalArgumentException.class, () -> missingBaseColumn.validate());
+        ColumnAdditionOperation invalidExpression = new ColumnAdditionOperation(
+                EngineConfig.reconstruct("{}"),
+                "bar",
+                "grel:foo(",
+                OnError.SetToBlank,
+                "newcolumn",
+                2);
+        assertThrows(IllegalArgumentException.class, () -> invalidExpression.validate());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnMoveOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnMoveOperationTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 
 import org.testng.annotations.BeforeMethod;
@@ -69,6 +71,14 @@ public class ColumnMoveOperationTests extends RefineTest {
                 + "\"columnName\":\"my column\","
                 + "\"index\":3}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ColumnMoveOperation.class), json);
+    }
+
+    @Test
+    public void testValidate() {
+        ColumnMoveOperation missingColumnName = new ColumnMoveOperation(null, 1);
+        assertThrows(IllegalArgumentException.class, () -> missingColumnName.validate());
+        ColumnMoveOperation negativeColumnIndex = new ColumnMoveOperation(null, -1);
+        assertThrows(IllegalArgumentException.class, () -> negativeColumnIndex.validate());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnRemovalOperationTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 
 import org.testng.annotations.BeforeMethod;
@@ -68,6 +70,12 @@ public class ColumnRemovalOperationTests extends RefineTest {
                 + "\"description\":\"Remove column my column\","
                 + "\"columnName\":\"my column\"}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ColumnRemovalOperation.class), json);
+    }
+
+    @Test
+    public void testValidate() {
+        ColumnRemovalOperation SUT = new ColumnRemovalOperation(null);
+        assertThrows(IllegalArgumentException.class, () -> SUT.validate());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnRenameOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnRenameOperationTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 
 import org.testng.annotations.BeforeMethod;
@@ -71,6 +73,14 @@ public class ColumnRenameOperationTests extends RefineTest {
                 + "\"newColumnName\":\"new name\"}";
         AbstractOperation op = ParsingUtilities.mapper.readValue(json, AbstractOperation.class);
         TestUtils.isSerializedTo(op, json);
+    }
+
+    @Test
+    public void testValidate() {
+        ColumnRenameOperation noOldName = new ColumnRenameOperation(null, "newfoo");
+        assertThrows(IllegalArgumentException.class, () -> noOldName.validate());
+        ColumnRenameOperation noNewName = new ColumnRenameOperation("foo", null);
+        assertThrows(IllegalArgumentException.class, () -> noNewName.validate());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnReorderOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnReorderOperationTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 import java.util.Arrays;
 
@@ -66,6 +68,12 @@ public class ColumnReorderOperationTests extends RefineTest {
         TestUtils.isSerializedTo(op, "{\"op\":\"core/column-reorder\","
                 + "\"description\":\"Reorder columns\","
                 + "\"columnNames\":[\"b\",\"c\",\"a\"]}");
+    }
+
+    @Test
+    public void testValidate() {
+        AbstractOperation op = new ColumnReorderOperation(null);
+        assertThrows(IllegalArgumentException.class, () -> op.validate());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnSplitOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnSplitOperationTests.java
@@ -27,6 +27,8 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.Serializable;
 import java.util.Collections;
 
@@ -103,6 +105,19 @@ public class ColumnSplitOperationTests extends RefineTest {
                 "    \"fieldLengths\": [1,1]\n" +
                 "  }";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ColumnSplitOperation.class), json);
+    }
+
+    @Test
+    public void testValidate() {
+        AbstractOperation op = new ColumnSplitOperation(invalidEngineConfig, "foo", false, false, ",",
+                false, 0);
+        assertThrows(IllegalArgumentException.class, () -> op.validate());
+        AbstractOperation noColumnName = new ColumnSplitOperation(EngineConfig.reconstruct("{}"), null, false, false, ",",
+                false, 0);
+        assertThrows(IllegalArgumentException.class, () -> noColumnName.validate());
+        AbstractOperation lengths = new ColumnSplitOperation(new EngineConfig(Collections.emptyList(), Mode.RowBased), "hello", false,
+                false, null);
+        assertThrows(IllegalArgumentException.class, () -> lengths.validate());
     }
 
     @Test


### PR DESCRIPTION
Following up on #7024, continuing the implementation for other classes in the `com.google.refine.operations.column` package.
