### PR TITLE
fix: Disable maximum string length in Jackson

### DIFF
--- a/modules/core/src/main/java/com/google/refine/util/ParsingUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/util/ParsingUtilities.java
@@ -57,6 +57,7 @@ import javax.servlet.http.HttpServletRequest;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -76,6 +77,9 @@ public class ParsingUtilities {
     public static JsonFactory jsonFactory = new JsonFactory();
     static {
         jsonFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
+        jsonFactory.setStreamReadConstraints(StreamReadConstraints.builder()
+                .maxStringLength(Integer.MAX_VALUE) // for https://github.com/OpenRefine/OpenRefine/issues/6680
+                .build());
     }
     public static final ObjectMapper mapper = new ObjectMapper(jsonFactory);
     static {


### PR DESCRIPTION
Fixes #6680.

To be included in 3.9.1.

I didn't include a test because it would involve loading rather large strings, whose length would be quite arbitrary. But I manually checked that the fix enables the project attached in #6680 to load correctly.