### PR TITLE
ui: Use 'Run operations' instead of 'Perform operations' in Apply dialog

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -897,7 +897,7 @@
     "core-buttons/refresh": "Refresh",
     "core-buttons/reset-all": "Reset all",
     "core-buttons/remove-all": "Remove all",
-    "core-buttons/perform-op": "Perform operations",
+    "core-buttons/perform-op": "Run operations",
     "core-buttons/add-std-svc": "Add standard service",
     "core-buttons/start-recon": "Start reconciling...",
     "core-buttons/add-service": "Add service",


### PR DESCRIPTION
In the dialog to apply a recipe, the confirmation button currently reads "Perform operations". In a testing session with @thadguidry, we realized "perform" has somewhat abstract / convoluted tones. @thadguidry suggested "Apply operations" or "Replay operations". I think "Run operations" is even simpler and more straightforward. What do you think?

![image](https://github.com/user-attachments/assets/58feed12-48f3-4e4c-94c6-3e2fc50bdfa6)
