### PR TITLE
Fix infinite loading spinner for invalid or unknown project IDs

### DIFF
--- a/main/src/com/google/refine/commands/project/GetModelsCommand.java
+++ b/main/src/com/google/refine/commands/project/GetModelsCommand.java
@@ -114,7 +114,12 @@ public class GetModelsCommand extends Command {
             }
         }
         if (project == null) {
-            project = getProject(request);
+            try {
+                project = getProject(request);
+            } catch (ServletException e) {
+                respondStatusError(response, e.getMessage());
+                return;
+            }
         }
 
         response.setHeader("Cache-Control", "no-cache");


### PR DESCRIPTION
Fixes #7175 

Changes proposed in this pull request:
- This change catches a `ServletException` when looking up a project ID and returns an error. This leverages the existing client-side error-handling mechanisms to show users an error message if the project ID doesn't map to an existing project.

Attached is a screenshot showing the error message shown when loading an invalid or unknown project ID.
![Screenshot from 2025-03-04 15-19-21](https://github.com/user-attachments/assets/7b026b37-79fc-45cc-a716-76e9602fd9ba)
