### PR TITLE
facets: Add a ability to translate after a column rename

### DIFF
--- a/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/ListFacetTests.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -74,6 +75,19 @@ public class ListFacetTests extends RefineTest {
             + "\"name\":\"facet A\","
             + "\"columnName\":\"Column A\","
             + "\"expression\":\"foo(\","
+            + "\"omitBlank\":false,"
+            + "\"omitError\":false,"
+            + "\"selection\":[{\"v\":{\"v\":\"foobar\",\"l\":\"true\"}}],"
+            + "\"selectBlank\":false,"
+            + "\"selectError\":false,"
+            + "\"invert\":false"
+            + "}";
+
+    private static String jsonConfigRenamed = "{"
+            + "\"type\":\"list\","
+            + "\"name\":\"facet A\","
+            + "\"columnName\":\"Column A2\","
+            + "\"expression\":\"grel:value + \\\"bar\\\"\","
             + "\"omitBlank\":false,"
             + "\"omitError\":false,"
             + "\"selection\":[{\"v\":{\"v\":\"foobar\",\"l\":\"true\"}}],"
@@ -138,6 +152,20 @@ public class ListFacetTests extends RefineTest {
     public void testColumnDependenciesWithError() throws Exception {
         ListFacetConfig facetConfig = ParsingUtilities.mapper.readValue(jsonConfigParseError, ListFacetConfig.class);
         assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.emptySet()));
+    }
+
+    @Test
+    public void testRenameColumns() throws Exception {
+        ListFacetConfig facetConfig = ParsingUtilities.mapper.readValue(jsonConfig, ListFacetConfig.class);
+        FacetConfig renamed = facetConfig.renameColumnDependencies(Map.of("Column A", "Column A2"));
+        TestUtils.isSerializedTo(renamed, jsonConfigRenamed);
+    }
+
+    @Test
+    public void testRenameColumnsWithParseError() throws Exception {
+        ListFacetConfig facetConfig = ParsingUtilities.mapper.readValue(jsonConfigParseError, ListFacetConfig.class);
+        FacetConfig renamed = facetConfig.renameColumnDependencies(Map.of("foo", "bar"));
+        TestUtils.isSerializedTo(renamed, jsonConfigParseError);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/browsing/facets/RangeFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/RangeFacetTests.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertEquals;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -75,6 +76,19 @@ public class RangeFacetTests extends RefineTest {
             "          \"to\": 90,\n" +
             "          \"type\": \"range\",\n" +
             "          \"columnName\": \"my column\"\n" +
+            "        }";
+
+    public static String configJsonRenamed = "{\n" +
+            "          \"selectNumeric\": true,\n" +
+            "          \"expression\": \"grel:value\",\n" +
+            "          \"selectBlank\": true,\n" +
+            "          \"selectNonNumeric\": true,\n" +
+            "          \"selectError\": true,\n" +
+            "          \"name\": \"new column\",\n" +
+            "          \"from\": -30,\n" +
+            "          \"to\": 90,\n" +
+            "          \"type\": \"range\",\n" +
+            "          \"columnName\": \"new column\"\n" +
             "        }";
 
     public static String facetJson = "{"
@@ -140,5 +154,12 @@ public class RangeFacetTests extends RefineTest {
     public void testColumnDependenciesWithError() throws Exception {
         RangeFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJsonWithParseError, RangeFacetConfig.class);
         assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.emptySet()));
+    }
+
+    @Test
+    public void testRenameColumnDependencies() throws Exception {
+        RangeFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJson, RangeFacetConfig.class);
+        FacetConfig renamed = facetConfig.renameColumnDependencies(Map.of("my column", "new column"));
+        TestUtils.isSerializedTo(renamed, configJsonRenamed);
     }
 }

