### PR TITLE
fixes #6608 - Expose diacritics normalization used in fingerprint()

### DIFF
--- a/modules/grel/src/main/java/com/google/refine/expr/functions/strings/Normalize.java
+++ b/modules/grel/src/main/java/com/google/refine/expr/functions/strings/Normalize.java
@@ -1,3 +1,4 @@
+
 package com.google.refine.expr.functions.strings;
 
 import java.text.Normalizer;
@@ -15,12 +16,11 @@ public class Normalize implements Function {
             // Lm = modifier letter, Sk = modifier symbol
             .compile("[\\p{InCombiningDiacriticalMarks}\\p{IsLm}\\p{IsSk}]+");
 
-
     @Override
     public Object call(Properties bindings, Object[] args) {
-        if(args.length==1 && args[0]!=null){
+        if (args.length == 1 && args[0] != null) {
             Object o = args[0];
-            return (o instanceof String ? normalize((String) o):normalize(o.toString()));
+            return (o instanceof String ? normalize((String) o) : normalize(o.toString()));
         }
         return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects a single string parameter");
 

--- a/modules/grel/src/main/java/com/google/refine/expr/functions/strings/Normalize.java
+++ b/modules/grel/src/main/java/com/google/refine/expr/functions/strings/Normalize.java
@@ -1,0 +1,49 @@
+package com.google.refine.expr.functions.strings;
+
+import java.text.Normalizer;
+import java.util.Properties;
+import java.util.regex.Pattern;
+
+import com.google.refine.expr.EvalError;
+import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.Function;
+import com.google.refine.grel.FunctionDescription;
+
+public class Normalize implements Function {
+
+    public static final Pattern DIACRITICS_AND_FRIENDS = Pattern
+            // Lm = modifier letter, Sk = modifier symbol
+            .compile("[\\p{InCombiningDiacriticalMarks}\\p{IsLm}\\p{IsSk}]+");
+
+
+    @Override
+    public Object call(Properties bindings, Object[] args) {
+        if(args.length==1 && args[0]!=null){
+            Object o = args[0];
+            return (o instanceof String ? normalize((String) o):normalize(o.toString()));
+        }
+        return new EvalError(ControlFunctionRegistry.getFunctionName(this) + " expects a single string parameter");
+
+    }
+
+    private String normalize(String o) {
+        o = Normalizer.normalize(o, Normalizer.Form.NFKD);
+        o = DIACRITICS_AND_FRIENDS.matcher(o).replaceAll("");
+        return o;
+    }
+
+    @Override
+    public String getDescription() {
+        return FunctionDescription.str_normalize();
+    }
+
+    @Override
+    public String getParams() {
+        return "string s";
+    }
+
+    @Override
+    public String getReturns() {
+        return "string";
+    }
+}

--- a/modules/grel/src/main/java/com/google/refine/grel/ControlFunctionRegistry.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ControlFunctionRegistry.java
@@ -271,7 +271,6 @@ public class ControlFunctionRegistry {
         registerFunction("levenshteinDistance", new LevenshteinDistance());
         registerFunction("normalize", new Normalize());
 
-
         registerFunction("parseUri", new ParseUri());
 
         // XML and HTML functions from JSoup

--- a/modules/grel/src/main/java/com/google/refine/grel/ControlFunctionRegistry.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ControlFunctionRegistry.java
@@ -118,6 +118,7 @@ import com.google.refine.expr.functions.strings.MD5;
 import com.google.refine.expr.functions.strings.Match;
 import com.google.refine.expr.functions.strings.NGram;
 import com.google.refine.expr.functions.strings.NGramFingerprint;
+import com.google.refine.expr.functions.strings.Normalize;
 import com.google.refine.expr.functions.strings.ParseJson;
 import com.google.refine.expr.functions.strings.ParseUri;
 import com.google.refine.expr.functions.strings.Partition;
@@ -268,6 +269,8 @@ public class ControlFunctionRegistry {
         registerFunction("match", new Match());
         registerFunction("find", new Find());
         registerFunction("levenshteinDistance", new LevenshteinDistance());
+        registerFunction("normalize", new Normalize());
+
 
         registerFunction("parseUri", new ParseUri());
 

--- a/modules/grel/src/main/resources/com/google/refine/grel/FunctionDescription.properties
+++ b/modules/grel/src/main/resources/com/google/refine/grel/FunctionDescription.properties
@@ -99,6 +99,8 @@ str_trim=Returns a copy of string s with leading and trailing whitespace removed
 str_unescape=Unescapes s in the given escaping mode. The mode can be one of: ''html'', ''xml'', ''csv'', ''url'', ''javascript''. Note that quotes are required around your mode.
 str_unicode=Returns an array of strings describing each character of s in their full unicode notation.
 str_unicode_type=Returns an array of strings describing each character of s by their unicode type.
+str_normalize=Returns a normalized version of the input string by removing diacritics and normalizing extended western characters to their ASCII representation.
+
 
 # 7. XML
 xml_innerxml=Returns the inner XML elements of an XML element. Does not return the text directly inside your chosen XML element - only the contents of its children. Use it in conjunction with parseXml() and select() to provide an element.

--- a/modules/grel/src/test/java/com/google/refine/expr/functions/strings/NormalizeTests.java
+++ b/modules/grel/src/test/java/com/google/refine/expr/functions/strings/NormalizeTests.java
@@ -1,0 +1,50 @@
+package com.google.refine.expr.functions.strings;
+
+import java.util.Properties;
+
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
+
+public class NormalizeTests extends GrelTestBase {
+
+    static Properties bindings;
+
+    @Override
+    @BeforeTest
+    public void init() {
+        logger = LoggerFactory.getLogger(this.getClass());
+    }
+
+    @Test
+    public void normalizeFunctionWithDiacriticsTest() throws Exception {
+        Object result = invoke("normalize", "Café");
+        Assert.assertEquals(result, "Cafe");
+    }
+
+    @Test
+    public void normalizeFunctionWithExtendedCharactersTest() throws Exception {
+        Object result = invoke("normalize", "Ångström");
+        Assert.assertEquals(result, "Angstrom");
+    }
+
+    @Test
+    public void normalizeFunctionWithNullTest() throws Exception {
+        Object result = invoke("normalize", (Object) null);
+        Assert.assertTrue(result instanceof EvalError);
+    }
+
+    @Test
+    public void normalizeFunctionWithEmptyStringTest() throws Exception {
+        Object result = invoke("normalize", "");
+        Assert.assertEquals(result, "");
+    }
+
+
+
+}

--- a/modules/grel/src/test/java/com/google/refine/expr/functions/strings/NormalizeTests.java
+++ b/modules/grel/src/test/java/com/google/refine/expr/functions/strings/NormalizeTests.java
@@ -1,3 +1,4 @@
+
 package com.google.refine.expr.functions.strings;
 
 import java.util.Properties;
@@ -5,7 +6,6 @@ import java.util.Properties;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 import com.google.refine.expr.EvalError;
@@ -44,7 +44,5 @@ public class NormalizeTests extends GrelTestBase {
         Object result = invoke("normalize", "");
         Assert.assertEquals(result, "");
     }
-
-
 
 }


### PR DESCRIPTION
Fixes #6608 

Changes proposed in this pull request:
- Made the normalize() public and accessible
- Modified the checkValue() in TextSearchFacet.java
- Introduced the junit tests for diacritic values
