### PR TITLE
Introduce the Recipe class to hold a list of operations

### DIFF
--- a/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
+++ b/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
@@ -34,9 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands.history;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
@@ -44,14 +41,10 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import org.apache.commons.lang.Validate;
-
 import com.google.refine.commands.Command;
 import com.google.refine.model.AbstractOperation;
-import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
-import com.google.refine.operations.UnknownOperation;
+import com.google.refine.operations.Recipe;
 import com.google.refine.process.Process;
 import com.google.refine.util.ParsingUtilities;
 
@@ -68,19 +61,11 @@ public class ApplyOperationsCommand extends Command {
             Project project = getProject(request);
             String jsonString = request.getParameter("operations");
 
-            List<AbstractOperation> operations = ParsingUtilities.mapper.readValue(jsonString,
-                    new TypeReference<List<AbstractOperation>>() {
-                    });
-
-            // Validate all operations first
-            for (AbstractOperation operation : operations) {
-                Validate.notNull(operation);
-                Validate.isTrue(!(operation instanceof UnknownOperation), "Unknown operation type: " + operation.getOperationId());
-                operation.validate();
-            }
+            Recipe recipe = ParsingUtilities.mapper.readValue(jsonString, Recipe.class);
+            recipe.validate();
 
             // check all required columns are present
-            Set<String> requiredColumns = computeRequiredColumns(operations);
+            Set<String> requiredColumns = recipe.computeRequiredColumns();
             for (String columnName : requiredColumns) {
                 if (project.columnModel.getColumnByName(columnName) == null) {
                     // TODO: present the user with a dialog to match all missing columns to ones that are present
@@ -90,7 +75,7 @@ public class ApplyOperationsCommand extends Command {
             }
 
             // Run all operations in sequence
-            for (AbstractOperation operation : operations) {
+            for (AbstractOperation operation : recipe.getOperations()) {
                 Process process = operation.createProcess(project, new Properties());
                 project.processManager.queueProcess(process);
             }
@@ -103,62 +88,5 @@ public class ApplyOperationsCommand extends Command {
         } catch (Exception e) {
             respondException(response, e);
         }
-    }
-
-    /**
-     * Computes which columns are required to be present in the project before applying a list of operations. The set
-     * that is returned is an under-approximation: if certain operations in the list fail to analyze their dependencies
-     * or their impact on the set of columns, then some required columns will be missed by this method, resulting in an
-     * error that will only be detected when the list of operations is applied.
-     * 
-     * @param operations
-     *            the operations to analyze. If any of them is null or of an unknown type (see
-     *            {@link UnknownOperation}), then {@link IllegalArgumentException} is thrown.
-     * @return a set of required column names
-     */
-    protected static Set<String> computeRequiredColumns(List<AbstractOperation> operations) {
-        // columnNames represents the current set of column names in the project,
-        // after having applied the operations scanned so far. If it is empty, then
-        // that means we lost track of which columns are present.
-        Optional<Set<String>> currentColumnNames = Optional.of(new HashSet<>());
-        // keeps track of which columns are required to exist in the project before
-        // the first operation is run.
-        Set<String> requiredColumnNames = new HashSet<>();
-
-        for (AbstractOperation op : operations) {
-            if (op == null) {
-                throw new IllegalArgumentException("The list of operations contains 'null'");
-            }
-            if (op instanceof UnknownOperation) {
-                throw new IllegalArgumentException("Unknown operation id: " + op.getOperationId());
-            }
-            op.validate();
-
-            Optional<Set<String>> columnDependencies = op.getColumnDependencies();
-            if (columnDependencies.isPresent() && currentColumnNames.isPresent()) {
-                for (String columnName : columnDependencies.get()) {
-                    if (!currentColumnNames.get().contains(columnName)) {
-                        if (requiredColumnNames.contains(columnName)) {
-                            // if this column has already been required before,
-                            // but is no longer part of the current columns,
-                            // that means it has been deleted since.
-                            throw new IllegalArgumentException(
-                                    "Inconsistent list of operations: column '" + columnName + "' used after being deleted or renamed");
-                        } else {
-                            requiredColumnNames.add(columnName);
-                        }
-                    }
-                }
-            }
-
-            Optional<ColumnsDiff> columnsDiff = op.getColumnsDiff();
-            if (columnsDiff.isEmpty()) {
-                currentColumnNames = Optional.empty();
-            } else if (currentColumnNames.isPresent()) {
-                currentColumnNames.get().removeAll(columnsDiff.get().getDeletedColumns());
-                currentColumnNames.get().addAll(columnsDiff.get().getAddedColumnNames());
-            }
-        }
-        return requiredColumnNames;
     }
 }

--- a/modules/core/src/main/java/com/google/refine/operations/Recipe.java
+++ b/modules/core/src/main/java/com/google/refine/operations/Recipe.java
@@ -1,0 +1,135 @@
+
+package com.google.refine.operations;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
+
+/**
+ * A list of operations to be applied in the specified order.
+ */
+public class Recipe {
+
+    private final List<AbstractOperation> operations;
+
+    @JsonCreator
+    public Recipe(
+            @JsonUnwrapped List<AbstractOperation> operations) {
+        this.operations = operations;
+    }
+
+    @JsonValue
+    public List<AbstractOperation> getOperations() {
+        return operations;
+    }
+
+    /**
+     * Checks that all operations in this recipe are valid (non null, known operations with valid parameters).
+     */
+    public void validate() {
+        for (AbstractOperation op : operations) {
+            if (op == null) {
+                throw new IllegalArgumentException("The list of operations contains 'null'");
+            }
+            if (op instanceof UnknownOperation) {
+                throw new IllegalArgumentException("Unknown operation id: " + op.getOperationId());
+            }
+            op.validate();
+        }
+    }
+
+    /**
+     * Computes which columns are required to be present in the project before applying the list of operations. The set
+     * that is returned is an under-approximation: if certain operations in the list fail to analyze their dependencies
+     * or their impact on the set of columns, then some required columns will be missed by this method, resulting in an
+     * error that will only be detected when the list of operations is applied.
+     * 
+     * @return a set of required column names
+     */
+    public Set<String> computeRequiredColumns() {
+        // columnNames represents the current set of column names in the project,
+        // after having applied the operations scanned so far. If it is empty, then
+        // that means we lost track of which columns are present.
+        Optional<Set<String>> currentColumnNames = Optional.of(new HashSet<>());
+        // keeps track of which columns are required to exist in the project before
+        // the first operation is run.
+        Set<String> requiredColumnNames = new HashSet<>();
+
+        for (AbstractOperation op : operations) {
+            if (currentColumnNames.isPresent()) {
+                Set<String> allDependencies = new HashSet<>();
+
+                Optional<Set<String>> columnDependencies = op.getColumnDependencies();
+                if (columnDependencies.isPresent()) {
+                    allDependencies.addAll(columnDependencies.get());
+                }
+
+                Optional<ColumnsDiff> columnsDiff = op.getColumnsDiff();
+                if (columnsDiff.isPresent()) {
+                    allDependencies.addAll(columnsDiff.get().getImpliedDependencies());
+                }
+
+                for (String columnName : allDependencies) {
+                    if (!currentColumnNames.get().contains(columnName)) {
+                        if (requiredColumnNames.contains(columnName)) {
+                            // if this column has already been required before,
+                            // but is no longer part of the current columns,
+                            // that means it has been deleted since.
+                            throw new IllegalArgumentException(
+                                    "Inconsistent list of operations: column '" + columnName + "' used after being deleted or renamed");
+                        } else {
+                            requiredColumnNames.add(columnName);
+                            currentColumnNames.get().add(columnName);
+                        }
+                    }
+                }
+            }
+
+            Optional<ColumnsDiff> columnsDiff = op.getColumnsDiff();
+            if (columnsDiff.isEmpty()) {
+                currentColumnNames = Optional.empty();
+            } else if (currentColumnNames.isPresent()) {
+                currentColumnNames.get().removeAll(columnsDiff.get().getDeletedColumns());
+                for (String addedColumn : columnsDiff.get().getAddedColumnNames()) {
+                    if (currentColumnNames.get().contains(addedColumn)) {
+                        throw new IllegalArgumentException(
+                                "Creation of column '" + addedColumn + "' conflicts with an existing column with the same name");
+                    }
+                }
+                currentColumnNames.get().addAll(columnsDiff.get().getAddedColumnNames());
+            }
+        }
+        return requiredColumnNames;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(operations);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Recipe other = (Recipe) obj;
+        return Objects.equals(operations, other.operations);
+    }
+
+    @Override
+    public String toString() {
+        return "Recipe [operations=" + operations + "]";
+    }
+}

--- a/modules/core/src/main/java/com/google/refine/operations/Recipe.java
+++ b/modules/core/src/main/java/com/google/refine/operations/Recipe.java
@@ -16,6 +16,7 @@ import com.google.refine.model.ColumnsDiff;
 
 /**
  * A list of operations to be applied in the specified order.
+ * @since 3.10
  */
 public class Recipe {
 
@@ -56,7 +57,7 @@ public class Recipe {
      * @return a set of required column names
      */
     public Set<String> computeRequiredColumns() {
-        // columnNames represents the current set of column names in the project,
+        // currentColumnNames represents the current set of column names in the project,
         // after having applied the operations scanned so far. If it is empty, then
         // that means we lost track of which columns are present.
         Optional<Set<String>> currentColumnNames = Optional.of(new HashSet<>());
@@ -83,7 +84,7 @@ public class Recipe {
                         if (requiredColumnNames.contains(columnName)) {
                             // if this column has already been required before,
                             // but is no longer part of the current columns,
-                            // that means it has been deleted since.
+                            // that means it has since been deleted.
                             throw new IllegalArgumentException(
                                     "Inconsistent list of operations: column '" + columnName + "' used after being deleted or renamed");
                         } else {

--- a/modules/core/src/main/java/com/google/refine/operations/Recipe.java
+++ b/modules/core/src/main/java/com/google/refine/operations/Recipe.java
@@ -16,6 +16,7 @@ import com.google.refine.model.ColumnsDiff;
 
 /**
  * A list of operations to be applied in the specified order.
+ * 
  * @since 3.10
  */
 public class Recipe {

--- a/modules/core/src/test/java/com/google/refine/operations/RecipeTests.java
+++ b/modules/core/src/test/java/com/google/refine/operations/RecipeTests.java
@@ -1,0 +1,199 @@
+
+package com.google.refine.operations;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
+import com.google.refine.util.ParsingUtilities;
+import com.google.refine.util.TestUtils;
+
+public class RecipeTests {
+
+    String json = "[{\"op\":\"unknown\",\"description\":\"some operation\"}]";
+
+    // Sample test operations
+    class ColumnRemovalOperation extends AbstractOperation {
+
+        final String columnName;
+
+        public ColumnRemovalOperation(String columnName) {
+            this.columnName = columnName;
+        }
+
+        @Override
+        public Optional<Set<String>> getColumnDependencies() {
+            return Optional.of(Set.of(columnName));
+        }
+
+        @Override
+        public Optional<ColumnsDiff> getColumnsDiff() {
+            return Optional.of(ColumnsDiff.builder().deleteColumn(columnName).build());
+        }
+    }
+
+    class ColumnRenameOperation extends AbstractOperation {
+
+        final String oldName;
+        final String newName;
+
+        public ColumnRenameOperation(String oldName, String newName) {
+            this.oldName = oldName;
+            this.newName = newName;
+        }
+
+        @Override
+        public Optional<Set<String>> getColumnDependencies() {
+            return Optional.of(Set.of(oldName));
+        }
+
+        @Override
+        public Optional<ColumnsDiff> getColumnsDiff() {
+            return Optional.of(ColumnsDiff.builder().deleteColumn(oldName).addColumn(newName, oldName).build());
+        }
+    }
+
+    class ColumnSplitOperation extends AbstractOperation {
+
+        final String columnName;
+
+        public ColumnSplitOperation(String columnName) {
+            this.columnName = columnName;
+        }
+
+        @Override
+        public Optional<Set<String>> getColumnDependencies() {
+            return Optional.of(Set.of(columnName));
+        }
+
+        @Override
+        public Optional<ColumnsDiff> getColumnsDiff() {
+            return Optional.empty();
+        }
+    }
+
+    class ColumnTransformOperation extends AbstractOperation {
+
+        final String columnName;
+
+        public ColumnTransformOperation(String columnName) {
+            this.columnName = columnName;
+        }
+
+        @Override
+        public Optional<Set<String>> getColumnDependencies() {
+            return Optional.of(Set.of(columnName));
+        }
+
+        @Override
+        public Optional<ColumnsDiff> getColumnsDiff() {
+            return Optional.of(ColumnsDiff.modifySingleColumn(columnName));
+        }
+    }
+
+    class OpaqueOperation extends AbstractOperation {
+
+        OpaqueOperation() {
+        }
+
+        @Override
+        public Optional<Set<String>> getColumnDependencies() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<ColumnsDiff> getColumnsDiff() {
+            return Optional.empty();
+        }
+    }
+
+    @Test
+    public void testDeserialize() throws Exception {
+        Recipe recipe = ParsingUtilities.mapper.readValue(json, Recipe.class);
+
+        assertEquals(recipe.getOperations().size(), 1);
+        assertEquals(recipe.getOperations().get(0).getOperationId(), "unknown");
+
+        TestUtils.isSerializedTo(recipe, json);
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class, () -> new Recipe(List.of(
+                new UnknownOperation("some-operation", "Some description"))).validate());
+
+        assertThrows(IllegalArgumentException.class, () -> new Recipe(Collections.singletonList(null)).validate());
+
+        new Recipe(List.of(
+                new ColumnRemovalOperation("foo"))).validate();
+    }
+
+    @Test
+    public void testComputeRequiredColumns() throws Exception {
+        assertEquals(
+                new Recipe(List.of()).computeRequiredColumns(),
+                Set.of());
+
+        assertEquals(
+                new Recipe(List.of(
+                        new ColumnRemovalOperation("foo"))).computeRequiredColumns(),
+                Set.of("foo"));
+
+        assertEquals(
+                new Recipe(List.of(
+                        new ColumnRemovalOperation("foo"),
+                        new ColumnRemovalOperation("bar"))).computeRequiredColumns(),
+                Set.of("foo", "bar"));
+
+        assertEquals(
+                new Recipe(List.of(
+                        new ColumnRenameOperation("foo", "foo2"),
+                        new ColumnRemovalOperation("bar"))).computeRequiredColumns(),
+                Set.of("foo", "bar"));
+
+        assertEquals(
+                new Recipe(List.of(
+                        new ColumnRenameOperation("foo", "foo2"),
+                        new ColumnSplitOperation("foo2"),
+                        // The dependency of the following operation is not taken into account,
+                        // because the previous operation does not expose a columns diff,
+                        // so we can't predict if "bar" is going to be produced by it or not.
+                        new ColumnRemovalOperation("bar"))).computeRequiredColumns(),
+                Set.of("foo"));
+
+        assertEquals(
+                new Recipe(List.of(
+                        new ColumnTransformOperation("foo"),
+                        new ColumnRemovalOperation("foo"))).computeRequiredColumns(),
+                Set.of("foo"));
+
+        // unanalyzable operation
+        assertEquals(
+                new Recipe(List.of(
+                        new OpaqueOperation())).computeRequiredColumns(),
+                Set.of());
+    }
+
+    @Test
+    public void testRequiredColumnsFromInconsistentOperations() {
+        assertThrows(IllegalArgumentException.class, () -> new Recipe(List.of(
+                new ColumnRemovalOperation("foo"),
+                new ColumnRenameOperation("foo", "bar"))).computeRequiredColumns());
+    }
+
+    @Test
+    public void testConflictingColumnCreation() {
+        assertThrows(IllegalArgumentException.class, () -> new Recipe(List.of(
+                new ColumnTransformOperation("bar"),
+                new ColumnRenameOperation("foo", "bar"))).computeRequiredColumns());
+    }
+
+}

--- a/modules/core/src/test/java/com/google/refine/operations/RecipeTests.java
+++ b/modules/core/src/test/java/com/google/refine/operations/RecipeTests.java
@@ -20,7 +20,12 @@ public class RecipeTests {
 
     String json = "[{\"op\":\"unknown\",\"description\":\"some operation\"}]";
 
-    // Sample test operations
+    //// Sample test operations
+
+    /**
+     * An operation which removes a column (faithful to the actual such operation in OpenRefine, which isn't visible in
+     * this module).
+     */
     class ColumnRemovalOperation extends AbstractOperation {
 
         final String columnName;
@@ -40,6 +45,10 @@ public class RecipeTests {
         }
     }
 
+    /**
+     * An operation which renames a column (also faithful to the actual such operation in OpenRefine, which isn't
+     * visible in this module).
+     */
     class ColumnRenameOperation extends AbstractOperation {
 
         final String oldName;
@@ -61,6 +70,10 @@ public class RecipeTests {
         }
     }
 
+    /**
+     * An operation which exposes its dependencies, but not its impact on columns after having run (just like the
+     * ColumnSplitOperation in OpenRefine, not visible here)
+     */
     class ColumnSplitOperation extends AbstractOperation {
 
         final String columnName;
@@ -80,6 +93,9 @@ public class RecipeTests {
         }
     }
 
+    /**
+     * An operation which modifies a single column, like the transform operation in OpenRefine (not visible here).
+     */
     class ColumnTransformOperation extends AbstractOperation {
 
         final String columnName;
@@ -99,6 +115,9 @@ public class RecipeTests {
         }
     }
 
+    /**
+     * An operation which declares neither the columns it depends on, nor its impact on the columns after having run.
+     */
     class OpaqueOperation extends AbstractOperation {
 
         OpaqueOperation() {
@@ -126,7 +145,7 @@ public class RecipeTests {
     }
 
     @Test
-    public void testValidate() {
+    public void testValidateMethod() {
         assertThrows(IllegalArgumentException.class, () -> new Recipe(List.of(
                 new UnknownOperation("some-operation", "Some description"))).validate());
 
@@ -137,7 +156,7 @@ public class RecipeTests {
     }
 
     @Test
-    public void testComputeRequiredColumns() throws Exception {
+    public void testComputeRequiredColumnsMethod() throws Exception {
         assertEquals(
                 new Recipe(List.of()).computeRequiredColumns(),
                 Set.of());


### PR DESCRIPTION
By introducing a `Recipe` class, we group together functionality that relates to lists of operations into a topical class.
This is a first step towards handling recipes in other contexts than `ApplyOperationsCommand`.
