### PR TITLE
operations: Renaming support for c.g.r.o.column

### DIFF
--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -225,6 +226,28 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.builder().addColumn(_newColumnName, _baseColumnName).build());
+    }
+
+    @Override
+    public ColumnAdditionByFetchingURLsOperation renameColumns(Map<String, String> newColumnNames) {
+        String renamedExpression;
+        try {
+            Evaluable evaluable = MetaParser.parse(_urlExpression);
+            Evaluable renamedEvaluable = evaluable.renameColumnDependencies(newColumnNames);
+            renamedExpression = renamedEvaluable.getFullSource();
+        } catch (ParsingException e) {
+            return this;
+        }
+        return new ColumnAdditionByFetchingURLsOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_baseColumnName, _baseColumnName),
+                renamedExpression,
+                _onError,
+                newColumnNames.getOrDefault(_newColumnName, _newColumnName),
+                _columnInsertIndex,
+                _delay,
+                _cacheResponses,
+                _httpHeadersJson);
     }
 
     @Override

--- a/main/src/com/google/refine/operations/column/ColumnMoveOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnMoveOperation.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.column;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -104,5 +105,10 @@ public class ColumnMoveOperation extends AbstractOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.empty());
+    }
+
+    @Override
+    public ColumnMoveOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ColumnMoveOperation(newColumnNames.getOrDefault(_columnName, _columnName), _index);
     }
 }

--- a/main/src/com/google/refine/operations/column/ColumnRemovalOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnRemovalOperation.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.column;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -82,6 +83,11 @@ public class ColumnRemovalOperation extends AbstractOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.builder().deleteColumn(_columnName).build());
+    }
+
+    @Override
+    public ColumnRemovalOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ColumnRemovalOperation(newColumnNames.getOrDefault(_columnName, _columnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/column/ColumnRenameOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnRenameOperation.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.operations.column;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -90,6 +91,13 @@ public class ColumnRenameOperation extends AbstractOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.builder().deleteColumn(_oldColumnName).addColumn(_newColumnName, _oldColumnName).build());
+    }
+
+    @Override
+    public ColumnRenameOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ColumnRenameOperation(
+                newColumnNames.getOrDefault(_oldColumnName, _oldColumnName),
+                newColumnNames.getOrDefault(_newColumnName, _newColumnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/column/ColumnReorderOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnReorderOperation.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.operations.column;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -82,6 +83,12 @@ public class ColumnReorderOperation extends AbstractOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.empty(); // we don't know what columns there were before, so we can't diff them
+    }
+
+    @Override
+    public ColumnReorderOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ColumnReorderOperation(
+                _columnNames.stream().map(name -> newColumnNames.getOrDefault(name, name)).collect(Collectors.toList()));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/column/ColumnSplitOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnSplitOperation.java
@@ -36,6 +36,7 @@ package com.google.refine.operations.column;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -215,6 +216,27 @@ public class ColumnSplitOperation extends EngineDependentOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.empty(); // sadly the columns created depend on the data and the name of existing columns
+    }
+
+    @Override
+    public ColumnSplitOperation renameColumns(Map<String, String> newColumnNames) {
+        if ("separator".equals(_mode)) {
+            return new ColumnSplitOperation(
+                    _engineConfig.renameColumnDependencies(newColumnNames),
+                    newColumnNames.getOrDefault(_columnName, _columnName),
+                    _guessCellType,
+                    _removeOriginalColumn,
+                    _separator,
+                    _regex,
+                    _maxColumns);
+        } else {
+            return new ColumnSplitOperation(
+                    _engineConfig.renameColumnDependencies(newColumnNames),
+                    newColumnNames.getOrDefault(_columnName, _columnName),
+                    _guessCellType,
+                    _removeOriginalColumn,
+                    _fieldLengths);
+        }
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -40,6 +40,7 @@ import static org.testng.Assert.assertTrue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
@@ -191,6 +192,25 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
                 true,
                 null);
         assertThrows(IllegalArgumentException.class, () -> missingExpression.validate());
