### PR TITLE
history: Validate column dependencies of operations before applying them

### DIFF
--- a/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
+++ b/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
@@ -34,8 +34,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands.history;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -46,6 +49,7 @@ import org.apache.commons.lang.Validate;
 
 import com.google.refine.commands.Command;
 import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.UnknownOperation;
 import com.google.refine.process.Process;
@@ -75,6 +79,16 @@ public class ApplyOperationsCommand extends Command {
                 operation.validate();
             }
 
+            // check all required columns are present
+            Set<String> requiredColumns = computeRequiredColumns(operations);
+            for (String columnName : requiredColumns) {
+                if (project.columnModel.getColumnByName(columnName) == null) {
+                    // TODO: present the user with a dialog to match all missing columns to ones that are present
+                    throw new IllegalArgumentException(
+                            "Column '" + columnName + "' is referenced in the list of operations but is absent from the project");
+                }
+            }
+
             // Run all operations in sequence
             for (AbstractOperation operation : operations) {
                 Process process = operation.createProcess(project, new Properties());
@@ -89,5 +103,62 @@ public class ApplyOperationsCommand extends Command {
         } catch (Exception e) {
             respondException(response, e);
         }
+    }
+
+    /**
+     * Computes which columns are required to be present in the project before applying a list of operations. The set
+     * that is returned is an under-approximation: if certain operations in the list fail to analyze their dependencies
+     * or their impact on the set of columns, then some required columns will be missed by this method, resulting in an
+     * error that will only be detected when the list of operations is applied.
+     * 
+     * @param operations
+     *            the operations to analyze. If any of them is null or of an unknown type (see
+     *            {@link UnknownOperation}), then {@link IllegalArgumentException} is thrown.
+     * @return a set of required column names
+     */
+    protected static Set<String> computeRequiredColumns(List<AbstractOperation> operations) {
+        // columnNames represents the current set of column names in the project,
+        // after having applied the operations scanned so far. If it is empty, then
+        // that means we lost track of which columns are present.
+        Optional<Set<String>> currentColumnNames = Optional.of(new HashSet<>());
+        // keeps track of which columns are required to exist in the project before
+        // the first operation is run.
+        Set<String> requiredColumnNames = new HashSet<>();
+
+        for (AbstractOperation op : operations) {
+            if (op == null) {
+                throw new IllegalArgumentException("The list of operations contains 'null'");
+            }
+            if (op instanceof UnknownOperation) {
+                throw new IllegalArgumentException("Unknown operation id: " + op.getOperationId());
+            }
+            op.validate();
+
+            Optional<Set<String>> columnDependencies = op.getColumnDependencies();
+            if (columnDependencies.isPresent() && currentColumnNames.isPresent()) {
+                for (String columnName : columnDependencies.get()) {
+                    if (!currentColumnNames.get().contains(columnName)) {
+                        if (requiredColumnNames.contains(columnName)) {
+                            // if this column has already been required before,
+                            // but is no longer part of the current columns,
+                            // that means it has been deleted since.
+                            throw new IllegalArgumentException(
+                                    "Inconsistent list of operations: column '" + columnName + "' used after being deleted or renamed");
+                        } else {
+                            requiredColumnNames.add(columnName);
+                        }
+                    }
+                }
+            }
+
+            Optional<ColumnsDiff> columnsDiff = op.getColumnsDiff();
+            if (columnsDiff.isEmpty()) {
+                currentColumnNames = Optional.empty();
+            } else if (currentColumnNames.isPresent()) {
+                currentColumnNames.get().removeAll(columnsDiff.get().getDeletedColumns());
+                currentColumnNames.get().addAll(columnsDiff.get().getAddedColumnNames());
+            }
+        }
+        return requiredColumnNames;
     }
 }

--- a/main/tests/server/src/com/google/refine/commands/history/ApplyOperationsCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/history/ApplyOperationsCommandTests.java
@@ -3,21 +3,35 @@ package com.google.refine.commands.history;
 
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 import javax.servlet.ServletException;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.refine.browsing.EngineConfig;
 import com.google.refine.commands.Command;
 import com.google.refine.commands.CommandTestBase;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
+import com.google.refine.operations.OnError;
 import com.google.refine.operations.OperationRegistry;
+import com.google.refine.operations.UnknownOperation;
 import com.google.refine.operations.cell.MassEditOperation;
