### PR TITLE
operations: Add validate() calls in commands

### DIFF
--- a/main/src/com/google/refine/commands/cell/JoinMultiValueCellsCommand.java
+++ b/main/src/com/google/refine/commands/cell/JoinMultiValueCellsCommand.java
@@ -64,6 +64,7 @@ public class JoinMultiValueCellsCommand extends Command {
             String separator = request.getParameter("separator");
 
             AbstractOperation op = new MultiValuedCellJoinOperation(columnName, keyColumnName, separator);
+            op.validate();
             Process process = op.createProcess(project, new Properties());
 
             performProcessAndRespond(request, response, project, process);

--- a/main/src/com/google/refine/commands/cell/KeyValueColumnizeCommand.java
+++ b/main/src/com/google/refine/commands/cell/KeyValueColumnizeCommand.java
@@ -65,7 +65,7 @@ public class KeyValueColumnizeCommand extends Command {
 
             AbstractOperation op = new KeyValueColumnizeOperation(
                     keyColumnName, valueColumnName, noteColumnName);
-
+            op.validate();
             Process process = op.createProcess(project, new Properties());
 
             performProcessAndRespond(request, response, project, process);

--- a/main/src/com/google/refine/commands/cell/SplitMultiValueCellsCommand.java
+++ b/main/src/com/google/refine/commands/cell/SplitMultiValueCellsCommand.java
@@ -86,6 +86,7 @@ public class SplitMultiValueCellsCommand extends Command {
                         separator,
                         regex);
             }
+            op.validate();
             Process process = op.createProcess(project, new Properties());
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {

--- a/main/src/com/google/refine/commands/cell/TextTransformCommand.java
+++ b/main/src/com/google/refine/commands/cell/TextTransformCommand.java
@@ -58,7 +58,6 @@ public class TextTransformCommand extends EngineDependentCommand {
             repeatCount = Math.max(Math.min(Integer.parseInt(repeatCountString), 10), 0);
         } catch (Exception e) {
         }
-
         return new TextTransformOperation(
                 engineConfig,
                 columnName,

--- a/main/src/com/google/refine/commands/cell/TransposeColumnsIntoRowsCommand.java
+++ b/main/src/com/google/refine/commands/cell/TransposeColumnsIntoRowsCommand.java
@@ -82,7 +82,7 @@ public class TransposeColumnsIntoRowsCommand extends Command {
                         ignoreBlankCells, fillDown,
                         keyColumnName, valueColumnName);
             }
-
+            op.validate();
             Process process = op.createProcess(project, new Properties());
 
             performProcessAndRespond(request, response, project, process);

--- a/main/src/com/google/refine/commands/cell/TransposeRowsIntoColumnsCommand.java
+++ b/main/src/com/google/refine/commands/cell/TransposeRowsIntoColumnsCommand.java
@@ -64,7 +64,7 @@ public class TransposeRowsIntoColumnsCommand extends Command {
 
             AbstractOperation op = new TransposeRowsIntoColumnsOperation(
                     columnName, rowCount);
-
+            op.validate();
             Process process = op.createProcess(project, new Properties());
 
             performProcessAndRespond(request, response, project, process);

--- a/main/src/com/google/refine/commands/column/MoveColumnCommand.java
+++ b/main/src/com/google/refine/commands/column/MoveColumnCommand.java
@@ -63,6 +63,7 @@ public class MoveColumnCommand extends Command {
             int index = Integer.parseInt(request.getParameter("index"));
 
             AbstractOperation op = new ColumnMoveOperation(columnName, index);
+            op.validate();
             Process process = op.createProcess(project, new Properties());
 
             performProcessAndRespond(request, response, project, process);

--- a/main/src/com/google/refine/commands/column/RemoveColumnCommand.java
+++ b/main/src/com/google/refine/commands/column/RemoveColumnCommand.java
@@ -62,6 +62,7 @@ public class RemoveColumnCommand extends Command {
             String columnName = request.getParameter("columnName");
 
             AbstractOperation op = new ColumnRemovalOperation(columnName);
+            op.validate();
             Process process = op.createProcess(project, new Properties());
 
             performProcessAndRespond(request, response, project, process);

--- a/main/src/com/google/refine/commands/column/RenameColumnCommand.java
+++ b/main/src/com/google/refine/commands/column/RenameColumnCommand.java
@@ -63,6 +63,7 @@ public class RenameColumnCommand extends Command {
             String newColumnName = request.getParameter("newColumnName");
 
             AbstractOperation op = new ColumnRenameOperation(oldColumnName, newColumnName);
+            op.validate();
             Process process = op.createProcess(project, new Properties());
 
             performProcessAndRespond(request, response, project, process);

--- a/main/src/com/google/refine/commands/row/AddRowsCommand.java
+++ b/main/src/com/google/refine/commands/row/AddRowsCommand.java
@@ -64,6 +64,7 @@ public class AddRowsCommand extends Command {
             int insertionIndex = getInsertionIndex(request, project);
 
             AbstractOperation op = new RowAdditionOperation(rows, insertionIndex);
+            op.validate();
             Process process = op.createProcess(project, new Properties());
 
             performProcessAndRespond(request, response, project, process);

--- a/main/tests/server/src/com/google/refine/commands/cell/JoinMultiValueCellsCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/cell/JoinMultiValueCellsCommandTests.java
@@ -1,25 +1,53 @@
 
 package com.google.refine.commands.cell;
 
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
 import java.io.IOException;
+import java.io.Serializable;
 
 import javax.servlet.ServletException;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.refine.commands.Command;
 import com.google.refine.commands.CommandTestBase;
+import com.google.refine.model.Project;
+import com.google.refine.util.ParsingUtilities;
 
 public class JoinMultiValueCellsCommandTests extends CommandTestBase {
 
+    Project project;
+
     @BeforeMethod
-    public void setUpCommand() {
+    public void setUpCommandAndProject() {
         command = new JoinMultiValueCellsCommand();
+        project = createProject(new String[] { "foo", "bar" },
+                new Serializable[][] {
+                        { 1, 2 },
+                        { null, 3 },
+                });
     }
 
     @Test
     public void testCSRFProtection() throws ServletException, IOException {
         command.doPost(request, response);
         assertCSRFCheckFailed();
+    }
+
+    @Test
+    public void testMissingColumnName() throws ServletException, IOException {
+        when(request.getParameter("project")).thenReturn(Long.toString(project.id));
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+
+        command.doPost(request, response);
+
+        JsonNode node = ParsingUtilities.mapper.readValue(writer.toString(), JsonNode.class);
+        assertEquals(node.get("code").asText(), "error");
+        assertTrue(node.get("message").asText().contains("Missing column name"));
     }
 }

--- a/modules/core/src/main/java/com/google/refine/commands/EngineDependentCommand.java
+++ b/modules/core/src/main/java/com/google/refine/commands/EngineDependentCommand.java
@@ -74,6 +74,7 @@ abstract public class EngineDependentCommand extends Command {
             Project project = getProject(request);
 
             AbstractOperation op = createOperation(project, request, getEngineConfig(request));
+            op.validate();
             Process process = op.createProcess(project, new Properties());
 
             performProcessAndRespond(request, response, project, process);


### PR DESCRIPTION
This adds calls to the `AbstractOperation::validate()` method in all operation commands.

This should generally not have an impact on user experience, because we expect the front-end to already validate operation parameters before submitting them to the backend. This is more of an additional safety net, in case that validation isn't done properly. The goal is to return an error message that's as helpful as possible instead of a random Java exception.

On the long term, I think we should deprecate all those operation commands and just use the generic `apply-operations` command with the operation represented in JSON. This would avoid having to devise how to represent operation metadata in two different ways (JSON and url-parameter encoding).