### PR TITLE
chore: Separate command and operation tests for duplicate row removal

### DIFF
--- a/main/tests/server/src/com/google/refine/commands/row/RemoveDuplicateRowsCommandTest.java
+++ b/main/tests/server/src/com/google/refine/commands/row/RemoveDuplicateRowsCommandTest.java
@@ -1,24 +1,17 @@
 
 package com.google.refine.commands.row;
 
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-
 import java.io.IOException;
-import java.io.Serializable;
-import java.util.List;
 
 import javax.servlet.ServletException;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.google.refine.browsing.EngineConfig;
 import com.google.refine.commands.CommandTestBase;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
-import com.google.refine.operations.row.RowDuplicatesRemovalOperation;
 
 public class RemoveDuplicateRowsCommandTest extends CommandTestBase {
 
@@ -38,132 +31,4 @@ public class RemoveDuplicateRowsCommandTest extends CommandTestBase {
         assertCSRFCheckFailed();
     }
 
-    @Test
-    public void testWithFacetRemoveDuplicateRows() throws Exception {
-        initProject();
-        List<String> duplicateRowCriteria = List.of(
-                new String[] { "SITE_ID", "SITE_NUM", "LATITUDE",
-                        "LONGITUDE", "ELEVATION", "UPDATE_DATE" });
-        String _engineConfig = "{\"facets\":[{\"type\":\"list\",\"name\":\"SITE_ID\",\"columnName\":\"SITE_ID\",\"expression\":\"value\",\"omitBlank\":false,\"omitError\":false,\"selection\":[{\"v\":{\"v\":\"ABT147\",\"l\":\"ABT147\"}}],\"selectBlank\":false,\"selectError\":false,\"invert\":false}],\"mode\":\"row-based\"}";
-
-        EngineConfig engineConfig = EngineConfig.reconstruct(_engineConfig);
-        RowDuplicatesRemovalOperation operation = new RowDuplicatesRemovalOperation(engineConfig, duplicateRowCriteria);
-        runOperation(operation, project);
-        assertEquals(project.rows.size(), 7);
-        assertEquals(project.history.getLastPastEntries(1).get(0).description, "Remove 2 rows");
-
-        Project expected = createProject(
-                new String[] { "SITE_ID", "SITE_NUM", "SITE_NAME",
-                        "LATITUDE", "LONGITUDE", "ELEVATION", "UPDATE_DATE" },
-                new Serializable[][] {
-                        { "ABT147", 147, "Abington",
-                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
-                        { "ABT147", 147, "Abington",
-                                41.8402, -72.01, 209, "2004-11-03 08:41:34" },
-                        { "ABT148", 148, "Blighton",
-                                41.8402, -72.01, 209, "2004-11-23 08:41:33" },
-                        { "ABT149", 149, "Coppertown",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
-                        { "ABT150", 150, "Duluth",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
-                        { "ABT151", 150, "Duluth",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
-                        { "ABT152", 150, "Duluth",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" }
-
-                });
-        assertProjectEquals(project, expected);
-    }
-
-    @Test
-    public void testWithSingleCriteriaRemoveDuplicateRows() throws Exception {
-        initProject();
-        List<String> duplicateRowCriteria = List.of(
-                new String[] { "SITE_ID" });
-        String _engineConfig = "{\"facets\":[],\"mode\":\"row-based\"}";
-
-        EngineConfig engineConfig = EngineConfig.reconstruct(_engineConfig);
-        RowDuplicatesRemovalOperation operation = new RowDuplicatesRemovalOperation(engineConfig, duplicateRowCriteria);
-        runOperation(operation, project);
-        assertEquals(project.rows.size(), 6);
-        assertEquals(project.history.getLastPastEntries(1).get(0).description, "Remove 3 rows");
-
-        Project expected = createProject(
-                new String[] { "SITE_ID", "SITE_NUM", "SITE_NAME",
-                        "LATITUDE", "LONGITUDE", "ELEVATION", "UPDATE_DATE" },
-                new Serializable[][] {
-                        { "ABT147", 147, "Abington",
-                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
-                        { "ABT148", 148, "Blighton",
-                                41.8402, -72.01, 209, "2004-11-23 08:41:33" },
-                        { "ABT149", 149, "Coppertown",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
-                        { "ABT150", 150, "Duluth",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
-                        { "ABT151", 150, "Duluth",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
-                        { "ABT152", 150, "Duluth",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" }
-
-                });
-        assertProjectEquals(project, expected);
-    }
-
-    @Test
-    public void testWithSingleNumberCriteriaRemoveDuplicateRows() throws Exception {
-        initProject();
-        List<String> duplicateRowCriteria = List.of(
-                new String[] { "SITE_NUM" });
-        String _engineConfig = "{\"facets\":[],\"mode\":\"row-based\"}";
-
-        EngineConfig engineConfig = EngineConfig.reconstruct(_engineConfig);
-        RowDuplicatesRemovalOperation operation = new RowDuplicatesRemovalOperation(engineConfig, duplicateRowCriteria);
-        runOperation(operation, project);
-        assertEquals(project.rows.size(), 4);
-        assertEquals(project.history.getLastPastEntries(1).get(0).description, "Remove 5 rows");
-
-        Project expected = createProject(
-                new String[] { "SITE_ID", "SITE_NUM", "SITE_NAME",
-                        "LATITUDE", "LONGITUDE", "ELEVATION", "UPDATE_DATE" },
-                new Serializable[][] {
-                        { "ABT147", 147, "Abington",
-                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
-                        { "ABT148", 148, "Blighton",
-                                41.8402, -72.01, 209, "2004-11-23 08:41:33" },
-                        { "ABT149", 149, "Coppertown",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
-                        { "ABT150", 150, "Duluth",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" }
-                });
-
-        assertProjectEquals(project, expected);
-    }
-
-    private void initProject() {
-        project = createProject(
-                new String[] { "SITE_ID", "SITE_NUM", "SITE_NAME",
-                        "LATITUDE", "LONGITUDE", "ELEVATION", "UPDATE_DATE" },
-                new Serializable[][] {
-                        { "ABT147", 147, "Abington",
-                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
-                        { "ABT147", 147, "Abington",
-                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
-                        { "ABT147", 147, "Abington",
-                                41.8402, -72.01, 209, "2004-11-03 08:41:34" },
-                        { "ABT147", 147, "Abington",
-                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
-                        { "ABT148", 148, "Blighton",
-                                41.8402, -72.01, 209, "2004-11-23 08:41:33" },
-                        { "ABT149", 149, "Coppertown",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
-                        { "ABT150", 150, "Duluth",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
-                        { "ABT151", 150, "Duluth",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
-                        { "ABT152", 150, "Duluth",
-                                41.8402, -72.01, 209, "2004-11-13 08:41:33" }
-
-                });
-        when(request.getParameter("project")).thenReturn(Long.toString(project.id));
-    }
 }

--- a/main/tests/server/src/com/google/refine/operations/row/RowDuplicatesRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowDuplicatesRemovalOperationTests.java
@@ -1,0 +1,151 @@
+
+package com.google.refine.operations.row;
+
+import static org.testng.Assert.assertEquals;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.refine.RefineTest;
+import com.google.refine.browsing.EngineConfig;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
+import com.google.refine.model.Project;
+
+public class RowDuplicatesRemovalOperationTests extends RefineTest {
+
+    private Project project = null;
+
+    @BeforeMethod
+    private void initProject() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+        project = createProject(
+                new String[] { "SITE_ID", "SITE_NUM", "SITE_NAME",
+                        "LATITUDE", "LONGITUDE", "ELEVATION", "UPDATE_DATE" },
+                new Serializable[][] {
+                        { "ABT147", 147, "Abington",
+                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
+                        { "ABT147", 147, "Abington",
+                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
+                        { "ABT147", 147, "Abington",
+                                41.8402, -72.01, 209, "2004-11-03 08:41:34" },
+                        { "ABT147", 147, "Abington",
+                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
+                        { "ABT148", 148, "Blighton",
+                                41.8402, -72.01, 209, "2004-11-23 08:41:33" },
+                        { "ABT149", 149, "Coppertown",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
+                        { "ABT150", 150, "Duluth",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
+                        { "ABT151", 150, "Duluth",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
+                        { "ABT152", 150, "Duluth",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" }
+
+                });
+    }
+
+    @Test
+    public void testWithFacetRemoveDuplicateRows() throws Exception {
+        initProject();
+        List<String> duplicateRowCriteria = List.of(
+                new String[] { "SITE_ID", "SITE_NUM", "LATITUDE",
+                        "LONGITUDE", "ELEVATION", "UPDATE_DATE" });
+        String _engineConfig = "{\"facets\":[{\"type\":\"list\",\"name\":\"SITE_ID\",\"columnName\":\"SITE_ID\",\"expression\":\"value\",\"omitBlank\":false,\"omitError\":false,\"selection\":[{\"v\":{\"v\":\"ABT147\",\"l\":\"ABT147\"}}],\"selectBlank\":false,\"selectError\":false,\"invert\":false}],\"mode\":\"row-based\"}";
+
+        EngineConfig engineConfig = EngineConfig.deserialize(_engineConfig);
+        RowDuplicatesRemovalOperation operation = new RowDuplicatesRemovalOperation(engineConfig, duplicateRowCriteria);
+
+        runOperation(operation, project);
+        assertEquals(project.rows.size(), 7);
+        assertEquals(project.history.getLastPastEntries(1).get(0).description, "Remove 2 rows");
+
+        Project expected = createProject(
+                new String[] { "SITE_ID", "SITE_NUM", "SITE_NAME",
+                        "LATITUDE", "LONGITUDE", "ELEVATION", "UPDATE_DATE" },
+                new Serializable[][] {
+                        { "ABT147", 147, "Abington",
+                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
+                        { "ABT147", 147, "Abington",
+                                41.8402, -72.01, 209, "2004-11-03 08:41:34" },
+                        { "ABT148", 148, "Blighton",
+                                41.8402, -72.01, 209, "2004-11-23 08:41:33" },
+                        { "ABT149", 149, "Coppertown",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
+                        { "ABT150", 150, "Duluth",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
+                        { "ABT151", 150, "Duluth",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
+                        { "ABT152", 150, "Duluth",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" }
+
+                });
+        assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testWithSingleCriteriaRemoveDuplicateRows() throws Exception {
+        initProject();
+        List<String> duplicateRowCriteria = List.of(
+                new String[] { "SITE_ID" });
+
+        EngineConfig engineConfig = EngineConfig.defaultRowBased();
+        RowDuplicatesRemovalOperation operation = new RowDuplicatesRemovalOperation(engineConfig, duplicateRowCriteria);
+        runOperation(operation, project);
+        assertEquals(project.rows.size(), 6);
+        assertEquals(project.history.getLastPastEntries(1).get(0).description, "Remove 3 rows");
+
+        Project expected = createProject(
+                new String[] { "SITE_ID", "SITE_NUM", "SITE_NAME",
+                        "LATITUDE", "LONGITUDE", "ELEVATION", "UPDATE_DATE" },
+                new Serializable[][] {
+                        { "ABT147", 147, "Abington",
+                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
+                        { "ABT148", 148, "Blighton",
+                                41.8402, -72.01, 209, "2004-11-23 08:41:33" },
+                        { "ABT149", 149, "Coppertown",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
+                        { "ABT150", 150, "Duluth",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
+                        { "ABT151", 150, "Duluth",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
+                        { "ABT152", 150, "Duluth",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" }
+
+                });
+        assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testWithSingleNumberCriteriaRemoveDuplicateRows() throws Exception {
+        initProject();
+        List<String> duplicateRowCriteria = List.of(
+                new String[] { "SITE_NUM" });
+
+        EngineConfig engineConfig = EngineConfig.defaultRowBased();
+        RowDuplicatesRemovalOperation operation = new RowDuplicatesRemovalOperation(engineConfig, duplicateRowCriteria);
+        runOperation(operation, project);
+        assertEquals(project.rows.size(), 4);
+        assertEquals(project.history.getLastPastEntries(1).get(0).description, "Remove 5 rows");
+
+        Project expected = createProject(
+                new String[] { "SITE_ID", "SITE_NUM", "SITE_NAME",
+                        "LATITUDE", "LONGITUDE", "ELEVATION", "UPDATE_DATE" },
+                new Serializable[][] {
+                        { "ABT147", 147, "Abington",
+                                41.8402, -72.01, 209, "2004-11-03 08:41:33" },
+                        { "ABT148", 148, "Blighton",
+                                41.8402, -72.01, 209, "2004-11-23 08:41:33" },
+                        { "ABT149", 149, "Coppertown",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" },
+                        { "ABT150", 150, "Duluth",
+                                41.8402, -72.01, 209, "2004-11-13 08:41:33" }
+                });
+
+        assertProjectEquals(project, expected);
+    }
+
+}


### PR DESCRIPTION
The tests of the operation and command classes for the duplicate row removal feature were mixed into one class. This PR separates them properly so that it matches the structure of the rest of our code.