### PR TITLE
fix: weird layout for wikitext importer

### DIFF
--- a/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.html
+++ b/main/webapp/modules/core/scripts/index/parser-interfaces/wikitext-parser-ui.html
@@ -1,46 +1,46 @@
 <div class="grid-layout layout-tight"><table role="presentation">
       <tr><td colspan="2" id="or-import-colsep"></td></tr>
-         
-      <tr><td width="1%"><input type="checkbox" bind="wikiCheckbox" id="$reconcileWiki" /></td><td><label for="$reconcileWiki" id="or-import-wiki-base-url"></label>
+
+      <tr><td><input type="checkbox" bind="wikiCheckbox" id="$reconcileWiki" /></td><td><label for="$reconcileWiki" id="or-import-wiki-base-url"></label>
         <input bind="wikiUrlInput" spellcheck="false" type="text" class="lightweight" size="30" id="$wikiUrl" /></td></tr>
 
-      <tr><td width="1%"><input type="checkbox" bind="headerLinesCheckbox" id="$headers" /></td>
+      <tr><td><input type="checkbox" bind="headerLinesCheckbox" id="$headers" /></td>
         <td><label for="$headers" id="or-import-parse"></label>
           <input bind="headerLinesInput" type="number" class="lightweight" size="7" value="1" />
           <label for="$headers" id="or-import-header"></label></td></tr>
-      <tr><td width="1%"><input type="checkbox" bind="limitCheckbox" id="$limit" /></td>
+      <tr><td><input type="checkbox" bind="limitCheckbox" id="$limit" /></td>
         <td><label for="$limit" id="or-import-load"></label>
           <input bind="limitInput" type="number" class="lightweight" size="7" value="0" />
           <label for="$limit" id="or-import-rows2"></label></td></tr>
-      <tr><td width="1%"><input type="checkbox" bind="guessCellValueTypesCheckbox" id="$guess" /></td>
+      <tr><td><input type="checkbox" bind="guessCellValueTypesCheckbox" id="$guess" /></td>
         <td><label for="$guess" id="or-import-parseCell"></label></td></tr>
-      <tr><td width="1%"><input type="checkbox" bind="blankSpanningCellsCheckbox" id="$blank-spanning-cells" /></td>
+      <tr><td><input type="checkbox" bind="blankSpanningCellsCheckbox" id="$blank-spanning-cells" /></td>
         <td><label for="$blank-spanning-cells" id="or-import-blankSpanningCells"></label></td></tr>
-      <tr><td width="1%"><input type="checkbox" bind="storeBlankRowsCheckbox" id="$store-blank-rows" /></td>
+      <tr><td><input type="checkbox" bind="storeBlankRowsCheckbox" id="$store-blank-rows" /></td>
         <td colspan="2"><label for="$store-blank-rows" id="or-import-blank"></label></td></tr>
-      <tr><td width="1%"><input type="checkbox" bind="storeBlankColumnsCheckbox" id="$store-blank-columns" /></td>
+      <tr><td><input type="checkbox" bind="storeBlankColumnsCheckbox" id="$store-blank-columns" /></td>
         <td colspan="2"><label for="$store-blank-columns" id="or-import-blank-columns"></label></td></tr>
-      <tr><td width="1%"><input type="checkbox" bind="includeRawTemplatesCheckbox" id="$include-raw-templates" /></td>
+      <tr><td><input type="checkbox" bind="includeRawTemplatesCheckbox" id="$include-raw-templates" /></td>
         <td colspan="2"><label for="$include-raw-templates" id="or-import-includeRawTemplates"></label></td></tr>
-      <tr><td width="1%"><input type="checkbox" bind="parseReferencesCheckbox" id="$parse-references" /></td>
+      <tr><td><input type="checkbox" bind="parseReferencesCheckbox" id="$parse-references" /></td>
         <td colspan="2"><label for="$parse-references" id="or-import-parseReferences"></label></td></tr>
 
-      <tr><td width="1%"><input type="checkbox" bind="storeBlankCellsAsNullsCheckbox" id="$store-blank-cells" /></td>
+      <tr><td><input type="checkbox" bind="storeBlankCellsAsNullsCheckbox" id="$store-blank-cells" /></td>
         <td colspan="2"><label for="$store-blank-cells" id="or-import-null"></label></td></tr>
         
-      <tr><td width="1%"><input type="checkbox" bind="includeFileSourcesCheckbox" id="$include-file-sources" /></td>
+      <tr><td><input type="checkbox" bind="includeFileSourcesCheckbox" id="$include-file-sources" /></td>
         <td><label for="$include-file-sources" id="or-import-source"></label></td></tr>
 
-      <tr><td width="1%"><input type="checkbox" bind="includeArchiveFileCheckbox" id="$include-archive-file" /></td>
+      <tr><td><input type="checkbox" bind="includeArchiveFileCheckbox" id="$include-archive-file" /></td>
         <td><label for="$include-archive-file" id="or-import-archive"></label></td></tr>
 
       <tr>
-        <td width="1%"></td>
+        <td></td>
         <td><button class="button" bind="previewButton"></button></td>
       </tr>
       <tr>
-          <td width="1%"></td>
-          <td width="1%"><input type="checkbox" bind="disableAutoPreviewCheckbox" id="$disable" />
+          <td></td>
+          <td><input type="checkbox" bind="disableAutoPreviewCheckbox" id="$disable" />
             <label for="$disable" id="or-disable-auto-preview"></label></td>
       </tr>
 </table></div>


### PR DESCRIPTION
Fixes #6498

Changes proposed in this pull request:
- remove the `width` attribute in the wikidata importer settings HTML to move the labels closer to the check boxes

Although the issue mentions a preference for moving away from using `table` to format the settings, I decided to leave the existing HTML as it's more consistent with the other settings HTML snippets. I think it makes more sense to track the migration of these snippets to more modern styles in a follow-up task.

I've attached a screenshot of the new settings. Given that `Disable auto preview` is below the `Update preview` button, I felt it made sense to leave the indentation for the final checkbox as-is, but I'd be happy to align the button and checkbox with the rest of the settings if others feel that is more appropriate.

![Screenshot from 2025-02-11 10-54-41](https://github.com/user-attachments/assets/e7819ff3-14c0-4747-9435-30a40f6bf87d)
