### PR TITLE
Introduce GetColumnDependenciesCommand

### DIFF
--- a/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
+++ b/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
@@ -65,7 +65,7 @@ public class ApplyOperationsCommand extends Command {
             recipe.validate();
 
             // check all required columns are present
-            Set<String> requiredColumns = recipe.computeRequiredColumns();
+            Set<String> requiredColumns = recipe.getRequiredColumns();
             for (String columnName : requiredColumns) {
                 if (project.columnModel.getColumnByName(columnName) == null) {
                     // TODO: present the user with a dialog to match all missing columns to ones that are present

--- a/main/src/com/google/refine/commands/history/GetColumnDependenciesCommand.java
+++ b/main/src/com/google/refine/commands/history/GetColumnDependenciesCommand.java
@@ -1,0 +1,54 @@
+
+package com.google.refine.commands.history;
+
+import java.io.IOException;
+import java.util.Set;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.google.refine.commands.Command;
+import com.google.refine.operations.Recipe;
+import com.google.refine.util.ParsingUtilities;
+
+/**
+ * Computes the column dependencies of a list of operations, provided in the same JSON format as to the
+ * {@link ApplyOperationsCommand}.
+ */
+public class GetColumnDependenciesCommand extends Command {
+
+    class Result {
+
+        @JsonProperty("code")
+        String code = "ok";
+        @JsonProperty("dependencies")
+        Set<String> dependencies;
+        @JsonProperty("newColumns")
+        Set<String> newColumns;
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        if (!hasValidCSRFToken(request)) {
+            respondCSRFError(response);
+            return;
+        }
+        try {
+            String jsonString = request.getParameter("operations");
+
+            Recipe recipe = ParsingUtilities.mapper.readValue(jsonString, Recipe.class);
+
+            Result result = new Result();
+            result.dependencies = recipe.getRequiredColumns();
+            result.newColumns = recipe.getNewColumns();
+
+            respondJSON(response, result);
+        } catch (Exception e) {
+            respondException(response, e);
+        }
+    }
+}

--- a/main/tests/server/src/com/google/refine/commands/history/GetColumnDependenciesCommandTest.java
+++ b/main/tests/server/src/com/google/refine/commands/history/GetColumnDependenciesCommandTest.java
@@ -1,0 +1,80 @@
+
+package com.google.refine.commands.history;
+
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.refine.commands.Command;
+import com.google.refine.commands.CommandTestBase;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
+import com.google.refine.operations.OperationRegistry;
+import com.google.refine.operations.cell.MassEditOperation;
+import com.google.refine.util.TestUtils;
+
+public class GetColumnDependenciesCommandTest extends CommandTestBase {
+
+    String historyJSON = "[\n"
+            + "  {\n"
+            + "    \"op\": \"core/mass-edit\",\n"
+            + "    \"engineConfig\": {\n"
+            + "      \"facets\": [],\n"
+            + "      \"mode\": \"row-based\"\n"
+            + "    },\n"
+            + "    \"columnName\": \"bar\",\n"
+            + "    \"expression\": \"value\",\n"
+            + "    \"edits\": [\n"
+            + "      {\n"
+            + "        \"from\": [\n"
+            + "          \"hello\"\n"
+            + "        ],\n"
+            + "        \"fromBlank\": false,\n"
+            + "        \"fromError\": false,\n"
+            + "        \"to\": \"hallo\"\n"
+            + "      }\n"
+            + "    ],\n"
+            + "    \"description\": \"Mass edit cells in column bar\"\n"
+            + "  }\n"
+            + "]";
+
+    @BeforeMethod
+    public void setUpDependencies() {
+        command = new GetColumnDependenciesCommand();
+        OperationRegistry.registerOperation(getCoreModule(), "mass-edit", MassEditOperation.class);
+    }
+
+    @BeforeMethod
+    public void registerGRELParser() {
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+    }
+
+    @AfterMethod
+    public void unregisterGRELParser() {
+        MetaParser.unregisterLanguageParser("grel");
+    }
+
+    @Test
+    public void testCSRFProtection() throws ServletException, IOException {
+        command.doPost(request, response);
+        assertCSRFCheckFailed();
+    }
+
+    @Test
+    public void testValidJSON() throws Exception {
+        when(request.getParameter("csrf_token")).thenReturn(Command.csrfFactory.getFreshToken());
+        when(request.getParameter("operations")).thenReturn(historyJSON);
+
+        command.doPost(request, response);
+
+        String response = writer.toString();
+        TestUtils.assertEqualsAsJson(response, "{\"code\":\"ok\", \"dependencies\":[\"bar\"], \"newColumns\":[] }");
+    }
+
+}

--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -86,6 +86,7 @@ function registerCommands() {
 
   RS.registerCommand(module, "undo-redo", new Packages.com.google.refine.commands.history.UndoRedoCommand());
   RS.registerCommand(module, "apply-operations", new Packages.com.google.refine.commands.history.ApplyOperationsCommand());
+  RS.registerCommand(module, "get-column-dependencies", new Packages.com.google.refine.commands.history.GetColumnDependenciesCommand());
   RS.registerCommand(module, "cancel-processes", new Packages.com.google.refine.commands.history.CancelProcessesCommand());
 
   RS.registerCommand(module, "compute-facets", new Packages.com.google.refine.commands.browsing.ComputeFacetsCommand());

--- a/modules/core/src/test/java/com/google/refine/operations/RecipeTests.java
+++ b/modules/core/src/test/java/com/google/refine/operations/RecipeTests.java
@@ -156,26 +156,26 @@ public class RecipeTests {
     }
 
     @Test
-    public void testComputeRequiredColumnsMethod() throws Exception {
+    public void testGetRequiredColumns() throws Exception {
         assertEquals(
-                new Recipe(List.of()).computeRequiredColumns(),
+                new Recipe(List.of()).getRequiredColumns(),
                 Set.of());
 
         assertEquals(
                 new Recipe(List.of(
-                        new ColumnRemovalOperation("foo"))).computeRequiredColumns(),
+                        new ColumnRemovalOperation("foo"))).getRequiredColumns(),
                 Set.of("foo"));
 
         assertEquals(
                 new Recipe(List.of(
                         new ColumnRemovalOperation("foo"),
-                        new ColumnRemovalOperation("bar"))).computeRequiredColumns(),
+                        new ColumnRemovalOperation("bar"))).getRequiredColumns(),
                 Set.of("foo", "bar"));
 
         assertEquals(
                 new Recipe(List.of(
                         new ColumnRenameOperation("foo", "foo2"),
-                        new ColumnRemovalOperation("bar"))).computeRequiredColumns(),
+                        new ColumnRemovalOperation("bar"))).getRequiredColumns(),
                 Set.of("foo", "bar"));
 
         assertEquals(
@@ -185,19 +185,43 @@ public class RecipeTests {
                         // The dependency of the following operation is not taken into account,
                         // because the previous operation does not expose a columns diff,
                         // so we can't predict if "bar" is going to be produced by it or not.
-                        new ColumnRemovalOperation("bar"))).computeRequiredColumns(),
+                        new ColumnRemovalOperation("bar"))).getRequiredColumns(),
                 Set.of("foo"));
 
         assertEquals(
                 new Recipe(List.of(
                         new ColumnTransformOperation("foo"),
-                        new ColumnRemovalOperation("foo"))).computeRequiredColumns(),
+                        new ColumnRemovalOperation("foo"))).getRequiredColumns(),
                 Set.of("foo"));
 
         // unanalyzable operation
         assertEquals(
                 new Recipe(List.of(
-                        new OpaqueOperation())).computeRequiredColumns(),
+                        new OpaqueOperation())).getRequiredColumns(),
+                Set.of());
+    }
+
+    @Test
+    public void testGetNewColumns() throws Exception {
+        assertEquals(
+                new Recipe(List.of()).getNewColumns(),
+                Set.of());
+
+        assertEquals(
+                new Recipe(List.of(
+                        new ColumnRemovalOperation("foo"))).getNewColumns(),
+                Set.of());
+
+        assertEquals(
+                new Recipe(List.of(
+                        new ColumnRenameOperation("foo", "foo2"),
+                        new ColumnRemovalOperation("bar"))).getNewColumns(),
+                Set.of("foo2"));
+
+        // unanalyzable operation
+        assertEquals(
+                new Recipe(List.of(
+                        new OpaqueOperation())).getNewColumns(),
                 Set.of());
     }
 
@@ -205,14 +229,14 @@ public class RecipeTests {
     public void testRequiredColumnsFromInconsistentOperations() {
         assertThrows(IllegalArgumentException.class, () -> new Recipe(List.of(
                 new ColumnRemovalOperation("foo"),
-                new ColumnRenameOperation("foo", "bar"))).computeRequiredColumns());
+                new ColumnRenameOperation("foo", "bar"))).getRequiredColumns());
     }
 
     @Test
     public void testConflictingColumnCreation() {
         assertThrows(IllegalArgumentException.class, () -> new Recipe(List.of(
                 new ColumnTransformOperation("bar"),
-                new ColumnRenameOperation("foo", "bar"))).computeRequiredColumns());
+                new ColumnRenameOperation("foo", "bar"))).getRequiredColumns());
     }
 
 }


### PR DESCRIPTION
This introduces a new command to compute the columns required by a sequence of operations. The command also returns the names of the new columns created by the recipe.

To that end, the `Recipe` class is improved to expose the new columns created. The processing of the operations list to derive such columns is moved to the validation stage of the recipe, so that the computation is done only once for both the required and created columns.