### PR TITLE
Add icons to operations in column menu

### DIFF
--- a/main/webapp/modules/core/images/operations/add-column.svg
+++ b/main/webapp/modules/core/images/operations/add-column.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="add-column.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="3.1963805"
+     inkscape:cx="48.49235"
+     inkscape:cy="97.141127"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-dasharray:none"
+       d="M 3.9995882,15.937216 H 29.624054"
+       id="path1550" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.754895,3.1514624 V 28.775928"
+       id="path1550-5" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/blank-down.svg
+++ b/main/webapp/modules/core/images/operations/blank-down.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="blank-down.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.1300911"
+     inkscape:cx="-76.10006"
+     inkscape:cy="-35.395377"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 21.087154,14.052839 17.069113,18.68474 13.45242,13.990023"
+       id="path1588-5"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="fill:#000004;fill-opacity:1;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
+       id="rect4722"
+       width="12.814583"
+       height="7.3339443"
+       x="10.735916"
+       y="3.0329003"
+       ry="0.32915962" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
+       id="rect4722-3"
+       width="12.814583"
+       height="7.3339443"
+       x="10.677723"
+       y="23.158232"
+       ry="0.32915962" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/blank-down.svg
+++ b/main/webapp/modules/core/images/operations/blank-down.svg
@@ -24,13 +24,13 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="1.1300911"
-     inkscape:cx="-76.10006"
-     inkscape:cy="-35.395377"
-     inkscape:window-width="1366"
-     inkscape:window-height="699"
+     inkscape:zoom="1.897292"
+     inkscape:cx="58.767969"
+     inkscape:cy="120.69834"
+     inkscape:window-width="1503"
+     inkscape:window-height="933"
      inkscape:window-x="0"
-     inkscape:window-y="32"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer1"
      showguides="true">
@@ -45,25 +45,19 @@
      inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666995;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
        d="M 21.087154,14.052839 17.069113,18.68474 13.45242,13.990023"
        id="path1588-5"
        sodipodi:nodetypes="ccc" />
-    <rect
-       style="fill:#000004;fill-opacity:1;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
-       id="rect4722"
-       width="12.814583"
-       height="7.3339443"
-       x="10.735916"
-       y="3.0329003"
-       ry="0.32915962" />
-    <rect
-       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
-       id="rect4722-3"
-       width="12.814583"
-       height="7.3339443"
-       x="10.677723"
-       y="23.158232"
-       ry="0.32915962" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.3807129,23.397355 H 25.65118 v 6.792381 l -17.2824981,0.01298 z"
+       id="path4240"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#000004;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       d="M 8.3441956,3.5833 H 25.614663 v 6.792381 l -17.2824984,0.01298 z"
+       id="path4240-4"
+       sodipodi:nodetypes="ccccc" />
   </g>
 </svg>

--- a/main/webapp/modules/core/images/operations/cluster.svg
+++ b/main/webapp/modules/core/images/operations/cluster.svg
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="cluster.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="2.2601822"
+     inkscape:cx="70.348311"
+     inkscape:cy="4.8668643"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 3.826943,26.945056 c 0,0 14.604349,-3.657175 16.65716,-7.78168 1.814887,-3.646469 0.002,-9.5810439 -4.396418,-11.3506235 C 12.149035,6.2281581 5.2858831,7.9610715 4.4862699,13.157614 3.3118525,20.789942 16.071596,30.592107 16.071596,30.592107"
+       id="path998"
+       sodipodi:nodetypes="csssc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208333;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 26.499107,17.608449 h 5.247282"
+       id="path1000" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208333;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 29.175635,14.998326 v 5.212445"
+       id="path1002" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.3636674,18.087065 H 13.61095"
+       id="path1000-3" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.040197,15.476942 v 5.212445"
+       id="path1002-6" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.392961,12.364555 h 5.247282"
+       id="path1000-7" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 14.06949,9.7544321 V 14.966877"
+       id="path1002-5" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 23.927479,9.4415792 h 5.247282"
+       id="path1000-35" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 26.604008,6.8314562 V 12.043901"
+       id="path1002-62" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/data-extension.svg
+++ b/main/webapp/modules/core/images/operations/data-extension.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="data-extension.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.5981902"
+     inkscape:cx="-43.799542"
+     inkscape:cy="91.666184"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 6.1039088,25.41717 H 27.529064"
+       id="path1550"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 10.863319,5.2145395 V 19.30839"
+       id="path1550-5"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 15.595498,14.549703 -4.819495,5.43721 -4.3380927,-5.510947"
+       id="path1588"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22.114561,5.291373 v 14.09385"
+       id="path1550-5-9"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 26.84674,14.626536 -4.819495,5.43721 -4.338093,-5.510947"
+       id="path1588-1"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/delete.svg
+++ b/main/webapp/modules/core/images/operations/delete.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="delete.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="3.1963805"
+     inkscape:cx="25.341163"
+     inkscape:cy="109.02957"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.95241;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 4.6573604,7.8964783 30.032249,7.9378663"
+       id="path1266"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10.676704,5.2713252 12.96216,-0.040628"
+       id="path1266-3"
+       sodipodi:nodetypes="cc" />
+    <rect
+       style="fill:none;fill-opacity:0.413127;stroke:#000000;stroke-width:1.85208;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1320"
+       width="15.678661"
+       height="18.141447"
+       x="9.2508936"
+       y="10.76624" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11379;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 13.202611,13.083841 v 13.50083"
+       id="path1322" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11379;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 17.188864,13.085951 v 13.50083"
+       id="path1322-6" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11379;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 21.095329,13.052857 V 26.553686"
+       id="path1322-7" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/delete.svg
+++ b/main/webapp/modules/core/images/operations/delete.svg
@@ -24,9 +24,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="3.1963805"
-     inkscape:cx="25.341163"
-     inkscape:cy="109.02957"
+     inkscape:zoom="4.5203647"
+     inkscape:cx="68.025485"
+     inkscape:cy="69.795254"
      inkscape:window-width="1918"
      inkscape:window-height="1054"
      inkscape:window-x="0"
@@ -45,32 +45,30 @@
      id="layer1">
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.95241;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="M 4.6573604,7.8964783 30.032249,7.9378663"
+       d="M 4.6924814,7.6474605 30.06737,7.6888485"
        id="path1266"
        sodipodi:nodetypes="cc" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 10.676704,5.2713252 12.96216,-0.040628"
+       d="m 10.711825,5.8309012 12.96216,-0.040628"
        id="path1266-3"
        sodipodi:nodetypes="cc" />
     <rect
        style="fill:none;fill-opacity:0.413127;stroke:#000000;stroke-width:1.85208;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
        id="rect1320"
-       width="15.678661"
-       height="18.141447"
-       x="9.2508936"
-       y="10.76624" />
+       width="14.770191"
+       height="18.141445"
+       x="9.9311962"
+       y="9.3184395" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11379;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 13.202611,13.083841 v 13.50083"
-       id="path1322" />
+       d="M 14.553831,12.299286 V 24.547949"
+       id="path1322"
+       sodipodi:nodetypes="cc" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11379;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 17.188864,13.085951 v 13.50083"
-       id="path1322-6" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11379;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="M 21.095329,13.052857 V 26.553686"
-       id="path1322-7" />
+       d="m 20.037132,12.290964 v 12.226"
+       id="path1322-7"
+       sodipodi:nodetypes="cc" />
   </g>
 </svg>

