### PR TITLE
ui: Fix rendering of submenu arrows on Chrome

### DIFF
--- a/main/webapp/modules/core/scripts/util/menu.js
+++ b/main/webapp/modules/core/scripts/util/menu.js
@@ -137,7 +137,7 @@ MenuSystem.createAndShowStandardMenu = function(items, elmt, options) {
   var createMenuItem = function(item) {
     if ("label" in item) {
       var menuItem = MenuSystem.createMenuItem().appendTo(menu);
-      menuItem.text(item.label);
+      $('<div></div>').text(item.label).appendTo(menuItem);
       if ("submenu" in item) {
         menuItem.addClass('submenu');
         menuItem.on('mouseenter click', function () {

--- a/main/webapp/modules/core/styles/util/menu.css
+++ b/main/webapp/modules/core/styles/util/menu.css
@@ -70,10 +70,11 @@ a.menu-item:hover {
   background-color: #dbe8f8;
 }
 
-.menu-item.submenu {
+.menu-item.submenu div {
   background: url('../../images/right-arrow.png') no-repeat;
-  background-position-x: right 7px;
+  background-position-x: right;
   background-position-y: 50%;
+  padding-right: 8px;
 }
 
 a.menu-item img {


### PR DESCRIPTION
This uses a slightly different DOM structure to avoid using a too recent CSS syntax.

Fixes #7070.