### PR TITLE
Add operation to remove multiple columns in one step

### DIFF
--- a/main/resources/com/google/refine/operations/OperationDescription.properties
+++ b/main/resources/com/google/refine/operations/OperationDescription.properties
@@ -19,6 +19,7 @@ column_addition_by_fetching_urls_brief=Create column {0} at index {1} by fetchin
 column_addition_brief=Create column {0} at index {1} based on column {2} using expression {3}
 column_move_brief=Move column {0} to position {1}
 column_removal_brief=Remove column {0}
+column_multi_removal_brief=Remove {0} columns
 column_rename_brief=Rename column {0} to {1}
 column_reorder_brief=Reorder columns
 column_split_brief=Split column {0} by field lengths

--- a/main/src/com/google/refine/operations/column/ColumnMultiRemovalOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnMultiRemovalOperation.java
@@ -1,0 +1,82 @@
+
+package com.google.refine.operations.column;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang.Validate;
+
+import com.google.refine.history.HistoryEntry;
+import com.google.refine.model.AbstractOperation;
+import com.google.refine.model.ColumnsDiff;
+import com.google.refine.model.Project;
+import com.google.refine.model.changes.ColumnReorderChange;
+import com.google.refine.operations.OperationDescription;
+
+/**
+ * Removes multiple columns in a single step.
+ */
+public class ColumnMultiRemovalOperation extends AbstractOperation {
+
+    final protected List<String> _columnNames;
+    final protected Set<String> _columnNameSet;
+
+    @JsonCreator
+    public ColumnMultiRemovalOperation(
+            @JsonProperty("columnNames") List<String> columnNames) {
+        _columnNames = columnNames;
+        _columnNameSet = columnNames == null ? null : _columnNames.stream().collect(Collectors.toSet());
+    }
+
+    @Override
+    public void validate() {
+        Validate.notNull(_columnNames, "Missing column names");
+    }
+
+    @JsonProperty("columnNames")
+    public List<String> getColumnNames() {
+        return _columnNames;
+    }
+
+    @Override
+    protected String getBriefDescription(Project project) {
+        return OperationDescription.column_multi_removal_brief(_columnNames.size());
+    }
+
+    @Override
+    public Optional<Set<String>> getColumnDependencies() {
+        return Optional.of(_columnNameSet);
+    }
+
+    @Override
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(new ColumnsDiff(List.of(), _columnNameSet, Set.of()));
+    }
+
+    @Override
+    public ColumnMultiRemovalOperation renameColumns(Map<String, String> newColumnNames) {
+        List<String> renamed = _columnNames.stream()
+                .map(old -> newColumnNames.getOrDefault(old, old))
+                .collect(Collectors.toList());
+        return new ColumnMultiRemovalOperation(renamed);
+    }
+
+    @Override
+    protected HistoryEntry createHistoryEntry(Project project, long historyEntryID) throws Exception {
+        List<String> remainingColumnNames = project.columnModel.getColumnNames()
+                .stream()
+                .filter(name -> !_columnNameSet.contains(name))
+                .collect(Collectors.toList());
+        return new HistoryEntry(
+                historyEntryID,
+                project,
+                getBriefDescription(project),
+                this,
+                new ColumnReorderChange(remainingColumnNames));
+    }
+}

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnMultiRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnMultiRemovalOperationTests.java
@@ -1,0 +1,91 @@
+
+package com.google.refine.operations.column;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import com.google.refine.RefineTest;
+import com.google.refine.expr.EvalError;
+import com.google.refine.model.ColumnsDiff;
+import com.google.refine.model.Project;
+import com.google.refine.operations.OperationDescription;
+import com.google.refine.operations.OperationRegistry;
+import com.google.refine.util.ParsingUtilities;
+import com.google.refine.util.TestUtils;
+
+public class ColumnMultiRemovalOperationTests extends RefineTest {
+
+    protected Project project;
+
+    @BeforeMethod
+    public void setUpInitialState() {
+        project = createProject(new String[] { "foo", "bar", "hello" },
+                new Serializable[][] {
+                        { "v1", "a", "d" },
+                        { "v3", "a", "f" },
+                        { "", "a", "g" },
+                        { "", "b", "h" },
+                        { new EvalError("error"), "a", "i" },
+                        { "v1", "b", "j" }
+                });
+    }
+
+    @BeforeSuite
+    public void setUp() {
+        OperationRegistry.registerOperation(getCoreModule(), "column-multi-removal", ColumnMultiRemovalOperation.class);
+    }
+
+    @Test
+    public void serializeColumnRemovalOperation() throws Exception {
+        String json = "{\"op\":\"core/column-multi-removal\","
+                + "\"description\":" + new TextNode(OperationDescription.column_multi_removal_brief(2)).toString() + ","
+                + "\"columnNames\":[\"my column\", \"some other column\"]}";
+        TestUtils.isSerializedTo(ParsingUtilities.mapper.readValue(json, ColumnMultiRemovalOperation.class), json);
+    }
+
+    @Test
+    public void testValidate() {
+        ColumnMultiRemovalOperation SUT = new ColumnMultiRemovalOperation(null);
+        assertThrows(IllegalArgumentException.class, () -> SUT.validate());
+    }
+
+    @Test
+    public void testRemoval() throws Exception {
+        ColumnMultiRemovalOperation SUT = new ColumnMultiRemovalOperation(List.of("foo", "bar"));
+        assertEquals(SUT.getColumnDependencies().get(), Set.of("foo", "bar"));
+        assertEquals(SUT.getColumnsDiff().get(), ColumnsDiff.builder().deleteColumn("foo").deleteColumn("bar").build());
+
+        runOperation(SUT, project);
+
+        Project expected = createProject(
+                new String[] { "hello" },
+                new Serializable[][] {
+                        { "d" },
+                        { "f" },
+                        { "g" },
+                        { "h" },
+                        { "i" },
+                        { "j" },
+                });
+        assertProjectEquals(project, expected);
+    }
+
+    @Test
+    public void testRename() {
+        ColumnMultiRemovalOperation SUT = new ColumnMultiRemovalOperation(List.of("foo", "bar"));
+
+        ColumnMultiRemovalOperation renamed = SUT.renameColumns(Map.of("foo", "foo2"));
+
+        assertEquals(renamed._columnNames, List.of("foo2", "bar"));
+    }
+}