--- a/main/webapp/modules/core/images/operations/fetch-urls.svg
+++ b/main/webapp/modules/core/images/operations/fetch-urls.svg
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="fetch-urls.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="2.2601823"
+     inkscape:cx="38.49247"
+     inkscape:cy="55.084052"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 6.1039088,25.41717 H 27.529064"
+       id="path1550"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.950252,4.0352158 V 19.431029"
+       id="path1550-5"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3.175;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22.987481,13.225937 -6.124545,6.883615 -5.759364,-6.91193"
+       id="path1588"
+       sodipodi:nodetypes="ccc" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/fill-down.svg
+++ b/main/webapp/modules/core/images/operations/fill-down.svg
@@ -24,13 +24,13 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="3.1963803"
-     inkscape:cx="56.939407"
-     inkscape:cy="64.4479"
-     inkscape:window-width="1366"
-     inkscape:window-height="699"
+     inkscape:zoom="1.897292"
+     inkscape:cx="58.767969"
+     inkscape:cy="120.69834"
+     inkscape:window-width="1503"
+     inkscape:window-height="933"
      inkscape:window-x="0"
-     inkscape:window-y="32"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer1"
      showguides="true">
@@ -45,25 +45,19 @@
      inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 21.142145,14.275802 -4.018041,4.631901 -3.616693,-4.694717"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666995;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 21.087154,14.052839 17.069113,18.68474 13.45242,13.990023"
        id="path1588-5"
        sodipodi:nodetypes="ccc" />
-    <rect
-       style="fill:#000004;fill-opacity:1;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
-       id="rect4722"
-       width="12.814583"
-       height="7.3339443"
-       x="10.735916"
-       y="3.0329003"
-       ry="0.32915962" />
-    <rect
-       style="fill:#000004;fill-opacity:1;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
-       id="rect4722-3"
-       width="12.814583"
-       height="7.3339443"
-       x="10.677723"
-       y="23.158232"
-       ry="0.32915962" />
+    <path
+       style="fill:#000004;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       d="M 8.3807129,23.397355 H 25.65118 v 6.792381 l -17.2824981,0.01298 z"
+       id="path4240"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#000004;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1;fill-opacity:1"
+       d="M 8.3441956,3.5833 H 25.614663 v 6.792381 l -17.2824984,0.01298 z"
+       id="path4240-4"
+       sodipodi:nodetypes="ccccc" />
   </g>
 </svg>

--- a/main/webapp/modules/core/images/operations/fill-down.svg
+++ b/main/webapp/modules/core/images/operations/fill-down.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="fill-down.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="3.1963803"
+     inkscape:cx="56.939407"
+     inkscape:cy="64.4479"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 21.142145,14.275802 -4.018041,4.631901 -3.616693,-4.694717"
+       id="path1588-5"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="fill:#000004;fill-opacity:1;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
+       id="rect4722"
+       width="12.814583"
+       height="7.3339443"
+       x="10.735916"
+       y="3.0329003"
+       ry="0.32915962" />
+    <rect
+       style="fill:#000004;fill-opacity:1;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
+       id="rect4722-3"
+       width="12.814583"
+       height="7.3339443"
+       x="10.677723"
+       y="23.158232"
+       ry="0.32915962" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/join-columns.svg
+++ b/main/webapp/modules/core/images/operations/join-columns.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="join-columns.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="2.2601823"
+     inkscape:cx="36.722702"
+     inkscape:cy="98.222167"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 1.1034137,17.240216 H 13.961759"
+       id="path1550-5"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 8.0707104,12.052423 6.0196246,5.335741 -6.1012603,4.802772"
+       id="path1588"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 33.162344,17.301207 H 20.303998"
+       id="path1550-5-7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 26.195047,12.113414 -6.019625,5.335741 6.10126,4.802772"
+       id="path1588-5"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208333;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 11.690082,11.221237 V 3.7515591 h 10.305413 v 7.6399439"
+       id="path737" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208333;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.763955,22.990828 v 7.469676 h 10.305413 v -7.639943"
+       id="path737-3" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/join-rows.svg
+++ b/main/webapp/modules/core/images/operations/join-rows.svg
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="join-rows.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="2.2601823"
+     inkscape:cx="37.165144"
+     inkscape:cy="98.664608"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.998694,1.0765664 V 13.934912"
+       id="path1550-5"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 22.186487,8.0438631 16.850746,14.063488 12.047974,7.9622274"
+       id="path1588"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.937703,33.135497 V 20.277151"
+       id="path1550-5-7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22.125496,26.1682 -5.335741,-6.019625 -4.802772,6.10126"
+       id="path1588-5"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 23.017673,11.663235 h 7.469678 v 10.305413 h -7.639944"
+       id="path737" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 11.248082,11.737108 H 3.7784064 v 10.305413 h 7.6399426"
+       id="path737-3" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/key-value-columnize.svg
+++ b/main/webapp/modules/core/images/operations/key-value-columnize.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="key-value-columnize.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="2.2601822"
+     inkscape:cx="79.197155"
+     inkscape:cy="70.348311"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2.38125;stroke-dasharray:none"
+       id="rect1743"
+       width="19.482"
+       height="7.2199326"
+       x="7.8520594"
+       y="20.167303"
+       ry="0.32573697" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.3704522,16.413496 V 6.4702621 H 17.411744 V 16.589583"
+       id="path5850" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.412348,16.417661 V 6.4744266 H 26.45364 V 16.593748"
+       id="path5850-1" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/magic-wand.svg
+++ b/main/webapp/modules/core/images/operations/magic-wand.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="magic-wand.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.5981902"
+     inkscape:cx="3.7542466"
+     inkscape:cy="82.593426"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.64583;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.4806714,25.430339 19.730087,12.567572"
+       id="path13714"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:type="star"
+       style="fill:#000004;fill-opacity:1;stroke:#000000;stroke-width:1.32292;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
+       id="path13768"
+       inkscape:flatsided="false"
+       sodipodi:sides="5"
+       sodipodi:cx="15.739393"
+       sodipodi:cy="3.7671988"
+       sodipodi:r1="5.6337204"
+       sodipodi:r2="1.2242661"
+       sodipodi:arg1="1.1818413"
+       sodipodi:arg2="1.8059566"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="M 17.875822,8.9801132 15.454141,4.9577694 11.44181,7.4099427 14.518945,3.863814 10.946912,0.80562395 15.270368,2.6363397 17.07506,-1.705899 l -0.405093,4.6775732 4.687395,0.374539 -4.573817,1.0601835 z"
+       inkscape:transform-center-x="-0.26251037"
+       inkscape:transform-center-y="-0.082740094"
+       transform="matrix(0.63601327,0,0,0.63601327,5.1699357,4.6555798)" />
+    <path
+       sodipodi:type="star"
+       style="fill:#000004;fill-opacity:1;stroke:#000000;stroke-width:1.32292;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
+       id="path13768-6"
+       inkscape:flatsided="false"
+       sodipodi:sides="5"
+       sodipodi:cx="15.739393"
+       sodipodi:cy="3.7671988"
+       sodipodi:r1="5.6337204"
+       sodipodi:r2="1.2242661"
+       sodipodi:arg1="1.1818413"
+       sodipodi:arg2="1.8059566"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="M 17.875822,8.9801132 15.454141,4.9577694 11.44181,7.4099427 14.518945,3.863814 10.946912,0.80562395 15.270368,2.6363397 17.07506,-1.705899 l -0.405093,4.6775732 4.687395,0.374539 -4.573817,1.0601835 z"
+       inkscape:transform-center-x="-0.26251037"
+       inkscape:transform-center-y="-0.082740094"
+       transform="matrix(0.63601327,0,0,0.63601327,14.314128,7.4237348)" />
+    <path
+       sodipodi:type="star"
+       style="fill:#000004;fill-opacity:1;stroke:#000000;stroke-width:1.32292;stroke-linecap:butt;stroke-miterlimit:0;stroke-dasharray:none"
+       id="path13768-6-7"
+       inkscape:flatsided="false"
+       sodipodi:sides="5"
+       sodipodi:cx="15.739393"
+       sodipodi:cy="3.7671988"
+       sodipodi:r1="5.6337204"
+       sodipodi:r2="1.2242661"
+       sodipodi:arg1="1.1818413"
+       sodipodi:arg2="1.8059566"
+       inkscape:rounded="0"
+       inkscape:randomized="0"
+       d="M 17.875822,8.9801132 15.454141,4.9577694 11.44181,7.4099427 14.518945,3.863814 10.946912,0.80562395 15.270368,2.6363397 17.07506,-1.705899 l -0.405093,4.6775732 4.687395,0.374539 -4.573817,1.0601835 z"
+       inkscape:transform-center-x="-0.26251037"
+       inkscape:transform-center-y="-0.082740094"
+       transform="matrix(0.63601327,0,0,0.63601327,14.356264,16.274468)" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/move-first.svg
+++ b/main/webapp/modules/core/images/operations/move-first.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="move-first.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="0.79909512"
+     inkscape:cx="-147.66703"
+     inkscape:cy="182.08095"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.350773;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.870425,6.7297761 V 27.916289 L 5.8612761,17.400502 Z"
+       id="path1848"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.350773;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 27.121387,6.732042 V 27.918555 L 15.112239,17.402768 Z"
+       id="path1848-9"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/move-last.svg
+++ b/main/webapp/modules/core/images/operations/move-last.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="move-last.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="3.1963805"
+     inkscape:cx="11.575593"
+     inkscape:cy="94.638296"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.350773;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.432932,6.7297761 V 27.916289 L 28.44208,17.400502 Z"
+       id="path1848"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.350773;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.1819698,6.732042 V 27.918555 L 19.191118,17.402768 Z"
+       id="path1848-9"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/move-left.svg
+++ b/main/webapp/modules/core/images/operations/move-left.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="move-left.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="4.5203646"
+     inkscape:cx="40.48346"
+     inkscape:cy="75.989446"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.350773;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 20.998852,5.9024477 V 27.088961 L 8.9897039,16.573174 Z"
+       id="path1848"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/move-right.svg
+++ b/main/webapp/modules/core/images/operations/move-right.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="move-right.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="4.5203646"
+     inkscape:cx="40.48346"
+     inkscape:cy="75.989446"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.350773;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 11.454593,5.9024477 V 27.088961 L 23.463741,16.573174 Z"
+       id="path1848"
+       sodipodi:nodetypes="cccc" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/reconcile.svg
+++ b/main/webapp/modules/core/images/operations/reconcile.svg
@@ -24,9 +24,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="false"
-     inkscape:zoom="1.1300912"
-     inkscape:cx="-171.66757"
-     inkscape:cy="-120.78672"
+     inkscape:zoom="3.1963806"
+     inkscape:cx="90.101911"
+     inkscape:cy="83.375553"
      inkscape:window-width="1918"
      inkscape:window-height="1054"
      inkscape:window-x="0"
