### PR TITLE
Show all column headers in full by default

### DIFF
--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -105,6 +105,9 @@ DataTableView.prototype._startResizing = function(columnIndex, clickEvent) {
   // for conversion from px to em
   state.emFactor = parseFloat(getComputedStyle($(".data-table-container colgroup")[0]).fontSize);
 
+  state.col.width(state.originalWidth);
+  columnHeader._td.classList.add('resized-column');
+
   $('body')
       .on('mousemove', DataTableView.mouseMoveListener)
       .on('mouseup', DataTableView.mouseReleaseListener);

--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -206,6 +206,10 @@ table.data-table td.column-header, table.data-table th.column-header {
   position: absolute;
 }
 
+th:last-child .column-header-name {
+  position: initial;
+}
+
 .column-header-menu {
   display: inline-block;
   margin: 0 4px 0 0;
@@ -217,6 +221,7 @@ table.data-table td.column-header, table.data-table th.column-header {
   border: none;
   padding: 0;
   background-color: transparent;
+  vertical-align: top;
 }
 
 .column-header-menu-expand {

--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -109,6 +109,7 @@ div.viewpanel-pagesize span:first-of-type {
   font-size: 1.05em;
   border-collapse: separate;
   width: max-content;
+  padding-right: 3em;
 }
 
 .data-table td, .data-table-header td, .data-table-header th {

--- a/main/webapp/modules/core/styles/views/data-table-view.css
+++ b/main/webapp/modules/core/styles/views/data-table-view.css
@@ -204,11 +204,11 @@ table.data-table td.column-header, table.data-table th.column-header {
 .column-header-name {
   padding: 4px 0 0 0;
   display: inline-block;
-  position: absolute;
+  position: initial;
 }
 
-th:last-child .column-header-name {
-  position: initial;
+th.resized-column .column-header-name {
+  position: absolute;
 }
 
 .column-header-menu {


### PR DESCRIPTION
Closes #7167.

This PR lets the name of the last column to expand to its full width. This is meant to improve the UX in two situations:
 * if the grid is narrower than the screen, then it makes little sense to
    cut off the last column name because there is free space afterwards,
    so better let it expand
 * if the grid is wider than the screen, then it is impossible to drag
    the edge of the last column to the right, since there is no space on
    the right. So better have the column expanded to show the full column
    name too.

Also, this PR adds padding to the grid to make it possible to resize the last column, which still makes sense if we want to adapt the column width to better fit the contents of the column.

I will follow up with a toggle to expand / shrink all column headers, and improvements to the resizing itself.

### Screenshots

#### Before

![image](https://github.com/user-attachments/assets/bdad178c-84b3-434b-af55-37c5b467e3c7)

#### After

![image](https://github.com/user-attachments/assets/8a0d7711-0a1f-45cc-8a82-fa8c5a3bfe46)
