### PR TITLE
move rename and remove column one menu up

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/rename_remove_column.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/rename_remove_column.cy.js
@@ -2,11 +2,11 @@ describe(__filename, function () {
   it('Ensures a column is removed from the data-table', function () {
     cy.loadAndVisitProject('food.mini');
 
-    cy.columnActionClick('Shrt_Desc', ['Edit column', 'Remove this column']);
+    cy.columnActionClick('Shrt_Desc', ['Remove column']);
 
     cy.assertNotificationContainingText('Remove column Shrt_Desc');
 
-    cy.columnActionClick('Water', ['Edit column', 'Remove this column']);
+    cy.columnActionClick('Water', ['Remove column']);
 
     cy.assertNotificationContainingText('Remove column Water');
 

--- a/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/rename_remove_column.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/edit-column/rename_remove_column.cy.js
@@ -26,7 +26,7 @@ describe(__filename, function () {
     cy.columnActionClick('Shrt_Desc', ['Facet', 'Text facet']);
     cy.getFacetContainer('Shrt_Desc').should('exist');
 
-    cy.columnActionClick('Shrt_Desc', ['Edit column', 'Rename this column']);
+    cy.columnActionClick('Shrt_Desc', ['Rename column']);
     cy.waitForDialogPanel();
     cy.get('.dialog-container .dialog-body input').clear();
     cy.get('.dialog-container .dialog-body input').type('test_rename_butter');

--- a/main/tests/cypress/cypress/e2e/project/undo_redo/undo_redo.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/undo_redo/undo_redo.cy.js
@@ -105,7 +105,7 @@ describe(__filename, function () {
   // it('Ensure the Undo button disappear after timeout after deleting a column', function () {
   // 	const ORNotificationTimeout = 15000;
   // cy.loadAndVisitProject('food.mini');
-  // 	cy.columnActionClick('NDB_No', ['Edit column', 'Remove this column']);
+  // 	cy.columnActionClick('NDB_No', ['Remove column']);
   // 	cy.get('#notification-container', { timeout: ORNotificationTimeout }).should('not.be.visible');
   // });
 });

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -223,7 +223,7 @@ Cypress.Commands.add('selectClojure', () => {
  */
 Cypress.Commands.add('deleteColumn', (columnName) => {
   cy.get('.data-table th[title="' + columnName + '"]').should('exist');
-  cy.columnActionClick(columnName, ['Edit column', 'Remove this column']);
+  cy.columnActionClick(columnName, ['Remove column']);
   cy.get('.data-table th[title="' + columnName + '"]').should('not.exist');
 });
 

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -683,6 +683,7 @@
     "core-views/after-split": "After splitting",
     "core-views/guess-cell": "Guess cell type",
     "core-views/remove-col": "Remove this column",
+    "core-views/remove-col2": "Remove column",
     "core-views/specify-sep": "Please specify a separator.",
     "core-views/warning-no-length": "No field length is specified.",
     "core-views/warning-format": "The given field lengths are not properly formatted.",

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -691,7 +691,7 @@
     "core-views/split-into-col": "Split into several columns…",
     "core-views/add-based-col": "Add column based on this column…",
     "core-views/add-by-urls": "Add column by fetching URLs…",
-    "core-views/rename-col": "Rename this column…",
+    "core-views/rename-col": "Rename column…",
     "core-views/move-to-beg": "Move column to beginning",
     "core-views/move-to-end": "Move column to end",
     "core-views/move-to-left": "Move column left",

--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -270,6 +270,21 @@ DataTableColumnHeaderUI.prototype._createMenuForColumnHeader = function(elmt) {
       tooltip: $.i18n('core-views/reconcile-tooltip'),
       width: "170px",
       submenu: []
+    },
+    {},
+    {
+      id: "core/remove-column",
+      label: $.i18n('core-views/remove-col2'),
+      click: function() {
+        Refine.postCoreProcess(
+          "remove-column",
+          {
+            columnName: self._column.name
+          },
+          null,
+          { modelsChanged: true, rowIdsPreserved: true }
+        );
+      }
     }
   ];
 

--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -275,6 +275,7 @@ DataTableColumnHeaderUI.prototype._createMenuForColumnHeader = function(elmt) {
     {
       id: "core/rename-column",
       label: $.i18n('core-views/rename-col'),
+      icon: 'images/operations/rename.svg',
       click: function() {
         var frame = $(DOM.loadHTML("core", "scripts/views/data-table/rename-column.html"));
 
@@ -330,6 +331,7 @@ DataTableColumnHeaderUI.prototype._createMenuForColumnHeader = function(elmt) {
     {
       id: "core/remove-column",
       label: $.i18n('core-views/remove-col2'),
+      icon: 'images/operations/delete.svg',
       click: function() {
         Refine.postCoreProcess(
           "remove-column",
@@ -347,7 +349,7 @@ DataTableColumnHeaderUI.prototype._createMenuForColumnHeader = function(elmt) {
     DataTableColumnHeaderUI._extenders[i].call(null, this._column, this, menu);
   }
 
-  MenuSystem.createAndShowStandardMenu(menu, elmt, { width: "120px", horizontal: false });
+  MenuSystem.createAndShowStandardMenu(menu, elmt, { width: "135px", horizontal: false });
 };
 
 DataTableColumnHeaderUI.prototype.createSortingMenu = function() {

--- a/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
+++ b/main/webapp/modules/core/scripts/views/data-table/column-header-ui.js
@@ -273,6 +273,61 @@ DataTableColumnHeaderUI.prototype._createMenuForColumnHeader = function(elmt) {
     },
     {},
     {
+      id: "core/rename-column",
+      label: $.i18n('core-views/rename-col'),
+      click: function() {
+        var frame = $(DOM.loadHTML("core", "scripts/views/data-table/rename-column.html"));
+
+        var elmts = DOM.bind(frame);
+        elmts.dialogHeader.text($.i18n('core-views/enter-col-name'));
+        elmts.columnNameInput.text();
+        elmts.columnNameInput.attr('aria-label',$.i18n('core-views/new-column-name'));
+        elmts.columnNameInput[0].value = self._column.name;
+        elmts.okButton.html($.i18n('core-buttons/ok'));
+        elmts.cancelButton.text($.i18n('core-buttons/cancel'));
+
+        var level = DialogSystem.showDialog(frame);
+        var dismiss = function() { DialogSystem.dismissUntil(level - 1); };
+        elmts.cancelButton.on('click',dismiss);
+        elmts.form.on('submit',function(event) {
+          event.preventDefault();
+          var newColumnName = jQueryTrim(elmts.columnNameInput[0].value);
+          if (newColumnName === self._column.name) {
+            dismiss();
+            return;
+          }
+          if (newColumnName.length > 0) {
+            Refine.postCoreProcess(
+                "rename-column",
+                {
+                  oldColumnName: self._column.name,
+                  newColumnName: newColumnName
+                },
+                null,
+                {
+                  modelsChanged: true,
+                  rowIdsPreserved: true,
+                  recordIdsPreserved: true,
+                  engineConfig: ui.browsingEngine.getJSON(true),
+                },
+                {
+                  onDone: function (response) {
+                    if (response.newEngineConfig !== undefined) {
+                      // updateLater is set to true as the update process for the operation
+                      // will also take care of updating the facets, so there is no need to
+                      // do it twice.
+                      ui.browsingEngine.setJSON(response.newEngineConfig, true);
+                    }
+                    dismiss();
+                  }
+                }
+            );
+          }
+        });
+        elmts.columnNameInput.trigger('focus').trigger('select');
+      }
+    },
+    {
       id: "core/remove-column",
       label: $.i18n('core-views/remove-col2'),
       click: function() {

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
@@ -199,17 +199,6 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     );
   };
 
-  var doRemoveColumn = function() {
-    Refine.postCoreProcess(
-      "remove-column", 
-      {
-        columnName: column.name
-      },
-      null,
-      { modelsChanged: true, rowIdsPreserved: true }
-    );
-  };
-
   var doRenameColumn = function() {
     var frame = $(
         DOM.loadHTML("core", "scripts/views/data-table/rename-column.html"));
@@ -617,12 +606,6 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         label: $.i18n('core-views/rename-col'),
         icon: 'images/operations/rename.svg',
         click: doRenameColumn
-      },
-      {
-        id: "core/remove-column",
-        label: $.i18n('core-views/remove-col'),
-        icon: 'images/operations/delete.svg',
-        click: doRemoveColumn
       },
       {},
       {

--- a/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
+++ b/main/webapp/modules/core/scripts/views/data-table/menu-edit-column.js
@@ -199,60 +199,6 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
     );
   };
 
-  var doRenameColumn = function() {
-    var frame = $(
-        DOM.loadHTML("core", "scripts/views/data-table/rename-column.html"));
-
-    var elmts = DOM.bind(frame);
-    elmts.dialogHeader.text($.i18n('core-views/enter-col-name'));
-    elmts.columnNameInput.text();
-    elmts.columnNameInput.attr('aria-label',$.i18n('core-views/new-column-name'));
-    elmts.columnNameInput[0].value = column.name;
-    elmts.okButton.html($.i18n('core-buttons/ok'));
-    elmts.cancelButton.text($.i18n('core-buttons/cancel'));
-
-    var level = DialogSystem.showDialog(frame);
-    var dismiss = function() { DialogSystem.dismissUntil(level - 1); };
-    elmts.cancelButton.on('click',dismiss);
-    elmts.form.on('submit',function(event) {
-      event.preventDefault();
-      var newColumnName = jQueryTrim(elmts.columnNameInput[0].value);
-      if (newColumnName === column.name) {
-        dismiss();
-        return;
-      }
-      if (newColumnName.length > 0) {
-        Refine.postCoreProcess(
-            "rename-column",
-            {
-              oldColumnName: column.name,
-              newColumnName: newColumnName
-            },
-            null,
-            {
-                modelsChanged: true,
-                rowIdsPreserved: true,
-                recordIdsPreserved: true,
-                engineConfig: ui.browsingEngine.getJSON(true), 
-            },
-            {
-              onDone: function (response) {
-                if (response.newEngineConfig !== undefined) {
-                  // updateLater is set to true as the update process for the operation
-                  // will also take care of updating the facets, so there is no need to
-                  // do it twice.
-                  ui.browsingEngine.setJSON(response.newEngineConfig, true);
-                }
-                dismiss();
-              }
-            }
-        );
-      }
-    });
-    elmts.columnNameInput.trigger('focus').trigger('select');
-  };
-  
-
   var doMoveColumnTo = function(index) {
     Refine.postCoreProcess(
       "move-column", 
@@ -599,13 +545,6 @@ DataTableColumnHeaderUI.extendMenu(function(column, columnHeaderUI, menu) {
         label: $.i18n('core-views/add-col-recon-val'),
         icon: 'images/operations/data-extension.svg',
         click: doAddColumnByReconciliation
-      },
-      {},
-      {
-        id: "core/rename-column",
-        label: $.i18n('core-views/rename-col'),
-        icon: 'images/operations/rename.svg',
-        click: doRenameColumn
       },
       {},
       {


### PR DESCRIPTION
Fixes #6280 

**Status Quo**:
Currently the operations "Rename this column" and "Remove this column" are placed within the sub-menu "Edit column".

**Changes proposed in this pull request**:
Operations  "Rename this column" and "Remove this column" are placed within the main column menu.

Before             |  After
:-------------------------:|:-------------------------:
![edit-column-before](https://github.com/user-attachments/assets/8b3207f6-d85a-4a1b-9566-7f97cee50316) | ![edit-column-after](https://github.com/user-attachments/assets/8ae9439f-88a3-4843-84d2-886b06192dc6)


**Notes**:
* left out the corresponding icons of the actions to make the look more coherent 
(pattern is main menu -> no icon, sub-menu -> icon)
* shortened the operation names: "Remove ~this~ column" / "Rename ~this~ column"
While this was straight forward for rename operation as the text is only used once, I added another translation for remove column as the translation is also used in other places