### PR TITLE
operations: Expose column dependencies in c.g.r.o.recon

### DIFF
--- a/main/src/com/google/refine/operations/recon/ExtendDataOperation.java
+++ b/main/src/com/google/refine/operations/recon/ExtendDataOperation.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -51,6 +52,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.ReconCandidate;
 import com.google.refine.model.ReconType;
@@ -115,6 +117,19 @@ public class ExtendDataOperation extends EngineDependentOperation {
                 project,
                 getEngineConfig(),
                 getBriefDescription(null));
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_baseColumnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        // Sadly, although the names of the properties fetched are present in the extension metadata,
+        // the names of the column created can differ from those, if there already are columns with any of those names.
+        // So we can't predict the name of the created columns in this context.
+        return Optional.empty();
     }
 
     public class ExtendDataProcess extends LongRunningProcess implements Runnable {

--- a/main/src/com/google/refine/operations/recon/ReconClearSimilarCellsOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconClearSimilarCellsOperation.java
@@ -34,6 +34,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.operations.recon;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -43,6 +45,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.Change;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.CellChange;
@@ -83,6 +86,16 @@ public class ReconClearSimilarCellsOperation extends EngineDependentMassCellOper
             List<CellChange> cellChanges) {
 
         return OperationDescription.recon_clear_similar_cells_desc(cellChanges.size(), _similarValue, _columnName);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/recon/ReconCopyAcrossColumnsOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconCopyAcrossColumnsOperation.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -51,6 +52,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Recon.Judgment;
@@ -99,6 +101,18 @@ public class ReconCopyAcrossColumnsOperation extends EngineDependentOperation {
     @JsonProperty("applyToJudgedCells")
     public boolean getApplyToJudgedCells() {
         return _applyToJudgedCells;
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        Set<String> columnNames = new HashSet<>(Set.of(_toColumnNames));
+        columnNames.add(_fromColumnName);
+        return Optional.of(columnNames);
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(new ColumnsDiff(List.of(), Set.of(), Set.of(_toColumnNames)));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/recon/ReconDiscardJudgmentsOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconDiscardJudgmentsOperation.java
@@ -36,6 +36,8 @@ package com.google.refine.operations.recon;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -45,6 +47,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.Change;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Recon.Judgment;
@@ -91,6 +94,16 @@ public class ReconDiscardJudgmentsOperation extends EngineDependentMassCellOpera
             List<CellChange> cellChanges) {
         return _clearData ? OperationDescription.recon_discard_judgments_clear_data_desc(cellChanges.size(), column.getName())
                 : OperationDescription.recon_discard_judgments_desc(cellChanges.size(), column.getName());
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsOperation.java
@@ -36,6 +36,8 @@ package com.google.refine.operations.recon;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -48,6 +50,7 @@ import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.history.Change;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Recon.Judgment;
@@ -138,6 +141,16 @@ public class ReconJudgeSimilarCellsOperation extends EngineDependentMassCellOper
                     _columnName);
         }
         throw new InternalError("Can't get here");
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/recon/ReconMarkNewTopicsOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconMarkNewTopicsOperation.java
@@ -37,6 +37,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -47,6 +49,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.Change;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Recon.Judgment;
@@ -120,6 +123,16 @@ public class ReconMarkNewTopicsOperation extends EngineDependentMassCellOperatio
         return _shareNewTopics ? OperationDescription.recon_mark_new_topics_shared_desc(cellChanges.size(), column.getName())
                 : OperationDescription.recon_mark_new_topics_desc(cellChanges.size(), column.getName());
 
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     protected ReconConfig getNewReconConfig(Column column) {

--- a/main/src/com/google/refine/operations/recon/ReconMatchBestCandidatesOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconMatchBestCandidatesOperation.java
@@ -36,6 +36,8 @@ package com.google.refine.operations.recon;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -45,6 +47,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.Change;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Recon.Judgment;
@@ -79,6 +82,16 @@ public class ReconMatchBestCandidatesOperation extends EngineDependentMassCellOp
             List<CellChange> cellChanges) {
 
         return OperationDescription.recon_match_best_candidates_desc(cellChanges.size(), column.getName());
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/recon/ReconMatchSpecificTopicOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconMatchSpecificTopicOperation.java
@@ -36,6 +36,8 @@ package com.google.refine.operations.recon;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -46,6 +48,7 @@ import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.Change;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Recon.Judgment;
@@ -112,6 +115,16 @@ public class ReconMatchSpecificTopicOperation extends EngineDependentMassCellOpe
     protected String createDescription(Column column,
             List<CellChange> cellChanges) {
         return OperationDescription.recon_match_specific_topic_desc(match.name, match.id, cellChanges.size(), column.getName());
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/recon/ReconOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconOperation.java
@@ -36,9 +36,12 @@ package com.google.refine.operations.recon;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -56,6 +59,7 @@ import com.google.refine.history.HistoryEntry;
 import com.google.refine.messages.OpenRefineMessage;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Row;
@@ -107,6 +111,22 @@ public class ReconOperation extends EngineDependentOperation {
     @JsonProperty("columnName")
     public String getColumnName() {
         return _columnName;
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        Optional<Set<String>> reconDeps = _reconConfig.getColumnDependencies();
+        if (reconDeps.isEmpty()) {
+            return Optional.empty();
+        }
+        Set<String> dependencies = new HashSet<>(reconDeps.get());
+        dependencies.add(_columnName);
+        return Optional.of(dependencies);
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     static protected class ReconEntry {

--- a/main/src/com/google/refine/operations/recon/ReconUseValuesAsIdentifiersOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconUseValuesAsIdentifiersOperation.java
@@ -29,6 +29,8 @@ package com.google.refine.operations.recon;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -40,6 +42,7 @@ import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.history.Change;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Recon.Judgment;
@@ -80,6 +83,16 @@ public class ReconUseValuesAsIdentifiersOperation extends EngineDependentMassCel
     @Override
     public String getBriefDescription(Project project) {
         return OperationDescription.recon_use_values_as_identifiers_brief(_columnName);
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of(_columnName));
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/operations/recon/ExtendDataOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ExtendDataOperationTests.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.operations.recon;
 
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -46,6 +47,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -255,6 +257,22 @@ public class ExtendDataOperationTests extends RefineTest {
     @AfterMethod
     public void cleanupHttpMocks() {
         mockedResponses.clear();
+    }
+
+    @Test
+    public void testColumnDependencies() throws IOException {
+        DataExtensionConfig extension = DataExtensionConfig
+                .reconstruct("{\"properties\":[{\"id\":\"P297\",\"name\":\"ISO 3166-1 alpha-2 code\"}]}");
+        EngineDependentOperation op = new ExtendDataOperation(engine_config,
+                "country",
+                "https://foo.com/bar",
+                RECON_IDENTIFIER_SPACE,
+                RECON_SCHEMA_SPACE,
+                extension,
+                1);
+
+        assertEquals(op.getColumnDependencies(), Optional.of(Set.of("country")));
+        assertEquals(op.getColumnsDiff(), Optional.empty());
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconClearSimilarCellsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconClearSimilarCellsOperationTests.java
@@ -27,8 +27,12 @@
 
 package com.google.refine.operations.recon;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.BeforeMethod;
@@ -40,6 +44,7 @@ import com.google.refine.browsing.Engine.Mode;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.operations.OperationDescription;
@@ -49,6 +54,12 @@ import com.google.refine.util.TestUtils;
 
 public class ReconClearSimilarCellsOperationTests extends RefineTest {
 
+    String json = "{\"op\":\"core/recon-clear-similar-cells\","
+            + "\"description\":"
+            + new TextNode(OperationDescription.recon_clear_similar_cells_brief("some value", "my column")).toString() + ","
+            + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":[]},"
+            + "\"columnName\":\"my column\","
+            + "\"similarValue\":\"some value\"}";
     Project project;
 
     @BeforeSuite
@@ -69,13 +80,14 @@ public class ReconClearSimilarCellsOperationTests extends RefineTest {
 
     @Test
     public void serializeReconClearSimilarCellsOperation() throws Exception {
-        String json = "{\"op\":\"core/recon-clear-similar-cells\","
-                + "\"description\":"
-                + new TextNode(OperationDescription.recon_clear_similar_cells_brief("some value", "my column")).toString() + ","
-                + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":[]},"
-                + "\"columnName\":\"my column\","
-                + "\"similarValue\":\"some value\"}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ReconClearSimilarCellsOperation.class), json);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        AbstractOperation op = ParsingUtilities.mapper.readValue(json, ReconClearSimilarCellsOperation.class);
+        assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("my column")));
+        assertEquals(op.getColumnDependencies(), Optional.of(Set.of("my column")));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconCopyAcrossColumnsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconCopyAcrossColumnsOperationTests.java
@@ -27,8 +27,12 @@
 
 package com.google.refine.operations.recon;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.BeforeMethod;
@@ -40,6 +44,7 @@ import com.google.refine.browsing.Engine.Mode;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.operations.OperationDescription;
@@ -49,6 +54,14 @@ import com.google.refine.util.TestUtils;
 
 public class ReconCopyAcrossColumnsOperationTests extends RefineTest {
 
+    String json = "{\"op\":\"core/recon-copy-across-columns\","
+            + "\"description\":"
+            + new TextNode(OperationDescription.recon_copy_across_columns_brief("source column", "first, second")).toString() + ","
+            + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":[]},"
+            + "\"fromColumnName\":\"source column\","
+            + "\"toColumnNames\":[\"first\",\"second\"],"
+            + "\"judgments\":[\"matched\",\"new\"],"
+            + "\"applyToJudgedCells\":true}";
     Project project;
 
     @BeforeSuite
@@ -69,15 +82,14 @@ public class ReconCopyAcrossColumnsOperationTests extends RefineTest {
 
     @Test
     public void serializeReconCopyAcrossColumnsOperation() throws Exception {
-        String json = "{\"op\":\"core/recon-copy-across-columns\","
-                + "\"description\":"
-                + new TextNode(OperationDescription.recon_copy_across_columns_brief("source column", "first, second")).toString() + ","
-                + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":[]},"
-                + "\"fromColumnName\":\"source column\","
-                + "\"toColumnNames\":[\"first\",\"second\"],"
-                + "\"judgments\":[\"matched\",\"new\"],"
-                + "\"applyToJudgedCells\":true}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ReconCopyAcrossColumnsOperation.class), json);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        AbstractOperation op = ParsingUtilities.mapper.readValue(json, ReconCopyAcrossColumnsOperation.class);
+        assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.builder().modifyColumn("first").modifyColumn("second").build()));
+        assertEquals(op.getColumnDependencies(), Optional.of(Set.of("source column", "first", "second")));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconDiscardJudgmentsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconDiscardJudgmentsOperationTests.java
@@ -27,8 +27,12 @@
 
 package com.google.refine.operations.recon;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.BeforeMethod;
@@ -40,6 +44,7 @@ import com.google.refine.browsing.Engine.Mode;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.operations.OperationDescription;
@@ -49,6 +54,17 @@ import com.google.refine.util.TestUtils;
 
 public class ReconDiscardJudgmentsOperationTests extends RefineTest {
 
+    String json = "{\n" +
+            "    \"op\": \"core/recon-discard-judgments\",\n" +
+            "    \"description\": "
+            + new TextNode(OperationDescription.recon_discard_judgments_clear_data_brief("researcher")).toString() + ",\n" +
+            "    \"engineConfig\": {\n" +
+            "      \"mode\": \"record-based\",\n" +
+            "      \"facets\": []\n" +
+            "    },\n" +
+            "    \"columnName\": \"researcher\",\n" +
+            "    \"clearData\": true\n" +
+            "  }";
     Project project;
 
     @BeforeSuite
@@ -68,18 +84,14 @@ public class ReconDiscardJudgmentsOperationTests extends RefineTest {
 
     @Test
     public void serializeReconDiscardJudgmentsOperation() throws Exception {
-        String json = "{\n" +
-                "    \"op\": \"core/recon-discard-judgments\",\n" +
-                "    \"description\": "
-                + new TextNode(OperationDescription.recon_discard_judgments_clear_data_brief("researcher")).toString() + ",\n" +
-                "    \"engineConfig\": {\n" +
-                "      \"mode\": \"record-based\",\n" +
-                "      \"facets\": []\n" +
-                "    },\n" +
-                "    \"columnName\": \"researcher\",\n" +
-                "    \"clearData\": true\n" +
-                "  }";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ReconDiscardJudgmentsOperation.class), json);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        AbstractOperation op = ParsingUtilities.mapper.readValue(json, ReconDiscardJudgmentsOperation.class);
+        assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("researcher")));
+        assertEquals(op.getColumnDependencies(), Optional.of(Set.of("researcher")));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsOperationTests.java
@@ -33,6 +33,8 @@ import static org.testng.Assert.assertNull;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.slf4j.LoggerFactory;
@@ -46,6 +48,7 @@ import com.google.refine.browsing.EngineConfig;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Recon.Judgment;
@@ -120,6 +123,18 @@ public class ReconJudgeSimilarCellsOperationTests extends RefineTest {
                 + "\"shareNewTopics\":false"
                 + "}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ReconJudgeSimilarCellsOperation.class), json);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        AbstractOperation op = new ReconJudgeSimilarCellsOperation(
+                ENGINE_CONFIG,
+                "A",
+                "foo",
+                Recon.Judgment.New,
+                null, true);
+        assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("A")));
+        assertEquals(op.getColumnDependencies(), Optional.of(Set.of("A")));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconMarkNewTopicsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconMarkNewTopicsOperationTests.java
@@ -31,12 +31,16 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
+import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.recon.StandardReconConfig;
@@ -82,6 +86,13 @@ public class ReconMarkNewTopicsOperationTests extends RefineTest {
     @Test
     public void serializeReconMarkNewTopicsOperationWithService() throws Exception {
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(jsonWithService, ReconMarkNewTopicsOperation.class), jsonWithService);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        AbstractOperation op = ParsingUtilities.mapper.readValue(jsonWithoutService, ReconMarkNewTopicsOperation.class);
+        assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("my column")));
+        assertEquals(op.getColumnDependencies(), Optional.of(Set.of("my column")));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconMatchBestCandidatesOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconMatchBestCandidatesOperationTests.java
@@ -27,10 +27,15 @@
 
 package com.google.refine.operations.recon;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -38,8 +43,11 @@ import org.testng.annotations.Test;
 import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine.Mode;
 import com.google.refine.browsing.EngineConfig;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.operations.OperationDescription;
@@ -49,11 +57,31 @@ import com.google.refine.util.TestUtils;
 
 public class ReconMatchBestCandidatesOperationTests extends RefineTest {
 
+    String json = "{"
+            + "\"op\":\"core/recon-match-best-candidates\","
+            + "\"description\":" + new TextNode(OperationDescription.recon_match_best_candidates_brief("organization_name")).toString()
+            + ","
+            + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":["
+            + "       {\"selectNumeric\":true,\"expression\":\"cell.recon.best.score\",\"selectBlank\":false,\"selectNonNumeric\":true,\"selectError\":true,\"name\":\"organization_name: best candidate's score\",\"from\":13,\"to\":101,\"type\":\"range\",\"columnName\":\"organization_name\"},"
+            + "       {\"selectNonTime\":true,\"expression\":\"grel:toDate(value)\",\"selectBlank\":true,\"selectError\":true,\"selectTime\":true,\"name\":\"start_year\",\"from\":410242968000,\"to\":1262309184000,\"type\":\"timerange\",\"columnName\":\"start_year\"}"
+            + "]},"
+            + "\"columnName\":\"organization_name\""
+            + "}";
     Project project;
 
     @BeforeSuite
     public void registerOperation() {
         OperationRegistry.registerOperation(getCoreModule(), "recon-match-best-candidates", ReconMatchBestCandidatesOperation.class);
+    }
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
     }
 
     @BeforeMethod
@@ -69,17 +97,14 @@ public class ReconMatchBestCandidatesOperationTests extends RefineTest {
 
     @Test
     public void serializeReconMatchBestCandidatesOperation() throws Exception {
-        String json = "{"
-                + "\"op\":\"core/recon-match-best-candidates\","
-                + "\"description\":" + new TextNode(OperationDescription.recon_match_best_candidates_brief("organization_name")).toString()
-                + ","
-                + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":["
-                + "       {\"selectNumeric\":true,\"expression\":\"cell.recon.best.score\",\"selectBlank\":false,\"selectNonNumeric\":true,\"selectError\":true,\"name\":\"organization_name: best candidate's score\",\"from\":13,\"to\":101,\"type\":\"range\",\"columnName\":\"organization_name\"},"
-                + "       {\"selectNonTime\":true,\"expression\":\"grel:toDate(value)\",\"selectBlank\":true,\"selectError\":true,\"selectTime\":true,\"name\":\"start_year\",\"from\":410242968000,\"to\":1262309184000,\"type\":\"timerange\",\"columnName\":\"start_year\"}"
-                + "]},"
-                + "\"columnName\":\"organization_name\""
-                + "}";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ReconMatchBestCandidatesOperation.class), json);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        ReconMatchBestCandidatesOperation op = ParsingUtilities.mapper.readValue(json, ReconMatchBestCandidatesOperation.class);
+        assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("organization_name")));
+        assertEquals(op.getColumnDependencies(), Optional.of(Set.of("organization_name", "start_year")));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconMatchSpecificTopicOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconMatchSpecificTopicOperationTests.java
@@ -27,8 +27,12 @@
 
 package com.google.refine.operations.recon;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.BeforeMethod;
@@ -40,6 +44,7 @@ import com.google.refine.browsing.Engine.Mode;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
 import com.google.refine.model.Recon.Judgment;
@@ -92,6 +97,17 @@ public class ReconMatchSpecificTopicOperationTests extends RefineTest {
                 "    \"schemaSpace\": \"http://www.wikidata.org/prop/direct/\"\n" +
                 "  }";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ReconMatchSpecificTopicOperation.class), json);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        ReconItem reconItem = new ReconItem("hello", "world", new String[] { "human" });
+        AbstractOperation operation = new ReconMatchSpecificTopicOperation(
+                new EngineConfig(Collections.emptyList(), Mode.RowBased),
+                "bar", reconItem,
+                "http://identifier.space", "http://schema.space");
+        assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("bar")));
+        assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("bar")));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconUseValuesAsIdsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconUseValuesAsIdsOperationTests.java
@@ -31,12 +31,16 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
 import java.io.Serializable;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
