### PR TITLE
windows: Don't offer to open the readme at the end of the installation

### DIFF
--- a/packaging/openrefine.iss
+++ b/packaging/openrefine.iss
@@ -75,7 +75,6 @@ Type: filesandordirs; Name: "{app}\webapp"
 [Files]
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 Source: "{#MyProgramFiles}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs
-Source: "{#MyProgramFiles}\README.md"; DestDir: "{app}"; Flags: isreadme ignoreversion
 ; recompressing compressed files takes unnecessary build time, with usually no perceivable gain
 ;Source: "{#MyProgramFiles}\*.jar"; DestDir: "{app}"; Flags: nocompression ignoreversion recursesubdirs
 ;Source: "{#MyProgramFiles}\*.png"; DestDir: "{app}"; Flags: nocompression ignoreversion recursesubdirs


### PR DESCRIPTION
After reviewing the install process on Windows, I am proposing to stop offering to open the README file at the end of the process. The current experience feels pretty bad to me, for the following reasons:
* our README.md file has an `.md` extension, meaning that on my fresh Windows install, Windows doesn't know which program to use to open this file. I need to manually select a text editor (if I know that this is indeed the right choice). This is annoying because the checkbox to open the README at the end of the install process is ticked by default, so it will happen even if I didn't explicitly request it, in which case it is burdensome to look for a program to open a file that I don't actually want to open
* the contents of our README.md file are not adapted at all to Windows users. It starts with a bunch of badges:

```
# OpenRefine

[![DOI](https://zenodo.org/badge/6220644.svg)](https://zenodo.org/badge/latestdoi/6220644)
[![Join the chat at https://gitter.im/OpenRefine/OpenRefine](https://badges.gitter.im/OpenRefine/OpenRefine.svg)](https://gitter.im/OpenRefine/OpenRefine)
[![Snapshot release](https://github.com/OpenRefine/OpenRefine/actions/workflows/snapshot_release.yml/badge.svg)](https://github.com/OpenRefine/OpenRefine/actions/workflows/snapshot_release.yml) [![Coverage Status](https://coveralls.io/repos/github/OpenRefine/OpenRefine/badge.svg?branch=master)](https://coveralls.io/github/OpenRefine/OpenRefine?branch=master) [![Translation progress](https://hosted.weblate.org/widgets/openrefine/-/svg-badge.svg)](https://hosted.weblate.org/engage/openrefine/?utm_source=widget)

OpenRefine is a Java-based power tool that allows you to load data, understand it,
clean it up, reconcile it, and augment it with data coming from
the web. All from a web browser and the comfort and privacy of your own computer.

...
```

This content is not useful at all as a user.

An alternative would be to offer a dedicated `README.txt` file, with contents adapted for Windows users. What do Windows users really need to know about running OpenRefine? Closing the console with Ctrl-C and not closing the window, for instance? Still, I'm not really sure about the UX of opening a text file in notepad at the end of the install process…