### PR TITLE
operations: Expose column dependencies and diffs

### DIFF
--- a/main/src/com/google/refine/operations/column/ColumnAdditionOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionOperation.java
@@ -36,7 +36,9 @@ package com.google.refine.operations.column;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -48,11 +50,13 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.expr.MetaParser;
+import com.google.refine.expr.ParsingException;
 import com.google.refine.expr.WrappedCell;
 import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.CellAtRow;
@@ -120,6 +124,21 @@ public class ColumnAdditionOperation extends EngineDependentOperation {
 
     protected String createDescription(Column column, List<CellAtRow> cellsAtRows) {
         return OperationDescription.column_addition_desc(_newColumnName, column.getName(), cellsAtRows.size(), _expression);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        try {
+            Evaluable evaluable = MetaParser.parse(_expression);
+            return evaluable.getColumnDependencies(Optional.of(_baseColumnName));
+        } catch (ParsingException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.builder().addColumn(_newColumnName, _baseColumnName).build());
     }
 
     @Override

--- a/main/src/com/google/refine/operations/column/ColumnMoveOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnMoveOperation.java
@@ -33,12 +33,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.column;
 
+import java.util.Optional;
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.changes.ColumnMoveChange;
 import com.google.refine.operations.OperationDescription;
@@ -83,5 +87,15 @@ public class ColumnMoveOperation extends AbstractOperation {
         Change change = new ColumnMoveChange(_columnName, _index);
 
         return new HistoryEntry(historyEntryID, project, getBriefDescription(null), ColumnMoveOperation.this, change);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.empty());
     }
 }

--- a/main/src/com/google/refine/operations/column/ColumnRemovalOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnRemovalOperation.java
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.column;
 
+import java.util.Optional;
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -40,6 +43,7 @@ import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.changes.ColumnRemovalChange;
 import com.google.refine.operations.OperationDescription;
@@ -62,6 +66,16 @@ public class ColumnRemovalOperation extends AbstractOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return OperationDescription.column_removal_brief(_columnName);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.builder().deleteColumn(_columnName).build());
     }
 
     @Override

--- a/main/src/com/google/refine/operations/column/ColumnRenameOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnRenameOperation.java
@@ -33,12 +33,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.column;
 
+import java.util.Optional;
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.changes.ColumnRenameChange;
 import com.google.refine.operations.OperationDescription;
@@ -69,6 +73,16 @@ public class ColumnRenameOperation extends AbstractOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return OperationDescription.column_rename_brief(_oldColumnName, _newColumnName);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(Set.of(_oldColumnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.builder().deleteColumn(_oldColumnName).addColumn(_newColumnName, _oldColumnName).build());
     }
 
     @Override

--- a/main/src/com/google/refine/operations/column/ColumnReorderOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnReorderOperation.java
@@ -34,12 +34,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.operations.column;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.changes.ColumnReorderChange;
 import com.google.refine.operations.OperationDescription;
@@ -62,6 +66,16 @@ public class ColumnReorderOperation extends AbstractOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return OperationDescription.column_reorder_brief();
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(_columnNames.stream().collect(Collectors.toSet()));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.empty(); // we don't know what columns there were before, so we can't diff them
     }
 
     @Override

