### PR TITLE
Show operation icons in history panel

### DIFF
--- a/main/tests/server/src/com/google/refine/commands/history/GetHistoryCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/history/GetHistoryCommandTests.java
@@ -1,0 +1,66 @@
+
+package com.google.refine.commands.history;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import javax.servlet.ServletException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.refine.browsing.EngineConfig;
+import com.google.refine.commands.CommandTestBase;
+import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.Project;
+import com.google.refine.operations.OperationRegistry;
+import com.google.refine.operations.cell.FillDownOperation;
+import com.google.refine.util.ParsingUtilities;
+import com.google.refine.util.TestUtils;
+
+public class GetHistoryCommandTests extends CommandTestBase {
+
+    @BeforeMethod
+    public void setUpCommand() {
+        command = new GetHistoryCommand();
+    }
+
+    @Test
+    public void testEmptyHistory() throws ServletException, IOException {
+        Project project = createProject(new String[] { "foo", "bar" },
+                new Serializable[][] {
+                        { "a", "b" },
+                        { null, "c" },
+                });
+        when(request.getParameter("project")).thenReturn(String.format("%d", project.id));
+
+        command.doGet(request, response);
+
+        String response = writer.toString();
+        TestUtils.assertEqualsAsJson(response, "{\"past\":[], \"future\":[]}");
+    }
+
+    @Test
+    public void testOperationId() throws Exception {
+        Project project = createProject(new String[] { "foo", "bar" },
+                new Serializable[][] {
+                        { "a", "b" },
+                        { null, "c" },
+                });
+        AbstractOperation op = new FillDownOperation(EngineConfig.defaultRowBased(), "foo");
+        OperationRegistry.registerOperation(getCoreModule(), "fill-down", FillDownOperation.class);
+        runOperation(op, project);
+
+        when(request.getParameter("project")).thenReturn(String.format("%d", project.id));
+
+        command.doGet(request, response);
+
+        String response = writer.toString();
+        JsonNode node = ParsingUtilities.mapper.readValue(response, JsonNode.class);
+        assertEquals(node.get("past").get(0).get("operation_id").asText(), "core/fill-down");
+    }
+}

--- a/main/webapp/modules/core/scripts/project/history-entry.html
+++ b/main/webapp/modules/core/scripts/project/history-entry.html
@@ -1,1 +1,6 @@
-<a class="history-entry"><span class="history-entry-index" bind="entryIndex"></span><span bind="entryDescription"></span></a>
+<a class="history-entry">
+    <div bind="operationIcon" class="history-entry-icon"></div>
+    <div class="history-entry-text">
+        <span class="history-entry-index" bind="entryIndex"></span> <span bind="entryDescription"></span>
+    </div>
+</a>

--- a/main/webapp/modules/core/scripts/project/history-panel.js
+++ b/main/webapp/modules/core/scripts/project/history-panel.js
@@ -98,8 +98,17 @@ HistoryPanel.prototype._render = function() {
       });
     }
 
