### PR TITLE
operations: Expose column dependencies in c.g.r.o.cells

### DIFF
--- a/main/src/com/google/refine/operations/cell/BlankDownOperation.java
+++ b/main/src/com/google/refine/operations/cell/BlankDownOperation.java
@@ -34,6 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.operations.cell;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -44,6 +46,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.CellChange;
@@ -69,6 +72,16 @@ public class BlankDownOperation extends EngineDependentMassCellOperation {
             List<CellChange> cellChanges) {
 
         return OperationDescription.cell_blank_down_desc(cellChanges.size(), column.getName());
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/FillDownOperation.java
+++ b/main/src/com/google/refine/operations/cell/FillDownOperation.java
@@ -34,6 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.operations.cell;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -45,6 +47,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.CellChange;
@@ -70,6 +73,16 @@ public class FillDownOperation extends EngineDependentMassCellOperation {
             List<CellChange> cellChanges) {
 
         return OperationDescription.cell_fill_down_desc(cellChanges.size(), column.getName());
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/KeyValueColumnizeOperation.java
+++ b/main/src/com/google/refine/operations/cell/KeyValueColumnizeOperation.java
@@ -35,8 +35,11 @@ package com.google.refine.operations.cell;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -47,6 +50,7 @@ import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.MassRowColumnChange;
@@ -94,6 +98,22 @@ public class KeyValueColumnizeOperation extends AbstractOperation {
     protected String getBriefDescription(Project project) {
         return _noteColumnName == null ? OperationDescription.cell_key_value_columnize_brief(_keyColumnName, _valueColumnName)
                 : OperationDescription.cell_key_value_columnize_note_column_brief(_keyColumnName, _valueColumnName, _noteColumnName);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        Set<String> result = new HashSet<>(3);
+        result.add(_keyColumnName);
+        result.add(_valueColumnName);
+        if (_noteColumnName != null) {
+            result.add(_noteColumnName);
+        }
+        return Optional.of(result);
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.empty();
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/MultiValuedCellJoinOperation.java
+++ b/main/src/com/google/refine/operations/cell/MultiValuedCellJoinOperation.java
@@ -35,6 +35,8 @@ package com.google.refine.operations.cell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -45,6 +47,7 @@ import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.MassRowChange;
@@ -86,6 +89,16 @@ public class MultiValuedCellJoinOperation extends AbstractOperation {
     @JsonProperty("separator")
     public String getSeparator() {
         return _separator;
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(Set.of(_columnName, _keyColumnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/MultiValuedCellSplitOperation.java
+++ b/main/src/com/google/refine/operations/cell/MultiValuedCellSplitOperation.java
@@ -35,6 +35,8 @@ package com.google.refine.operations.cell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -48,6 +50,7 @@ import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.MassRowChange;
@@ -173,6 +176,16 @@ public class MultiValuedCellSplitOperation extends AbstractOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return OperationDescription.cell_multivalued_cell_split_brief(_columnName);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(Set.of(_columnName, _keyColumnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/TextTransformOperation.java
+++ b/main/src/com/google/refine/operations/cell/TextTransformOperation.java
@@ -35,7 +35,9 @@ package com.google.refine.operations.cell;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -49,6 +51,7 @@ import com.google.refine.expr.ParsingException;
 import com.google.refine.expr.WrappedCell;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.CellChange;
@@ -122,6 +125,21 @@ public class TextTransformOperation extends EngineDependentMassCellOperation {
             List<CellChange> cellChanges) {
 
         return OperationDescription.cell_text_transform_desc(cellChanges.size(), column.getName(), _expression);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        try {
+            Evaluable parsed = MetaParser.parse(_expression);
+            return parsed.getColumnDependencies(Optional.of(_columnName));
+        } catch (ParsingException e) {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperation.java
+++ b/main/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperation.java
@@ -35,6 +35,8 @@ package com.google.refine.operations.cell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -48,6 +50,7 @@ import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.MassRowColumnChange;
@@ -188,6 +191,16 @@ public class TransposeColumnsIntoRowsOperation extends AbstractOperation {
                         _valueColumnName);
             }
         }
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.empty();
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperation.java
+++ b/main/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperation.java
@@ -35,6 +35,8 @@ package com.google.refine.operations.cell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -44,6 +46,7 @@ import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.MassRowColumnChange;
@@ -80,6 +83,16 @@ public class TransposeRowsIntoColumnsOperation extends AbstractOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return OperationDescription.cell_transpose_rows_into_columns_brief(_rowCount, _columnName);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.empty();
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/BlankDownTests.java
@@ -27,12 +27,14 @@
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.AfterMethod;
@@ -50,6 +52,7 @@ import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.operations.OperationDescription;
@@ -135,6 +138,17 @@ public class BlankDownTests extends RefineTest {
     public void testValidate() {
         assertThrows(IllegalArgumentException.class, () -> new BlankDownOperation(invalidEngineConfig, "bar").validate());
         assertThrows(IllegalArgumentException.class, () -> new BlankDownOperation(defaultEngineConfig, null).validate());
+    }
+
+    @Test
+    public void testColumnsDiff() {
+        assertEquals(new BlankDownOperation(defaultEngineConfig, "bar").getColumnsDiff().get(), ColumnsDiff.modifySingleColumn("bar"));
+    }
+
+    @Test
+    public void testColumnsDependencies() {
+        assertEquals(new BlankDownOperation(defaultEngineConfig, "bar").getColumnDependencies().get(), Set.of("bar"));
+        assertEquals(new BlankDownOperation(engineConfigWithColumnDeps, "bar").getColumnDependencies().get(), Set.of("bar", "facet_1"));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/FillDownTests.java
@@ -27,12 +27,14 @@
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.AfterMethod;
@@ -50,6 +52,7 @@ import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.operations.OperationDescription;
@@ -122,6 +125,17 @@ public class FillDownTests extends RefineTest {
     public void testValidate() {
         assertThrows(IllegalArgumentException.class, () -> new FillDownOperation(invalidEngineConfig, "bar").validate());
         assertThrows(IllegalArgumentException.class, () -> new FillDownOperation(defaultEngineConfig, null).validate());
+    }
+
+    @Test
+    public void testColumnsDiff() {
+        assertEquals(new FillDownOperation(defaultEngineConfig, "bar").getColumnsDiff().get(), ColumnsDiff.modifySingleColumn("bar"));
+    }
+
+    @Test
+    public void testColumnsDependencies() {
+        assertEquals(new FillDownOperation(defaultEngineConfig, "bar").getColumnDependencies().get(), Set.of("bar"));
+        assertEquals(new FillDownOperation(engineConfigWithColumnDeps, "bar").getColumnDependencies().get(), Set.of("bar", "facet_1"));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
@@ -33,11 +33,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.slf4j.LoggerFactory;
@@ -124,6 +127,17 @@ public class KeyValueColumnizeTests extends RefineTest {
     public void testValidate() {
         assertThrows(IllegalArgumentException.class, () -> new KeyValueColumnizeOperation(null, "foo", "bar").validate());
         assertThrows(IllegalArgumentException.class, () -> new KeyValueColumnizeOperation("foo", null, "bar").validate());
+    }
+
+    @Test
+    public void testColumnsDiff() {
+        assertEquals(new KeyValueColumnizeOperation("foo", "baz", "bar").getColumnsDiff(), Optional.empty());
+    }
+
+    @Test
+    public void testColumnsDependencies() {
+        assertEquals(new KeyValueColumnizeOperation("foo", "baz", "bar").getColumnDependencies().get(), Set.of("foo", "baz", "bar"));
+        assertEquals(new KeyValueColumnizeOperation("foo", "baz", null).getColumnDependencies().get(), Set.of("foo", "baz"));
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/operations/cell/MassOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MassOperationTests.java
@@ -27,12 +27,14 @@
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -50,6 +52,7 @@ import com.google.refine.browsing.facets.ListFacet.ListFacetConfig;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationDescription;
 import com.google.refine.operations.OperationRegistry;
@@ -182,6 +185,18 @@ public class MassOperationTests extends RefineTest {
                 () -> new MassEditOperation(defaultEngineConfig, "foo", "grel:invalid(", editsWithFromBlank).validate());
         assertThrows(IllegalArgumentException.class,
                 () -> new MassEditOperation(defaultEngineConfig, "foo", "grel:value", null).validate());
+    }
+
+    @Test
+    public void testColumnsDiff() {
+        assertEquals(new MassEditOperation(defaultEngineConfig, "foo", "grel:value", editsWithFromBlank).getColumnsDiff().get(),
+                ColumnsDiff.modifySingleColumn("foo"));
+    }
+
+    @Test
+    public void testColumnsDependencies() {
+        assertEquals(new MassEditOperation(engineConfigWithColumnDeps, "foo", "grel:cells['bar'].value", editsWithFromBlank)
+                .getColumnDependencies().get(), Set.of("foo", "bar", "facet_1"));
     }
 
     // Not yet testing for mass edit from OR Error

--- a/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellJoinOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellJoinOperationTests.java
@@ -33,9 +33,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.slf4j.LoggerFactory;
@@ -46,6 +48,7 @@ import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationDescription;
 import com.google.refine.operations.OperationRegistry;
@@ -104,6 +107,17 @@ public class MultiValuedCellJoinOperationTests extends RefineTest {
         assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellJoinOperation(null, "key", "sep").validate());
         assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellJoinOperation("value", null, "sep").validate());
         assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellJoinOperation("value", "key", null).validate());
+    }
+
+    @Test
+    public void testColumnsDiff() {
+        assertEquals(new MultiValuedCellJoinOperation("value", "key", "sep").getColumnsDiff().get(),
+                ColumnsDiff.modifySingleColumn("value"));
+    }
+
+    @Test
+    public void testColumnsDependencies() {
+        assertEquals(new MultiValuedCellJoinOperation("value", "key", "sep").getColumnDependencies().get(), Set.of("value", "key"));
     }
 
     /*

--- a/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellSplitOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellSplitOperationTests.java
@@ -33,9 +33,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -47,6 +49,7 @@ import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationDescription;
 import com.google.refine.operations.OperationRegistry;
@@ -161,6 +164,24 @@ public class MultiValuedCellSplitOperationTests extends RefineTest {
         assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellSplitOperation(null, "key", "sep", false).validate());
         assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellSplitOperation("value", null, "sep", false).validate());
         assertThrows(IllegalArgumentException.class, () -> new MultiValuedCellSplitOperation("value", "key", null, false).validate());
+    }
+
+    @Test
+    public void testColumnsDiff() {
+        assertEquals(new MultiValuedCellSplitOperation(
+                "Value",
+                "Key",
+                ":",
+                false).getColumnsDiff().get(), ColumnsDiff.modifySingleColumn("Value"));
+    }
+
+    @Test
+    public void testColumnsDependencies() {
+        assertEquals(new MultiValuedCellSplitOperation(
+                "Value",
+                "Key",
+                ":",
+                false).getColumnDependencies().get(), Set.of("Value", "Key"));
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/operations/cell/TextTransformOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TextTransformOperationTests.java
@@ -1,9 +1,11 @@
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.AfterMethod;
@@ -16,6 +18,7 @@ import com.google.refine.browsing.EngineConfig;
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OnError;
 import com.google.refine.operations.OperationDescription;
@@ -92,6 +95,26 @@ public class TextTransformOperationTests extends RefineTest {
                 "grel:foo(",
                 OnError.SetToBlank,
                 false, 0).validate());
+    }
+
+    @Test
+    public void testColumnsDiff() {
+        assertEquals(new TextTransformOperation(
+                defaultEngineConfig,
+                "bar",
+                "grel:cells[\"foo\"].value+'_'+value",
+                OnError.SetToBlank,
+                false, 0).getColumnsDiff().get(), ColumnsDiff.modifySingleColumn("bar"));
+    }
+
+    @Test
+    public void testColumnsDependencies() {
+        assertEquals(new TextTransformOperation(
+                engineConfigWithColumnDeps,
+                "bar",
+                "grel:cells[\"foo\"].value+'_'+value",
+                OnError.SetToBlank,
+                false, 0).getColumnDependencies().get(), Set.of("foo", "bar", "facet_1"));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperationTest.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperationTest.java
@@ -1,9 +1,11 @@
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.BeforeSuite;
@@ -51,6 +53,17 @@ public class TransposeColumnsIntoRowsOperationTest extends RefineTest {
                 "b 1", 2, true, false, null, "value").validate());
         assertThrows(IllegalArgumentException.class, () -> new TransposeColumnsIntoRowsOperation(
                 "b 1", 2, true, false, "key", null).validate());
+    }
+
+    @Test
+    public void testColumnsDiff() {
+        assertEquals(new TransposeColumnsIntoRowsOperation("num1", -1, true, false, "a", true, ":").getColumnsDiff(), Optional.empty());
+    }
+
+    @Test
+    public void testColumnsDependencies() {
+        assertEquals(new TransposeColumnsIntoRowsOperation("num1", -1, true, false, "a", true, ":").getColumnDependencies(),
+                Optional.empty());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperationTests.java
@@ -33,9 +33,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.cell;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.slf4j.LoggerFactory;
@@ -86,6 +89,16 @@ public class TransposeRowsIntoColumnsOperationTests extends RefineTest {
     @Test
     public void testValidate() {
         assertThrows(IllegalArgumentException.class, () -> new TransposeRowsIntoColumnsOperation(null, 2).validate());
+    }
+
+    @Test
+    public void testColumnsDiff() {
+        assertEquals(new TransposeRowsIntoColumnsOperation("b", 2).getColumnsDiff(), Optional.empty());
+    }
+
+    @Test
+    public void testColumnsDependencies() {
+        assertEquals(new TransposeRowsIntoColumnsOperation("b", 2).getColumnDependencies(), Optional.of(Set.of("b")));
     }
 
     @Test

--- a/modules/core/src/test/java/com/google/refine/RefineTest.java
+++ b/modules/core/src/test/java/com/google/refine/RefineTest.java
@@ -103,6 +103,7 @@ public class RefineTest {
 
     protected EngineConfig invalidEngineConfig;
     protected EngineConfig defaultEngineConfig;
+    protected EngineConfig engineConfigWithColumnDeps;
 
     @BeforeSuite
     public void init() {
@@ -134,6 +135,9 @@ public class RefineTest {
         invalidEngineConfig = mock(EngineConfig.class);
         doThrow(IllegalArgumentException.class).when(invalidEngineConfig).validate();
         defaultEngineConfig = new EngineConfig(Collections.emptyList(), Mode.RowBased);
+        engineConfigWithColumnDeps = mock(EngineConfig.class);
+        when(engineConfigWithColumnDeps.getMode()).thenReturn(Mode.RowBased);
+        when(engineConfigWithColumnDeps.getColumnDependencies()).thenReturn(Optional.of(Set.of("facet_1")));
     }
 
     protected Project createProjectWithColumns(String projectName, String... columnNames) throws IOException, ModelException {


### PR DESCRIPTION
Following up on #7056, this adds the column dependencies and diffs to all operations in the `com.google.refine.operations.cells` package.
