### PR TITLE
operations: Expose column dependencies for c.g.r.o.rows

### DIFF
--- a/main/src/com/google/refine/operations/row/RowAdditionOperation.java
+++ b/main/src/com/google/refine/operations/row/RowAdditionOperation.java
@@ -28,12 +28,16 @@
 package com.google.refine.operations.row;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.RowAdditionChange;
@@ -65,6 +69,16 @@ public class RowAdditionOperation extends AbstractOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return OperationDescription.row_addition_brief();
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(Set.of());
+    }
+
+    @JsonIgnore
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.empty());
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowFlagOperation.java
+++ b/main/src/com/google/refine/operations/row/RowFlagOperation.java
@@ -35,8 +35,11 @@ package com.google.refine.operations.row;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.browsing.Engine;
@@ -45,6 +48,7 @@ import com.google.refine.browsing.FilteredRows;
 import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.MassChange;
@@ -73,6 +77,16 @@ public class RowFlagOperation extends EngineDependentOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return _flagged ? OperationDescription.row_flag_brief() : OperationDescription.row_unflag_brief();
+    }
+
+    @Override
+    protected Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of());
+    }
+
+    @JsonIgnore
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.empty());
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowRemovalOperation.java
+++ b/main/src/com/google/refine/operations/row/RowRemovalOperation.java
@@ -35,8 +35,11 @@ package com.google.refine.operations.row;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.browsing.Engine;
@@ -44,6 +47,7 @@ import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.FilteredRows;
 import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.HistoryEntry;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.RowRemovalChange;
@@ -61,6 +65,16 @@ public class RowRemovalOperation extends EngineDependentOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return OperationDescription.row_removal_brief();
+    }
+
+    @Override
+    protected Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of());
+    }
+
+    @JsonIgnore
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.empty());
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowReorderOperation.java
+++ b/main/src/com/google/refine/operations/row/RowReorderOperation.java
@@ -35,8 +35,11 @@ package com.google.refine.operations.row;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.browsing.Engine;
@@ -45,6 +48,7 @@ import com.google.refine.browsing.RecordVisitor;
 import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Record;
 import com.google.refine.model.Row;
@@ -75,6 +79,16 @@ public class RowReorderOperation extends AbstractOperation {
     @JsonProperty("sorting")
     public SortingConfig getSortingConfig() {
         return _sorting;
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(Set.of());
+    }
+
+    @JsonIgnore
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.empty());
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowStarOperation.java
+++ b/main/src/com/google/refine/operations/row/RowStarOperation.java
@@ -35,8 +35,11 @@ package com.google.refine.operations.row;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.browsing.Engine;
@@ -45,6 +48,7 @@ import com.google.refine.browsing.FilteredRows;
 import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.Change;
 import com.google.refine.history.HistoryEntry;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.MassChange;
@@ -73,6 +77,16 @@ public class RowStarOperation extends EngineDependentOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return _starred ? OperationDescription.row_star_brief() : OperationDescription.row_unstar_brief();
+    }
+
+    @Override
+    protected Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of());
+    }
+
+    @JsonIgnore
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.empty());
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/operations/row/RowAdditionOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowAdditionOperationTests.java
@@ -32,9 +32,10 @@ import static org.testng.Assert.assertEquals;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
@@ -43,6 +44,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Row;
 import com.google.refine.operations.OperationDescription;
 import com.google.refine.operations.OperationRegistry;
