### PR TITLE
Fix: column dependencies in cell split/join operations

### DIFF
--- a/main/src/com/google/refine/operations/cell/MultiValuedCellJoinOperation.java
+++ b/main/src/com/google/refine/operations/cell/MultiValuedCellJoinOperation.java
@@ -94,7 +94,7 @@ public class MultiValuedCellJoinOperation extends AbstractOperation {
 
     @Override
     public Optional<Set<String>> getColumnDependencies() {
-        return Optional.of(Set.of(_columnName, _keyColumnName));
+        return Optional.of(_columnName.equals(_keyColumnName) ? Set.of(_columnName) : Set.of(_columnName, _keyColumnName));
     }
 
     @Override

--- a/main/src/com/google/refine/operations/cell/MultiValuedCellSplitOperation.java
+++ b/main/src/com/google/refine/operations/cell/MultiValuedCellSplitOperation.java
@@ -181,7 +181,7 @@ public class MultiValuedCellSplitOperation extends AbstractOperation {
 
     @Override
     public Optional<Set<String>> getColumnDependencies() {
-        return Optional.of(Set.of(_columnName, _keyColumnName));
+        return Optional.of(_columnName.equals(_keyColumnName) ? Set.of(_columnName) : Set.of(_columnName, _keyColumnName));
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellJoinOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellJoinOperationTests.java
@@ -122,6 +122,11 @@ public class MultiValuedCellJoinOperationTests extends RefineTest {
     }
 
     @Test
+    public void testColumnsDependenciesWithIdenticalColumns() {
+        assertEquals(new MultiValuedCellJoinOperation("key", "key", "sep").getColumnDependencies().get(), Set.of("key"));
+    }
+
+    @Test
     public void testRename() {
         var SUT = new MultiValuedCellJoinOperation("value", "key", "sep");
 

--- a/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellSplitOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/cell/MultiValuedCellSplitOperationTests.java
@@ -186,6 +186,15 @@ public class MultiValuedCellSplitOperationTests extends RefineTest {
     }
 
     @Test
+    public void testColumnsDependenciesWithIdenticalColumns() {
+        assertEquals(new MultiValuedCellSplitOperation(
+                "Key",
+                "Key",
+                ":",
+                false).getColumnDependencies().get(), Set.of("Key"));
+    }
+
+    @Test
     public void testRename() {
         var SUT = new MultiValuedCellSplitOperation(
                 "Value",


### PR DESCRIPTION
When run on the first column of the project (which is also the one used to define the records), the operations to split or join multi-valued cells would fail to expose their columnar dependencies, because `Set.of(value1, value2)` throws an exception when `value1.equals(value2)`. This fixes it.