+import com.google.refine.operations.column.ColumnAdditionOperation;
+import com.google.refine.operations.column.ColumnRemovalOperation;
+import com.google.refine.operations.column.ColumnRenameOperation;
+import com.google.refine.operations.column.ColumnSplitOperation;
 import com.google.refine.util.ParsingUtilities;
 
 public class ApplyOperationsCommandTests extends CommandTestBase {
@@ -57,6 +71,16 @@ public class ApplyOperationsCommandTests extends CommandTestBase {
         OperationRegistry.registerOperation(getCoreModule(), "mass-edit", MassEditOperation.class);
     }
 
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
+
     @Test
     public void testCSRFProtection() throws ServletException, IOException {
         command.doPost(request, response);
@@ -87,5 +111,84 @@ public class ApplyOperationsCommandTests extends CommandTestBase {
         String response = writer.toString();
         JsonNode node = ParsingUtilities.mapper.readValue(response, JsonNode.class);
         assertEquals(node.get("code").toString(), "\"error\"");
+    }
+
+    @Test
+    public void testMissingColumnInJSON() throws Exception {
+        String json = "[{\"op\":\"core/column-rename\","
+                + "\"description\":\"Rename column old name to new name\","
+                + "\"oldColumnName\":\"old name\","
+                + "\"newColumnName\":\"new name\"}]";
+
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("project")).thenReturn(Long.toString(project.id));
+        when(request.getParameter("operations")).thenReturn(json);
+
+        command.doPost(request, response);
+
+        String response = writer.toString();
+        JsonNode node = ParsingUtilities.mapper.readValue(response, JsonNode.class);
+        assertEquals(node.get("code").toString(), "\"error\"");
+    }
+
+    @Test
+    public void testComputeRequiredColumns() throws Exception {
+        assertEquals(
+                ApplyOperationsCommand.computeRequiredColumns(Collections.emptyList()),
+                Set.of());
+
+        assertEquals(
+                ApplyOperationsCommand.computeRequiredColumns(List.of(
+                        new ColumnRemovalOperation("foo"))),
+                Set.of("foo"));
+
+        assertEquals(
+                ApplyOperationsCommand.computeRequiredColumns(List.of(
+                        new ColumnRemovalOperation("foo"),
+                        new ColumnRemovalOperation("bar"))),
+                Set.of("foo", "bar"));
+
+        assertEquals(
+                ApplyOperationsCommand.computeRequiredColumns(List.of(
+                        new ColumnRenameOperation("foo", "foo2"),
+                        new ColumnRemovalOperation("bar"))),
+                Set.of("foo", "bar"));
+
+        assertEquals(
+                ApplyOperationsCommand.computeRequiredColumns(List.of(
+                        new ColumnRenameOperation("foo", "foo2"),
+                        new ColumnSplitOperation(EngineConfig.reconstruct("{}"), "foo2", false, false, "|", false, 3),
+                        // The dependency of the following operation is not taken into account,
+                        // because the previous operation does not expose a columns diff,
+                        // so we can't predict if "bar" is going to be produced by it or not.
+                        new ColumnRemovalOperation("bar"))),
+                Set.of("foo"));
+
+        // unanalyzable operation
+        assertEquals(
+                ApplyOperationsCommand.computeRequiredColumns(List.of(
+                        new ColumnAdditionOperation(
+                                EngineConfig.reconstruct("{\"mode\":\"row-based\",\"facets\":[]}"),
+                                "bar",
+                                "grel:cells[value].value",
+                                OnError.SetToBlank,
+                                "newcolumn",
+                                2))),
+                Set.of());
+    }
+
+    @Test
+    public void testRequiredColumnsFromInconsistentOperations() {
+        assertThrows(IllegalArgumentException.class, () -> ApplyOperationsCommand.computeRequiredColumns(List.of(
+                new ColumnRemovalOperation("foo"),
+                new ColumnRenameOperation("foo", "bar"))));
+    }
+
+    @Test
+    public void testRequiredColumnsFromInvalidOperations() {
+        assertThrows(IllegalArgumentException.class, () -> ApplyOperationsCommand.computeRequiredColumns(List.of(
+                new UnknownOperation("some-operation", "Some description"))));
+
+        assertThrows(IllegalArgumentException.class, () -> ApplyOperationsCommand.computeRequiredColumns(Collections.singletonList(null)));
     }
 }


### PR DESCRIPTION
This PR introduces a simple algorithm to detect any missing columns referenced by a list of operations to be applied (currently supplied as JSON by the user in the "Apply" dialog).

This improves the error reporting in the dialog. Instead of applying each operation until an error is thrown (leaving the project in a state where the recipe has been half-applied), this makes it possible to report the missing column to the user without applying any operation. Later on, the same algorithm will be used to explicitly list those required columns in the UI, letting the user rename them on the fly.

The computation of the required columns is done by scanning the list of operations to be applied while maintaining a list of the column names required to be in the project at the current scanning state. Some operations are opaque, or unanalyzable, when the methods introduced in #7056 have not been implemented (or simply because the required information cannot be deduced from the operation's metadata only). When an opaque operation is encountered, we reset that list as we don't know which column names can be assumed to be in the project after applying the opaque operation.