### PR TITLE
Fixes missing wmic command output running refine.bat if Powershell

### DIFF
--- a/refine.bat
+++ b/refine.bat
@@ -1,6 +1,12 @@
 @echo off
 setlocal EnableDelayedExpansion
 
+if "%PSModulePath"=="" (
+    SET PS=false
+) else (
+    SET PS=true
+)
+
 rem Change current working directory to directory of the batch script
 cd %~dp0
 
@@ -193,7 +199,13 @@ if ""%ACTION%"" == """" goto doRun
 
 :doRun
 
-for /f "tokens=2 delims==" %%i in ('wmic OS get FreePhysicalMemory /Value') do set /a freeRam=%%i/1024
+@echo off
+if "!PS!"=="true" (
+    for /f %%i in ('powershell -Command "(Get-CimInstance Win32_OperatingSystem).FreePhysicalMemory"') do set /a freeRam=%%i/1024
+) else (
+    for /f "tokens=2 delims==" %%i in ('wmic OS get FreePhysicalMemory /Value') do set /a freeRam=%%i/1024
+)
+
 echo -------------------------------------------------------------------------------------------------
 echo You have %freeRam%M of free memory.
 echo Your current configuration is set to use %REFINE_MEMORY% of memory.

--- a/refine.bat
+++ b/refine.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-if "%PSModulePath"=="" (
+if "%PSModulePath%"=="" (
     SET PS=false
 ) else (
     SET PS=true


### PR DESCRIPTION
Fixes problem where if `refine.bat` is run from a dev environment or PS, that the `wmic` command is not found and doesn't provide free memory amount in megabytes.

```

PS E:\GitHubRepos\OpenRefine> ./refine
'wmic' is not recognized as an internal or external command,
operable program or batch file.
-------------------------------------------------------------------------------------------------
You have M of free memory.
Your current configuration is set to use 1400M of memory.
OpenRefine can run better when given more memory. Read our FAQ on how to allocate more memory here:
https://openrefine.org/docs/manual/installing\#increasing-memory-allocation
-------------------------------------------------------------------------------------------------
Java 21 (21.0.5)
05:57:02.913 [            refine_server] Java runtime version 21.0.5+11-LTS from java.home: E:\Program Files\Eclipse Adoptium\jdk-21.0.5.11-hotspot (0ms)
```

Changes proposed in this pull request:
- Adds new PS Powershell? check at the beginning of refine.bat to use PS method of checking free memory of the system.

