### PR TITLE
operations: Improve data extension operation to control the created columm names

### DIFF
--- a/main/src/com/google/refine/commands/recon/ExtendDataCommand.java
+++ b/main/src/com/google/refine/commands/recon/ExtendDataCommand.java
@@ -33,7 +33,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.commands.recon;
 
+import java.util.List;
+
 import javax.servlet.http.HttpServletRequest;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.commands.EngineDependentCommand;
@@ -41,6 +45,7 @@ import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.model.recon.ReconciledDataExtensionJob.DataExtensionConfig;
 import com.google.refine.operations.recon.ExtendDataOperation;
+import com.google.refine.util.ParsingUtilities;
 
 public class ExtendDataCommand extends EngineDependentCommand {
 
@@ -56,6 +61,9 @@ public class ExtendDataCommand extends EngineDependentCommand {
 
         String jsonString = request.getParameter("extension");
         DataExtensionConfig extension = DataExtensionConfig.reconstruct(jsonString);
+        String columnsString = request.getParameter("resultColumns");
+        List<String> resultColumnNames = ParsingUtilities.mapper.readValue(columnsString, new TypeReference<List<String>>() {
+        });
 
         return new ExtendDataOperation(
                 engineConfig,
@@ -64,7 +72,8 @@ public class ExtendDataCommand extends EngineDependentCommand {
                 identifierSpace,
                 schemaSpace,
                 extension,
-                columnInsertIndex);
+                columnInsertIndex,
+                resultColumnNames);
     }
 
 }

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
@@ -180,6 +180,20 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
       columnIndex, 
       o.rowIndices,
       function(extension, endpoint, identifierSpace, schemaSpace) {
+        // deduplicate columns
+        let currentColumns = new Set(theProject.columnModel.columns.map(c => c.name));
+        let resultColumns = [];
+        for (let property of extension.properties) {
+          let attempt = property.name;
+          let counter = 1;
+          while (currentColumns.has(attempt)) {
+            counter++;
+            attempt = `${property.name} ${counter}`;
+          }
+          resultColumns.push(attempt);
+          currentColumns.add(attempt);
+        }
+
         Refine.postProcess(
             "core",
             "extend-data", 
@@ -191,7 +205,8 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
               columnInsertIndex: columnIndex + 1
             },
             {
-              extension: JSON.stringify(extension)
+              extension: JSON.stringify(extension),
+              resultColumns: JSON.stringify(resultColumns),
             },
             { rowsChanged: true, modelsChanged: true }
         );

--- a/modules/core/src/main/java/com/google/refine/model/changes/DataExtensionChange.java
+++ b/modules/core/src/main/java/com/google/refine/model/changes/DataExtensionChange.java
@@ -95,7 +95,7 @@ public class DataExtensionChange implements Change {
         _schemaSpace = schemaSpace;
         _columnInsertIndex = columnInsertIndex;
 
-        _columnNames = columnNames;
+        _columnNames = new ArrayList<>(columnNames); // make sure it is modifiable because we update it later on
         _columnTypes = columnTypes;
 
         _rowIndices = rowIndices;
@@ -125,7 +125,7 @@ public class DataExtensionChange implements Change {
         _schemaSpace = schemaSpace;
         _columnInsertIndex = columnInsertIndex;
 
-        _columnNames = columnNames;
+        _columnNames = new ArrayList<>(columnNames); // make sure it is modifiable because we update it later on
         _columnTypes = columnTypes;
 
         _rowIndices = rowIndices;


### PR DESCRIPTION
This makes it possible to control the names of the columns created by a data extension operation, using a new field in the operation metadata. The field is added in a backwards compatible way, meaning that operations which are missing that field will still be recognized and run as before.

By introducing this field, the goal is to make it possible to rename the columns created by this operation as part of the column renaming feature in the Apply dialog for recipes. Potentially, we could also expose this feature in the frontend, letting users change the name of the created columns when previewing the effect on the project.