### PR TITLE
ci: Run release workflow when a draft release is published

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -8,7 +8,7 @@ on:
     paths-ignore:
       - 'docs/**'
   release:
-    types: [created]
+    types: [created, published]
 
 jobs:
   prepare_e2e_test_matrix:


### PR DESCRIPTION
The GitHub Actions workflow that creates our release artifacts was not triggered when first creating a draft release and then publishing it. This fixes it.