### PR TITLE
Update LoadLanguageCommand.java

### DIFF
--- a/main/src/com/google/refine/commands/lang/LoadLanguageCommand.java
+++ b/main/src/com/google/refine/commands/lang/LoadLanguageCommand.java
@@ -161,7 +161,9 @@ public class LoadLanguageCommand extends Command {
             fisLang = new FileInputStream(langFile);
         } catch (FileNotFoundException e) {
             // Could be normal if we've got a list of languages as fallbacks
-            logger.info("Language file " + strMessage + " not found " + e.getMessage());
+            logger.info("Language file " + strMessage + " not found");
+            logger.debug("Exception details: " + e.getMessage());
+
         } catch (SecurityException e) {
             logger.error("Language file " + strMessage + " cannot be read (security)", e);
         }

--- a/main/src/com/google/refine/commands/lang/LoadLanguageCommand.java
+++ b/main/src/com/google/refine/commands/lang/LoadLanguageCommand.java
@@ -161,7 +161,7 @@ public class LoadLanguageCommand extends Command {
             fisLang = new FileInputStream(langFile);
         } catch (FileNotFoundException e) {
             // Could be normal if we've got a list of languages as fallbacks
-            logger.info("Language file " + strMessage + " not found", e);
+            logger.info("Language file " + strMessage + " not found " + e.getMessage());
         } catch (SecurityException e) {
             logger.error("Language file " + strMessage + " cannot be read (security)", e);
         }


### PR DESCRIPTION
closes #6963

Fixes #{6963}

Changes proposed in this pull request:
- Updated line 164 to improve logging.
Replaced logger.info("Language file " + strMessage + " not found", e);
with logger.info("Language file " + strMessage + " not found: " + e.getMessage());
This change removes the stack trace while keeping the error message for clarity.