--- a/main/tests/server/src/com/google/refine/browsing/facets/ScatterplotFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/ScatterplotFacetTests.java
@@ -34,6 +34,7 @@ import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -69,6 +70,23 @@ public class ScatterplotFacetTests extends RefineTest {
             "          \"ey\": \"value\",\n" +
             "          \"cx\": \"my column\",\n" +
             "          \"cy\": \"e\",\n" +
+            "          \"name\": \"my column (x) vs. e (y)\"\n" +
+            "        }";
+
+    public static String configJsonRenamed = "{\n" +
+            "          \"to_x\": 1,\n" +
+            "          \"to_y\": 1,\n" +
+            "          \"dot\": 1,\n" +
+            "          \"from_x\": 0.21333333333333335,\n" +
+            "          \"l\": 150,\n" +
+            "          \"type\": \"scatterplot\",\n" +
+            "          \"from_y\": 0.26666666666666666,\n" +
+            "          \"dim_y\": \"lin\",\n" +
+            "          \"ex\": \"grel:value\",\n" +
+            "          \"dim_x\": \"lin\",\n" +
+            "          \"ey\": \"grel:value\",\n" +
+            "          \"cx\": \"my column\",\n" +
+            "          \"cy\": \"f\",\n" +
             "          \"name\": \"my column (x) vs. e (y)\"\n" +
             "        }";
 
@@ -158,4 +176,12 @@ public class ScatterplotFacetTests extends RefineTest {
         ScatterplotFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJsonWithParseError, ScatterplotFacetConfig.class);
         assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.emptySet()));
     }
+
+    @Test
+    public void testRenameColumnDependencies() throws Exception {
+        ScatterplotFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJson, ScatterplotFacetConfig.class);
+        FacetConfig renamed = facetConfig.renameColumnDependencies(Map.of("foo", "bar", "e", "f"));
+        TestUtils.isSerializedTo(renamed, configJsonRenamed);
+    }
+
 }

--- a/main/tests/server/src/com/google/refine/browsing/facets/TimeRangeFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/TimeRangeFacetTests.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.core.JsonParseException;
@@ -98,6 +99,19 @@ public class TimeRangeFacetTests extends RefineTest {
             "          \"columnName\": \"my column\"\n" +
             "        }";
 
+    public static String configJsonRenamed = "{\n" +
+            "          \"selectNonTime\": true,\n" +
+            "          \"expression\": \"grel:value\",\n" +
+            "          \"selectBlank\": true,\n" +
+            "          \"selectError\": true,\n" +
+            "          \"selectTime\": true,\n" +
+            "          \"name\": \"my column\",\n" +
+            "          \"from\": 1262443349000,\n" +
+            "          \"to\": 1514966950000,\n" +
+            "          \"type\": \"timerange\",\n" +
+            "          \"columnName\": \"my column\"\n" +
+            "        }";
+
     @BeforeMethod
     public void registerGRELParser() {
         MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
@@ -142,5 +156,12 @@ public class TimeRangeFacetTests extends RefineTest {
     public void testColumnDependenciesWithError() throws Exception {
         TimeRangeFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJsonWithParseError, TimeRangeFacetConfig.class);
         assertEquals(facetConfig.getColumnDependencies(), Optional.of(Collections.emptySet()));
+    }
+
+    @Test
+    public void testRenameColumnDependencies() throws Exception {
+        TimeRangeFacetConfig facetConfig = ParsingUtilities.mapper.readValue(configJson, TimeRangeFacetConfig.class);
+        FacetConfig renamed = facetConfig.renameColumnDependencies(Map.of("foo", "bar"));
+        TestUtils.isSerializedTo(renamed, configJsonRenamed);
     }
 }

--- a/main/tests/server/src/com/google/refine/commands/browsing/ComputeFacetsCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/browsing/ComputeFacetsCommandTests.java
@@ -22,4 +22,5 @@ public class ComputeFacetsCommandTests extends CommandTestBase {
         command.doPost(request, response);
         assertCSRFCheckFailed();
     }
+
 }

--- a/modules/core/src/main/java/com/google/refine/browsing/EngineConfig.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/EngineConfig.java
@@ -31,8 +31,10 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -104,6 +106,23 @@ public class EngineConfig {
             }
         }
         return Optional.of(result);
