### PR TITLE
Use all 4 cores during build test for server

### DIFF
--- a/.github/workflows/pull_request_server.yml
+++ b/.github/workflows/pull_request_server.yml
@@ -3,6 +3,7 @@ name: server CI
 on:
   pull_request:
     paths:
+      - '.github/workflows/pull_request_server.yml'
       - 'benchmark/**'
       - 'conf/**'
       - 'extensions/database/src/**'

--- a/.github/workflows/pull_request_server.yml
+++ b/.github/workflows/pull_request_server.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Check Java linting
         id: java_linting
         run: |
-          mvn -B compile test-compile formatter:validate impsort:check javadoc:javadoc -Ddoclint=html,syntax,accessibility,reference
+          mvn -T 4 -B compile test-compile formatter:validate impsort:check javadoc:javadoc -Ddoclint=html,syntax,accessibility,reference
 
       - name: Configure connections to databases
         id: configure_db_connections
@@ -108,7 +108,7 @@ jobs:
           PGPASSWORD: postgres
 
       - name: Build and test with Maven
-        run: mvn -B jacoco:prepare-agent test jacoco:report
+        run: mvn -T 4 -B jacoco:prepare-agent test jacoco:report
 
       - name: Coveralls main
         uses: coverallsapp/github-action@v2
@@ -183,7 +183,7 @@ jobs:
           mvn -B formatter:validate impsort:check
 
       - name: Build and test with Maven
-        run: mvn -B jacoco:prepare-agent test
+        run: mvn -T 4 -B jacoco:prepare-agent test
 
   finish:
     needs: linux_server_tests


### PR DESCRIPTION
Ref: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

GitHub Runners for Ubuntu have 4 cores.
Maven 3+ has experimental support for parallel builds https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3
I've tested locally on my Windows 11 PC with `mvn -T 8 clean package` and saw no issues, but instead a vastly faster build about 1/4 the time, since we already did a pretty good job of our multi-module project and declaring all the dependencies correctly, it's able to figure out what can run in parallel over the CPU cores I have (8 cores).

The other alternative is to use Maven Daemon (built with GraalVM and fast like Gradle) https://github.com/apache/maven-mvnd But that's much more involved and requires building and setting up a custom Runner image that has Maven Daemon installed (since the normal Ubuntu runner image [does not include it](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md), but only Maven); and then we'd need to keep it up to date; more maintenance we don't need to take on.

Fixes #{issue number here}

Changes proposed in this pull request:
- 
- 
- 
