### PR TITLE
operations: Renaming support for c.g.r.o.recon

### DIFF
--- a/main/src/com/google/refine/operations/recon/ReconClearSimilarCellsOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconClearSimilarCellsOperation.java
@@ -34,6 +34,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.operations.recon;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -96,6 +97,14 @@ public class ReconClearSimilarCellsOperation extends EngineDependentMassCellOper
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
+    }
+
+    @Override
+    public ReconClearSimilarCellsOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ReconClearSimilarCellsOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_columnName, _columnName),
+                _similarValue);
     }
 
     @Override

--- a/main/src/com/google/refine/operations/recon/ReconCopyAcrossColumnsOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconCopyAcrossColumnsOperation.java
@@ -34,12 +34,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.operations.recon;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -113,6 +115,19 @@ public class ReconCopyAcrossColumnsOperation extends EngineDependentOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(new ColumnsDiff(List.of(), Set.of(), Set.of(_toColumnNames)));
+    }
+
+    @Override
+    public ReconCopyAcrossColumnsOperation renameColumns(Map<String, String> newColumnNames) {
+        List<String> translatedToColumnNames = Arrays.asList(_toColumnNames).stream()
+                .map(name -> newColumnNames.getOrDefault(name, name))
+                .collect(Collectors.toList());
+        return new ReconCopyAcrossColumnsOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_fromColumnName, _fromColumnName),
+                translatedToColumnNames.toArray(new String[translatedToColumnNames.size()]),
+                _judgments,
+                _applyToJudgedCells);
     }
 
     @Override

--- a/main/src/com/google/refine/operations/recon/ReconDiscardJudgmentsOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconDiscardJudgmentsOperation.java
@@ -107,6 +107,14 @@ public class ReconDiscardJudgmentsOperation extends EngineDependentMassCellOpera
     }
 
     @Override
+    public ReconDiscardJudgmentsOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ReconDiscardJudgmentsOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_columnName, _columnName),
+                _clearData);
+    }
+
+    @Override
     protected RowVisitor createRowVisitor(Project project, List<CellChange> cellChanges, long historyEntryID) throws Exception {
         Column column = project.columnModel.getColumnByName(_columnName);
 

--- a/main/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsOperation.java
@@ -154,6 +154,17 @@ public class ReconJudgeSimilarCellsOperation extends EngineDependentMassCellOper
     }
 
     @Override
+    public ReconJudgeSimilarCellsOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ReconJudgeSimilarCellsOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_columnName, _columnName),
+                _similarValue,
+                _judgment,
+                _match,
+                _shareNewTopics);
+    }
+
+    @Override
     protected RowVisitor createRowVisitor(Project project, List<CellChange> cellChanges, long historyEntryID) throws Exception {
         Column column = project.columnModel.getColumnByName(_columnName);
         ReconConfig reconConfig = column.getReconConfig();
@@ -264,4 +275,5 @@ public class ReconJudgeSimilarCellsOperation extends EngineDependentMassCellOper
                 column.getReconConfig(),
                 null);
     }
+
 }

--- a/main/src/com/google/refine/operations/recon/ReconMarkNewTopicsOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconMarkNewTopicsOperation.java
@@ -135,6 +135,17 @@ public class ReconMarkNewTopicsOperation extends EngineDependentMassCellOperatio
         return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
+    @Override
+    public ReconMarkNewTopicsOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ReconMarkNewTopicsOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_columnName, _columnName),
+                _shareNewTopics,
+                _service,
+                _identifierSpace,
+                _schemaSpace);
+    }
+
     protected ReconConfig getNewReconConfig(Column column) {
         return column.getReconConfig() != null ? column.getReconConfig()
                 : new StandardReconConfig(
@@ -225,4 +236,5 @@ public class ReconMarkNewTopicsOperation extends EngineDependentMassCellOperatio
                 getNewReconConfig(column),
                 null);
     }
+
 }

--- a/main/src/com/google/refine/operations/recon/ReconMatchBestCandidatesOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconMatchBestCandidatesOperation.java
@@ -95,6 +95,13 @@ public class ReconMatchBestCandidatesOperation extends EngineDependentMassCellOp
     }
 
     @Override
+    public ReconMatchBestCandidatesOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ReconMatchBestCandidatesOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_columnName, _columnName));
+    }
+
+    @Override
     protected RowVisitor createRowVisitor(Project project, List<CellChange> cellChanges, long historyEntryID) throws Exception {
         Column column = project.columnModel.getColumnByName(_columnName);
 

--- a/main/src/com/google/refine/operations/recon/ReconMatchSpecificTopicOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconMatchSpecificTopicOperation.java
@@ -128,6 +128,16 @@ public class ReconMatchSpecificTopicOperation extends EngineDependentMassCellOpe
     }
 
     @Override
+    public ReconMatchSpecificTopicOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ReconMatchSpecificTopicOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_columnName, _columnName),
+                match,
+                identifierSpace,
+                schemaSpace);
+    }
+
+    @Override
     protected RowVisitor createRowVisitor(Project project, List<CellChange> cellChanges, long historyEntryID) throws Exception {
         Column column = project.columnModel.getColumnByName(_columnName);
         ReconCandidate candidate = match.getCandidate();
@@ -202,4 +212,5 @@ public class ReconMatchSpecificTopicOperation extends EngineDependentMassCellOpe
                 column.getReconConfig(),
                 null);
     }
+
 }

--- a/main/src/com/google/refine/operations/recon/ReconOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconOperation.java
@@ -129,6 +129,14 @@ public class ReconOperation extends EngineDependentOperation {
         return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
     }
 