+import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.recon.StandardReconConfig;
 import com.google.refine.operations.OperationDescription;
@@ -64,6 +68,13 @@ public class ReconUseValuesAsIdsOperationTests extends RefineTest {
     @Test
     public void serializeReconUseValuesAsIdentifiersOperation() throws Exception {
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ReconUseValuesAsIdentifiersOperation.class), json);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        AbstractOperation operation = ParsingUtilities.mapper.readValue(json, ReconUseValuesAsIdentifiersOperation.class);
+        assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("ids")));
+        assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("ids")));
     }
 
     @Test

--- a/modules/core/src/main/java/com/google/refine/model/recon/ReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/ReconConfig.java
@@ -39,6 +39,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -133,4 +135,13 @@ abstract public class ReconConfig {
      */
     @JsonIgnore
     abstract public String getMode();
+
+    /**
+     * @return the set of columns referred to by this reconciliation configuration, or {@link Optional#empty()} if the
+     *         reconciliation might depend on any column.
+     */
+    @JsonIgnore
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.empty();
+    }
 }

--- a/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -327,6 +328,13 @@ public class StandardReconConfig extends ReconConfig {
     @Override
     public String getBriefDescription(Project project, String columnName) {
         return "Reconcile cells in column " + columnName + " to type " + typeID;
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(columnDetails.stream()
+                .map(columnDetail -> columnDetail.columnName)
+                .collect(Collectors.toSet()));
     }
 
     public ReconJob createSimpleJob(String query) {

--- a/modules/core/src/test/java/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/modules/core/src/test/java/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -37,6 +37,8 @@ import java.io.Serializable;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -213,6 +215,24 @@ public class StandardReconConfigTests extends RefineTest {
         assertEquals(c.getBatchSize(120), 12);
         assertEquals(c.getBatchSize(1200), 50);
         assertEquals(c.getBatchSize(10000), 50);
+    }
+
+    @Test
+    public void testGetColumnDependencies() throws IOException {
+        String json = "{\"mode\":\"standard-service\","
+                + "\"service\":\"https://tools.wmflabs.org/openrefine-wikidata/en/api\","
+                + "\"identifierSpace\":\"http://www.wikidata.org/entity/\","
+                + "\"schemaSpace\":\"http://www.wikidata.org/prop/direct/\","
+                + "\"type\":null,"
+                + "\"autoMatch\":true,"
+                + "\"batchSize\":50,"
+                + "\"columnDetails\":["
+                + "    {\"column\":\"_ - id\","
+                + "     \"property\":{\"id\":\"P3153\",\"name\":\"Crossref funder ID\"}}"
+                + "],"
+                + "\"limit\":0}";
+        StandardReconConfig c = StandardReconConfig.reconstruct(json);
+        assertEquals(c.getColumnDependencies(), Optional.of(Set.of("_ - id")));
     }
 
     @Test


### PR DESCRIPTION
Following up on #7056, this adds the column dependencies and diffs to operations in the `com.google.refine.operations.recon` package.

The data extension operation does not expose anything yet: this will be tackled in a separate PR, as it requires adaptations to the operation metadata.