### PR TITLE
Pure CSS alternative to highlighting history entries on hover

### DIFF
--- a/main/webapp/modules/core/scripts/project/history-panel.html
+++ b/main/webapp/modules/core/scripts/project/history-panel.html
@@ -12,10 +12,8 @@
 </div>
 <div class="history-panel-body" bind="bodyDiv">
   <div class="history-past" bind="pastDiv">
-    <div class="history-highlight" bind="pastHighlightDiv"></div>
   </div>
   <div class="history-now" bind="nowDiv"></div>
   <div class="history-future" bind="futureDiv">
-    <div class="history-highlight" bind="futureHighlightDiv"></div>
   </div>
 </div>'

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -95,20 +95,6 @@ HistoryPanel.prototype._render = function() {
       a.attr("href", "javascript:{}")
       .on('click',function(evt) {
         return self._onClickHistoryEntry(evt, entry, lastDoneID);
-      })
-      .on('mouseover',function() {
-        if (past) {
-          elmts.pastHighlightDiv.show().height(elmts.pastDiv.height() - this.offsetTop - this.offsetHeight);
-        } else {
-          elmts.futureHighlightDiv.show().height(this.offsetTop + this.offsetHeight);
-        }
-      })
-      .on('mouseout',function() {
-        if (past) {
-          elmts.pastHighlightDiv.hide();
-        } else {
-          elmts.futureHighlightDiv.hide();
-        }
       });
     }
 

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -193,6 +193,10 @@ a.history-entry.filtered-out>* {
 .history-past {
   position: relative;
   background: var(--background-primary);
+
+  a.history-entry:hover ~ a.history-entry {
+    background: var(--chrome-secondary);
+  }
 }
 
 .history-now {
@@ -202,23 +206,10 @@ a.history-entry.filtered-out>* {
 .history-future {
   position: relative;
   padding-bottom: var(--padding-loose);
-}
 
-.history-highlight {
-  position: absolute;
-  left: 0px;
-  width: 100%;
-  display: none;
-}
-
-.history-past .history-highlight {
-  background: var(--chrome-secondary);
-  bottom: 0;
-}
-
-.history-future .history-highlight {
-  background: var(--background-primary);
-  top: 0;
+  a.history-entry:hover, a.history-entry:has(~ a.history-entry:hover) {
+    background: var(--background-primary);
+  }
 }
 
 .history-future a.history-entry, .history-future a.history-entry-index {


### PR DESCRIPTION
This changes the way history entries are highlighted when hovering one of them. So far, this was done with event listeners to maintain an absolutely positioned div which would add a special background color on the entries between the currently selected one and the hovered one. This simplifies it by removing that Javascript logic and defining the changes of background via CSS only. This relies on the [`:has()` pseudo-class](https://developer.mozilla.org/fr/docs/Web/CSS/:has), which is a recent CSS feature, but is available in "Baseline 2023".

This is a preparation for including operation icons in the history.

The behaviour remains unchanged as far as I can tell:
![screencast](https://github.com/user-attachments/assets/637df937-6337-48d8-adb2-1968ad2bcb7d)

Tested on Firefox and Chromium.