### PR TITLE
fix: Double opening of file selection in 'Apply' dialog

### DIFF
--- a/main/webapp/modules/core/scripts/dialogs/apply-operations-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/apply-operations-dialog.js
@@ -39,27 +39,25 @@ function ApplyOperationsDialog() {
   elmts.dialogHeader.html($.i18n('core-project/apply-operation'));
   elmts.or_proj_pasteJson.html($.i18n('core-project/paste-json'));
 
-  elmts.operationJsonButton.on('click', async function() {
-    const fileInput = elmts.operationJsonButton[0];
-    fileInput.accept = '.json';
-    fileInput.onchange = async function() {
-      const file = fileInput.files[0];
-      const reader = new FileReader();
-      reader.onload = function(e) {
-        try {
-          const fileContent = JSON.parse(e.target.result);
-          const textAreaElement = elmts.textarea[0];
-          if (textAreaElement) {
-            textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
-          }
-        } catch (error) {
-          elmts.errorContainer.text($.i18n('core-project/json-invalid', e.message));   
+  const fileInput = elmts.operationJsonButton[0];
+  fileInput.accept = '.json';
+  fileInput.onchange = async function() {
+    const file = fileInput.files[0];
+    const reader = new FileReader();
+    reader.onload = function(e) {
+      try {
+        const fileContent = JSON.parse(e.target.result);
+        const textAreaElement = elmts.textarea[0];
+        if (textAreaElement) {
+          textAreaElement.textContent = JSON.stringify(fileContent, null, 2)
         }
-      };
-      reader.readAsText(file);
+      } catch (error) {
+        elmts.errorContainer.text($.i18n('core-project/json-invalid', e.message));   
+      }
     };
-    fileInput.click();
-  });
+    reader.readAsText(file);
+  };
+
   elmts.textarea.on('change', function() {
      elmts.errorContainer.empty();
   });


### PR DESCRIPTION
In Chrome-based browsers, the "Browse" button in the "Apply" dialog would open the file selection dialog twice when clicked.
This was because the file selection dialog was only set up after the first click. This PR simplifies that.

Discovered in a testing session with @thadguidry.