@@ -34,11 +34,29 @@
      inkscape:window-maximized="1"
      inkscape:current-layer="layer1" />
   <defs
-     id="defs2" />
+     id="defs2">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1904">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.5875;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         id="circle1906"
+         cx="11.606934"
+         cy="17.216995"
+         r="8.4922943" />
+    </clipPath>
+  </defs>
   <g
      inkscape:label="Calque 1"
      inkscape:groupmode="layer"
      id="layer1">
+    <circle
+       style="fill:#b3b3b3;fill-opacity:1;stroke:none;stroke-width:1.5875;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       id="path958-3-3"
+       cx="22.477894"
+       cy="17.184381"
+       r="8.4922943"
+       clip-path="url(#clipPath1904)" />
     <circle
        style="fill:none;fill-opacity:0.413127;stroke:#000000;stroke-width:1.5875;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
        id="path958"

--- a/main/webapp/modules/core/images/operations/reconcile.svg
+++ b/main/webapp/modules/core/images/operations/reconcile.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="reconcile.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.1300912"
+     inkscape:cx="-171.66757"
+     inkscape:cy="-120.78672"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:none;fill-opacity:0.413127;stroke:#000000;stroke-width:1.5875;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       id="path958"
+       cx="11.579464"
+       cy="17.274986"
+       r="8.4922943" />
+    <circle
+       style="fill:none;fill-opacity:0.413127;stroke:#000000;stroke-width:1.5875;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       id="path958-3"
+       cx="22.492035"
+       cy="17.232346"
+       r="8.4922943" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/rename.svg
+++ b/main/webapp/modules/core/images/operations/rename.svg
@@ -24,9 +24,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="4.5203646"
-     inkscape:cx="24.555541"
-     inkscape:cy="74.219677"
+     inkscape:zoom="6.3927609"
+     inkscape:cx="10.793459"
+     inkscape:cy="69.6882"
      inkscape:window-width="1918"
      inkscape:window-height="1054"
      inkscape:window-x="0"
@@ -44,12 +44,12 @@
      inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.74132;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
        d="m 11.008861,4.6678401 h 2.808789 c 1.369881,0.040469 2.89201,1.9412373 2.89201,3.2541978 V 24.246715 c 0.02003,1.658895 -1.329652,3.140953 -2.908329,3.169529 h -2.768589"
        id="path1750"
        sodipodi:nodetypes="ccsccc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.74132;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
        d="m 22.422004,4.7098912 h -2.808789 c -1.369881,0.040469 -2.89201,1.9412373 -2.89201,3.2541979 V 24.288766 c -0.02003,1.658895 1.329652,3.140953 2.908329,3.169529 h 2.768589"
        id="path1750-0"
        sodipodi:nodetypes="ccsccc" />

--- a/main/webapp/modules/core/images/operations/rename.svg
+++ b/main/webapp/modules/core/images/operations/rename.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="rename.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="4.5203646"
+     inkscape:cx="24.555541"
+     inkscape:cy="74.219677"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.74132;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.008861,4.6678401 h 2.808789 c 1.369881,0.040469 2.89201,1.9412373 2.89201,3.2541978 V 24.246715 c 0.02003,1.658895 -1.329652,3.140953 -2.908329,3.169529 h -2.768589"
+       id="path1750"
+       sodipodi:nodetypes="ccsccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.74132;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22.422004,4.7098912 h -2.808789 c -1.369881,0.040469 -2.89201,1.9412373 -2.89201,3.2541979 V 24.288766 c -0.02003,1.658895 1.329652,3.140953 2.908329,3.169529 h 2.768589"
+       id="path1750-0"
+       sodipodi:nodetypes="ccsccc" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/rename.svg
+++ b/main/webapp/modules/core/images/operations/rename.svg
@@ -24,9 +24,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="6.3927609"
-     inkscape:cx="10.793459"
-     inkscape:cy="69.6882"
+     inkscape:zoom="3.1963805"
+     inkscape:cx="127.1751"
+     inkscape:cy="63.040055"
      inkscape:window-width="1918"
      inkscape:window-height="1054"
      inkscape:window-x="0"
