### PR TITLE
operations: Renaming support for c.g.r.o.row

### DIFF
--- a/main/src/com/google/refine/operations/row/RowAdditionOperation.java
+++ b/main/src/com/google/refine/operations/row/RowAdditionOperation.java
@@ -28,6 +28,7 @@
 package com.google.refine.operations.row;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -79,6 +80,11 @@ public class RowAdditionOperation extends AbstractOperation {
     @JsonIgnore
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.empty());
+    }
+
+    @Override
+    public RowAdditionOperation renameColumns(Map<String, String> newColumnNames) {
+        return this;
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowDuplicatesRemovalOperation.java
+++ b/main/src/com/google/refine/operations/row/RowDuplicatesRemovalOperation.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -70,6 +71,15 @@ public class RowDuplicatesRemovalOperation extends EngineDependentOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return OperationDescription.row_remove_duplicates_brief();
+    }
+
+    @Override
+    public RowDuplicatesRemovalOperation renameColumns(Map<String, String> newColumnNames) {
+        return new RowDuplicatesRemovalOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                _criteria.stream()
+                        .map(criterion -> newColumnNames.getOrDefault(criterion, criterion))
+                        .collect(Collectors.toList()));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowFlagOperation.java
+++ b/main/src/com/google/refine/operations/row/RowFlagOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.row;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -87,6 +88,13 @@ public class RowFlagOperation extends EngineDependentOperation {
     @JsonIgnore
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.empty());
+    }
+
+    @Override
+    public RowFlagOperation renameColumns(Map<String, String> newColumnNames) {
+        return new RowFlagOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                _flagged);
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowKeepMatchedOperation.java
+++ b/main/src/com/google/refine/operations/row/RowKeepMatchedOperation.java
@@ -7,6 +7,7 @@ import static com.google.refine.operations.OperationDescription.row_keep_matchin
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -38,6 +39,11 @@ public class RowKeepMatchedOperation extends EngineDependentOperation {
 
     protected String createDescription(Project project, int rowCount) {
         return row_keep_matching_rows_desc(rowCount);
+    }
+
+    @Override
+    public RowKeepMatchedOperation renameColumns(Map<String, String> newColumnNames) {
+        return new RowKeepMatchedOperation(_engineConfig.renameColumnDependencies(newColumnNames));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowRemovalOperation.java
+++ b/main/src/com/google/refine/operations/row/RowRemovalOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.row;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -75,6 +76,11 @@ public class RowRemovalOperation extends EngineDependentOperation {
     @JsonIgnore
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.empty());
+    }
+
+    @Override
+    public RowRemovalOperation renameColumns(Map<String, String> newColumnNames) {
+        return new RowRemovalOperation(_engineConfig.renameColumnDependencies(newColumnNames));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowReorderOperation.java
+++ b/main/src/com/google/refine/operations/row/RowReorderOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.row;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -89,6 +90,11 @@ public class RowReorderOperation extends AbstractOperation {
     @JsonIgnore
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.empty());
+    }
+
+    @Override
+    public RowReorderOperation renameColumns(Map<String, String> newColumnNames) {
+        return new RowReorderOperation(_mode, _sorting.renameColumns(newColumnNames));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowStarOperation.java
+++ b/main/src/com/google/refine/operations/row/RowStarOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.row;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -90,6 +91,11 @@ public class RowStarOperation extends EngineDependentOperation {
     }
 
     @Override
+    public RowStarOperation renameColumns(Map<String, String> newColumnNames) {
+        return new RowStarOperation(_engineConfig.renameColumnDependencies(newColumnNames), _starred);
+    }
+
+    @Override
     protected HistoryEntry createHistoryEntry(Project project, long historyEntryID) throws Exception {
         Engine engine = createEngine(project);
 
@@ -138,4 +144,5 @@ public class RowStarOperation extends EngineDependentOperation {
             }
         }.init(changes);
     }
+
 }

--- a/main/tests/server/src/com/google/refine/operations/row/RowAdditionOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowAdditionOperationTests.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertEquals;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -99,6 +100,13 @@ public class RowAdditionOperationTests extends RefineTest {
     public void testColumnDependencies() {
         assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
         assertEquals(op.getColumnDependencies(), Optional.of(Set.of()));
+    }
+
+    @Test
+    public void testRename() {
+        RowAdditionOperation renamed = op.renameColumns(Map.of("foo", "bar"));
+
+        TestUtils.isSerializedTo(renamed, json);
     }
 
 }