+    @Override
+    public ReconOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ReconOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_columnName, _columnName),
+                _reconConfig.renameColumns(newColumnNames));
+    }
+
     static protected class ReconEntry {
 
         final public int rowIndex;

--- a/main/src/com/google/refine/operations/recon/ReconUseValuesAsIdentifiersOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconUseValuesAsIdentifiersOperation.java
@@ -29,6 +29,7 @@ package com.google.refine.operations.recon;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -93,6 +94,16 @@ public class ReconUseValuesAsIdentifiersOperation extends EngineDependentMassCel
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
+    }
+
+    @Override
+    public ReconUseValuesAsIdentifiersOperation renameColumns(Map<String, String> newColumnNames) {
+        return new ReconUseValuesAsIdentifiersOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_columnName, _columnName),
+                service,
+                identifierSpace,
+                schemaSpace);
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconClearSimilarCellsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconClearSimilarCellsOperationTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -88,6 +89,21 @@ public class ReconClearSimilarCellsOperationTests extends RefineTest {
         AbstractOperation op = ParsingUtilities.mapper.readValue(json, ReconClearSimilarCellsOperation.class);
         assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("my column")));
         assertEquals(op.getColumnDependencies(), Optional.of(Set.of("my column")));
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        ReconClearSimilarCellsOperation op = ParsingUtilities.mapper.readValue(json, ReconClearSimilarCellsOperation.class);
+
+        ReconClearSimilarCellsOperation renamed = op.renameColumns(Map.of("my column", "your column"));
+
+        String expectedJson = "{\"op\":\"core/recon-clear-similar-cells\","
+                + "\"description\":"
+                + new TextNode(OperationDescription.recon_clear_similar_cells_brief("some value", "your column")).toString() + ","
+                + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":[]},"
+                + "\"columnName\":\"your column\","
+                + "\"similarValue\":\"some value\"}";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconCopyAcrossColumnsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconCopyAcrossColumnsOperationTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -114,6 +115,28 @@ public class ReconCopyAcrossColumnsOperationTests extends RefineTest {
                 });
 
         assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        AbstractOperation operation = new ReconCopyAcrossColumnsOperation(
+                new EngineConfig(Collections.emptyList(), Mode.RowBased),
+                "bar",
+                new String[] { "foo" },
+                new String[] { "matched", "none" },
+                true);
+
+        AbstractOperation renamed = operation.renameColumns(Map.of("bar", "bar2", "foo", "foo2", "none", "what?"));
+
+        String expectedJson = "{\"op\":\"core/recon-copy-across-columns\","
+                + "\"description\":"
+                + new TextNode(OperationDescription.recon_copy_across_columns_brief("bar2", "foo2")).toString() + ","
+                + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":[]},"
+                + "\"fromColumnName\":\"bar2\","
+                + "\"toColumnNames\":[\"foo2\"],"
+                + "\"judgments\":[\"matched\",\"none\"],"
+                + "\"applyToJudgedCells\":true}";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
 }

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconDiscardJudgmentsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconDiscardJudgmentsOperationTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -92,6 +93,26 @@ public class ReconDiscardJudgmentsOperationTests extends RefineTest {
         AbstractOperation op = ParsingUtilities.mapper.readValue(json, ReconDiscardJudgmentsOperation.class);
         assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("researcher")));
         assertEquals(op.getColumnDependencies(), Optional.of(Set.of("researcher")));
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        AbstractOperation op = ParsingUtilities.mapper.readValue(json, ReconDiscardJudgmentsOperation.class);
+
+        AbstractOperation renamed = op.renameColumns(Map.of("researcher", "employee"));
+
+        String expectedJson = "{\n" +
+                "    \"op\": \"core/recon-discard-judgments\",\n" +
+                "    \"description\": "
+                + new TextNode(OperationDescription.recon_discard_judgments_clear_data_brief("employee")).toString() + ",\n" +
+                "    \"engineConfig\": {\n" +
+                "      \"mode\": \"record-based\",\n" +
+                "      \"facets\": []\n" +
+                "    },\n" +
+                "    \"columnName\": \"employee\",\n" +
+                "    \"clearData\": true\n" +
+                "  }";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconJudgeSimilarCellsOperationTests.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.assertNull;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -135,6 +136,32 @@ public class ReconJudgeSimilarCellsOperationTests extends RefineTest {
                 null, true);
         assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("A")));
         assertEquals(op.getColumnDependencies(), Optional.of(Set.of("A")));
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        String json = "{\"op\":\"core/recon-judge-similar-cells\","
+                + "\"description\":" + new TextNode(OperationDescription.recon_judge_similar_cells_new_share_brief("foo", "A")).toString()
+                + ","
+                + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":[]},"
+                + "\"columnName\":\"A\","
+                + "\"similarValue\":\"foo\","
+                + "\"judgment\":\"new\","
+                + "\"shareNewTopics\":true}";
+
+        var SUT = ParsingUtilities.mapper.readValue(json, ReconJudgeSimilarCellsOperation.class);
+
+        ReconJudgeSimilarCellsOperation renamed = SUT.renameColumns(Map.of("A", "B"));
+
+        String expectedJson = "{\"op\":\"core/recon-judge-similar-cells\","
+                + "\"description\":" + new TextNode(OperationDescription.recon_judge_similar_cells_new_share_brief("foo", "B")).toString()
+                + ","
+                + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":[]},"
+                + "\"columnName\":\"B\","
+                + "\"similarValue\":\"foo\","
+                + "\"judgment\":\"new\","
+                + "\"shareNewTopics\":true}";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconMarkNewTopicsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconMarkNewTopicsOperationTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -93,6 +94,22 @@ public class ReconMarkNewTopicsOperationTests extends RefineTest {
         AbstractOperation op = ParsingUtilities.mapper.readValue(jsonWithoutService, ReconMarkNewTopicsOperation.class);
         assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("my column")));
         assertEquals(op.getColumnDependencies(), Optional.of(Set.of("my column")));
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        var SUT = ParsingUtilities.mapper.readValue(jsonWithoutService, ReconMarkNewTopicsOperation.class);
+
+        ReconMarkNewTopicsOperation renamed = SUT.renameColumns(Map.of("my column", "new name"));
+
+        String expectedJson = "{"
+                + "\"op\":\"core/recon-mark-new-topics\","
+                + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":[]},"
+                + "\"columnName\":\"new name\","
+                + "\"shareNewTopics\":true,"
+                + "\"description\":" + new TextNode(OperationDescription.recon_mark_new_topics_shared_brief("new name")).toString()
+                + "}";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconMatchBestCandidatesOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconMatchBestCandidatesOperationTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -105,6 +106,25 @@ public class ReconMatchBestCandidatesOperationTests extends RefineTest {
         ReconMatchBestCandidatesOperation op = ParsingUtilities.mapper.readValue(json, ReconMatchBestCandidatesOperation.class);
         assertEquals(op.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("organization_name")));
         assertEquals(op.getColumnDependencies(), Optional.of(Set.of("organization_name", "start_year")));