@@ -38,20 +38,74 @@
        id="grid1359" />
   </sodipodi:namedview>
   <defs
-     id="defs2" />
+     id="defs2">
+    <rect
+       x="6.9902141"
+       y="90.099872"
+       width="45.334787"
+       height="34.325563"
+       id="rect2215" />
+    <rect
+       x="32.211909"
+       y="56.192209"
+       width="26.284986"
+       height="17.485589"
+       id="rect2207" />
+    <rect
+       x="28.349413"
+       y="48.823827"
+       width="35.299231"
+       height="28.367133"
+       id="rect2149" />
+  </defs>
   <g
      inkscape:label="Calque 1"
      inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 11.008861,4.6678401 h 2.808789 c 1.369881,0.040469 2.89201,1.9412373 2.89201,3.2541978 V 24.246715 c 0.02003,1.658895 -1.329652,3.140953 -2.908329,3.169529 h -2.768589"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 17.161558,7.0144412 h 2.386056 c 1.163708,0.034378 2.456751,1.6490737 2.456751,2.7644286 V 23.646621 c 0.01702,1.409225 -1.129534,2.668228 -2.470614,2.692503 h -2.351906"
        id="path1750"
        sodipodi:nodetypes="ccsccc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 22.422004,4.7098912 h -2.808789 c -1.369881,0.040469 -2.89201,1.9412373 -2.89201,3.2541979 V 24.288766 c -0.02003,1.658895 1.329652,3.140953 2.908329,3.169529 h 2.768589"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 26.856979,7.0501634 h -2.386055 c -1.163709,0.034378 -2.456752,1.6490737 -2.456752,2.7644287 V 23.682343 c -0.01702,1.409225 1.129535,2.668228 2.470615,2.692503 h 2.351906"
        id="path1750-0"
        sodipodi:nodetypes="ccsccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 19.232443,22.458946 H 4.3856988 V 11.075268 H 19.235811"
+       id="path1708"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 24.880196,22.441495 H 28.90201 V 11.057818 h -4.025182"
+       id="path1708-5"
+       sodipodi:nodetypes="cccc" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text2147"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:26.6667px;line-height:125%;font-family:STIXIntegralsUp;-inkscape-font-specification:STIXIntegralsUp;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2149);fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <text
+       xml:space="preserve"
+       transform="scale(0.26458333)"
+       id="text2205"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.6667px;line-height:125%;font-family:STIXIntegralsUp;-inkscape-font-specification:STIXIntegralsUp;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2207);fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><tspan
+         x="32.210938"
+         y="90.011097"
+         id="tspan2261"><tspan
+           style="font-size:13.3333px"
+           id="tspan2259">a</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(0.96105751,0,0,0.96105751,-0.22370098,-78.408693)"
+       id="text2213"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:STIXIntegralsUp;-inkscape-font-specification:STIXIntegralsUp;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2215);fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><tspan
+         x="6.9902344"
+         y="102.83786"
+         id="tspan2265"><tspan
+           style="font-weight:bold;-inkscape-font-specification:'STIXIntegralsUp Bold'"
+           id="tspan2263">a</tspan></tspan></text>
   </g>
 </svg>

--- a/main/webapp/modules/core/images/operations/rename.svg
+++ b/main/webapp/modules/core/images/operations/rename.svg
@@ -24,9 +24,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="3.1963805"
-     inkscape:cx="127.1751"
-     inkscape:cy="63.040055"
+     inkscape:zoom="2.2601823"
+     inkscape:cx="-20.794783"
+     inkscape:cy="-24.997983"
      inkscape:window-width="1918"
      inkscape:window-height="1054"
      inkscape:window-x="0"
@@ -63,23 +63,23 @@
      inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 17.161558,7.0144412 h 2.386056 c 1.163708,0.034378 2.456751,1.6490737 2.456751,2.7644286 V 23.646621 c 0.01702,1.409225 -1.129534,2.668228 -2.470614,2.692503 h -2.351906"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.85208333;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 17.245085,5.3372225 h 2.771025 c 1.351462,0.040334 2.853127,1.9347968 2.853127,3.2434012 V 24.85114 c 0.01977,1.653391 -1.311775,3.130532 -2.869226,3.159013 h -2.731366"
        id="path1750"
        sodipodi:nodetypes="ccsccc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 26.856979,7.0501634 h -2.386055 c -1.163709,0.034378 -2.456752,1.6490737 -2.456752,2.7644287 V 23.682343 c -0.01702,1.409225 1.129535,2.668228 2.470615,2.692503 h 2.351906"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.85208333;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 28.504778,5.379134 H 25.733753 C 24.38229,5.4194684 22.880626,7.3139308 22.880626,8.6225353 V 24.893051 c -0.01977,1.653391 1.311776,3.130533 2.869227,3.159014 h 2.731366"
        id="path1750-0"
        sodipodi:nodetypes="ccsccc" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="M 19.232443,22.458946 H 4.3856988 V 11.075268 H 19.235811"
+       d="M 19.650089,23.927472 H 2.4079522 l 0,-14.4797422 H 19.654001"
        id="path1708"
        sodipodi:nodetypes="cccc" />
     <path
        style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="M 24.880196,22.441495 H 28.90201 V 11.057818 h -4.025182"
+       d="m 26.209058,23.966792 h 4.670699 l 0,-14.4646401 h -4.67461"
        id="path1708-5"
        sodipodi:nodetypes="cccc" />
     <text
@@ -94,18 +94,18 @@
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18.6667px;line-height:125%;font-family:STIXIntegralsUp;-inkscape-font-specification:STIXIntegralsUp;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2207);fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><tspan
          x="32.210938"
          y="90.011097"
-         id="tspan2261"><tspan
+         id="tspan1075"><tspan
            style="font-size:13.3333px"
-           id="tspan2259">a</tspan></tspan></text>
+           id="tspan1073">a</tspan></tspan></text>
     <text
        xml:space="preserve"
-       transform="matrix(0.96105751,0,0,0.96105751,-0.22370098,-78.408693)"
+       transform="matrix(1.1161158,0,0,1.127573,-2.9451341,-94.982325)"
        id="text2213"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:14px;line-height:125%;font-family:STIXIntegralsUp;-inkscape-font-specification:STIXIntegralsUp;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect2215);fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><tspan
          x="6.9902344"
          y="102.83786"
-         id="tspan2265"><tspan
+         id="tspan1079"><tspan
            style="font-weight:bold;-inkscape-font-specification:'STIXIntegralsUp Bold'"
-           id="tspan2263">a</tspan></tspan></text>
+           id="tspan1077">a</tspan></tspan></text>
   </g>
 </svg>

--- a/main/webapp/modules/core/images/operations/replace.svg
+++ b/main/webapp/modules/core/images/operations/replace.svg
@@ -8,7 +8,7 @@
    version="1.1"
    id="svg5"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   sodipodi:docname="replace.svg"