+    }
+
+    /**
+     * Translates this engine config by simultaneously substituting column names, as specified by the supplied map. This
+     * is a best effort transformation: some facets might not be fully updated to reflect the new column names, for
+     * instance if the column dependencies of the expressions they rely on cannot be isolated.
+     *
+     * @param substitutions
+     *            a map specifying new names for some columns. Keys of the map are old column names, values are the new
+     *            names for those columns. If a column name is not present in the map, the column is not renamed.
+     * @return a new engine config with updated column names.
+     */
+    public EngineConfig renameColumnDependencies(Map<String, String> substitutions) {
+        List<FacetConfig> newFacets = _facets.stream()
+                .map(facetConfig -> facetConfig.renameColumnDependencies(substitutions))
+                .collect(Collectors.toList());
+        return new EngineConfig(newFacets, _mode);
     }
 
     /**

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/FacetConfig.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/FacetConfig.java
@@ -27,6 +27,7 @@
 
 package com.google.refine.browsing.facets;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -91,4 +92,20 @@ public interface FacetConfig {
     public default Optional<Set<String>> getColumnDependencies() {
         return Optional.empty();
     }
+
+    /**
+     * Translates this facet by simultaneously substituting column names, as specified by the supplied map. This is a
+     * best effort transformation: some references to columns might not get renamed in complex expressions. It can
+     * generate an invalid facet configuration. Returning the same facet configuration is the default.
+     *
+     * @param substitutions
+     *            a map specifying new names for some columns. Keys of the map are old column names, values are the new
+     *            names for those columns. If a column name is not present in the map, the column is not renamed.
+     * @return a new facet with updated column names. If this renaming isn't supported, the same facet config should be
+     *         returned
+     */
+    public default FacetConfig renameColumnDependencies(Map<String, String> substitutions) {
+        return this;
+    }
+
 }

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ListFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ListFacet.java
@@ -36,6 +36,8 @@ package com.google.refine.browsing.facets;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -61,6 +63,7 @@ import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
+import com.google.refine.util.NotImplementedException;
 
 public class ListFacet implements Facet {
 
@@ -153,6 +156,32 @@ public class ListFacet implements Facet {
             }
         }
 