+    }
+
+    @Test
+    public void testRenameColumns() throws Exception {
+        var SUT = ParsingUtilities.mapper.readValue(json, ReconMatchBestCandidatesOperation.class);
+
+        ReconMatchBestCandidatesOperation renamed = SUT.renameColumns(Map.of("organization_name", "org", "start_year", "start"));
+
+        String expectedJson = "{"
+                + "\"op\":\"core/recon-match-best-candidates\","
+                + "\"description\":" + new TextNode(OperationDescription.recon_match_best_candidates_brief("org")).toString()
+                + ","
+                + "\"engineConfig\":{\"mode\":\"row-based\",\"facets\":["
+                + "       {\"selectNumeric\":true,\"expression\":\"grel:cell.recon.best.score\",\"selectBlank\":false,\"selectNonNumeric\":true,\"selectError\":true,\"name\":\"organization_name: best candidate's score\",\"from\":13,\"to\":101,\"type\":\"range\",\"columnName\":\"org\"},"
+                + "       {\"selectNonTime\":true,\"expression\":\"grel:toDate(value)\",\"selectBlank\":true,\"selectError\":true,\"selectTime\":true,\"name\":\"start\",\"from\":410242968000,\"to\":1262309184000,\"type\":\"timerange\",\"columnName\":\"start\"}"
+                + "]},"
+                + "\"columnName\":\"org\""
+                + "}";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconMatchSpecificTopicOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconMatchSpecificTopicOperationTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -108,6 +109,37 @@ public class ReconMatchSpecificTopicOperationTests extends RefineTest {
                 "http://identifier.space", "http://schema.space");
         assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("bar")));
         assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("bar")));
+    }
+
+    @Test
+    public void testRename() {
+        ReconItem reconItem = new ReconItem("hello", "world", new String[] { "human" });
+
+        var SUT = new ReconMatchSpecificTopicOperation(
+                new EngineConfig(Collections.emptyList(), Mode.RowBased),
+                "bar", reconItem,
+                "http://identifier.space", "http://schema.space");
+
+        ReconMatchSpecificTopicOperation renamed = SUT.renameColumns(Map.of("bar", "foo"));
+
+        String expectedJson = "{\n"
+                + "       \"columnName\" : \"foo\",\n"
+                + "       \"description\" : "
+                + new TextNode(OperationDescription.recon_match_specific_topic_brief("world", "hello", "foo")).toString() + ",\n"
+                + "       \"engineConfig\" : {\n"
+                + "         \"facets\" : [ ],\n"
+                + "         \"mode\" : \"row-based\"\n"
+                + "       },\n"
+                + "       \"identifierSpace\" : \"http://identifier.space\",\n"
+                + "       \"match\" : {\n"
+                + "         \"id\" : \"hello\",\n"
+                + "         \"name\" : \"world\",\n"
+                + "         \"types\" : [ \"human\" ]\n"
+                + "       },\n"
+                + "       \"op\" : \"core/recon-match-specific-topic-to-cells\",\n"
+                + "       \"schemaSpace\" : \"http://schema.space\"\n"
+                + "     }";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
@@ -42,6 +42,7 @@ import java.io.Serializable;
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -248,6 +249,45 @@ public class ReconOperationTests extends RefineTest {
         AbstractOperation operation = ParsingUtilities.mapper.readValue(jsonWithColumnDetails, ReconOperation.class);
         assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("researcher")));
         assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("researcher", "organization_country", "organization_id")));
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        ReconOperation SUT = ParsingUtilities.mapper.readValue(jsonWithColumnDetails, ReconOperation.class);
+
+        ReconOperation renamed = SUT.renameColumns(Map.of("organization_country", "country", "researcher", "employee"));
+
+        String expectedJson = "{\n"
+                + "       \"columnName\" : \"employee\",\n"
+                + "       \"config\" : {\n"
+                + "         \"autoMatch\" : true,\n"
+                + "         \"columnDetails\" : [ {\n"
+                + "           \"column\" : \"country\",\n"
+                + "           \"propertyID\" : \"P17/P297\",\n"
+                + "           \"propertyName\" : \"SPARQL: P17/P297\"\n"
+                + "         }, {\n"
+                + "           \"column\" : \"organization_id\",\n"
+                + "           \"propertyID\" : \"P3500|P2427\",\n"
+                + "           \"propertyName\" : \"SPARQL: P3500|P2427\"\n"
+                + "         } ],\n"
+                + "         \"identifierSpace\" : \"http://www.wikidata.org/entity/\",\n"
+                + "         \"limit\" : 0,\n"
+                + "         \"mode\" : \"standard-service\",\n"
+                + "         \"schemaSpace\" : \"http://www.wikidata.org/prop/direct/\",\n"
+                + "         \"service\" : \"https://tools.wmflabs.org/openrefine-wikidata/en/api\",\n"
+                + "         \"type\" : {\n"
+                + "           \"id\" : \"Q5\",\n"
+                + "           \"name\" : \"human\"\n"
+                + "         }\n"
+                + "       },\n"
+                + "       \"description\" : \"Reconcile cells in column employee to type Q5\",\n"
+                + "       \"engineConfig\" : {\n"
+                + "         \"facets\" : [ ],\n"
+                + "         \"mode\" : \"row-based\"\n"
+                + "       },\n"
+                + "       \"op\" : \"core/recon\"\n"
+                + "     }";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconUseValuesAsIdsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconUseValuesAsIdsOperationTests.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -75,6 +76,28 @@ public class ReconUseValuesAsIdsOperationTests extends RefineTest {
         AbstractOperation operation = ParsingUtilities.mapper.readValue(json, ReconUseValuesAsIdentifiersOperation.class);
         assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.modifySingleColumn("ids")));
         assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("ids")));
