### PR TITLE
ui: Remove usage of table for layout in menu system

### DIFF
--- a/main/webapp/modules/core/scripts/util/menu.js
+++ b/main/webapp/modules/core/scripts/util/menu.js
@@ -137,14 +137,9 @@ MenuSystem.createAndShowStandardMenu = function(items, elmt, options) {
   var createMenuItem = function(item) {
     if ("label" in item) {
       var menuItem = MenuSystem.createMenuItem().appendTo(menu);
+      menuItem.text(item.label);
       if ("submenu" in item) {
-        menuItem.html(
-          '<table role="presentation" width="100%" cellspacing="0" cellpadding="0" class="menu-item-layout"><tr>' +
-          '<td>' + item.label + '</td>' +
-          '<td width="1%"><img src="images/right-arrow.png" /></td>' +
-          '</tr></table>'
-        );
-
+        menuItem.addClass('submenu');
         menuItem.on('mouseenter click', function () {
         clearTimeout(MenuSystem._hoverTimeout);
         MenuSystem._hoverTimeout = setTimeout(function () {
@@ -162,11 +157,10 @@ MenuSystem.createAndShowStandardMenu = function(items, elmt, options) {
 
       } else {
         if ("download" in item) {
-          menuItem.html(item.label);
           menuItem.attr("href",item.download);
           menuItem.attr("download","");
         } else {
-          menuItem.html(item.label).on('click', function (evt) {
+          menuItem.on('click', function (evt) {
             item.click.call(this, evt);
             MenuSystem.dismissAll();
           });

--- a/main/webapp/modules/core/styles/util/menu.css
+++ b/main/webapp/modules/core/styles/util/menu.css
@@ -67,15 +67,17 @@ a.menu-item {
 }
 
 a.menu-item:hover {
-  background: #dbe8f8;
+  background-color: #dbe8f8;
+}
+
+.menu-item.submenu {
+  background: url('../../images/right-arrow.png') no-repeat;
+  background-position-x: right 7px;
+  background-position-y: 50%;
 }
 
 a.menu-item img {
   border: none;
-}
-
-table.menu-item-layout td {
-  vertical-align: middle;
 }
 
 .menu-section {


### PR DESCRIPTION
This shouldn't make any difference to users, just simplifies/cleans up the DOM. (The only minor difference I am aware of on Firefox is that the right triangle gets downloaded only once and not requested every time a menu is opened, which seems to be a rather good thing!)

I also changed the introduction of the label to use `$.text()` instead of `$.html()`, which could break some extensions which rely on inserting custom HTML in menus, but makes us safe from special characters in translations of menu entries.