-    a[0].childNodes[0].appendChild(document.createTextNode(index + "."));
-    a[0].childNodes[1].appendChild(document.createTextNode(entry.description));
+    var fields = DOM.bind(a);
+    fields.entryIndex.text(index + ".");
+    fields.entryDescription.text(entry.description);
+    if (entry.operation_id != null) {
+      let icon = OperationIconRegistry.getIcon(entry.operation_id);
+      if (icon != null) {
+        $('<img />')
+          .attr('src', icon)
+          .appendTo(fields.operationIcon);
+      }
+    }
 
     return a;
   };

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -167,7 +167,7 @@ a.history-entry.filtered-out>* {
 }
 
 .history-entry-text, .history-entry-icon {
-  align-self: center;
+  align-self: baseline;
 }
 
 .history-panel-controls {

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -139,23 +139,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 }
 
 a.history-entry {
-  display: block;
-  position: relative;
+  display: grid;
+  grid-template-columns: 2em 1fr;
   padding: var(--padding-normal);
-  padding-left: calc(var(--padding-normal) + 30px);
   text-decoration: none;
   color: var(--text-primary);
   border-bottom: 1px dotted #ddd;
-}
-
-.history-entry-index {
-  position: absolute;
-  top: 8px;
-  left: 0;
-  width: 30px;
-  text-align: right;
-  font-size: 80%;
-  padding: 2px 0px;
 }
 
 a.history-entry.filtered-out {
@@ -166,6 +155,19 @@ a.history-entry.filtered-out {
 
 a.history-entry.filtered-out>* {
   display: none;
+}
+
+.history-entry-icon img {
+  max-height: 1.5em;
+  max-width: 1.5em;
+}
+
+.history-future .history-entry-icon img {
+  opacity: 0.5;
+}
+
+.history-entry-text, .history-entry-icon {
+  align-self: center;
 }
 
 .history-panel-controls {

--- a/modules/core/src/main/java/com/google/refine/history/HistoryEntry.java
+++ b/modules/core/src/main/java/com/google/refine/history/HistoryEntry.java
@@ -42,6 +42,7 @@ import java.util.Properties;
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.InjectableValues;
@@ -132,6 +133,13 @@ public class HistoryEntry {
             logger.error("Failed to get history entry manager from project manager: "
                     + ProjectManager.singleton);
         }
+    }
+
+    @JsonProperty("operation_id")
+    @JsonView(JsonViews.NonSaveMode.class)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getOperationId() {
+        return operation == null ? null : operation.getOperationId();
     }
 
     public void save(Writer writer, Properties options) {

--- a/modules/core/src/test/java/com/google/refine/history/HistoryEntryTests.java
+++ b/modules/core/src/test/java/com/google/refine/history/HistoryEntryTests.java
@@ -99,7 +99,8 @@ public class HistoryEntryTests extends RefineTest {
         String jsonSimple = "{"
                 + "\"id\":1533633623158,"
                 + "\"description\":\"Create new column uri based on column country by filling 269 rows with grel:\\\"https://www.wikidata.org/wiki/\\\"+cell.recon.match.id\","
-                + "\"time\":\"2018-08-07T09:06:37Z\"}";
+                + "\"time\":\"2018-08-07T09:06:37Z\","
+                + "\"operation_id\":\"core/mock-operation\"}";
 
         HistoryEntry historyEntry = HistoryEntry.load(project, fullJson);
         TestUtils.isSerializedTo(historyEntry, jsonSimple, false);

--- a/modules/core/src/test/java/com/google/refine/history/HistoryTests.java
+++ b/modules/core/src/test/java/com/google/refine/history/HistoryTests.java
@@ -127,7 +127,8 @@ public class HistoryTests extends RefineTest {
                 + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":[]}}}";
         String json1simple = "{\"id\":1533650900300,"
                 + "\"description\":\"Reconcile cells in column organization_name to type Q43229\","
-                + "\"time\":\"2018-08-07T13:57:17Z\"}";
+                + "\"time\":\"2018-08-07T13:57:17Z\","
+                + "\"operation_id\":\"core/recon\"}";
         String json2 = "{\"id\":1533651586483,"
                 + "\"description\":\"Edit single cell on row 94, column organization_id\","
                 + "\"time\":\"2018-08-07T14:18:21Z\"}";


### PR DESCRIPTION
Changes proposed in this pull request:
- change the GetHistoryCommand to expose operation ids
- use those operation ids to show operation icons in the undo-redo panel

This requires #7134 to get the hovering behaviour to work correctly.

I'm not sure about the vertical alignment of the icons compared to the other descriptions. Currently they are centered, but perhaps it's better if their top boundaries are aligned.

Another question is whether step indices ("1. ", "2. "…) are really worth retaining. In my opinion they aren't very useful, I remember Zoe also proposed to remove them.

Another question is whether there should be an icon placeholder for steps which are either not associated to an operation (such as edits of single cells) or whose operation doesn't declare an icon. For now, the space is left blank.

### Screenshot

![image](https://github.com/user-attachments/assets/32c3f1fd-0dc5-4c3c-8d1b-71d702ab7efa)