+    }
+
+    @Test
+    public void testRename() throws Exception {
+        ReconUseValuesAsIdentifiersOperation SUT = ParsingUtilities.mapper.readValue(json, ReconUseValuesAsIdentifiersOperation.class);
+
+        ReconUseValuesAsIdentifiersOperation renamed = SUT.renameColumns(Map.of("ids", "identifiers"));
+
+        String expectedJson = "{\n"
+                + "       \"columnName\" : \"identifiers\",\n"
+                + "       \"description\" : "
+                + new TextNode(OperationDescription.recon_use_values_as_identifiers_brief("identifiers")).toString() + ",\n"
+                + "       \"engineConfig\" : {\n"
+                + "         \"facets\" : [ ],\n"
+                + "         \"mode\" : \"row-based\"\n"
+                + "       },\n"
+                + "       \"identifierSpace\" : \"http://test.org/entities/\",\n"
+                + "       \"op\" : \"core/recon-use-values-as-identifiers\",\n"
+                + "       \"schemaSpace\" : \"http://test.org/schema/\",\n"
+                + "       \"service\" : \"http://localhost:8080/api\"\n"
+                + "     }";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/modules/core/src/main/java/com/google/refine/model/recon/ReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/ReconConfig.java
@@ -144,4 +144,14 @@ abstract public class ReconConfig {
     public Optional<Set<String>> getColumnDependencies() {
         return Optional.empty();
     }
+
+    /**
+     * Returns a copy of this recon config, with updated column names.
+     * 
+     * @param newColumnNames
+     *            a map from old to new column names
+     */
+    public ReconConfig renameColumns(Map<String, String> newColumnNames) {
+        return this;
+    }
 }

--- a/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
@@ -107,6 +107,14 @@ public class StandardReconConfig extends ReconConfig {
             this.propertyID = property == null ? propertyID : property.id;
         }
 
+        public ColumnDetail renameColumn(Map<String, String> newColumnNames) {
+            return new ColumnDetail(
+                    newColumnNames.getOrDefault(columnName, columnName),
+                    propertyName,
+                    propertyID,
+                    null);
+        }
+
         @Override
         public String toString() {
             try {
@@ -335,6 +343,23 @@ public class StandardReconConfig extends ReconConfig {
         return Optional.of(columnDetails.stream()
                 .map(columnDetail -> columnDetail.columnName)
                 .collect(Collectors.toSet()));
+    }
+
+    @Override
+    public StandardReconConfig renameColumns(Map<String, String> newColumnNames) {
+        List<ColumnDetail> translatedColumnDetails = columnDetails.stream()
+                .map(column -> column.renameColumn(newColumnNames))
+                .collect(Collectors.toList());
+        return new StandardReconConfig(
+                service,
+                identifierSpace,
+                schemaSpace,
+                typeID,
+                typeName,
+                autoMatch,
+                batchSize,
+                translatedColumnDetails,
+                limit);
     }
 
     public ReconJob createSimpleJob(String query) {
@@ -744,4 +769,5 @@ public class StandardReconConfig extends ReconConfig {
     public String getMode() {
         return "standard-service";
     }
+
 }


### PR DESCRIPTION
This adds support for updating the column names referenced in operations that are classified under the `com.google.refine.operations.recon` package, following up on #7132.