--- a/main/tests/server/src/com/google/refine/operations/row/RowDuplicatesRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowDuplicatesRemovalOperationTests.java
@@ -5,6 +5,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -146,6 +147,15 @@ public class RowDuplicatesRemovalOperationTests extends RefineTest {
                 });
 
         assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testRenameColumns() {
+        RowDuplicatesRemovalOperation SUT = new RowDuplicatesRemovalOperation(EngineConfig.defaultRowBased(), List.of("foo", "bar"));
+
+        RowDuplicatesRemovalOperation renamed = SUT.renameColumns(Map.of("foo", "foo2"));
+
+        assertEquals(renamed._criteria, List.of("foo2", "bar"));
     }
 
 }

--- a/main/tests/server/src/com/google/refine/operations/row/RowFlagOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowFlagOperationTests.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertEquals;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -114,6 +115,43 @@ public class RowFlagOperationTests extends RefineTest {
     public void testColumnDependencies() {
         assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
         assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("hello")));
+    }
+
+    @Test
+    public void testRenameColumns() {
+        String expectedJson = "{\n"
+                + "       \"description\" : " + new TextNode(OperationDescription.row_flag_brief()).toString() + ",\n"
+                + "       \"engineConfig\" : {\n"
+                + "         \"facets\" : [ {\n"
+                + "           \"columnName\" : \"world\",\n"
+                + "           \"expression\" : \"grel:value\",\n"
+                + "           \"invert\" : false,\n"
+                + "           \"name\" : \"world\",\n"
+                + "           \"omitBlank\" : false,\n"
+                + "           \"omitError\" : false,\n"
+                + "           \"selectBlank\" : false,\n"
+                + "           \"selectError\" : false,\n"
+                + "           \"selection\" : [ {\n"
+                + "             \"v\" : {\n"
+                + "               \"l\" : \"h\",\n"
+                + "               \"v\" : \"h\"\n"
+                + "             }\n"
+                + "           }, {\n"
+                + "             \"v\" : {\n"
+                + "               \"l\" : \"d\",\n"
+                + "               \"v\" : \"d\"\n"
+                + "             }\n"
+                + "           } ],\n"
+                + "           \"type\" : \"list\"\n"
+                + "         } ],\n"
+                + "         \"mode\" : \"row-based\"\n"
+                + "       },\n"
+                + "       \"flagged\" : true,\n"
+                + "       \"op\" : \"core/row-flag\"\n"
+                + "     }";
+        RowFlagOperation renamed = operation.renameColumns(Map.of("hello", "world"));
+
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/row/RowKeepMatchedOperationTest.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowKeepMatchedOperationTest.java
@@ -6,8 +6,10 @@ import static com.google.refine.operations.OperationDescription.row_keep_matchin
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Properties;
 
+import com.fasterxml.jackson.databind.node.TextNode;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -198,5 +200,46 @@ public class RowKeepMatchedOperationTest extends RefineTest {
                 });
 
         assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testRename() {
+        facet.selection = Arrays.asList(
+                new DecoratedValue("h", "h"),
+                new DecoratedValue("i", "i"));
+        EngineConfig engineConfig = new EngineConfig(Arrays.asList(facet), Engine.Mode.RecordBased);
+        RowKeepMatchedOperation operation = new RowKeepMatchedOperation(engineConfig);
+
+        RowKeepMatchedOperation renamed = operation.renameColumns(Map.of("hello", "hello2"));
+
+        String json = "{"
+                + "\"op\":\"core/row-keep-matched\","
+                + "\"engineConfig\":{\"facets\":["
+                + "  {\n"
+                + "    \"columnName\" : \"hello2\",\n"
+                + "    \"expression\" : \"grel:value\",\n"
+                + "    \"invert\" : false,\n"
+                + "    \"name\" : \"hello2\",\n"
+                + "    \"omitBlank\" : false,\n"
+                + "    \"omitError\" : false,\n"
+                + "    \"selectBlank\" : false,\n"
+                + "    \"selectError\" : false,\n"
+                + "    \"selection\" : [ {\n"
+                + "       \"v\" : {\n"
+                + "          \"l\" : \"h\",\n"
+                + "          \"v\" : \"h\"\n"
+                + "       }\n"
+                + "    }, {\n"
+                + "       \"v\" : {\n"
+                + "          \"l\" : \"i\",\n"
+                + "          \"v\" : \"i\"\n"
+                + "       }\n"
+                + "    } ],\n"
+                + "    \"type\" : \"list\"\n"
+                + "  }"
+                + "],\"mode\":\"record-based\"},"
+                + "\"description\":" + new TextNode(row_keep_matching_brief()).toString()
+                + "}";
+        TestUtils.isSerializedTo(renamed, json);
     }
 }