--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -170,6 +170,7 @@ function registerOperations() {
 
   OR.registerOperation(module, "column-addition", Packages.com.google.refine.operations.column.ColumnAdditionOperation);
   OR.registerOperation(module, "column-removal", Packages.com.google.refine.operations.column.ColumnRemovalOperation);
+  OR.registerOperation(module, "column-multi-removal", Packages.com.google.refine.operations.column.ColumnMultiRemovalOperation);
   OR.registerOperation(module, "column-rename", Packages.com.google.refine.operations.column.ColumnRenameOperation);
   OR.registerOperation(module, "column-move", Packages.com.google.refine.operations.column.ColumnMoveOperation);
   OR.registerOperation(module, "column-split", Packages.com.google.refine.operations.column.ColumnSplitOperation);

--- a/main/webapp/modules/core/scripts/project/operation-icons.js
+++ b/main/webapp/modules/core/scripts/project/operation-icons.js
@@ -30,6 +30,7 @@ OperationIconRegistry.setIcon('core/key-value-columnize', 'images/operations/key
 
 OperationIconRegistry.setIcon('core/column-addition', 'images/operations/add-column.svg');
 OperationIconRegistry.setIcon('core/column-removal', 'images/operations/delete.svg');
+OperationIconRegistry.setIcon('core/column-multi-removal', 'images/operations/delete.svg');
 OperationIconRegistry.setIcon('core/column-rename', 'images/operations/rename.svg');
 // OperationIconRegistry.setIcon('core/column-move', undefined);
 OperationIconRegistry.setIcon('core/column-split', 'images/operations/split-columns.svg');


### PR DESCRIPTION
For #5576 (but doesn't fix it yet).

This PR introduces a new operation which can remove multiple columns in one go. The columns to be removed are named in the operation metadata. This is meant to provide an alternative to the column reorder operation, where only the retained columns are mentioned in the operation metadata.

Instead of generalizing the existing `column-removal` operation, I have introduced a new class, so that there aren't any breaking changes.

The operation cannot be triggered from the UI yet.