+   sodipodi:docname="new_replace.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -24,13 +24,13 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="4.5203644"
-     inkscape:cx="80.524482"
-     inkscape:cy="45.129105"
-     inkscape:window-width="1366"
-     inkscape:window-height="699"
+     inkscape:zoom="3.3198014"
+     inkscape:cx="60.997625"
+     inkscape:cy="58.437231"
+     inkscape:window-width="1503"
+     inkscape:window-height="933"
      inkscape:window-x="0"
-     inkscape:window-y="32"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer1"
      showguides="true">
@@ -45,30 +45,28 @@
      inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="M 8.5215247,11.600476 C 12.85991,4.7245911 20.293128,4.5378033 23.796915,10.975468"
-       id="path1550-5-7"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.518224,5.8661447 c 7.515149,0.5567723 7.297311,3.0916809 8.384088,9.1585863"
+       id="path1550-5"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 24.561897,5.7404805 -0.63264,5.7723475 -5.193339,-1.161056"
-       id="path1588-5"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 29.72333,8.5238418 27.004062,14.731741 21.523951,10.871249"
+       id="path1588"
        sodipodi:nodetypes="ccc" />
     <rect
-       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-dasharray:none"
-       id="rect1743"
-       width="7.5381956"
-       height="10.996837"
-       x="4.3881316"
-       y="15.509556"
-       ry="0.32573697" />
-    <rect
-       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-dasharray:none"
-       id="rect1743-9"
-       width="7.5381956"
-       height="10.996837"
-       x="21.249575"
-       y="15.599813"
-       ry="0.32573697" />
+       style="fill:none;stroke:#000000;stroke-width:2.11666667;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect754"
+       width="7.5595832"
+       height="8.3806553"
+       x="7.3810158"
+       y="5.7496696" />
+    <ellipse
+       style="fill:none;stroke:#000000;stroke-width:2.11666667;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="path1414"
+       cx="24.044025"
+       cy="24.098814"
+       rx="4.6930771"
+       ry="5.1458216" />
   </g>
 </svg>

--- a/main/webapp/modules/core/images/operations/replace.svg
+++ b/main/webapp/modules/core/images/operations/replace.svg
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="replace.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="4.5203644"
+     inkscape:cx="80.524482"
+     inkscape:cy="45.129105"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.5215247,11.600476 C 12.85991,4.7245911 20.293128,4.5378033 23.796915,10.975468"
+       id="path1550-5-7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 24.561897,5.7404805 -0.63264,5.7723475 -5.193339,-1.161056"
+       id="path1588-5"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-dasharray:none"
+       id="rect1743"
+       width="7.5381956"
+       height="10.996837"
+       x="4.3881316"
+       y="15.509556"
+       ry="0.32573697" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-dasharray:none"
+       id="rect1743-9"
+       width="7.5381956"
+       height="10.996837"
+       x="21.249575"
+       y="15.599813"
+       ry="0.32573697" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/split-columns.svg
+++ b/main/webapp/modules/core/images/operations/split-columns.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="split-columns.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.1300911"
+     inkscape:cx="111.49543"
+     inkscape:cy="59.287254"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 15.077059,17.077537 2.9280431,17.200205"
+       id="path1550-5"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 8.8676872,12.081262 2.7984064,17.346189 8.949996,22.08522"
+       id="path1588"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.797782,17.114034 h 12.19519"
+       id="path1550-5-7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 25.053327,11.995091 6.069281,5.264927 -6.15159,4.739031"
+       id="path1588-5"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 11.820802,11.261107 V 3.8905659 h 10.390422 v 7.5385481"
+       id="path737" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 11.895284,22.874495 v 7.370541 h 10.390423 v -7.538548"
+       id="path737-3" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/split-rows.svg
+++ b/main/webapp/modules/core/images/operations/split-rows.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="split-rows.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.1300911"
+     inkscape:cx="14.158151"
+     inkscape:cy="25.661648"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.950771,15.184353 16.828103,3.0353368"
+       id="path1550-5"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 21.947046,8.9749809 16.682119,2.9057001 11.943088,9.0572897"
+       id="path1588"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 16.914274,18.905076 v 12.19519"
+       id="path1550-5-7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22.033217,25.160621 -5.264927,6.069281 -4.739031,-6.15159"
+       id="path1588-5"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 22.767201,11.928096 h 7.370541 v 10.390422 h -7.538548"
+       id="path737" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.85208;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 11.153813,12.002578 H 3.7832722 V 22.393001 H 11.32182"
+       id="path737-3" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/transform.svg
+++ b/main/webapp/modules/core/images/operations/transform.svg
@@ -25,8 +25,8 @@
      inkscape:document-units="mm"
      showgrid="true"
      inkscape:zoom="1.1300911"
-     inkscape:cx="-209.71761"
-     inkscape:cy="96.894843"
+     inkscape:cx="-209.27516"
+     inkscape:cy="71.233195"
      inkscape:window-width="1918"
      inkscape:window-height="1054"
      inkscape:window-x="0"
@@ -45,38 +45,38 @@
      inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 18.139313,7.005743 c 7.263325,0.4959035 7.052787,2.7536844 8.103148,8.157328"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.518224,5.8661447 c 7.515149,0.5567723 7.297311,3.0916809 8.384088,9.1585863"
        id="path1550-5"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="M 28.968949,9.3728887 26.3408,14.902112 21.044321,11.463666"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 29.72333,8.5238418 27.004062,14.731741 21.523951,10.871249"
        id="path1588"
        sodipodi:nodetypes="ccc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="M 16.294996,26.35233 C 9.0235976,25.993762 9.1914356,23.732406 8.0391556,18.349574"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.609964,27.587398 C 9.086462,27.184818 9.260119,24.645895 8.0678889,18.602356"
        id="path1550-5-3"
        sodipodi:nodetypes="cc" />
     <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 5.5750434,24.334589 2.523201,-5.577897 5.3605056,3.337751"
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 5.5183446,25.321992 2.6106818,-6.262547 5.5463576,3.747438"
        id="path1588-6"
        sodipodi:nodetypes="ccc" />
     <rect
-       style="fill:none;stroke:#000000;stroke-width:2.381;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#000000;stroke-width:2.11666667;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
        id="rect754"
-       width="7.3062711"
-       height="7.4644442"
-       x="7.375299"
-       y="6.9020014" />
+       width="7.5595832"
+       height="8.3806553"
+       x="7.3810158"
+       y="5.7496696" />
     <ellipse
-       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#000000;stroke-width:2.11666667;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
        id="path1414"
-       cx="23.479952"
-       cy="23.245134"
-       rx="4.5358181"
-       ry="4.5832572" />
+       cx="24.044025"
+       cy="24.098814"
+       rx="4.6930771"
+       ry="5.1458216" />
   </g>
 </svg>

--- a/main/webapp/modules/core/images/operations/transform.svg
+++ b/main/webapp/modules/core/images/operations/transform.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="transform.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.1300911"
+     inkscape:cx="-11.503497"
+     inkscape:cy="99.107054"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 23.916922,8.752939 H 10.686935 l 6.372856,8.131665 -5.939778,7.88166 h 12.769832"
+       id="path12254"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/transform.svg
+++ b/main/webapp/modules/core/images/operations/transform.svg
@@ -25,12 +25,12 @@
      inkscape:document-units="mm"
      showgrid="true"
      inkscape:zoom="1.1300911"