+    }
+
+    @Test
+    public void testRename() {
+        ColumnAdditionByFetchingURLsOperation SUT = new ColumnAdditionByFetchingURLsOperation(engine_config,
+                "fruits",
+                "grel:\"https://example.com/api?city=\"+value",
+                OnError.StoreError,
+                "results",
+                1,
+                5,
+                true,
+                null);
+
+        ColumnAdditionByFetchingURLsOperation renamed = SUT.renameColumns(Map.of("fruits", "vegetables", "results", "json"));
+
+        assertEquals(renamed._baseColumnName, "vegetables");
+        assertEquals(renamed._newColumnName, "json");
+        assertEquals(renamed._urlExpression, "grel:\"https://example.com/api?city=\" + value");
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnMoveOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnMoveOperationTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -147,6 +148,15 @@ public class ColumnMoveOperationTests extends RefineTest {
                         { "v1", "j", "b" },
                 });
         assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testRename() {
+        ColumnMoveOperation SUT = new ColumnMoveOperation("hello", 1);
+
+        ColumnMoveOperation renamed = SUT.renameColumns(Map.of("hello", "world"));
+
+        assertEquals(renamed._columnName, "world");
     }
 
 }

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnRemovalOperationTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -102,5 +103,14 @@ public class ColumnRemovalOperationTests extends RefineTest {
                         { "b", "j" },
                 });
         assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testRename() {
+        ColumnRemovalOperation SUT = new ColumnRemovalOperation("foo");
+
+        ColumnRemovalOperation renamed = SUT.renameColumns(Map.of("foo", "bar"));
+
+        assertEquals(renamed._columnName, "bar");
     }
 }

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnRenameOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnRenameOperationTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -107,5 +108,15 @@ public class ColumnRenameOperationTests extends RefineTest {
                         { "v1", "b", "j" },
                 });
         assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testRenameDependencies() throws Exception {
+        ColumnRenameOperation SUT = new ColumnRenameOperation("foo", "newfoo");
+
+        ColumnRenameOperation renamed = SUT.renameColumns(Map.of("foo", "foo2", "newfoo", "newfoo2"));
+
+        assertEquals(renamed._oldColumnName, "foo2");
+        assertEquals(renamed._newColumnName, "newfoo2");
     }
 }

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnReorderOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnReorderOperationTests.java
@@ -32,6 +32,8 @@ import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -124,5 +126,14 @@ public class ColumnReorderOperationTests extends RefineTest {
                         { "g", "f" },
                 });
         assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testRename() {
+        ColumnReorderOperation SUT = new ColumnReorderOperation(Arrays.asList("c", "b"));
+
+        ColumnReorderOperation renamed = SUT.renameColumns(Map.of("a", "a2", "b", "b2"));
+
+        assertEquals(renamed._columnNames, List.of("c", "b2"));
     }
 }

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnSplitOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnSplitOperationTests.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -257,5 +258,49 @@ public class ColumnSplitOperationTests extends RefineTest {
                         { "12,true", "b", "g1", "g", "1" },
                 });
         assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testRenameLengths() {
+        ColumnSplitOperation SUT = new ColumnSplitOperation(EngineConfig.defaultRowBased(), "hello", false,
+                false, new int[] { 1, 2 });
+
+        ColumnSplitOperation renamed = SUT.renameColumns(Map.of("hello", "world"));
+        TestUtils.isSerializedTo(renamed, "{\n"
+                + "       \"columnName\" : \"world\",\n"
+                + "       \"description\" : " + new TextNode(OperationDescription.column_split_brief("world")).toString() + ",\n"
+                + "       \"engineConfig\" : {\n"
+                + "         \"facets\" : [ ],\n"
+                + "         \"mode\" : \"row-based\"\n"
+                + "       },\n"
+                + "       \"fieldLengths\" : [ 1, 2 ],\n"
+                + "       \"guessCellType\" : false,\n"
+                + "       \"mode\" : \"lengths\",\n"
+                + "       \"op\" : \"core/column-split\",\n"
+                + "       \"removeOriginalColumn\" : false\n"
+                + "     }");
+    }
+
+    @Test
+    public void testRenameSeparator() {
+        ColumnSplitOperation SUT = new ColumnSplitOperation(EngineConfig.defaultRowBased(), "foo", true, true, ",",
+                false, 2);
+
+        ColumnSplitOperation renamed = SUT.renameColumns(Map.of("foo", "bar"));
+        TestUtils.isSerializedTo(renamed, "{\n"
+                + "       \"columnName\" : \"bar\",\n"
+                + "       \"description\" : " + new TextNode(OperationDescription.column_split_separator_brief("bar")).toString() + ",\n"
+                + "       \"engineConfig\" : {\n"
+                + "         \"facets\" : [ ],\n"
+                + "         \"mode\" : \"row-based\"\n"
+                + "       },\n"
+                + "       \"guessCellType\" : true,\n"
+                + "       \"maxColumns\": 2,\n"
+                + "       \"regex\": false,\n"
+                + "       \"mode\" : \"separator\",\n"
+                + "       \"separator\": \",\",\n"
+                + "       \"op\" : \"core/column-split\",\n"
+                + "       \"removeOriginalColumn\" : true\n"
+                + "     }");
     }
 }


### PR DESCRIPTION
This adds support for updating the column names referenced in operations that are classified under the `com.google.refine.operations.column` package, following up on #7132.