### PR TITLE
grel: More faithful pretty-printing for string and regex literals

### DIFF
--- a/modules/grel/src/main/java/com/google/refine/grel/Scanner.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/Scanner.java
@@ -74,6 +74,20 @@ public class Scanner {
         }
     }
 
+    static public class StringToken extends Token {
+
+        final public char delimiter;
+
+        public StringToken(int start, int end, String text, char delimiter) {
+            super(start, end, TokenType.String, text);
+            this.delimiter = delimiter;
+        }
+
+        public String fullSource() {
+            return String.format("%c%s%c", delimiter, text, delimiter);
+        }
+    }
+
     static public class RegexToken extends Token {
 
         final public boolean caseInsensitive;
@@ -81,6 +95,10 @@ public class Scanner {
         public RegexToken(int start, int end, String text, boolean caseInsensitive) {
             super(start, end, TokenType.Regex, text);
             this.caseInsensitive = caseInsensitive;
+        }
+
+        public String fullSource() {
+            return String.format("/%s/", text);
         }
     }
 
@@ -176,11 +194,11 @@ public class Scanner {
                 if (c == delimiter) {
                     _index++; // skip closing delimiter
 
-                    return new Token(
+                    return new StringToken(
                             start,
                             _index,
-                            TokenType.String,
-                            sb.toString());
+                            sb.toString(),
+                            delimiter);
                 } else if (c == '\\') {
                     _index++; // skip escaping marker
                     if (_index < _limit) {

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/FunctionCallExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/FunctionCallExpr.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.apache.commons.lang3.Validate;
 
 import com.google.refine.expr.EvalError;
@@ -169,7 +170,7 @@ public class FunctionCallExpr extends GrelExpr {
             String newColumnName = substitutions.getOrDefault(columnName, columnName);
             return new FunctionCallExpr(new Evaluable[] {
                     _args[0],
-                    new LiteralExpr(newColumnName)
+                    new LiteralExpr(newColumnName, new TextNode(newColumnName).toString())
             }, _function, _functionName, _fluentStyle);
         } else {
             Evaluable[] translatedArgs = new Evaluable[_args.length];

--- a/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ast/LiteralExpr.java
@@ -50,9 +50,20 @@ import com.google.refine.expr.Evaluable;
 public class LiteralExpr extends GrelExpr {
 
     final protected Object _value;
+    final protected String _source;
 
+    /**
+     * @deprecated use the version of the constructor which supplies the full source of the literal
+     */
+    @Deprecated(since = "3.10")
     public LiteralExpr(Object value) {
         _value = value;
+        _source = null;
+    }
+
+    public LiteralExpr(Object value, String source) {
+        _value = value;
+        _source = source;
     }
 
     protected Object getValue() {
@@ -76,12 +87,16 @@ public class LiteralExpr extends GrelExpr {
 
     @Override
     public String toString() {
-        return _value instanceof String ? new TextNode((String) _value).toString() : _value.toString();
+        if (_source != null) {
+            return _source;
+        } else {
+            return _value instanceof String ? new TextNode((String) _value).toString() : _value.toString();
+        }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(_value);
+        return Objects.hash(_source);
     }
 
     @Override
@@ -93,6 +108,7 @@ public class LiteralExpr extends GrelExpr {
         if (getClass() != obj.getClass())
             return false;
         LiteralExpr other = (LiteralExpr) obj;
-        return Objects.equals(_value, other._value);
+        // ignore _value on purpose because it is entirely determined from _source
+        return Objects.equals(_source, other._source);
     }
 }

--- a/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.grel;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
 
@@ -232,6 +233,14 @@ public class GrelTests extends GrelTestBase {
     }
 
     @Test
+    public void testRegexParsing() throws ParsingException {
+        String test = "value.replace(/foo/, 'bar')";
+
+        Evaluable eval = MetaParser.parse("grel:" + test);
+        assertEquals(eval.getSource(), test);
+    }
+
+    @Test
     public void testColumnDependencies() throws ParsingException {
         // integration test for column dependency extraction
 
@@ -268,13 +277,14 @@ public class GrelTests extends GrelTestBase {
         String tests[][] = {
                 { "value", "value" },
                 { "cell.recon.match.id", "cell.recon.match.id" },
-                { "value + 'a'", "value + \"a\"" },
+                { "value + 'a'", "value + 'a'" },
                 { "\"foo\"", "\"foo\"" },
-                { "'\"'", "\"\\\"\"" }, // TODO we could print the string with the original quotes to avoid the escaping
+                { "'\"'", "'\"'" },
+                { "/\"/", "/\"/" },
                 { "1", "1" },
                 { "4 * (5 + 6)", "4 * (5 + 6)" },
                 { "cells.foo", "cells.foo" },
-                { "value + ' ' + cells.foo.value", "value + \" \" + cells.foo.value" },
+                { "value + ' ' + cells.foo.value", "value + ' ' + cells.foo.value" },
                 { "cells[\"foo\"].value", "cells.get(\"foo\").value" }, // TODO this could be more faithful
                 { "toDate( value+4 )", "toDate(value + 4)" },
                 { "(value + 4).toDate()", "(value + 4).toDate()" },
@@ -302,6 +312,7 @@ public class GrelTests extends GrelTestBase {
                 { "\"foo\"", "\"foo\"" },
                 { "1", "1" },
                 { "cells.foo", "cells.bar" },
+                { "value.replace(/foo/, 'bar')", "value.replace(/foo/, 'bar')" },
                 { "value + ' ' + cells.foo.value", "value + ' ' + cells.bar.value" },
                 { "cells[\"foo\"].value+'_'+value", "cells[\"bar\"].value+'_'+value" },
                 { "toDate(cells[\"foo\"].value)", "toDate(cells[\"bar\"].value)" },

--- a/modules/grel/src/test/java/com/google/refine/grel/ast/LiteralExprTest.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/ast/LiteralExprTest.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertEquals;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.testng.annotations.Test;
 
@@ -39,24 +40,31 @@ public class LiteralExprTest {
 
     @Test
     public void intLiteralToString() {
-        LiteralExpr expr = new LiteralExpr(42);
+        LiteralExpr expr = new LiteralExpr(42, "42");
         assertEquals("42", expr.toString());
     }
 
     @Test
     public void columnDependencies() {
-        LiteralExpr expr = new LiteralExpr(34);
+        LiteralExpr expr = new LiteralExpr(34, "34");
         assertEquals(expr.getColumnDependencies(Optional.of("column")), Optional.of(Collections.emptySet()));
         assertEquals(expr.renameColumnDependencies(Map.of("foo", "bar")), expr);
 
-        LiteralExpr string = new LiteralExpr("foo");
+        LiteralExpr string = new LiteralExpr("foo", "\"foo\"");
         assertEquals(string.getColumnDependencies(Optional.of("foo")), Optional.of(Collections.emptySet()));
         assertEquals(string.renameColumnDependencies(Map.of("foo", "bar")), string);
     }
 
     @Test
     public void stringLiteralToString() {
-        LiteralExpr expr = new LiteralExpr("string with \"\\backslash\"");
+        LiteralExpr expr = new LiteralExpr("string with \"\\backslash\"", "\"string with \\\"\\\\backslash\\\"\"");
         assertEquals("\"string with \\\"\\\\backslash\\\"\"", expr.toString());
+    }
+
+    @Test
+    public void testPattern() {
+        Pattern pattern = Pattern.compile("foo");
+        LiteralExpr expr = new LiteralExpr(pattern, "/foo/");
+        assertEquals(expr.toString(), "/foo/");
     }
 }


### PR DESCRIPTION
Changing column names in GREL expressions relies on the ability to print back a parsed GREL evaluable to a string. This printing process was incorrect for regular expression literals such as `/.*/`, which it printed back as `.*` (missing the delimiters).

This fixes that, and also introduces the preservation of literals for string constants (whereas single quotes would be translated to double quotes earlier). 