-     inkscape:cx="-11.503497"
-     inkscape:cy="99.107054"
-     inkscape:window-width="1366"
-     inkscape:window-height="699"
+     inkscape:cx="-209.71761"
+     inkscape:cy="96.894843"
+     inkscape:window-width="1918"
+     inkscape:window-height="1054"
      inkscape:window-x="0"
-     inkscape:window-y="32"
+     inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer1"
      showguides="true">
@@ -45,9 +45,38 @@
      inkscape:groupmode="layer"
      id="layer1">
     <path
-       style="fill:none;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="M 23.916922,8.752939 H 10.686935 l 6.372856,8.131665 -5.939778,7.88166 h 12.769832"
-       id="path12254"
-       sodipodi:nodetypes="ccccc" />
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 18.139313,7.005743 c 7.263325,0.4959035 7.052787,2.7536844 8.103148,8.157328"
+       id="path1550-5"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 28.968949,9.3728887 26.3408,14.902112 21.044321,11.463666"
+       id="path1588"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 16.294996,26.35233 C 9.0235976,25.993762 9.1914356,23.732406 8.0391556,18.349574"
+       id="path1550-5-3"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 5.5750434,24.334589 2.523201,-5.577897 5.3605056,3.337751"
+       id="path1588-6"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:2.381;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="rect754"
+       width="7.3062711"
+       height="7.4644442"
+       x="7.375299"
+       y="6.9020014" />
+    <ellipse
+       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       id="path1414"
+       cx="23.479952"
+       cy="23.245134"
+       rx="4.5358181"
+       ry="4.5832572" />
   </g>
 </svg>

--- a/main/webapp/modules/core/images/operations/transform.svg
+++ b/main/webapp/modules/core/images/operations/transform.svg
@@ -24,13 +24,13 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="2.2601822"
-     inkscape:cx="93.134085"
-     inkscape:cy="41.810789"
-     inkscape:window-width="1918"
-     inkscape:window-height="1054"
+     inkscape:zoom="2.3100587"
+     inkscape:cx="9.7400124"
+     inkscape:cy="12.120904"
+     inkscape:window-width="1503"
+     inkscape:window-height="933"
      inkscape:window-x="0"
-     inkscape:window-y="24"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer1"
      showguides="true">
@@ -46,6 +46,12 @@
        width="86.076181"
        height="87.027807"
        id="rect969" />
+    <rect
+       x="22.525585"
+       y="21.070324"
+       width="86.07618"
+       height="87.027809"
+       id="rect969-0" />
   </defs>
   <g
      inkscape:label="Calque 1"
@@ -53,13 +59,23 @@
      id="layer1">
     <text
        xml:space="preserve"
-       transform="matrix(0.93268228,0,0,1.0114424,-18.916529,-17.439169)"
+       transform="matrix(0.93268228,0,0,1.0114424,-6.5221109,-19.062123)"
        id="text967"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.3333px;line-height:125%;font-family:STIXIntegralsUp;-inkscape-font-specification:STIXIntegralsUp;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect969);display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><tspan
          x="22.525391"
          y="40.480952"
-         id="tspan1083"><tspan
-           style="font-family:sans-serif;-inkscape-font-specification:sans-serif"
-           id="tspan1081">f(x)</tspan></tspan></text>
+         id="tspan6765"><tspan
+           style="font-weight:bold;font-size:14.5286px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold'"
+           id="tspan6763">(x)</tspan></tspan></text>
+    <text
+       xml:space="preserve"
+       transform="matrix(1.0967606,-0.10003733,0.11287046,1.2374568,-23.093836,-25.173661)"
+       id="text967-9"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.3333px;line-height:125%;font-family:STIXIntegralsUp;-inkscape-font-specification:STIXIntegralsUp;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect969-0);display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><tspan
+         x="22.525391"
+         y="40.480952"
+         id="tspan6769"><tspan
+           style="font-family:Z003;-inkscape-font-specification:Z003"
+           id="tspan6767">f</tspan></tspan></text>
   </g>
 </svg>

--- a/main/webapp/modules/core/images/operations/transform.svg
+++ b/main/webapp/modules/core/images/operations/transform.svg
@@ -24,9 +24,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="1.1300911"
-     inkscape:cx="-209.27516"
-     inkscape:cy="71.233195"
+     inkscape:zoom="2.2601822"
+     inkscape:cx="93.134085"
+     inkscape:cy="41.810789"
      inkscape:window-width="1918"
      inkscape:window-height="1054"
      inkscape:window-x="0"
@@ -39,44 +39,27 @@
        id="grid1359" />
   </sodipodi:namedview>
   <defs