--- a/main/tests/server/src/com/google/refine/operations/row/RowRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowRemovalOperationTests.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertEquals;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -245,4 +246,43 @@ public class RowRemovalOperationTests extends RefineTest {
         assertProjectEquals(project, expected);
     }
 
+    @Test
+    public void testRename() {
+        facet.selection = Arrays.asList(
+                new DecoratedValue("h", "h"),
+                new DecoratedValue("i", "i"));
+        EngineConfig engineConfig = new EngineConfig(Arrays.asList(facet), Engine.Mode.RecordBased);
+        RowRemovalOperation operation = new RowRemovalOperation(engineConfig);
+
+        RowRemovalOperation renamed = operation.renameColumns(Map.of("hello", "hello2"));
+        String json = "{"
+                + "\"op\":\"core/row-removal\","
+                + "\"engineConfig\":{\"facets\":["
+                + "  {\n"
+                + "    \"columnName\" : \"hello2\",\n"
+                + "    \"expression\" : \"grel:value\",\n"
+                + "    \"invert\" : false,\n"
+                + "    \"name\" : \"hello2\",\n"
+                + "    \"omitBlank\" : false,\n"
+                + "    \"omitError\" : false,\n"
+                + "    \"selectBlank\" : false,\n"
+                + "    \"selectError\" : false,\n"
+                + "    \"selection\" : [ {\n"
+                + "       \"v\" : {\n"
+                + "          \"l\" : \"h\",\n"
+                + "          \"v\" : \"h\"\n"
+                + "       }\n"
+                + "    }, {\n"
+                + "       \"v\" : {\n"
+                + "          \"l\" : \"i\",\n"
+                + "          \"v\" : \"i\"\n"
+                + "       }\n"
+                + "    } ],\n"
+                + "    \"type\" : \"list\"\n"
+                + "  }"
+                + "],\"mode\":\"record-based\"},"
+                + "\"description\":" + new TextNode(OperationDescription.row_removal_brief()).toString()
+                + "}";
+        TestUtils.isSerializedTo(renamed, json);
+    }
 }

--- a/main/tests/server/src/com/google/refine/operations/row/RowReorderOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowReorderOperationTests.java
@@ -30,6 +30,7 @@ package com.google.refine.operations.row;
 import static org.testng.Assert.assertEquals;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -55,6 +56,23 @@ import com.google.refine.util.TestUtils;
 public class RowReorderOperationTests extends RefineTest {
 
     Project project = null;
+
+    String json = "  {\n" +
+            "    \"op\": \"core/row-reorder\",\n" +
+            "    \"description\": " + new TextNode(OperationDescription.row_reorder_brief()).toString() + ",\n" +
+            "    \"mode\": \"record-based\",\n" +
+            "    \"sorting\": {\n" +
+            "      \"criteria\": [\n" +
+            "        {\n" +
+            "          \"errorPosition\": 1,\n" +
+            "          \"valueType\": \"number\",\n" +
+            "          \"column\": \"start_year\",\n" +
+            "          \"blankPosition\": 2,\n" +
+            "          \"reverse\": false\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  }";
 
     @BeforeSuite
     public void registerOperation() {
@@ -162,7 +180,16 @@ public class RowReorderOperationTests extends RefineTest {
 
     @Test
     public void serializeRowReorderOperation() throws Exception {
-        String json = "  {\n" +
+        TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, RowReorderOperation.class), json);
+    }
+
+    @Test
+    public void testRenameColumns() throws Exception {
+        RowReorderOperation SUT = ParsingUtilities.mapper.readValue(json, RowReorderOperation.class);
+
+        RowReorderOperation renamed = SUT.renameColumns(Map.of("start_year", "new_name"));
+
+        String json = "{\n" +
                 "    \"op\": \"core/row-reorder\",\n" +
                 "    \"description\": " + new TextNode(OperationDescription.row_reorder_brief()).toString() + ",\n" +
                 "    \"mode\": \"record-based\",\n" +
@@ -171,14 +198,14 @@ public class RowReorderOperationTests extends RefineTest {
                 "        {\n" +
                 "          \"errorPosition\": 1,\n" +
                 "          \"valueType\": \"number\",\n" +
-                "          \"column\": \"start_year\",\n" +
+                "          \"column\": \"new_name\",\n" +
                 "          \"blankPosition\": 2,\n" +
                 "          \"reverse\": false\n" +
                 "        }\n" +
                 "      ]\n" +
                 "    }\n" +
                 "  }";
-        TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, RowReorderOperation.class), json);
+        TestUtils.isSerializedTo(renamed, json);
     }
 
 }