@@ -52,6 +54,7 @@ import com.google.refine.util.TestUtils;
 public class RowAdditionOperationTests extends RefineTest {
 
     String json;
+    RowAdditionOperation op;
 
     @BeforeSuite
     public void registerOperation() {
@@ -65,6 +68,13 @@ public class RowAdditionOperationTests extends RefineTest {
                 + "\"rows\":[{\"starred\":false,\"flagged\":false,\"cells\":[]},{\"starred\":false,\"flagged\":false,\"cells\":[]}],"
                 + "\"index\":0,"
                 + "\"description\":" + new TextNode(OperationDescription.row_addition_brief()).toString() + "}";
+
+        List<Row> rows = new ArrayList<>(2);
+        rows.add(new Row(0)); // Blank row
+        rows.add(new Row(0)); // Blank row
+        int index = 0; // Prepend rows
+
+        op = new RowAdditionOperation(rows, index);
     }
 
     @Override
@@ -81,15 +91,14 @@ public class RowAdditionOperationTests extends RefineTest {
 
     @Test
     public void testSerialization() throws JsonProcessingException {
-        List<Row> rows = new ArrayList<>(2);
-        rows.add(new Row(0)); // Blank row
-        rows.add(new Row(0)); // Blank row
-        int index = 0; // Prepend rows
-
-        RowAdditionOperation op = new RowAdditionOperation(rows, index);
-        ObjectMapper objectMapper = new ObjectMapper();
-        String serializedObject = objectMapper.writeValueAsString(op);
+        String serializedObject = ParsingUtilities.mapper.writeValueAsString(op);
         assertEquals(serializedObject, json);
+    }
+
+    @Test
+    public void testColumnDependencies() {
+        assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
+        assertEquals(op.getColumnDependencies(), Optional.of(Set.of()));
     }
 
 }

--- a/main/tests/server/src/com/google/refine/operations/row/RowFlagOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowFlagOperationTests.java
@@ -27,9 +27,13 @@
 
 package com.google.refine.operations.row;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -46,6 +50,7 @@ import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.facets.ListFacet.ListFacetConfig;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationDescription;
 import com.google.refine.operations.OperationRegistry;
@@ -56,6 +61,7 @@ public class RowFlagOperationTests extends RefineTest {
 
     Project project;
     ListFacetConfig facet;
+    RowFlagOperation operation;
 
     @BeforeSuite
     public void registerOperation() {
@@ -87,6 +93,11 @@ public class RowFlagOperationTests extends RefineTest {
         facet.name = "hello";
         facet.expression = "grel:value";
         facet.columnName = "hello";
+        facet.selection = Arrays.asList(
+                new DecoratedValue("h", "h"),
+                new DecoratedValue("d", "d"));
+        EngineConfig engineConfig = new EngineConfig(Arrays.asList(facet), Engine.Mode.RowBased);
+        operation = new RowFlagOperation(engineConfig, true);
     }
 
     @Test
@@ -100,12 +111,13 @@ public class RowFlagOperationTests extends RefineTest {
     }
 
     @Test
+    public void testColumnDependencies() {
+        assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
+        assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("hello")));
+    }
+
+    @Test
     public void testFlagRows() throws Exception {
-        facet.selection = Arrays.asList(
-                new DecoratedValue("h", "h"),
-                new DecoratedValue("d", "d"));
-        EngineConfig engineConfig = new EngineConfig(Arrays.asList(facet), Engine.Mode.RowBased);
-        RowFlagOperation operation = new RowFlagOperation(engineConfig, true);
 
         runOperation(operation, project);
 

--- a/main/tests/server/src/com/google/refine/operations/row/RowRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowRemovalOperationTests.java
@@ -27,10 +27,14 @@
 
 package com.google.refine.operations.row;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.slf4j.LoggerFactory;
@@ -53,6 +57,7 @@ import com.google.refine.grel.Function;
 import com.google.refine.grel.Parser;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.Cell;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
@@ -188,6 +193,18 @@ public class RowRemovalOperationTests extends RefineTest {
         public void end(Project project) {
             Assert.assertEquals(count, target);
         }
+    }
+
+    @Test
+    public void testColumnDependencies() {
+        facet.selection = Arrays.asList(
+                new DecoratedValue("h", "h"),
+                new DecoratedValue("i", "i"));
+        EngineConfig engineConfig = new EngineConfig(Arrays.asList(facet), Engine.Mode.RowBased);
+        RowRemovalOperation operation = new RowRemovalOperation(engineConfig);
+
+        assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("hello")));
+        assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/row/RowReorderOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowReorderOperationTests.java
@@ -27,7 +27,11 @@
 
 package com.google.refine.operations.row;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
+import java.util.Optional;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.testng.annotations.AfterMethod;
@@ -40,6 +44,7 @@ import com.google.refine.RefineTest;
 import com.google.refine.browsing.Engine.Mode;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Cell;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationDescription;
 import com.google.refine.operations.OperationRegistry;
@@ -73,6 +78,17 @@ public class RowReorderOperationTests extends RefineTest {
     @AfterMethod
     public void tearDown() {
         ProjectManager.singleton.deleteProject(project.id);
+    }
+
+    @Test
+    public void testColumnDependencies() throws Exception {
+        String sortingJson = "{\"criteria\":[{\"column\":\"key\",\"valueType\":\"number\",\"reverse\":true,\"blankPosition\":-1,\"errorPosition\":1}]}";
+        SortingConfig sortingConfig = SortingConfig.reconstruct(sortingJson);
+        AbstractOperation op = new RowReorderOperation(
+                Mode.RowBased, sortingConfig);
+
+        assertEquals(op.getColumnDependencies(), Optional.of(Set.of()));
+        assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/row/RowStarOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowStarOperationTests.java
@@ -27,9 +27,13 @@
 
 package com.google.refine.operations.row;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -46,6 +50,7 @@ import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.facets.ListFacet.ListFacetConfig;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.operations.OperationDescription;
 import com.google.refine.operations.OperationRegistry;
@@ -56,6 +61,7 @@ public class RowStarOperationTests extends RefineTest {
 
     Project project;
     ListFacetConfig facet;
+    RowStarOperation operation;
 
     @BeforeSuite
     public void registerOperation() {
@@ -87,6 +93,11 @@ public class RowStarOperationTests extends RefineTest {
         facet.name = "hello";
         facet.expression = "grel:value";
         facet.columnName = "hello";
+        facet.selection = Arrays.asList(
+                new DecoratedValue("h", "h"),
+                new DecoratedValue("d", "d"));
+        EngineConfig engineConfig = new EngineConfig(Arrays.asList(facet), Engine.Mode.RowBased);
+        operation = new RowStarOperation(engineConfig, true);
     }
 
     @Test
@@ -100,13 +111,13 @@ public class RowStarOperationTests extends RefineTest {
     }
 
     @Test
-    public void testStarRows() throws Exception {
-        facet.selection = Arrays.asList(
-                new DecoratedValue("h", "h"),
-                new DecoratedValue("d", "d"));
-        EngineConfig engineConfig = new EngineConfig(Arrays.asList(facet), Engine.Mode.RowBased);
-        RowStarOperation operation = new RowStarOperation(engineConfig, true);
+    public void testColumnDependencies() {
+        assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
+        assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("hello")));
+    }
 
+    @Test
+    public void testStarRows() throws Exception {
         runOperation(operation, project);
 
         List<Boolean> flagged = project.rows.stream().map(row -> row.starred).collect(Collectors.toList());


### PR DESCRIPTION
Following up on #7056, this adds the column dependencies and diffs to all operations in the `com.google.refine.operations.rows` package.
