### PR TITLE
operations: Let core and extensions register icons

### DIFF
--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -503,6 +503,7 @@ function init() {
       "scripts/project/summary-bar.js",
       "scripts/project/exporters.js",
       "scripts/project/scripting.js",
+      "scripts/project/operation-icons.js",
 
       "scripts/facets/facet.js",
       "scripts/facets/list-facet.js",

--- a/main/webapp/modules/core/scripts/project/operation-icons.js
+++ b/main/webapp/modules/core/scripts/project/operation-icons.js
@@ -4,6 +4,13 @@ var OperationIconRegistry = {
 };
 
 OperationIconRegistry.setIcon = function(operationId, iconPath) {
+  if (!iconPath.endsWith(".svg")) {
+    throw new Error('Operation icon must be a path to a SVG file.');
+  }
+  // this will cause the image to load so that once it is added to the DOM it will already be in the browser cache
+  var image = new Image();
+  image.src = iconPath;
+
   this.map.set(operationId, iconPath);
 }
 

--- a/main/webapp/modules/core/scripts/project/operation-icons.js
+++ b/main/webapp/modules/core/scripts/project/operation-icons.js
@@ -1,0 +1,13 @@
+
+var OperationIconRegistry = {
+  map: new Map()
+};
+
+OperationIconRegistry.setIcon = function(operationId, iconPath) {
+  this.map.set(operationId, iconPath);
+}
+
+OperationIconRegistry.getIcon = function(operationId) {
+  return this.map.get(operationId);
+}
+


### PR DESCRIPTION
This PR makes it possible to associate icons to operations.

Those icons are meant to be added to menu items, dialog headers, history entries and more. They are meant to help users recognize operations visually, instead of relying on text. See [the forum topic about their design](https://forum.openrefine.org/t/operation-logos/1307).

Properly registering the logos and including them in the UI will follow.

There are surely many other ways to associate operations to icons (for instance, supplying the icon at the same time as providing the Java class for it), I am not particularly attached to this approach.