--- a/main/src/com/google/refine/operations/column/ColumnSplitOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnSplitOperation.java
@@ -36,6 +36,8 @@ package com.google.refine.operations.column;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -53,6 +55,7 @@ import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.importers.ImporterUtilities;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.ColumnSplitChange;
@@ -192,6 +195,16 @@ public class ColumnSplitOperation extends EngineDependentOperation {
     protected String getBriefDescription(Project project) {
         return ("separator".equals(_mode)) ? OperationDescription.column_split_separator_brief(_columnName)
                 : OperationDescription.column_split_brief(_columnName);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.empty(); // sadly the columns created depend on the data and the name of existing columns
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.HttpUrl;
@@ -62,6 +63,7 @@ import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
@@ -169,6 +171,8 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
                     5,
                     true,
                     null);
+            assertEquals(op.getColumnDependencies().get(), Set.of("fruits"));
+            assertEquals(op.getColumnsDiff().get(), ColumnsDiff.builder().addColumn("rand", "fruits").build());
 
             runOperation(op, project, 1500);
 

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionOperationTests.java
@@ -27,8 +27,11 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Set;
 
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -43,6 +46,7 @@ import com.google.refine.browsing.facets.ListFacet;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OnError;
 import com.google.refine.operations.OperationRegistry;
@@ -93,6 +97,26 @@ public class ColumnAdditionOperationTests extends RefineTest {
     }
 
     @Test
+    public void testColumnDependenciesIncludeFacets() {
+        ListFacet.ListFacetConfig facetConfig = new ListFacet.ListFacetConfig();
+        facetConfig.name = "my facet";
+        facetConfig.expression = "grel:value";
+        facetConfig.columnName = "other_column";
+        facetConfig.selection = Collections.singletonList(new DecoratedValue("a", "a"));
+        EngineConfig engineConfig = new EngineConfig(Collections.singletonList(facetConfig), Mode.RowBased);
+
+        ColumnAdditionOperation operation = new ColumnAdditionOperation(
+                engineConfig,
+                "bar",
+                "grel:cells[\"foo\"].value+'_'+value",
+                OnError.SetToBlank,
+                "newcolumn",
+                2);
+
+        assertEquals(operation.getColumnDependencies().get(), Set.of("foo", "bar", "other_column"));
+    }
+
+    @Test
     public void testAddColumnRowsMode() throws Exception {
         ColumnAdditionOperation operation = new ColumnAdditionOperation(
                 EngineConfig.deserialize("{\"mode\":\"row-based\",\"facets\":[]}"),
@@ -101,6 +125,8 @@ public class ColumnAdditionOperationTests extends RefineTest {
                 OnError.SetToBlank,
                 "newcolumn",
                 2);
+        assertEquals(operation.getColumnDependencies().get(), Set.of("foo", "bar"));
+        assertEquals(operation.getColumnsDiff().get(), ColumnsDiff.builder().addColumn("newcolumn", "bar").build());
 
         runOperation(operation, project);
 
@@ -132,6 +158,8 @@ public class ColumnAdditionOperationTests extends RefineTest {
                 OnError.SetToBlank,
                 "newcolumn",
                 2);
+        assertEquals(operation.getColumnDependencies().get(), Set.of("foo", "bar"));
+        assertEquals(operation.getColumnsDiff().get(), ColumnsDiff.builder().addColumn("newcolumn", "bar").build());
 
         runOperation(operation, project);
 
@@ -157,6 +185,7 @@ public class ColumnAdditionOperationTests extends RefineTest {
                 OnError.SetToBlank,
                 "newcolumn",
                 2);
+        assertEquals(operation.getColumnsDiff().get(), ColumnsDiff.builder().addColumn("newcolumn", "bar").build());
 
         runOperation(operation, project);
 
@@ -188,6 +217,7 @@ public class ColumnAdditionOperationTests extends RefineTest {
                 OnError.SetToBlank,
                 "newcolumn",
                 2);
+        assertEquals(operation.getColumnsDiff().get(), ColumnsDiff.builder().addColumn("newcolumn", "bar").build());
 
         runOperation(operation, project);
 
@@ -213,6 +243,8 @@ public class ColumnAdditionOperationTests extends RefineTest {
                 OnError.SetToBlank,
                 "newcolumn",
                 2);
+        assertEquals(operation.getColumnDependencies().get(), Set.of("bar"));
+        assertEquals(operation.getColumnsDiff().get(), ColumnsDiff.builder().addColumn("newcolumn", "bar").build());
 
         runOperation(operation, project);
 
@@ -238,6 +270,8 @@ public class ColumnAdditionOperationTests extends RefineTest {
                 OnError.SetToBlank,
                 "newcolumn",
                 2);
+        assertEquals(operation.getColumnDependencies().get(), Set.of("bar"));
+        assertEquals(operation.getColumnsDiff().get(), ColumnsDiff.builder().addColumn("newcolumn", "bar").build());
 
         runOperation(operation, project);
 
@@ -269,6 +303,8 @@ public class ColumnAdditionOperationTests extends RefineTest {
                 OnError.SetToBlank,
                 "newcolumn",
                 2);
+        assertEquals(operation.getColumnDependencies().get(), Set.of("bar"));
+        assertEquals(operation.getColumnsDiff().get(), ColumnsDiff.builder().addColumn("newcolumn", "bar").build());
 
         runOperation(operation, project);
 

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnMoveOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnMoveOperationTests.java
@@ -27,7 +27,10 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
+import java.util.Set;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
@@ -35,6 +38,7 @@ import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationRegistry;
 import com.google.refine.util.ParsingUtilities;
@@ -74,6 +78,8 @@ public class ColumnMoveOperationTests extends RefineTest {
     @Test
     public void testForward() throws Exception {
         ColumnMoveOperation operation = new ColumnMoveOperation("foo", 1);
+        assertEquals(operation.getColumnDependencies().get(), Set.of("foo"));
+        assertEquals(operation.getColumnsDiff().get(), ColumnsDiff.empty());
 
         runOperation(operation, project);
 
@@ -93,6 +99,8 @@ public class ColumnMoveOperationTests extends RefineTest {
     @Test
     public void testSamePosition() throws Exception {
         ColumnMoveOperation SUT = new ColumnMoveOperation("bar", 1);
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("bar"));
+        assertEquals(SUT.getColumnsDiff().get(), ColumnsDiff.empty());
 
         runOperation(SUT, project);
 
@@ -112,6 +120,8 @@ public class ColumnMoveOperationTests extends RefineTest {
     @Test
     public void testBackward() throws Exception {
         ColumnMoveOperation SUT = new ColumnMoveOperation("hello", 1);
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("hello"));
+        assertEquals(SUT.getColumnsDiff().get(), ColumnsDiff.empty());
 
         runOperation(SUT, project);
 

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnRemovalOperationTests.java
@@ -27,7 +27,10 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
+import java.util.Set;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
@@ -35,6 +38,7 @@ import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationRegistry;
 import com.google.refine.util.ParsingUtilities;
@@ -73,6 +77,8 @@ public class ColumnRemovalOperationTests extends RefineTest {
     @Test
     public void testRemoval() throws Exception {
         ColumnRemovalOperation SUT = new ColumnRemovalOperation("foo");
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("foo"));
+        assertEquals(SUT.getColumnsDiff().get(), ColumnsDiff.builder().deleteColumn("foo").build());
 
         runOperation(SUT, project);
 

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnRenameOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnRenameOperationTests.java
@@ -27,7 +27,10 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
+import java.util.Set;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
@@ -36,6 +39,7 @@ import org.testng.annotations.Test;
 import com.google.refine.RefineTest;
 import com.google.refine.expr.EvalError;
 import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationRegistry;
 import com.google.refine.util.ParsingUtilities;
@@ -76,6 +80,8 @@ public class ColumnRenameOperationTests extends RefineTest {
     @Test
     public void testRename() throws Exception {
         ColumnRenameOperation SUT = new ColumnRenameOperation("foo", "newfoo");
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("foo"));
+        assertEquals(SUT.getColumnsDiff().get(), ColumnsDiff.builder().deleteColumn("foo").addColumn("newfoo", "foo").build());
 
         runOperation(SUT, project);
 

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnReorderOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnReorderOperationTests.java
@@ -27,8 +27,12 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -75,6 +79,8 @@ public class ColumnReorderOperationTests extends RefineTest {
         int cCol = project.columnModel.getColumnByName("c").getCellIndex();
 
         AbstractOperation op = new ColumnReorderOperation(Arrays.asList("a"));
+        assertEquals(op.getColumnDependencies().get(), Set.of("a"));
+        assertEquals(op.getColumnsDiff(), Optional.empty());
 
         runOperation(op, project);
 
@@ -97,6 +103,8 @@ public class ColumnReorderOperationTests extends RefineTest {
     @Test
     public void testReorder() throws Exception {
         ColumnReorderOperation SUT = new ColumnReorderOperation(Arrays.asList("c", "b"));
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("b", "c"));
+        assertEquals(SUT.getColumnsDiff(), Optional.empty());
 
         runOperation(SUT, project);
 

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnSplitOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnSplitOperationTests.java
@@ -27,8 +27,12 @@
 
 package com.google.refine.operations.column;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
@@ -109,6 +113,8 @@ public class ColumnSplitOperationTests extends RefineTest {
     public void testSeparator() throws Exception {
         AbstractOperation SUT = new ColumnSplitOperation(new EngineConfig(Collections.emptyList(), Mode.RowBased), "foo", false, false, ",",
                 false, 0);
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("foo"));
+        assertEquals(SUT.getColumnsDiff(), Optional.empty());
 
         runOperation(SUT, project);
 
@@ -129,6 +135,8 @@ public class ColumnSplitOperationTests extends RefineTest {
     public void testSeparatorMaxColumns() throws Exception {
         AbstractOperation SUT = new ColumnSplitOperation(new EngineConfig(Collections.emptyList(), Mode.RowBased), "foo", false, false, ",",
                 false, 2);
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("foo"));
+        assertEquals(SUT.getColumnsDiff(), Optional.empty());
 
         runOperation(SUT, project);
 
@@ -149,6 +157,9 @@ public class ColumnSplitOperationTests extends RefineTest {
     public void testSeparatorDetectType() throws Exception {
         AbstractOperation SUT = new ColumnSplitOperation(new EngineConfig(Collections.emptyList(), Mode.RowBased), "foo", true, false, ",",
                 false, 2);
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("foo"));
+        assertEquals(SUT.getColumnsDiff(), Optional.empty());
+
         runOperation(SUT, project);
 
         Project expected = createProject(
@@ -168,6 +179,8 @@ public class ColumnSplitOperationTests extends RefineTest {
     public void testSeparatorRemoveColumn() throws Exception {
         AbstractOperation SUT = new ColumnSplitOperation(new EngineConfig(Collections.emptyList(), Mode.RowBased), "foo", true, true, ",",
                 false, 2);
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("foo"));
+        assertEquals(SUT.getColumnsDiff(), Optional.empty());
 
         runOperation(SUT, project);
 
@@ -188,6 +201,8 @@ public class ColumnSplitOperationTests extends RefineTest {
     public void testRegex() throws Exception {
         AbstractOperation SUT = new ColumnSplitOperation(new EngineConfig(Collections.emptyList(), Mode.RowBased), "bar", false, false,
                 "[A-Z]", true, 0);
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("bar"));
+        assertEquals(SUT.getColumnsDiff(), Optional.empty());
 
         runOperation(SUT, project);
 
@@ -208,6 +223,8 @@ public class ColumnSplitOperationTests extends RefineTest {
     public void testLengths() throws Exception {
         AbstractOperation operation = new ColumnSplitOperation(new EngineConfig(Collections.emptyList(), Mode.RowBased), "hello", false,
                 false, new int[] { 1, 2 });
+        assertEquals(operation.getColumnDependencies().get(), Set.of("hello"));
+        assertEquals(operation.getColumnsDiff(), Optional.empty());
 
         runOperation(operation, project);
 

--- a/modules/core/src/main/java/com/google/refine/model/AbstractOperation.java
+++ b/modules/core/src/main/java/com/google/refine/model/AbstractOperation.java
@@ -33,7 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.model;
 
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -98,5 +100,24 @@ abstract public class AbstractOperation {
     @JsonProperty("description")
     public String getJsonDescription() {
         return getBriefDescription(null);
+    }
+
+    /**
+     * A set of columns required by this operation to run. If present, the operation is guaranteed to be able to run on
+     * any project which has at least those columns. If equal to {@link Optional#empty()} the operation could
+     * potentially depend on any column.
+     */
+    @JsonIgnore
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.empty();
+    }
+
+    /**
+     * If the effect of the operation on the set of columns in the project is predictable, this effect can be exposed in
+     * this method. Otherwise, {@link Optional#empty()} can be returned.
+     */
+    @JsonIgnore
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.empty();
     }
 }

--- a/modules/core/src/main/java/com/google/refine/model/AddedColumn.java
+++ b/modules/core/src/main/java/com/google/refine/model/AddedColumn.java
@@ -1,0 +1,66 @@
+
+package com.google.refine.model;
+
+import java.util.Objects;
+
+import org.apache.commons.lang.Validate;
+
+/**
+ * A column added by an operation, part of a {@link ColumnDiff}. <br>
+ * Supplying the name of the column it is inserted after makes it possible to pre-compute the order of the columns in
+ * the resulting grid, which is useful for visualization purposes.
+ */
+public class AddedColumn {
+
+    private final String name;
+    private final String afterName;
+
+    /**
+     * @param name
+     *            the name of the column being added
+     * @param afterName
+     *            optionally, the name of the column to its left, specifying the insertion point of the column.
+     *            Otherwise, null.
+     */
+    public AddedColumn(String name, String afterName) {
+        Validate.notNull(name);
+        this.name = name;
+        this.afterName = afterName;
+    }
+
+    /**
+     * The name of the column being added.
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * The name of the column it is added after, or null if it is not known.
+     */
+    public String getAfterName() {
+        return afterName;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(afterName, name);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        AddedColumn other = (AddedColumn) obj;
+        return Objects.equals(afterName, other.afterName) && Objects.equals(name, other.name);
+    }
+
+    @Override
+    public String toString() {
+        return "AddedColumn [name=" + name + ", afterName=" + afterName + "]";
+    }
+}

--- a/modules/core/src/main/java/com/google/refine/model/ColumnsDiff.java
+++ b/modules/core/src/main/java/com/google/refine/model/ColumnsDiff.java
@@ -1,0 +1,153 @@
+
+package com.google.refine.model;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.Validate;
+
+/**
+ * Represents the changes made by an operation to the set of columns in a project.
+ */
+public class ColumnsDiff {
+
+    private final List<AddedColumn> addedColumns;
+    private final Set<String> deletedColumns;
+    private final Set<String> modifiedColumns;
+
+    private final static ColumnsDiff empty = new ColumnsDiff(List.of(), Set.of(), Set.of());
+
+    /**
+     * An empty diff, for when columns don't change at all.
+     */
+    public static ColumnsDiff empty() {
+        return empty;
+    }
+
+    /**
+     * A column diff which for an operation that only modifies a single column
+     */
+    public static ColumnsDiff modifySingleColumn(String name) {
+        return builder().modifyColumn(name).build();
+    }
+
+    /**
+     * A fresh builder object.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Constructor. Consider using {@link Builder} instead.
+     * 
+     * @param addedColumns
+     *            the list of column names that appear after this operation, in the order they appear in the new table
+     * @param deletedColumns
+     *            the set of column names that disappear after this operation
+     * @param modifiedColumns
+     *            the names of existing columns whose contents are modified by this operation
+     */
+    public ColumnsDiff(List<AddedColumn> addedColumns, Set<String> deletedColumns, Set<String> modifiedColumns) {
+        this.addedColumns = addedColumns;
+        this.deletedColumns = deletedColumns;
+        this.modifiedColumns = modifiedColumns;
+    }
+
+    /**
+     * The columns names that were absent before and present after the operation. This includes the new names of any
+     * renamed columns.
+     */
+    public List<AddedColumn> getAddedColumns() {
+        return addedColumns;
+    }
+
+    /**
+     * Convenience method to return only added column names, without position info.
+     */
+    public List<String> getAddedColumnNames() {
+        return addedColumns.stream().map(AddedColumn::getName).collect(Collectors.toList());
+    }
+
+    /**
+     * The columns names that were present before and absent after the operation. This includes the old names of any
+     * renamed columns.
+     */
+    public Set<String> getDeletedColumns() {
+        return deletedColumns;
+    }
+
+    /**
+     * The names of columns that are modified by this operation.
+     */
+    public Set<String> getModifiedColumns() {
+        return modifiedColumns;
+    }
+
+    public static class Builder {
+
+        private final List<AddedColumn> added = new ArrayList<>();
+        private final Set<String> deleted = new HashSet<>();
+        private final Set<String> modified = new HashSet<>();
+        private boolean built = false;
+
+        public Builder addColumn(AddedColumn columnName) {
+            Validate.isTrue(!built, "The ColumnsDiff was already built");
+            added.add(columnName);
+            return this;
+        }
+
+        public Builder addColumn(String name, String after) {
+            Validate.isTrue(!built, "The ColumnsDiff was already built");
+            added.add(new AddedColumn(name, after));
+            return this;
+        }
+
+        public Builder deleteColumn(String columnName) {
+            Validate.isTrue(!built, "The ColumnsDiff was already built");
+            deleted.add(columnName);
+            return this;
+        }
+
+        public Builder modifyColumn(String columnName) {
+            Validate.isTrue(!built, "The ColumnsDiff was already built");
+            modified.add(columnName);
+            return this;
+        }
+
+        public ColumnsDiff build() {
+            Validate.isTrue(!built, "The ColumnsDiff was already built");
+            built = true;
+            return new ColumnsDiff(added, deleted, modified);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(addedColumns, deletedColumns, modifiedColumns);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ColumnsDiff other = (ColumnsDiff) obj;
+        return Objects.equals(addedColumns, other.addedColumns) && Objects.equals(deletedColumns, other.deletedColumns)
+                && Objects.equals(modifiedColumns, other.modifiedColumns);
+    }
+
+    @Override
+    public String toString() {
+        return "ColumnsDiff [addedColumns=" + addedColumns + ", deletedColumns=" + deletedColumns + ", modifiedColumns=" + modifiedColumns
+                + "]";
+    }
+
+}


### PR DESCRIPTION
This pull request adds metadata fields to operations:
* the _column dependencies_, which is a set of column names that are required to be present in the project for this operation to be applicable
* the _columns diff_, which is an object indicating which columns are added, modified or deleted by this operation.

Those two metadata fields are currently not added to the JSON serialization of operations, in the interest of keeping that representation unchanged and because their contents can be derived from other operation parameters. The fields are also optional, to ensure backwards compatibility.

Those fields will enable two things:
* to predict the set of columns present at each stage of the execution of a list of operations, so that we can anticipate missing columns before running any operation. For instance, consider a case where the user wants to apply a recipe which starts by fetching URLs from a column `foo`, storing the responses in column `bar`, and then running a text transform operation on the column `bar`. Thanks to the operation metadata introduced by this PR, we will be able to detect that the recipe requires column `foo` to exist in the project. We can validate that the column `bar` required by the second operation in the recipe is created by the first operation. We can also infer that the recipe requires column `bar` not to exist in the initial project (since it would conflict with the newly created column).
* to offer a graphical representation of a recipe, to help the user understand its structure. I would like this graphical representation to eventually replace the JSON representation that is currently exposed to users.

I imagine that it could be useful to still tweak the public API introduced by this PR, so I would rather not include it in the upcoming 3.9 release, but only merge it afterwards, so that it gives a bit more time to do adjustments if needed.