### PR TITLE
fix: Better error reporting in apply opertations dialog

### DIFF
--- a/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
+++ b/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
@@ -45,6 +45,7 @@ import com.google.refine.commands.Command;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 import com.google.refine.operations.Recipe;
+import com.google.refine.operations.Recipe.RecipeValidationException;
 import com.google.refine.process.Process;
 import com.google.refine.util.ParsingUtilities;
 
@@ -68,7 +69,6 @@ public class ApplyOperationsCommand extends Command {
             Set<String> requiredColumns = recipe.computeRequiredColumns();
             for (String columnName : requiredColumns) {
                 if (project.columnModel.getColumnByName(columnName) == null) {
-                    // TODO: present the user with a dialog to match all missing columns to ones that are present
                     throw new IllegalArgumentException(
                             "Column '" + columnName + "' is referenced in the list of operations but is absent from the project");
                 }
@@ -85,6 +85,8 @@ public class ApplyOperationsCommand extends Command {
             } else {
                 respond(response, "{ \"code\" : \"ok\" }");
             }
+        } catch (RecipeValidationException e) {
+            respondJSON(response, e);
         } catch (Exception e) {
             respondException(response, e);
         }

--- a/main/src/com/google/refine/operations/cell/MassEditOperation.java
+++ b/main/src/com/google/refine/operations/cell/MassEditOperation.java
@@ -124,7 +124,7 @@ public class MassEditOperation extends EngineDependentMassCellOperation {
         try {
             MetaParser.parse(_expression);
         } catch (ParsingException e) {
-            throw new IllegalArgumentException(e);
+            throw new IllegalArgumentException(String.format("Invalid expression '%s': %s", _expression, e.getMessage()), e);
         }
         Validate.notNull(_edits, "Missing edits");
     }

--- a/main/src/com/google/refine/operations/cell/TextTransformOperation.java
+++ b/main/src/com/google/refine/operations/cell/TextTransformOperation.java
@@ -111,7 +111,7 @@ public class TextTransformOperation extends EngineDependentMassCellOperation {
         try {
             MetaParser.parse(_expression);
         } catch (ParsingException e) {
-            throw new IllegalArgumentException(e);
+            throw new IllegalArgumentException(String.format("Invalid expression '%s': %s", _expression, e.getMessage()), e);
         }
     }
 

--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -154,7 +154,7 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
         try {
             MetaParser.parse(_urlExpression);
         } catch (ParsingException e) {
-            throw new IllegalArgumentException(e);
+            throw new IllegalArgumentException(String.format("Invalid expression '%s': %s", _urlExpression, e.getMessage()), e);
         }
         Validate.notNull(_onError, "Missing 'on error' behaviour");
         Validate.notNull(_newColumnName, "Missing new column name");

--- a/main/src/com/google/refine/operations/column/ColumnAdditionOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionOperation.java
@@ -101,7 +101,7 @@ public class ColumnAdditionOperation extends EngineDependentOperation {
         try {
             MetaParser.parse(_expression);
         } catch (ParsingException e) {
-            throw new IllegalArgumentException(e);
+            throw new IllegalArgumentException(String.format("Invalid expression '%s': %s", _expression, e.getMessage()), e);
         }
         Validate.notNull(_onError, "Missing 'on error' behaviour");
         Validate.notNull(_newColumnName, "Missing new column name");


### PR DESCRIPTION
This improves the error messages shown in the "Apply" dialog so that they better indicate which operation failed validation. The error messages pertaining to invalid expressions are also more explicit, showing which expression is invalid.

As a follow-up improvement, those error messages could be displayed alongside the particular operation which raised the error. I prepared the ground for this improvement by exposing the operation index in the JSON serialization of the exception.