### PR TITLE
Update column-header-ui.js

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -37,6 +37,7 @@ function DataTableColumnHeaderUI(dataTableView, column, columnIndex, td, col) {
   this._columnIndex = columnIndex;
   this._td = td;
   this._col = col;
+  this._isResizing = false;
 
   this._render();
 }
@@ -70,6 +71,21 @@ DataTableColumnHeaderUI.prototype._render = function() {
   elmts.dropdownMenu.on('click',function() {
     self._createMenuForColumnHeader(this);
   });
+
+  // Add event listeners for column resizing
+  td.on("mousedown", function(event) {
+    if (self._isOnColumnEdge(event, td)) {
+      self._isResizing = true;
+      td.addClass("resizing");
+      $(document).on("mouseup", stopResizing);
+    }
+  });
+
+  function stopResizing() {
+    self._isResizing = false;
+    td.removeClass("resizing");
+    $(document).off("mouseup", stopResizing);
+  }
 
   var serviceUrl = null;
   if (this._column.reconConfig) {
@@ -136,6 +152,23 @@ DataTableColumnHeaderUI.prototype._render = function() {
     }
   }
 };
+
+DataTableColumnHeaderUI.prototype._isOnColumnEdge = function(event, td) {
+  var offset = td.offset();
+  var x = event.pageX - offset.left;
+  var edgeThreshold = 5; // Define edge sensitivity
+  return x > td.width() - edgeThreshold;
+};
+
+// Add CSS for resizing indication
+var style = document.createElement('style');
+style.innerHTML = `
+  .resizing {
+    border-right: 3px solid blue !important;
+  }
+`;
+document.head.appendChild(style);
+
 
 DataTableColumnHeaderUI.prototype._createMenuForColumnHeader = function(elmt) {
   var self = this;


### PR DESCRIPTION
closes #6934

Fixes #{6934}

Changes proposed in this pull request:
- Highlight the border of a column when we want to resize it. It highlights only on mouse click and existing behavior is unchanged

Sample output:
<img width="1293" alt="image" src="https://github.com/user-attachments/assets/ff71df48-be1b-42c0-9168-4ae9a8f5210b" />