--- a/main/tests/server/src/com/google/refine/operations/row/RowStarOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowStarOperationTests.java
@@ -32,6 +32,7 @@ import static org.testng.Assert.assertEquals;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -114,6 +115,43 @@ public class RowStarOperationTests extends RefineTest {
     public void testColumnDependencies() {
         assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
         assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("hello")));
+    }
+
+    @Test
+    public void testRenameColumns() {
+        String expectedJson = "{\n"
+                + "       \"description\" : " + new TextNode(OperationDescription.row_star_brief()).toString() + ",\n"
+                + "       \"engineConfig\" : {\n"
+                + "         \"facets\" : [ {\n"
+                + "           \"columnName\" : \"world\",\n"
+                + "           \"expression\" : \"grel:value\",\n"
+                + "           \"invert\" : false,\n"
+                + "           \"name\" : \"world\",\n"
+                + "           \"omitBlank\" : false,\n"
+                + "           \"omitError\" : false,\n"
+                + "           \"selectBlank\" : false,\n"
+                + "           \"selectError\" : false,\n"
+                + "           \"selection\" : [ {\n"
+                + "             \"v\" : {\n"
+                + "               \"l\" : \"h\",\n"
+                + "               \"v\" : \"h\"\n"
+                + "             }\n"
+                + "           }, {\n"
+                + "             \"v\" : {\n"
+                + "               \"l\" : \"d\",\n"
+                + "               \"v\" : \"d\"\n"
+                + "             }\n"
+                + "           } ],\n"
+                + "           \"type\" : \"list\"\n"
+                + "         } ],\n"
+                + "         \"mode\" : \"row-based\"\n"
+                + "       },\n"
+                + "       \"starred\" : true,\n"
+                + "       \"op\" : \"core/row-star\"\n"
+                + "     }";
+        RowStarOperation renamed = operation.renameColumns(Map.of("hello", "world"));
+
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/modules/core/src/main/java/com/google/refine/sorting/BooleanCriterion.java
+++ b/modules/core/src/main/java/com/google/refine/sorting/BooleanCriterion.java
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.sorting;
 
+import java.util.Map;
+
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.ExpressionUtils;
 
@@ -68,5 +70,15 @@ public class BooleanCriterion extends Criterion {
     @Override
     public String getValueType() {
         return "boolean";
+    }
+
+    @Override
+    public BooleanCriterion renameColumns(Map<String, String> newColumnNames) {
+        BooleanCriterion adapted = new BooleanCriterion();
+        adapted.blankPosition = blankPosition;
+        adapted.errorPosition = errorPosition;
+        adapted.reverse = reverse;
+        adapted.columnName = newColumnNames.getOrDefault(columnName, columnName);
+        return adapted;
     }
 }

--- a/modules/core/src/main/java/com/google/refine/sorting/Criterion.java
+++ b/modules/core/src/main/java/com/google/refine/sorting/Criterion.java
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.sorting;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -83,6 +85,15 @@ abstract public class Criterion {
         }
         return cellIndex;
     }
