### PR TITLE
Implement missing column dependencies and columns diff on new operations

### DIFF
--- a/main/src/com/google/refine/operations/row/RowDuplicatesRemovalOperation.java
+++ b/main/src/com/google/refine/operations/row/RowDuplicatesRemovalOperation.java
@@ -33,9 +33,12 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.browsing.Engine;
@@ -44,6 +47,7 @@ import com.google.refine.browsing.FilteredRows;
 import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.Column;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.RowRemovalChange;
@@ -71,6 +75,16 @@ public class RowDuplicatesRemovalOperation extends EngineDependentOperation {
     @Override
     protected String getBriefDescription(Project project) {
         return OperationDescription.row_remove_duplicates_brief();
+    }
+
+    @Override
+    protected Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(_criteria.stream().collect(Collectors.toSet()));
+    }
+
+    @JsonIgnore
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.empty());
     }
 
     @Override

--- a/main/src/com/google/refine/operations/row/RowKeepMatchedOperation.java
+++ b/main/src/com/google/refine/operations/row/RowKeepMatchedOperation.java
@@ -8,9 +8,11 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.browsing.Engine;
@@ -18,6 +20,7 @@ import com.google.refine.browsing.EngineConfig;
 import com.google.refine.browsing.FilteredRows;
 import com.google.refine.browsing.RowVisitor;
 import com.google.refine.history.HistoryEntry;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
 import com.google.refine.model.changes.RowRemovalChange;
@@ -39,6 +42,16 @@ public class RowKeepMatchedOperation extends EngineDependentOperation {
 
     protected String createDescription(Project project, int rowCount) {
         return row_keep_matching_rows_desc(rowCount);
+    }
+
+    @Override
+    protected Optional<Set<String>> getColumnDependenciesWithoutEngine() {
+        return Optional.of(Set.of());
+    }
+
+    @JsonIgnore
+    public Optional<ColumnsDiff> getColumnsDiff() {
+        return Optional.of(ColumnsDiff.empty());
     }
 
     @Override

--- a/main/tests/server/src/com/google/refine/operations/row/RowDuplicatesRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowDuplicatesRemovalOperationTests.java
@@ -6,6 +6,8 @@ import static org.testng.Assert.assertEquals;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -14,6 +16,7 @@ import com.google.refine.RefineTest;
 import com.google.refine.browsing.EngineConfig;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.grel.Parser;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.Project;
 
 public class RowDuplicatesRemovalOperationTests extends RefineTest {
@@ -59,6 +62,9 @@ public class RowDuplicatesRemovalOperationTests extends RefineTest {
 
         EngineConfig engineConfig = EngineConfig.deserialize(_engineConfig);
         RowDuplicatesRemovalOperation operation = new RowDuplicatesRemovalOperation(engineConfig, duplicateRowCriteria);
+        assertEquals(operation.getColumnDependencies(),
+                Optional.of(Set.of("SITE_ID", "SITE_NUM", "LATITUDE", "LONGITUDE", "ELEVATION", "UPDATE_DATE")));
+        assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
 
         runOperation(operation, project);
         assertEquals(project.rows.size(), 7);
@@ -95,6 +101,9 @@ public class RowDuplicatesRemovalOperationTests extends RefineTest {
 
         EngineConfig engineConfig = EngineConfig.defaultRowBased();
         RowDuplicatesRemovalOperation operation = new RowDuplicatesRemovalOperation(engineConfig, duplicateRowCriteria);
+        assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("SITE_ID")));
+        assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
+
         runOperation(operation, project);
         assertEquals(project.rows.size(), 6);
         assertEquals(project.history.getLastPastEntries(1).get(0).description, "Remove 3 rows");

--- a/main/tests/server/src/com/google/refine/operations/row/RowKeepMatchedOperationTest.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowKeepMatchedOperationTest.java
@@ -2,12 +2,15 @@
 package com.google.refine.operations.row;
 
 import static com.google.refine.operations.OperationDescription.row_keep_matching_brief;
+import static org.testng.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.slf4j.LoggerFactory;
@@ -30,6 +33,7 @@ import com.google.refine.grel.Function;
 import com.google.refine.grel.Parser;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.model.Cell;
+import com.google.refine.model.ColumnsDiff;
 import com.google.refine.model.ModelException;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
@@ -171,6 +175,9 @@ public class RowKeepMatchedOperationTest extends RefineTest {
                 new DecoratedValue("i", "i"));
         EngineConfig engineConfig = new EngineConfig(Arrays.asList(facet), Engine.Mode.RowBased);
         RowKeepMatchedOperation operation = new RowKeepMatchedOperation(engineConfig);
+        assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("hello")));
+        assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
+
         runOperation(operation, project);
 
         Project expected = createProject(new String[] { "foo", "bar", "hello" },
@@ -189,6 +196,8 @@ public class RowKeepMatchedOperationTest extends RefineTest {
                 new DecoratedValue("i", "i"));
         EngineConfig engineConfig = new EngineConfig(Arrays.asList(facet), Engine.Mode.RecordBased);
         RowKeepMatchedOperation operation = new RowKeepMatchedOperation(engineConfig);
+        assertEquals(operation.getColumnDependencies(), Optional.of(Set.of("hello")));
+        assertEquals(operation.getColumnsDiff(), Optional.of(ColumnsDiff.empty()));
 
         runOperation(operation, project);
 


### PR DESCRIPTION
This adds support for the columnar analysis developed for the reproducibility project, for operations which were added since. This avoids those operations being treated as opaque, degrading the UX for recipes which rely on them.