+        @Override
+        public FacetConfig renameColumnDependencies(Map<String, String> substitutions) {
+            String newExpression;
+            try {
+                Evaluable evaluable = MetaParser.parse(expression);
+                Evaluable translated = evaluable.renameColumnDependencies(substitutions);
+                newExpression = translated.getFullSource();
+            } catch (ParsingException | NotImplementedException e) {
+                return this;
+            }
+            ListFacetConfig newConfig = new ListFacetConfig();
+            newConfig.expression = newExpression;
+            newConfig.columnName = substitutions.getOrDefault(columnName, columnName);
+            if (Objects.equals(name, columnName)) {
+                newConfig.name = newConfig.columnName;
+            } else {
+                newConfig.name = name;
+            }
+            newConfig.invert = invert;
+            newConfig.omitBlank = omitBlank;
+            newConfig.omitError = omitError;
+            newConfig.selection = selection;
+            newConfig.selectBlank = selectBlank;
+            newConfig.selectError = selectError;
+            return newConfig;
+        }
     }
 
     /**

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/RangeFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/RangeFacet.java
@@ -34,6 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.browsing.facets;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -60,6 +62,7 @@ import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
+import com.google.refine.util.NotImplementedException;
 
 public class RangeFacet implements Facet {
 
@@ -147,6 +150,30 @@ public class RangeFacet implements Facet {
             } catch (ParsingException e) {
                 return Optional.of(Collections.emptySet());
             }
+        }
+
+        @Override
+        public FacetConfig renameColumnDependencies(Map<String, String> substitutions) {
+            String newExpression;
+            try {
+                Evaluable evaluable = MetaParser.parse(_expression);
+                Evaluable translated = evaluable.renameColumnDependencies(substitutions);
+                newExpression = translated.getFullSource();
+            } catch (ParsingException | NotImplementedException e) {
+                return this;
+            }
+            String newColumnName = substitutions.getOrDefault(_columnName, _columnName);
+            RangeFacetConfig newConfig = new RangeFacetConfig(
+                    Objects.equals(_name, _columnName) ? newColumnName : _name,
+                    newExpression,
+                    newColumnName,
+                    _selected ? _from : null,
+                    _selected ? _to : null,
+                    _selectNumeric,
+                    _selectNonNumeric,
+                    _selectBlank,
+                    _selectError);
+            return newConfig;
         }
     }
 

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
@@ -42,6 +42,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -70,6 +71,7 @@ import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
+import com.google.refine.util.NotImplementedException;
 
 public class ScatterplotFacet implements Facet {
 
@@ -200,6 +202,45 @@ public class ScatterplotFacet implements Facet {
             } catch (ParsingException e) {
                 return Optional.of(Collections.emptySet());
             }
+        }
+
+        @Override
+        public FacetConfig renameColumnDependencies(Map<String, String> substitutions) {
+            String newExpressionX;
+            try {
+                Evaluable evaluableX = MetaParser.parse(expression_x);
+                Evaluable translatedX = evaluableX.renameColumnDependencies(substitutions);
+                newExpressionX = translatedX.getFullSource();
+            } catch (ParsingException | NotImplementedException e) {
+                return this;
+            }
+            String newExpressionY;
+            try {
+                Evaluable evaluableY = MetaParser.parse(expression_y);
+                Evaluable translatedY = evaluableY.renameColumnDependencies(substitutions);
+                newExpressionY = translatedY.getFullSource();
+            } catch (ParsingException e) {
+                return this;
+            }
+            var newConfig = new ScatterplotFacetConfig();
+            newConfig.name = name;
+            newConfig.expression_x = newExpressionX;
+            newConfig.expression_y = newExpressionY;
+            newConfig.columnName_x = substitutions.getOrDefault(columnName_x, columnName_x);
+            newConfig.columnName_y = substitutions.getOrDefault(columnName_y, columnName_y);
+            newConfig.size = size;
+            newConfig.dim_x = dim_x;
+            newConfig.dim_y = dim_y;
+            newConfig.rotation_str = rotation_str;
+            newConfig.rotation = rotation;
+            newConfig.l = l;
+            newConfig.dot = dot;
+            newConfig.color_str = color_str;
+            newConfig.from_x = from_x;
+            newConfig.from_y = from_y;
+            newConfig.to_x = to_x;
+            newConfig.to_y = to_y;
+            return newConfig;
         }
     }
 

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/TextSearchFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/TextSearchFacet.java
@@ -34,6 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.browsing.facets;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -101,6 +103,22 @@ public class TextSearchFacet implements Facet {
         @Override
         public Optional<Set<String>> getColumnDependencies() {
             return Optional.of(Collections.singleton(_columnName));
+        }
+
+        @Override
+        public FacetConfig renameColumnDependencies(Map<String, String> substitutions) {
+            TextSearchFacetConfig newConfig = new TextSearchFacetConfig();
+            newConfig._columnName = substitutions.getOrDefault(_columnName, _columnName);
+            if (Objects.equals(_name, _columnName)) {
+                newConfig._name = newConfig._columnName;
+            } else {
+                newConfig._name = _name;
+            }
+            newConfig._query = _query;
+            newConfig._mode = _mode;
+            newConfig._caseSensitive = _caseSensitive;
+            newConfig._invert = _invert;
+            return newConfig;
         }
     }
 

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/TimeRangeFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/TimeRangeFacet.java
@@ -34,6 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.browsing.facets;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -59,6 +61,7 @@ import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
 import com.google.refine.model.Column;
 import com.google.refine.model.Project;
+import com.google.refine.util.NotImplementedException;
 
 public class TimeRangeFacet implements Facet {
 
@@ -124,6 +127,33 @@ public class TimeRangeFacet implements Facet {
             } catch (ParsingException e) {
                 return Optional.of(Collections.emptySet());
             }
+        }
+
+        @Override
+        public FacetConfig renameColumnDependencies(Map<String, String> substitutions) {
+            String newExpression;
+            try {
+                Evaluable evaluable = MetaParser.parse(_expression);
+                Evaluable translated = evaluable.renameColumnDependencies(substitutions);
+                newExpression = translated.getFullSource();
+            } catch (ParsingException | NotImplementedException e) {
+                return this;
+            }
+            TimeRangeFacetConfig newConfig = new TimeRangeFacetConfig();
+            newConfig._expression = newExpression;
+            newConfig._columnName = substitutions.getOrDefault(_columnName, _columnName);
+            if (Objects.equals(_name, _columnName)) {
+                newConfig._name = newConfig._columnName;
+            } else {
+                newConfig._name = _name;
+            }
+            newConfig._from = _from;
+            newConfig._to = _to;
+            newConfig._selectTime = _selectTime;
+            newConfig._selectNonTime = _selectNonTime;
+            newConfig._selectBlank = _selectBlank;
+            newConfig._selectError = _selectError;
+            return newConfig;
         }
     }
 

--- a/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
+++ b/modules/core/src/main/java/com/google/refine/expr/Evaluable.java
@@ -67,6 +67,13 @@ public interface Evaluable {
     }
 
     /**
+     * The full source of this evaluable, including the language prefix.
+     */
+    public default String getFullSource() {
+        return getLanguagePrefix() + ":" + getSource();
+    }
+
+    /**
      * Evaluate this expression in the given environment (bindings).
      * 
      * @param bindings

--- a/modules/core/src/test/java/com/google/refine/browsing/EngineConfigTests.java
+++ b/modules/core/src/test/java/com/google/refine/browsing/EngineConfigTests.java
@@ -29,6 +29,7 @@ package com.google.refine.browsing;
 
 import static org.testng.Assert.assertThrows;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -51,6 +52,21 @@ public class EngineConfigTests {
             + "          \"name\": \"reference\",\n"
             + "          \"type\": \"text\",\n"
             + "          \"columnName\": \"reference\"\n"
+            + "        }\n"
+            + "      ]\n"
+            + "    }";
+
+    public static String engineConfigJsonRenamed = "{\n"
+            + "      \"mode\": \"row-based\",\n"
+            + "      \"facets\": [\n"
+            + "        {\n"
+            + "          \"mode\": \"text\",\n"
+            + "          \"invert\": false,\n"
+            + "          \"caseSensitive\": false,\n"
+            + "          \"query\": \"www\",\n"
+            + "          \"name\": \"website\",\n"
+            + "          \"type\": \"text\",\n"
+            + "          \"columnName\": \"website\"\n"
             + "        }\n"
             + "      ]\n"
             + "    }";
@@ -78,6 +94,13 @@ public class EngineConfigTests {
     public void columnDependencies() {
         EngineConfig ec = EngineConfig.reconstruct(engineConfigJson);
         Assert.assertEquals(ec.getColumnDependencies(), Optional.of(Set.of("reference")));
+    }
+
+    @Test
+    public void renameColumnDependencies() {
+        EngineConfig ec = EngineConfig.reconstruct(engineConfigJson);
+        EngineConfig renamed = ec.renameColumnDependencies(Map.of("reference", "website"));
+        TestUtils.isSerializedTo(renamed, engineConfigJsonRenamed);
     }
 
     @Test

--- a/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
@@ -304,6 +304,7 @@ public class GrelTests extends GrelTestBase {
                 { "cells.foo", "cells.bar" },
                 { "value + ' ' + cells.foo.value", "value + ' ' + cells.bar.value" },
                 { "cells[\"foo\"].value+'_'+value", "cells[\"bar\"].value+'_'+value" },
+                { "toDate(cells[\"foo\"].value)", "toDate(cells[\"bar\"].value)" },
                 { "parseHtml(value.trim())", "parseHtml(value.trim())" },
                 // when the dependencies cannot be isolated, we just return the original
                 { "cells", "cells" },


### PR DESCRIPTION
For #133.

This doesn't just translate the columns to which the facets are applied, but also the expressions they rely on, in case other columns are mentioned there.

Beyond #133, this will then be used to offer similar functionality on operation classes, so that the column names referenced by a recipe (JSON representation of operation history) can be adapted when applying it. See the design discussions on the forum: https://forum.openrefine.org/t/column-selection-ui-for-applying-recipes/1998