### PR TITLE
fix: Windows installer removes previous install

### DIFF
--- a/packaging/openrefine.iss
+++ b/packaging/openrefine.iss
@@ -66,6 +66,12 @@ Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
+; Make sure we delete any previous install before copying our files.
+; See https://github.com/OpenRefine/OpenRefine/issues/7122
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\server"
+Type: filesandordirs; Name: "{app}\webapp"
+
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 Source: "{#MyProgramFiles}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs


### PR DESCRIPTION
Fixes #7122.

See https://jrsoftware.org/ishelp/index.php?topic=installdeletesection for more details about this `[InstallDelete]` section.

Note: I haven't tried it out yet. I plan to check the behaviour of the installer once this is merged (since the installer will get built in the snapshot releases), because I don't have a Windows dev environment set up.