+
+    /**
+     * Adapt the criterion to column renames, without modifying this instance.
+     * 
+     * @param newColumnNames
+     *            a map from old to new column names
+     * @return an adapted criterion
+     */
+    public abstract Criterion renameColumns(Map<String, String> newColumnNames);
 
     // TODO: We'd like things to be more strongly typed a la the following, but
     // it's too involved to change right now

--- a/modules/core/src/main/java/com/google/refine/sorting/DateCriterion.java
+++ b/modules/core/src/main/java/com/google/refine/sorting/DateCriterion.java
@@ -35,6 +35,7 @@ package com.google.refine.sorting;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.util.Map;
 
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.ExpressionUtils;
@@ -69,5 +70,15 @@ public class DateCriterion extends Criterion {
     @Override
     public String getValueType() {
         return "date";
+    }
+
+    @Override
+    public DateCriterion renameColumns(Map<String, String> newColumnNames) {
+        DateCriterion adapted = new DateCriterion();
+        adapted.blankPosition = blankPosition;
+        adapted.errorPosition = errorPosition;
+        adapted.reverse = reverse;
+        adapted.columnName = newColumnNames.getOrDefault(columnName, columnName);
+        return adapted;
     }
 }

--- a/modules/core/src/main/java/com/google/refine/sorting/NumberCriterion.java
+++ b/modules/core/src/main/java/com/google/refine/sorting/NumberCriterion.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.sorting;
 
 import java.time.OffsetDateTime;
+import java.util.Map;
 
 import com.google.refine.expr.EvalError;
 import com.google.refine.expr.ExpressionUtils;
@@ -82,5 +83,15 @@ public class NumberCriterion extends Criterion {
     @Override
     public String getValueType() {
         return "number";
+    }
+
+    @Override
+    public NumberCriterion renameColumns(Map<String, String> newColumnNames) {
+        NumberCriterion adapted = new NumberCriterion();
+        adapted.blankPosition = blankPosition;
+        adapted.errorPosition = errorPosition;
+        adapted.reverse = reverse;
+        adapted.columnName = newColumnNames.getOrDefault(columnName, columnName);
+        return adapted;
     }
 }

--- a/modules/core/src/main/java/com/google/refine/sorting/SortingConfig.java
+++ b/modules/core/src/main/java/com/google/refine/sorting/SortingConfig.java
@@ -28,6 +28,9 @@
 package com.google.refine.sorting;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -57,5 +60,19 @@ public final class SortingConfig {
 
     public static SortingConfig reconstruct(String obj) throws IOException {
         return ParsingUtilities.mapper.readValue(obj, SortingConfig.class);
+    }
+
+    /**
+     * Adapt the sorting configuration to column renames, without modifying this instance.
+     * 
+     * @param newColumnNames
+     *            a map from old to new column names
+     * @return an adapted sorting config
+     */
+    public SortingConfig renameColumns(Map<String, String> newColumnNames) {
+        List<Criterion> renamedCriteria = List.<Criterion> of(_criteria).stream()
+                .map(criterion -> criterion.renameColumns(newColumnNames))
+                .collect(Collectors.toList());
+        return new SortingConfig(renamedCriteria.toArray(new Criterion[renamedCriteria.size()]));
     }
 }

--- a/modules/core/src/main/java/com/google/refine/sorting/StringCriterion.java
+++ b/modules/core/src/main/java/com/google/refine/sorting/StringCriterion.java
@@ -35,6 +35,7 @@ package com.google.refine.sorting;
 
 import java.text.CollationKey;
 import java.text.Collator;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -78,5 +79,16 @@ public class StringCriterion extends Criterion {
     @Override
     public String getValueType() {
         return "string";
+    }
+
+    @Override
+    public StringCriterion renameColumns(Map<String, String> newColumnNames) {
+        StringCriterion adapted = new StringCriterion();
+        adapted.caseSensitive = caseSensitive;
+        adapted.blankPosition = blankPosition;
+        adapted.errorPosition = errorPosition;
+        adapted.reverse = reverse;
+        adapted.columnName = newColumnNames.getOrDefault(columnName, columnName);
+        return adapted;
     }
 }

