### PR TITLE
operations: Renaming support for c.g.r.o.cell

### DIFF
--- a/main/src/com/google/refine/operations/cell/KeyValueColumnizeOperation.java
+++ b/main/src/com/google/refine/operations/cell/KeyValueColumnizeOperation.java
@@ -117,6 +117,14 @@ public class KeyValueColumnizeOperation extends AbstractOperation {
     }
 
     @Override
+    public KeyValueColumnizeOperation renameColumns(Map<String, String> newColumnNames) {
+        return new KeyValueColumnizeOperation(
+                newColumnNames.getOrDefault(_keyColumnName, _keyColumnName),
+                newColumnNames.getOrDefault(_valueColumnName, _valueColumnName),
+                _noteColumnName == null ? null : newColumnNames.getOrDefault(_noteColumnName, _noteColumnName));
+    }
+
+    @Override
     protected HistoryEntry createHistoryEntry(Project project, long historyEntryID) throws Exception {
         int keyColumnIndex = project.columnModel.getColumnIndexByName(_keyColumnName);
         int valueColumnIndex = project.columnModel.getColumnIndexByName(_valueColumnName);

--- a/main/src/com/google/refine/operations/cell/MultiValuedCellJoinOperation.java
+++ b/main/src/com/google/refine/operations/cell/MultiValuedCellJoinOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.cell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -99,6 +100,14 @@ public class MultiValuedCellJoinOperation extends AbstractOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
+    }
+
+    @Override
+    public MultiValuedCellJoinOperation renameColumns(Map<String, String> newColumnNames) {
+        return new MultiValuedCellJoinOperation(
+                newColumnNames.getOrDefault(_columnName, _columnName),
+                newColumnNames.getOrDefault(_keyColumnName, _keyColumnName),
+                _separator);
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/MultiValuedCellSplitOperation.java
+++ b/main/src/com/google/refine/operations/cell/MultiValuedCellSplitOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.cell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -186,6 +187,22 @@ public class MultiValuedCellSplitOperation extends AbstractOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
+    }
+
+    @Override
+    public MultiValuedCellSplitOperation renameColumns(Map<String, String> newColumnNames) {
+        if ("separator".equals(_mode)) {
+            return new MultiValuedCellSplitOperation(
+                    newColumnNames.getOrDefault(_columnName, _columnName),
+                    newColumnNames.getOrDefault(_keyColumnName, _keyColumnName),
+                    _separator,
+                    _regex);
+        } else {
+            return new MultiValuedCellSplitOperation(
+                    newColumnNames.getOrDefault(_columnName, _columnName),
+                    newColumnNames.getOrDefault(_keyColumnName, _keyColumnName),
+                    _fieldLengths);
+        }
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/TextTransformOperation.java
+++ b/main/src/com/google/refine/operations/cell/TextTransformOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.cell;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
@@ -140,6 +141,25 @@ public class TextTransformOperation extends EngineDependentMassCellOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.of(ColumnsDiff.modifySingleColumn(_columnName));
+    }
+
+    @Override
+    public TextTransformOperation renameColumns(Map<String, String> newColumnNames) {
+        String renamedExpression;
+        try {
+            Evaluable evaluable = MetaParser.parse(_expression);
+            Evaluable renamedEvaluable = evaluable.renameColumnDependencies(newColumnNames);
+            renamedExpression = renamedEvaluable.getFullSource();
+        } catch (ParsingException e) {
+            return this;
+        }
+        return new TextTransformOperation(
+                _engineConfig.renameColumnDependencies(newColumnNames),
+                newColumnNames.getOrDefault(_columnName, _columnName),
+                renamedExpression,
+                _onError,
+                _repeat,
+                _repeatCount);
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperation.java
+++ b/main/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.cell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -201,6 +202,28 @@ public class TransposeColumnsIntoRowsOperation extends AbstractOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.empty();
+    }
+
+    @Override
+    public TransposeColumnsIntoRowsOperation renameColumns(Map<String, String> newColumnNames) {
+        if (_combinedColumnName != null) {
+            return new TransposeColumnsIntoRowsOperation(
+                    newColumnNames.getOrDefault(_startColumnName, _startColumnName),
+                    _columnCount,
+                    _ignoreBlankCells,
+                    _fillDown,
+                    newColumnNames.getOrDefault(_combinedColumnName, _combinedColumnName),
+                    _prependColumnName,
+                    _separator);
+        } else {
+            return new TransposeColumnsIntoRowsOperation(
+                    newColumnNames.getOrDefault(_startColumnName, _startColumnName),
+                    _columnCount,
+                    _ignoreBlankCells,
+                    _fillDown,
+                    newColumnNames.getOrDefault(_keyColumnName, _keyColumnName),
+                    newColumnNames.getOrDefault(_valueColumnName, _valueColumnName));
+        }
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperation.java
+++ b/main/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperation.java
@@ -35,6 +35,7 @@ package com.google.refine.operations.cell;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -93,6 +94,13 @@ public class TransposeRowsIntoColumnsOperation extends AbstractOperation {
     @Override
     public Optional<ColumnsDiff> getColumnsDiff() {
         return Optional.empty();
+    }
+
+    @Override
+    public TransposeRowsIntoColumnsOperation renameColumns(Map<String, String> newColumnNames) {
+        return new TransposeRowsIntoColumnsOperation(
+                newColumnNames.getOrDefault(_columnName, _columnName),
+                _rowCount);
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/KeyValueColumnizeTests.java
@@ -39,6 +39,7 @@ import static org.testng.Assert.assertThrows;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -138,6 +139,38 @@ public class KeyValueColumnizeTests extends RefineTest {
     public void testColumnsDependencies() {
         assertEquals(new KeyValueColumnizeOperation("foo", "baz", "bar").getColumnDependencies().get(), Set.of("foo", "baz", "bar"));
         assertEquals(new KeyValueColumnizeOperation("foo", "baz", null).getColumnDependencies().get(), Set.of("foo", "baz"));
+    }
+
+    @Test
+    public void testRename() {
+        KeyValueColumnizeOperation SUT = new KeyValueColumnizeOperation("foo", "baz", null);
+
+        KeyValueColumnizeOperation renamed = SUT.renameColumns(Map.of("foo", "foo2", "bar", "bar2"));
+
+        TestUtils.isSerializedTo(renamed, "{\n"
+                + "   \"description\" : " + new TextNode(OperationDescription.cell_key_value_columnize_brief("foo2", "baz")).toString()
+                + ",\n"
+                + "   \"keyColumnName\" : \"foo2\",\n"
+                + "   \"noteColumnName\" : null,\n"
+                + "   \"op\" : \"core/key-value-columnize\",\n"
+                + "   \"valueColumnName\" : \"baz\"\n"
+                + "}");
+    }
+
+    @Test
+    public void testRenameNoNotesColumn() {
+        KeyValueColumnizeOperation SUT = new KeyValueColumnizeOperation("foo", "baz", "bar");
+
+        KeyValueColumnizeOperation renamed = SUT.renameColumns(Map.of("foo", "foo2", "bar", "bar2"));
+
+        TestUtils.isSerializedTo(renamed, "{\n"
+                + "   \"description\" : "
+                + new TextNode(OperationDescription.cell_key_value_columnize_note_column_brief("foo2", "baz", "bar2")).toString() + ",\n"
+                + "   \"keyColumnName\" : \"foo2\",\n"
+                + "   \"noteColumnName\" : \"bar2\",\n"
+                + "   \"op\" : \"core/key-value-columnize\",\n"
+                + "   \"valueColumnName\" : \"baz\"\n"
+                + "}");
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellJoinOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellJoinOperationTests.java
@@ -37,6 +37,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -118,6 +119,20 @@ public class MultiValuedCellJoinOperationTests extends RefineTest {
     @Test
     public void testColumnsDependencies() {
         assertEquals(new MultiValuedCellJoinOperation("value", "key", "sep").getColumnDependencies().get(), Set.of("value", "key"));
+    }
+
+    @Test
+    public void testRename() {
+        var SUT = new MultiValuedCellJoinOperation("value", "key", "sep");
+
+        MultiValuedCellJoinOperation renamed = SUT.renameColumns(Map.of("value", "value2", "key", "key2", "sep", "sep2"));
+
+        String expectedJson = "{\"op\":\"core/multivalued-cell-join\","
+                + "\"description\":" + new TextNode(OperationDescription.cell_multivalued_cell_join_brief("value2")).toString() + ","
+                + "\"columnName\":\"value2\","
+                + "\"keyColumnName\":\"key2\","
+                + "\"separator\":\"sep\"}";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     /*

--- a/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellSplitOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellSplitOperationTests.java
@@ -37,6 +37,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -182,6 +183,28 @@ public class MultiValuedCellSplitOperationTests extends RefineTest {
                 "Key",
                 ":",
                 false).getColumnDependencies().get(), Set.of("Value", "Key"));
+    }
+
+    @Test
+    public void testRename() {
+        var SUT = new MultiValuedCellSplitOperation(
+                "Value",
+                "Key",
+                ":",
+                false);
+
+        MultiValuedCellSplitOperation renamed = SUT.renameColumns(Map.of("Value", "value2", "key", "Key2"));
+
+        String expectedJson = "{\n"
+                + "  \"columnName\" : \"value2\",\n"
+                + "  \"description\" : " + new TextNode(OperationDescription.cell_multivalued_cell_split_brief("value2")).toString() + ",\n"
+                + "  \"keyColumnName\" : \"Key\",\n"
+                + "  \"mode\" : \"separator\",\n"
+                + "  \"op\" : \"core/multivalued-cell-split\",\n"
+                + "  \"regex\" : false,\n"
+                + "  \"separator\" : \":\"\n"
+                + "}";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     /**

--- a/main/tests/server/src/com/google/refine/operations/cell/TextTransformOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TextTransformOperationTests.java
@@ -5,6 +5,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -115,6 +116,31 @@ public class TextTransformOperationTests extends RefineTest {
                 "grel:cells[\"foo\"].value+'_'+value",
                 OnError.SetToBlank,
                 false, 0).getColumnDependencies().get(), Set.of("foo", "bar", "facet_1"));
+    }
+
+    @Test
+    public void testRename() {
+        var SUT = new TextTransformOperation(
+                engineConfigWithColumnDeps,
+                "bar",
+                "grel:cells[\"foo\"].value+'_'+value",
+                OnError.SetToBlank,
+                false, 0);
+
+        TextTransformOperation renamed = SUT.renameColumns(Map.of("foo", "foo2", "bar", "bar2"));
+        String description = OperationDescription.cell_text_transform_brief("bar2",
+                "grel:cells.get(\"foo2\").value + '_' + value");
+        String expectedJson = "{\n"
+                + "  \"columnName\" : \"bar2\",\n"
+                + "  \"description\" : " + new TextNode(description).toString() + ",\n"
+                + "  \"engineConfig\" : null,\n"
+                + "  \"expression\" : \"grel:cells.get(\\\"foo2\\\").value + '_' + value\",\n"
+                + "  \"onError\" : \"set-to-blank\",\n"
+                + "  \"op\" : \"core/text-transform\",\n"
+                + "  \"repeat\" : false,\n"
+                + "  \"repeatCount\" : 0\n"
+                + "}";
+        TestUtils.isSerializedTo(renamed, expectedJson);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperationTest.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TransposeColumnsIntoRowsOperationTest.java
@@ -5,6 +5,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -64,6 +65,50 @@ public class TransposeColumnsIntoRowsOperationTest extends RefineTest {
     public void testColumnsDependencies() {
         assertEquals(new TransposeColumnsIntoRowsOperation("num1", -1, true, false, "a", true, ":").getColumnDependencies(),
                 Optional.empty());
+    }
+
+    @Test
+    public void testRename() {
+        var SUT = new TransposeColumnsIntoRowsOperation("num1", -1, true, false, "a", true, ":");
+
+        TransposeColumnsIntoRowsOperation renamed = SUT.renameColumns(Map.of("num1", "num2", "a", "a2"));
+
+        TestUtils.isSerializedTo(renamed, "{\n"
+                + "  \"columnCount\" : -1,\n"
+                + "  \"combinedColumnName\" : \"a2\",\n"
+                + "  \"description\" : "
+                + new TextNode(OperationDescription.cell_transpose_columns_into_rows_combined_neg_brief("num2", "a2")).toString() + ",\n"
+                + "  \"fillDown\" : false,\n"
+                + "  \"ignoreBlankCells\" : true,\n"
+                + "  \"keyColumnName\" : null,\n"
+                + "  \"op\" : \"core/transpose-columns-into-rows\",\n"
+                + "  \"prependColumnName\" : true,\n"
+                + "  \"separator\" : \":\",\n"
+                + "  \"startColumnName\" : \"num2\",\n"
+                + "  \"valueColumnName\" : null\n"
+                + "}");
+    }
+
+    @Test
+    public void testRename2() {
+        var SUT = new TransposeColumnsIntoRowsOperation(
+                "b 1", 2, true, false, "key", "value");
+
+        TransposeColumnsIntoRowsOperation renamed = SUT.renameColumns(Map.of("b 1", "b", "key", "key2"));
+
+        TestUtils.isSerializedTo(renamed, "{\n"
+                + "  \"columnCount\" : 2,\n"
+                + "  \"description\" : " + new TextNode(OperationDescription.cell_transpose_columns_into_rows_not_combined_pos_brief(2, "b",
+                        "key2", "value")).toString()
+                + ",\n"
+                + "  \"fillDown\" : false,\n"
+                + "  \"ignoreBlankCells\" : true,\n"
+                + "  \"keyColumnName\" : \"key2\",\n"
+                + "  \"op\" : \"core/transpose-columns-into-rows\",\n"
+                + "  \"separator\" : null,\n"
+                + "  \"startColumnName\" : \"b\",\n"
+                + "  \"valueColumnName\" : \"value\"\n"
+                + "}");
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/TransposeRowsIntoColumnsOperationTests.java
@@ -37,6 +37,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 import java.io.Serializable;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -99,6 +100,21 @@ public class TransposeRowsIntoColumnsOperationTests extends RefineTest {
     @Test
     public void testColumnsDependencies() {
         assertEquals(new TransposeRowsIntoColumnsOperation("b", 2).getColumnDependencies(), Optional.of(Set.of("b")));
+    }
+
+    @Test
+    public void testRename() {
+        var SUT = new TransposeRowsIntoColumnsOperation("b", 2);
+
+        TransposeRowsIntoColumnsOperation renamed = SUT.renameColumns(Map.of("b", "c"));
+
+        TestUtils.isSerializedTo(renamed, "{\n"
+                + "  \"columnName\" : \"c\",\n"
+                + "  \"description\" : " + new TextNode(OperationDescription.cell_transpose_rows_into_columns_brief(2, "c")).toString()
+                + ",\n"
+                + "  \"op\" : \"core/transpose-rows-into-columns\",\n"
+                + "  \"rowCount\" : 2\n"
+                + "}");
     }
 
     @Test


### PR DESCRIPTION
This adds support for updating the column names referenced in operations that are classified under the `com.google.refine.operations.cell` package, following up on #7132.