-     id="defs2" />
+     id="defs2">
+    <rect
+       x="22.525585"
+       y="21.070324"
+       width="86.076181"
+       height="87.027807"
+       id="rect969" />
+  </defs>
   <g
      inkscape:label="Calque 1"
      inkscape:groupmode="layer"
      id="layer1">
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 18.518224,5.8661447 c 7.515149,0.5567723 7.297311,3.0916809 8.384088,9.1585863"
-       id="path1550-5"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="M 29.72333,8.5238418 27.004062,14.731741 21.523951,10.871249"
-       id="path1588"
-       sodipodi:nodetypes="ccc" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="M 16.609964,27.587398 C 9.086462,27.184818 9.260119,24.645895 8.0678889,18.602356"
-       id="path1550-5-3"
-       sodipodi:nodetypes="cc" />
-    <path
-       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.11666667;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       d="m 5.5183446,25.321992 2.6106818,-6.262547 5.5463576,3.747438"
-       id="path1588-6"
-       sodipodi:nodetypes="ccc" />
-    <rect
-       style="fill:none;stroke:#000000;stroke-width:2.11666667;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       id="rect754"
-       width="7.5595832"
-       height="8.3806553"
-       x="7.3810158"
-       y="5.7496696" />
-    <ellipse
-       style="fill:none;stroke:#000000;stroke-width:2.11666667;stroke-linecap:square;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
-       id="path1414"
-       cx="24.044025"
-       cy="24.098814"
-       rx="4.6930771"
-       ry="5.1458216" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.93268228,0,0,1.0114424,-18.916529,-17.439169)"
+       id="text967"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:21.3333px;line-height:125%;font-family:STIXIntegralsUp;-inkscape-font-specification:STIXIntegralsUp;letter-spacing:0px;word-spacing:0px;white-space:pre;shape-inside:url(#rect969);display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"><tspan
+         x="22.525391"
+         y="40.480952"
+         id="tspan1083"><tspan
+           style="font-family:sans-serif;-inkscape-font-specification:sans-serif"
+           id="tspan1081">f(x)</tspan></tspan></text>
   </g>
 </svg>

--- a/main/webapp/modules/core/images/operations/transpose-into-columns.svg
+++ b/main/webapp/modules/core/images/operations/transpose-into-columns.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="transpose-into-columns.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="0.39954754"
+     inkscape:cx="-305.34539"
+     inkscape:cy="-22.52548"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.7603816,15.308115 C 8.0854887,9.0606119 10.106729,8.5905909 15.886792,9.1531859"
+       id="path1550-5-7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 12.557944,5.2049789 3.777848,4.409999 -4.399382,2.9940361"
+       id="path1588-5"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2.38125;stroke-dasharray:none"
+       id="rect1743"
+       width="19.482"
+       height="7.2199326"
+       x="-27.520561"
+       y="21.117023"
+       ry="0.32573697"
+       transform="rotate(-90)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 17.363216,27.778331 H 7.4199826 V 18.737039 H 17.539303"
+       id="path5850" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/images/operations/transpose-into-rows.svg
+++ b/main/webapp/modules/core/images/operations/transpose-into-rows.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128"
+   height="128"
+   viewBox="0 0 33.866666 33.866667"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="transpose-into-rows.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="1.5981902"
+     inkscape:cx="30.659681"
+     inkscape:cy="36.291051"
+     inkscape:window-width="1366"
+     inkscape:window-height="699"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1359" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 19.270025,6.5815824 c 6.247503,0.3251071 6.717524,2.3463478 6.154929,8.1264106"
+       id="path1550-5-7"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="m 29.373161,11.379145 -4.409999,3.777848 -2.994036,-4.399382"
+       id="path1588-5"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:2.38125;stroke-dasharray:none"
+       id="rect1743"
+       width="19.482"
+       height="7.2199326"
+       x="7.057579"
+       y="19.938225"
+       ry="0.32573697" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2.38125;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+       d="M 6.7998089,16.184417 V 6.2411834 H 15.841101 V 16.360504"
+       id="path5850" />
+  </g>
+</svg>

--- a/main/webapp/modules/core/scripts/project/operation-icons.js
+++ b/main/webapp/modules/core/scripts/project/operation-icons.js
@@ -18,3 +18,40 @@ OperationIconRegistry.getIcon = function(operationId) {
   return this.map.get(operationId);
 }
 
+OperationIconRegistry.setIcon('core/text-transform', 'images/operations/transform.svg');
+// OperationIconRegistry.setIcon('core/mass-edit', undefined);
+OperationIconRegistry.setIcon('core/multivalued-cell-join', 'images/operations/join-rows.svg');
+OperationIconRegistry.setIcon('core/multivalued-cell-split', 'images/operations/split-rows.svg');
+OperationIconRegistry.setIcon('core/fill-down', 'images/operations/fill-down.svg');
+OperationIconRegistry.setIcon('core/blank-down', 'images/operations/blank-down.svg');
+OperationIconRegistry.setIcon('core/transpose-columns-into-rows', 'images/operations/transpose-into-rows.svg');
+OperationIconRegistry.setIcon('core/transpose-rows-into-columns', 'images/operations/transpose-into-columns.svg');
+OperationIconRegistry.setIcon('core/key-value-columnize', 'images/operations/key-value-columnize.svg');
+
+OperationIconRegistry.setIcon('core/column-addition', 'images/operations/add-column.svg');
+OperationIconRegistry.setIcon('core/column-removal', 'images/operations/delete.svg');
+OperationIconRegistry.setIcon('core/column-rename', 'images/operations/rename.svg');
+// OperationIconRegistry.setIcon('core/column-move', undefined);
+OperationIconRegistry.setIcon('core/column-split', 'images/operations/split-columns.svg');
+OperationIconRegistry.setIcon('core/column-addition-by-fetching-urls', 'images/operations/fetch-urls.svg');
+
+// OperationIconRegistry.setIcon('core/column-reorder', undefined);
+
+OperationIconRegistry.setIcon('core/row-removal', 'images/operations/delete.svg');
+// OperationIconRegistry.setIcon('core/row-star', undefined);
+// OperationIconRegistry.setIcon('core/row-flag', undefined);
+// OperationIconRegistry.setIcon('core/row-reorder', undefined);
+// OperationIconRegistry.setIcon('core/row-addition', undefined);
+// OperationIconRegistry.setIcon('core/row-duplicate-removal', undefined);
+
+OperationIconRegistry.setIcon('core/recon', 'images/operations/reconcile.svg');
+// OperationIconRegistry.setIcon('core/recon-mark-new-topics', undefined);
+// OperationIconRegistry.setIcon('core/recon-match-best-candidates', undefined);
+// OperationIconRegistry.setIcon('core/recon-discard-judgments', undefined);
+// OperationIconRegistry.setIcon('core/recon-match-specific-topic-to-cells', undefined);
+// OperationIconRegistry.setIcon('core/recon-judge-similar-cells', undefined);
+// OperationIconRegistry.setIcon('core/recon-clear-similar-cells', undefined);
+// OperationIconRegistry.setIcon('core/recon-copy-across-columns', undefined);
+OperationIconRegistry.setIcon('core/extend-reconciled-data', 'images/operations/data-extension.svg');
+// OperationIconRegistry.setIcon('core/recon-use-values-as-identifiers', undefined);
+

--- a/main/webapp/modules/core/scripts/util/menu.js
+++ b/main/webapp/modules/core/scripts/util/menu.js
@@ -167,14 +167,6 @@ MenuSystem.createAndShowStandardMenu = function(items, elmt, options) {
           if ("tooltip" in item) {
             menuItem.attr("title", item.tooltip);
           }
-          if ("icon" in item) {
-            let img = $('<img />')
-             .attr('src', item.icon)
-             .addClass('menu-icon')
-             .attr('aria-hidden', 'true');
-            contentsDiv.prepend(' ');
-            contentsDiv.prepend(img);
-          }
           menuItem.on('mouseenter click', function () {
             clearTimeout(MenuSystem._hoverTimeout);
             MenuSystem._hoverTimeout = setTimeout(function () {
@@ -182,6 +174,14 @@ MenuSystem.createAndShowStandardMenu = function(items, elmt, options) {
             }, 300);
           });
         }
+      }
+      if ("icon" in item) {
+        let img = $('<img />')
+          .attr('src', item.icon)
+          .addClass('menu-icon')
+          .attr('aria-hidden', 'true');
+        contentsDiv.prepend(' ');
+        contentsDiv.prepend(img);
       }
     } else if ("heading" in item) {
       $('<div></div>').addClass("menu-section").text(item.heading).appendTo(menu);

--- a/main/webapp/modules/core/scripts/util/menu.js
+++ b/main/webapp/modules/core/scripts/util/menu.js
@@ -137,7 +137,7 @@ MenuSystem.createAndShowStandardMenu = function(items, elmt, options) {
   var createMenuItem = function(item) {
     if ("label" in item) {
       var menuItem = MenuSystem.createMenuItem().appendTo(menu);
-      $('<div></div>').text(item.label).appendTo(menuItem);
+      let contentsDiv = $('<div></div>').text(item.label).appendTo(menuItem);
       if ("submenu" in item) {
         menuItem.addClass('submenu');
         menuItem.on('mouseenter click', function () {
@@ -166,6 +166,14 @@ MenuSystem.createAndShowStandardMenu = function(items, elmt, options) {
           });
           if ("tooltip" in item) {
             menuItem.attr("title", item.tooltip);
+          }
+          if ("icon" in item) {
+            let img = $('<img />')
+             .attr('src', item.icon)
+             .addClass('menu-icon')
+             .attr('aria-hidden', 'true');
+            contentsDiv.prepend(' ');
+            contentsDiv.prepend(img);
           }
           menuItem.on('mouseenter click', function () {
             clearTimeout(MenuSystem._hoverTimeout);

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-cells.js
@@ -393,11 +393,13 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     {
       id: "core/text-transform",
       label: $.i18n('core-views/transform'),
+      icon: 'images/operations/transform.svg',
       click: function() { doTextTransformPrompt(); }
     },
     {
       id: "core/common-transforms",
       label: $.i18n('core-views/common-transform'),
+      icon: 'images/operations/magic-wand.svg',
       submenu: [
         {
           id: "core/trim-whitespace",
@@ -469,6 +471,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     {
       id: "core/fill-down",
       label: $.i18n('core-views/fill-down'),
+      icon: 'images/operations/fill-down.svg',
       click: function () {
         if (columnHeaderUI._dataTableView._getSortingCriteriaCount() > 0) {
            columnHeaderUI._dataTableView._createPendingSortWarningDialog(doFillDown);
@@ -481,6 +484,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     {
       id: "core/blank-down",
       label: $.i18n('core-views/blank-down'),
+      icon: 'images/operations/blank-down.svg',
       click: function () {
         if (columnHeaderUI._dataTableView._getSortingCriteriaCount() > 0) {
            columnHeaderUI._dataTableView._createPendingSortWarningDialog(doBlankDown);
@@ -494,23 +498,27 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     {
       id: "core/split-multi-valued-cells",
       label: $.i18n('core-views/split-cells'),
+      icon: 'images/operations/split-rows.svg',
       click: doSplitMultiValueCells
     },
     {
       id: "core/join-multi-valued-cells",
       label: $.i18n('core-views/join-cells'),
+      icon: 'images/operations/join-rows.svg',
       click: doJoinMultiValueCells
     },
     {},
     {
       id: "core/cluster",
       label: $.i18n('core-views/cluster-edit'),
+      icon: 'images/operations/cluster.svg',
       click: function() { new ClusteringDialog(column, "value"); }
     },
     {},
     {
       id: "core/replace",
       label: $.i18n('core-views/replace'),
+      icon: 'images/operations/replace.svg',
       click: doReplace
     }
   ]);
@@ -738,17 +746,20 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       {
         id: "core/transpose-columns-into-rows",
         label: $.i18n('core-views/transp-cell-row'),
+        icon: 'images/operations/transpose-into-rows.svg',
         click: doTransposeColumnsIntoRows
       },
       {
         id: "core/transpose-rows-into-columns",
         label: $.i18n('core-views/transp-cell-col'),
+        icon: 'images/operations/transpose-into-columns.svg',
         click: doTransposeRowsIntoColumns
       },
       {},
       {
         id: "core/key-value-columnize",
         label: $.i18n('core-views/columnize-col'),
+        icon: 'images/operations/key-value-columnize.svg',
         click: doKeyValueColumnize
       }
     ]

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
@@ -572,59 +572,70 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       {
         id: "core/split-column",
         label: $.i18n('core-views/split-into-col'),
+        icon: 'images/operations/split-columns.svg',
         click: doSplitColumn
       },
       {
         id: "core/join-column",
         label: $.i18n('core-views/join-col'),
-          click : doJoinColumns
-        },
+        icon: 'images/operations/join-columns.svg',
+        click : doJoinColumns
+      },
       {},
       {
         id: "core/add-column",
         label: $.i18n('core-views/add-based-col'),
+        icon: 'images/operations/add-column.svg',
         click: doAddColumn
       },
       {
         id: "core/add-column-by-fetching-urls",
         label: $.i18n('core-views/add-by-urls'),
+        icon: 'images/operations/fetch-urls.svg',
         click: doAddColumnByFetchingURLs
       },
       {
         id: "core/add-column-by-reconciliation",
         label: $.i18n('core-views/add-col-recon-val'),
+        icon: 'images/operations/data-extension.svg',
         click: doAddColumnByReconciliation
       },
       {},
       {
         id: "core/rename-column",
         label: $.i18n('core-views/rename-col'),
+        icon: 'images/operations/rename.svg',
         click: doRenameColumn
       },
       {
         id: "core/remove-column",
         label: $.i18n('core-views/remove-col'),
+        icon: 'images/operations/delete.svg',
         click: doRemoveColumn
       },
       {},
       {
         id: "core/move-column-to-beginning",
         label: $.i18n('core-views/move-to-beg'),
+        icon: 'images/operations/move-first.svg',
         click: function() { doMoveColumnTo(0); }
       },
       {
         id: "core/move-column-to-end",
         label: $.i18n('core-views/move-to-end'),
+        icon: 'images/operations/move-last.svg',
         click: function() { doMoveColumnTo(theProject.columnModel.columns.length - 1); }
       },
       {
         id: "core/move-column-to-left",
         label: $.i18n('core-views/move-to-left'),
+        icon: 'images/operations/move-left.svg',
         click: function() { doMoveColumnBy(-1);}
       },
       {
         id: "core/move-column-to-right",
         label: $.i18n('core-views/move-to-right'),
+        icon: 'images/operations/move-right.svg',
         click: function() { doMoveColumnBy(1); }
       }
     ]

--- a/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-reconcile.js
@@ -406,6 +406,7 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       id: "core/reconcile",
       label: $.i18n('core-views/start-recon'),
       tooltip: $.i18n('core-views/recon-text-fb'),
+      icon: 'images/operations/reconcile.svg',
       click: doReconcile
     },
     {},

--- a/main/webapp/modules/core/styles/util/menu.css
+++ b/main/webapp/modules/core/styles/util/menu.css
@@ -81,6 +81,13 @@ a.menu-item img {
   border: none;
 }
 
+a.menu-item .menu-icon {
+  display: inline;
+  height: 1.5em;
+  vertical-align: middle;
+  margin-left: -2px;
+}
+
 .menu-section {
   padding: 2px 7px;
   background: #aaa;

--- a/main/webapp/modules/core/styles/util/menu.css
+++ b/main/webapp/modules/core/styles/util/menu.css
@@ -83,9 +83,10 @@ a.menu-item img {
 
 a.menu-item .menu-icon {
   display: inline;
-  height: 1.5em;
+  height: 1.6em;
   vertical-align: middle;
   margin-left: -2px;
+  margin-top: -1px;
 }
 
 .menu-section {


### PR DESCRIPTION
This adds icons to the column menu, with the aim:
* to help users identify menu items visually, rather than by reading text
* to help users better relate the menu entries to the history entries (once the icons will be made available there, which requires #7055), and then in the graphical representations of recipes
* open up the possibility to move out of the column menus, by integrating operations in a toolbar for instance

The icons are all made by me based on [the design proposed on the forum](https://forum.openrefine.org/t/operation-logos/1307). I have made a few tweaks, mostly to simplify the icons so that they are recognizable at the small scale needed to fit them in operation menus.

The icons can surely be improved further. I don't know what is the best place to discuss changes to them. We can try doing that in this PR. This doesn't cover all operations or menu entries, we would need to add more later on, but I think this is already a rather big batch, which I anticipate you'll have many suggestions of improvements.

Once there is consensus on the icons, I would work on optimizing them for size and making them load ahead of time to avoid the small delay when opening a menu for the first time.

## Screenshots

![image](https://github.com/user-attachments/assets/42adbb18-33f9-4ee9-beda-71be657d28d1)

![image](https://github.com/user-attachments/assets/0be1f513-bffd-4997-aa5d-175e144294eb)

![image](https://github.com/user-attachments/assets/d1bed616-1c32-44c3-bb78-3a920fbf5775)

![image](https://github.com/user-attachments/assets/feeaba2e-e69a-43af-b546-c5ad501cd8b0)