--- a/modules/core/src/test/java/com/google/refine/sorting/BooleanCriterionTest.java
+++ b/modules/core/src/test/java/com/google/refine/sorting/BooleanCriterionTest.java
@@ -28,6 +28,7 @@
 package com.google.refine.sorting;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -36,15 +37,29 @@ import com.google.refine.util.TestUtils;
 
 public class BooleanCriterionTest {
 
+    String json = "{\n" +
+            "  \"errorPosition\": 1,\n" +
+            "  \"valueType\": \"boolean\",\n" +
+            "  \"column\": \"start_year\",\n" +
+            "  \"blankPosition\": 2,\n" +
+            "  \"reverse\": false\n" +
+            "}\n";
+
     @Test
     public void serializeBooleanCriterion() throws IOException {
-        String json = "        {\n" +
-                "          \"errorPosition\": 1,\n" +
-                "          \"valueType\": \"boolean\",\n" +
-                "          \"column\": \"start_year\",\n" +
-                "          \"blankPosition\": 2,\n" +
-                "          \"reverse\": false\n" +
-                "        }\n";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, Criterion.class), json);
+    }
+
+    @Test
+    public void testRenameColumn() throws Exception {
+        String renamedJson = "{\n" +
+                "  \"errorPosition\": 1,\n" +
+                "  \"valueType\": \"boolean\",\n" +
+                "  \"column\": \"start\",\n" +
+                "  \"blankPosition\": 2,\n" +
+                "  \"reverse\": false\n" +
+                "}\n";
+        Criterion renamed = ParsingUtilities.mapper.readValue(json, Criterion.class).renameColumns(Map.of("start_year", "start"));
+        TestUtils.isSerializedTo(renamed, renamedJson);
     }
 }

--- a/modules/core/src/test/java/com/google/refine/sorting/DateCriterionTest.java
+++ b/modules/core/src/test/java/com/google/refine/sorting/DateCriterionTest.java
@@ -28,6 +28,7 @@
 package com.google.refine.sorting;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -36,15 +37,29 @@ import com.google.refine.util.TestUtils;
 
 public class DateCriterionTest {
 
+    String json = "{\n" +
+            "  \"errorPosition\": 2,\n" +
+            "  \"valueType\": \"date\",\n" +
+            "  \"column\": \"start_year\",\n" +
+            "  \"blankPosition\": -1,\n" +
+            "  \"reverse\": true\n" +
+            "}\n";
+
     @Test
     public void serializeDateCriterion() throws IOException {
-        String json = "        {\n" +
-                "          \"errorPosition\": 2,\n" +
-                "          \"valueType\": \"date\",\n" +
-                "          \"column\": \"start_year\",\n" +
-                "          \"blankPosition\": -1,\n" +
-                "          \"reverse\": true\n" +
-                "        }\n";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, Criterion.class), json);
+    }
+
+    @Test
+    public void testRenameColumn() throws Exception {
+        String renamedJson = "{\n" +
+                "  \"errorPosition\": 2,\n" +
+                "  \"valueType\": \"date\",\n" +
+                "  \"column\": \"start\",\n" +
+                "  \"blankPosition\": -1,\n" +
+                "  \"reverse\": true\n" +
+                "}\n";
+        Criterion renamed = ParsingUtilities.mapper.readValue(json, Criterion.class).renameColumns(Map.of("start_year", "start"));
+        TestUtils.isSerializedTo(renamed, renamedJson);
     }
 }

--- a/modules/core/src/test/java/com/google/refine/sorting/NumberCriterionTest.java
+++ b/modules/core/src/test/java/com/google/refine/sorting/NumberCriterionTest.java
@@ -28,6 +28,7 @@
 package com.google.refine.sorting;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -36,15 +37,29 @@ import com.google.refine.util.TestUtils;
 
 public class NumberCriterionTest {
 
+    String json = "{\n" +
+            "  \"errorPosition\": 2,\n" +
+            "  \"valueType\": \"number\",\n" +
+            "  \"column\": \"start_year\",\n" +
+            "  \"blankPosition\": 1,\n" +
+            "  \"reverse\": true\n" +
+            "}\n";
+
     @Test
     public void serializeNumberCriterion() throws IOException {
-        String json = "        {\n" +
-                "          \"errorPosition\": 2,\n" +
-                "          \"valueType\": \"number\",\n" +
-                "          \"column\": \"start_year\",\n" +
-                "          \"blankPosition\": 1,\n" +
-                "          \"reverse\": true\n" +
-                "        }\n";
         TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, Criterion.class), json);
+    }
+
+    @Test
+    public void testRenameColumn() throws Exception {
+        String renamedJson = "{\n" +
+                "  \"errorPosition\": 2,\n" +
+                "  \"valueType\": \"number\",\n" +
+                "  \"column\": \"start\",\n" +
+                "  \"blankPosition\": 1,\n" +
+                "  \"reverse\": true\n" +
+                "}\n";
+        Criterion renamed = ParsingUtilities.mapper.readValue(json, Criterion.class).renameColumns(Map.of("start_year", "start"));
+        TestUtils.isSerializedTo(renamed, renamedJson);
     }
 }

--- a/modules/core/src/test/java/com/google/refine/sorting/SortingConfigTests.java
+++ b/modules/core/src/test/java/com/google/refine/sorting/SortingConfigTests.java
@@ -28,6 +28,7 @@
 package com.google.refine.sorting;
 
 import java.io.IOException;
+import java.util.Map;
 
 import org.testng.annotations.Test;
 
@@ -35,19 +36,40 @@ import com.google.refine.util.TestUtils;
 
 public class SortingConfigTests {
 
+    String json = "{\n" +
+            "      \"criteria\": [\n" +
+            "        {\n" +
+            "          \"errorPosition\": 1,\n" +
+            "          \"valueType\": \"number\",\n" +
+            "          \"column\": \"start_year\",\n" +
+            "          \"blankPosition\": 2,\n" +
+            "          \"reverse\": false\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }";
+
     @Test
     public void serializeSortingConfig() throws IOException {
-        String json = "{\n" +
+        TestUtils.isSerializedTo(SortingConfig.reconstruct(json), json);
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        SortingConfig SUT = SortingConfig.reconstruct(json);
+
+        SortingConfig renamed = SUT.renameColumns(Map.of("start_year", "new_name"));
+
+        String jsonRenamed = "{\n" +
                 "      \"criteria\": [\n" +
                 "        {\n" +
                 "          \"errorPosition\": 1,\n" +
                 "          \"valueType\": \"number\",\n" +
-                "          \"column\": \"start_year\",\n" +
+                "          \"column\": \"new_name\",\n" +
                 "          \"blankPosition\": 2,\n" +
                 "          \"reverse\": false\n" +
                 "        }\n" +
                 "      ]\n" +
                 "    }";
-        TestUtils.isSerializedTo(SortingConfig.reconstruct(json), json);
+        TestUtils.isSerializedTo(renamed, jsonRenamed);
     }
 }

--- a/modules/core/src/test/java/com/google/refine/sorting/StringCriterionTest.java
+++ b/modules/core/src/test/java/com/google/refine/sorting/StringCriterionTest.java
@@ -1,0 +1,41 @@
+
+package com.google.refine.sorting;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import com.google.refine.util.ParsingUtilities;
+import com.google.refine.util.TestUtils;
+
+public class StringCriterionTest {
+
+    String json = "{\n" +
+            "  \"errorPosition\": 2,\n" +
+            "  \"valueType\": \"string\",\n" +
+            "  \"column\": \"start_year\",\n" +
+            "  \"blankPosition\": 1,\n" +
+            "  \"reverse\": true,\n" +
+            "  \"caseSensitive\": true\n" +
+            "}\n";
+
+    @Test
+    public void serializeNumberCriterion() throws IOException {
+        TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, Criterion.class), json);
+    }
+
+    @Test
+    public void testRenameColumn() throws Exception {
+        String renamedJson = "{\n" +
+                "  \"errorPosition\": 2,\n" +
+                "  \"valueType\": \"string\",\n" +
+                "  \"column\": \"start\",\n" +
+                "  \"blankPosition\": 1,\n" +
+                "  \"reverse\": true,\n" +
+                "  \"caseSensitive\": true\n" +
+                "}\n";
+        Criterion renamed = ParsingUtilities.mapper.readValue(json, Criterion.class).renameColumns(Map.of("start_year", "start"));
+        TestUtils.isSerializedTo(renamed, renamedJson);
+    }
+}


### PR DESCRIPTION
This adds support for updating the column names referenced in operations that are classified under the `com.google.refine.operations.row` package, following up on #7132.