### PR TITLE
Add recipe visualization to Extract dialog

### DIFF
--- a/main/src/com/google/refine/commands/history/GetColumnDependenciesCommand.java
+++ b/main/src/com/google/refine/commands/history/GetColumnDependenciesCommand.java
@@ -17,6 +17,7 @@ import com.google.refine.commands.Command;
 import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.ColumnsDiff;
 import com.google.refine.operations.Recipe;
+import com.google.refine.operations.Recipe.RecipeValidationException;
 import com.google.refine.util.ParsingUtilities;
 
 /**
@@ -77,6 +78,8 @@ public class GetColumnDependenciesCommand extends Command {
                     .collect(Collectors.toList());
 
             respondJSON(response, result);
+        } catch (RecipeValidationException e) {
+            respondJSON(response, e);
         } catch (Exception e) {
             respondException(response, e);
         }

--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -504,6 +504,7 @@ function init() {
 
       "scripts/widgets/histogram-widget.js",
       "scripts/widgets/slider-widget.js",
+      "scripts/widgets/recipe-widget.js",
 
       "scripts/project/browsing-engine.js",
       "scripts/project/history-panel.js",
@@ -584,6 +585,7 @@ function init() {
 
       "styles/widgets/histogram-widget.css",
       "styles/widgets/slider-widget.css",
+      "styles/widgets/recipe-widget.css",
 
       "styles/views/data-table-view.css",
       "styles/views/column-join.css",
@@ -597,6 +599,7 @@ function init() {
       "styles/dialogs/sql-exporter-dialog.css",
       "styles/dialogs/recon-service-selection-dialog.css",
       "styles/dialogs/confirm-history-erasure-dialog.less",
+      "styles/dialogs/extract-operations-dialog.css",
       "styles/reconciliation/recon-dialog.css",
       "styles/reconciliation/standard-service-panel.css",
       "styles/reconciliation/add-column-by-reconciliation.css",

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -456,6 +456,8 @@
     "core-project/extract-history": "Extract operation history",
     "core-project/operation-history-json": "Operation history JSON",
     "core-project/extract-save": "Extract and save parts of your operation history as JSON that you can apply to this or other projects in the future.",
+    "core-project/recipe-json-tab": "JSON",
+    "core-project/recipe-visualization-tab": "Visualization",
     "core-project/apply-operation": "Apply operation history",
     "core-project/paste-json": "Select a file or paste an extracted JSON history of operations to perform:",
     "core-project/percent-complete": "$1% complete",

--- a/main/webapp/modules/core/scripts/dialogs/extract-operations-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/extract-operations-dialog.html
@@ -11,7 +11,21 @@
         <tr>
           <td width="50%" style="vertical-align: top"><div class="history-extract-dialog-panel"><table role="presentation" class="history-extract-dialog-entries" bind="entryTable"></table></div></td>
           <td width="50%" rowspan="2" style="vertical-align: top">
-              <div class="input-container"><textarea aria-label="" spellcheck="false" wrap="off" class="history-operation-json" bind="textarea"></textarea></div>
+            <div id="recipe-extract-tabs" class="refine-tabs">
+              <ul>
+                <li><a href="#recipe-json" bind="recipeJSONTabLink"></a></li>
+                <li><a href="#recipe-visualization" bind="recipeVisualizationTabLink"></a></li>
+              </ul>
+              <div id="recipe-json" class="input-container">
+                 <textarea aria-label="" spellcheck="false" wrap="off" class="history-operation-json" bind="textarea"></textarea>
+              </div>
+              <div id="recipe-visualization">
+                <div class="recipe-svg-container" style="max-height: 500px">
+                  <svg bind="recipeSvg" id="recipe-svg">
+                  </svg>
+                </div>
+              </div> 
+            </div>
           </td>
         </tr>
         <tr>

--- a/main/webapp/modules/core/scripts/dialogs/extract-operations-dialog.html
+++ b/main/webapp/modules/core/scripts/dialogs/extract-operations-dialog.html
@@ -10,7 +10,7 @@
         </tr>
         <tr>
           <td width="50%" style="vertical-align: top"><div class="history-extract-dialog-panel"><table role="presentation" class="history-extract-dialog-entries" bind="entryTable"></table></div></td>
-          <td width="50%" rowspan="2" style="vertical-align: top">
+          <td width="50%" style="vertical-align: top">
             <div id="recipe-extract-tabs" class="refine-tabs">
               <ul>
                 <li><a href="#recipe-json" bind="recipeJSONTabLink"></a></li>
@@ -33,6 +33,9 @@
             <button class="button" bind="selectAllButton"></button>
             <button class="button" bind="deselectAllButton"></button>
             <button class="button" bind="saveJsonAsFileButton" style="float: right"></button>
+          </td>
+          <td>
+            <span class="history-operation-json-error" bind="recipeError"></span>
           </td>
         </tr>
       </table></div>

--- a/main/webapp/modules/core/scripts/dialogs/extract-operations-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/extract-operations-dialog.js
@@ -76,8 +76,17 @@ function ExtractOperationsDialog(json) {
         { operations: JSON.stringify(self.historyJson) },
         function(response) {
           elmts.recipeSvg.empty();
-          let visualizer = new RecipeVisualizer(response.steps, elmts.recipeSvg);
-          visualizer.draw();
+          elmts.recipeError.empty();
+          if (response.code === 'ok') {
+            let visualizer = new RecipeVisualizer(response.steps, elmts.recipeSvg);
+            visualizer.draw();
+          } else {
+            if (response.message) {
+              elmts.recipeError.text(response.message);
+            } else {
+              elmts.recipeError.text($.i18n("core-dialogs/internal-err"));
+            }
+          }
         },
         "json",
         function(e) {

--- a/main/webapp/modules/core/scripts/widgets/recipe-widget.html
+++ b/main/webapp/modules/core/scripts/widgets/recipe-widget.html
@@ -1,0 +1,17 @@
+<div bind="recipe-widget" class="refine-tabs">
+  <ul>
+    <li><a href="#recipe-graph" bind="graphButton"></a></li>
+    <li><a href="#recipe-json" bind="jsonButton"></a></li>
+  </ul>
+  <div id="recipe-graph">
+    <div class="recipe-widget-container recipe-svg-container" bind="graphContainer">
+      <svg bind="recipeSvg" id="recipe-svg">
+      </svg>
+    </div>
+  </div>
+  <div id="recipe-json" style="display: none;">
+    <div class="recipe-widget-container" bind="jsonContainer">
+      <textarea bind="jsonTextarea" spellcheck="false"></textarea>
+    </div>
+  </div>
+</div>

--- a/main/webapp/modules/core/scripts/widgets/recipe-widget.js
+++ b/main/webapp/modules/core/scripts/widgets/recipe-widget.js
@@ -1,0 +1,570 @@
+/*
+
+Copyright 2024, OpenRefine contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+ * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+ * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ */
+
+function addToMultiMap(multiMap, key, value) {
+    let list = multiMap.get(key);
+    if (list === undefined) {
+        list = [];
+        multiMap.set(key, list);
+    }
+    list.push(value);
+}
+
+/*
+ Takes a JSON representation of operations as produced by the get-column-dependencies operation
+ and draws a graphical representation of the operations as a SVG diagram.
+ */
+class RecipeVisualizer {
+    
+    constructor(analyzedOperations, svg) {
+      this.analyzedOperations = analyzedOperations;
+      this.hoverTimeout = null;
+      this.tooltip = null;
+      this.svg = svg;
+      this.minWidth = 400;
+    }
+
+    draw() {
+        let operationsWithIds = this.computeColumnIds();
+        let columnPositions = this.computeColumnPositions(operationsWithIds);
+
+        const svg = this.svg;
+        let sliceHeight = 35;
+        let columnDistance = 35;
+        let columnHoverMargin = 10;
+        let opaqueMargin = 5;
+        let columnColor = '#888';
+        let columnWidth = 2;
+        let dependencyRadius = 5;
+
+        // Define arrow marker
+        let defs = $(document.createElementNS('http://www.w3.org/2000/svg', 'defs'))
+          .appendTo(svg);
+        let marker = $(document.createElementNS('http://www.w3.org/2000/svg', 'marker'))
+          .attr('id', 'arrow')
+          .attr('viewBox', '0 0 10 10')
+          .attr('refX', '5')
+          .attr('refY', '5')
+          .attr('markerWidth', '4')
+          .attr('markerHeight', '4')
+          .attr('orient', 'auto-start-reverse')
+          .appendTo(defs);
+        let markerPath = $(document.createElementNS('http://www.w3.org/2000/svg', 'path'))
+          .attr('d', 'M 0 0 L 10 5 L 0 10 z')
+          .attr('fill', 'context-stroke')
+          .appendTo(marker);
+
+        // Compute diagram boundaries
+        let maxX = columnDistance * 2;
+        for (const column of operationsWithIds.columns) {
+            maxX = Math.max(maxX, (columnPositions.get(column.id) + 2) * columnDistance);
+        }
+        let maxY = operationsWithIds.translatedOperations.length * sliceHeight;
+
+        // Draw slices
+        let boundaryMin = - columnDistance;
+        let boundaryMax = maxX + 2 * columnDistance;
+        if (boundaryMax - boundaryMin < this.minWidth) {
+          boundaryMin -= (this.minWidth - boundaryMax + boundaryMin) / 2;
+          boundaryMax += (this.minWidth - boundaryMax + boundaryMin) / 2;
+        }
+        for (let i = 0; i < operationsWithIds.translatedOperations.length; i += 2) {
+          $(document.createElementNS('http://www.w3.org/2000/svg', 'rect'))
+              .attr('x', boundaryMin)
+              .attr('y', i * sliceHeight)
+              .attr('width', boundaryMax - boundaryMin)
+              .attr('height', sliceHeight)
+              .attr('fill', '#f2f2f2')
+              .appendTo(svg);
+        }
+
+        // Draw all column lines
+        let edgesGroup = $(document.createElementNS('http://www.w3.org/2000/svg', 'g'))
+          .appendTo(svg);
+        for(const column of operationsWithIds.columns) {
+            let xPos = (columnPositions.get(column.id) + 1) * columnDistance;
+            for(const name of column.names) {
+              let start = name.start;
+              let end = name.end === undefined ? column.end : name.end;
+              let line = $(document.createElementNS('http://www.w3.org/2000/svg', 'line'))
+                .attr('id', `column-${column.id}-${start}`)
+                .attr('x1', xPos)
+                .attr('y1', (start - 0.5) * sliceHeight)
+                .attr('x2', xPos)
+                .attr('y2', (end + 0.5) * sliceHeight)
+                .attr("stroke", columnColor)
+                .attr("stroke-width", columnWidth)
+                .attr("alt", name.name)
+                .appendTo(edgesGroup);
+              let hoverArea = $(document.createElementNS('http://www.w3.org/2000/svg', 'rect'))
+                .attr('x', xPos - columnHoverMargin)
+                .attr('y', (start - 0.5) * sliceHeight)
+                .attr('width', columnHoverMargin * 2)
+                .attr('height', (end - start + 1)*sliceHeight)
+                .attr('fill', 'white')
+                .attr('fill-opacity', 0)
+                .appendTo(svg);
+              this.setUpTooltip(svg, hoverArea, line, 2, name.name, true);
+              if (start === 0) {
+                this.drawBoundaryColumnName(svg, xPos,  -0.6 * sliceHeight, false, name.name);
+              }
+              if (end === operationsWithIds.translatedOperations.length) {
+                this.drawBoundaryColumnName(svg, xPos,  (end + 0.8) * sliceHeight, true, name.name);
+                line.attr('marker-end', 'url(#arrow)');
+              }
+            }
+        }
+
+        // Draw all operations
+        let sliceId = 0;
+        for(const slice of operationsWithIds.translatedOperations) {
+          if (slice.operation.columnsDiff == null) {
+            let posX = opaqueMargin;
+            let posY = sliceId * sliceHeight + opaqueMargin;
+            let width = maxX - 2*opaqueMargin;
+            let height = sliceHeight - 2*opaqueMargin;
+            let rect = $(document.createElementNS('http://www.w3.org/2000/svg', 'rect'))
+              .attr('id', `opaque-${sliceId}`)
+              .attr('x', posX)
+              .attr('y', posY)
+              .attr('width', width)
+              .attr('height', height)
+              .attr('stroke', 'black')
+              .attr('stroke-width', 1)
+              .attr('fill', 'white')
+              .appendTo(svg);
+            this.addOperationLogo(svg, maxX / 2, (sliceId + 0.5) * sliceHeight, slice.operation.operation, sliceId, false);
+            let hoverArea = $(document.createElementNS('http://www.w3.org/2000/svg', 'rect'))
+              .attr('id', `opaque-${sliceId}`)
+              .attr('x', posX)
+              .attr('y', posY)
+              .attr('width', width)
+              .attr('height', height)
+              .attr('fill', 'white')
+              .attr('fill-opacity', 0)
+              .appendTo(svg);
+            this.setUpTooltip(svg, hoverArea, rect, 10, slice.operation.operation.description, false);
+          } else {
+            // Draw operation circles for added columns
+            for (const addedColumn of slice.columnIds.added) {
+              let columnId = addedColumn.id;
+              let xPos = (columnPositions.get(columnId) + 1) * columnDistance;
+              let yPos = (sliceId + 0.5)* sliceHeight;
+              if (addedColumn.afterId !== undefined) {
+                let xPosSource = (columnPositions.get(addedColumn.afterId) + 1) * columnDistance;
+                var line = $(document.createElementNS('http://www.w3.org/2000/svg', 'line'))
+                  .attr('x1', xPosSource)
+                  .attr('y1', yPos)
+                  .attr('x2', xPos - 15)
+                  .attr('y2', yPos)
+                  .attr('stroke', columnColor)
+                  .attr('stroke-width', columnWidth)
+                  .attr('marker-end', 'url(#arrow)')
+                  .appendTo(edgesGroup);
+              }
+              this.makeOperationCircle(svg, xPos, yPos, `circle-${sliceId}-${columnId}`, slice.operation.operation);
+            }
+
+            // Draw operation circles for modified and deleted columns
+            for (const columnId of slice.columnIds.modified.concat(slice.columnIds.deleted)) {
+              let xPos = (columnPositions.get(columnId) + 1) * columnDistance;
+              let yPos = (sliceId + 0.5)* sliceHeight;
+              this.makeOperationCircle(svg, xPos, yPos, `circle-${sliceId}-${columnId}`, slice.operation.operation);
+            }
+
+            // For operations that don't add, modify or delete any columns, draw one operation circle in the left margin
+            if (slice.columnIds.added.length == 0 && slice.columnIds.modified.length == 0 && slice.columnIds.deleted.length == 0) {
+              let xPos = 0;
+              let yPos = (sliceId + 0.5)* sliceHeight;
+              this.makeOperationCircle(svg, xPos, yPos, `circle-${sliceId}-default`, slice.operation.operation);
+            }
+
+            // Draw other column dependencies
+            let modifiedOrDeleted = new Set(slice.columnIds.modified.concat(slice.columnIds.deleted));
+            for (const columnId of slice.columnIds.dependencies || []) {
+              if (!modifiedOrDeleted.has(columnId)) {
+                let xPos = (columnPositions.get(columnId) + 1) * columnDistance;
+                let yPos = (sliceId + 0.5) * sliceHeight;
+                let circle = $(document.createElementNS('http://www.w3.org/2000/svg', 'circle'))
+                  .attr('cx', xPos)
+                  .attr('cy', yPos)
+                  .attr('r', dependencyRadius)
+                  .attr('fill', columnColor)
+                  .appendTo(svg);
+                this.setUpTooltip(svg, circle, circle, dependencyRadius, this.nameAtSlice(operationsWithIds.columns[columnId], sliceId), false);
+              }
+            }
+          }
+          sliceId++;
+        }
+
+        // Resize canvas to make it of a fitting size
+        let bbox = svg[0].getBBox();
+        let margin = 5;
+        svg.attr("viewBox", `${bbox.x} ${bbox.y - margin} ${bbox.width} ${bbox.height + 2*margin}`);
+        svg.attr("width", `${bbox.width}`);
+    }
+
+    nameAtSlice(column, sliceId) {
+      for (let i = 0; i != column.names.length; i++) {
+        if (column.names[i].end === undefined || sliceId <= column.names[i].end) {
+          return column.names[i].name;
+        }
+      }
+    }
+
+    makeOperationCircle(svg, xPos, yPos, id, operation) {
+      let circleRadius = 12;
+      let circleHoverRadius = 15;
+      let circle = $(document.createElementNS('http://www.w3.org/2000/svg', 'circle'))
+        .attr('id', id)
+        .attr('cx', xPos)
+        .attr('cy', yPos)
+        .attr('r', circleRadius)
+        .attr('stroke', 'black')
+        .attr('fill', 'white')
+        .appendTo(svg);
+      this.addOperationLogo(svg, xPos, yPos, operation, id, true);
+      let hoverArea = $(document.createElementNS('http://www.w3.org/2000/svg', 'circle'))
+        .attr('id', id)
+        .attr('cx', xPos)
+        .attr('cy', yPos)
+        .attr('r', circleHoverRadius)
+        .attr('opacity', 0)
+        .attr('fill', 'white')
+        .appendTo(svg);
+      this.setUpTooltip(svg, hoverArea, circle, circleHoverRadius, operation.description, false);
+      return circle;
+    }
+
+    addOperationLogo(svg, xPos, yPos, operation, id, clipToCircle) {
+      let operationIcon = OperationIconRegistry.getIcon(operation.op);
+      if (operationIcon === undefined) {
+        let firstLetter = operation.description[0];
+        $(document.createElementNS('http://www.w3.org/2000/svg', 'text'))
+          .attr('x', xPos)
+          .attr('y', yPos)
+          .attr('dominant-baseline', 'middle')
+          .attr('text-anchor', 'middle')
+          .text(firstLetter)
+          .appendTo(svg);
+      } else {
+        let imageRadius = 10;
+        let clipId = undefined;
+        if (clipToCircle) {
+          clipId = `icon-clip-${id}`;
+          let clipPath = $(document.createElementNS('http://www.w3.org/2000/svg', 'clipPath'))
+            .attr('id', clipId)
+            .appendTo(svg);
+          $(document.createElementNS('http://www.w3.org/2000/svg', 'circle'))
+            .attr('id', id)
+            .attr('cx', xPos)
+            .attr('cy', yPos)
+            .attr('r', imageRadius)
+            .appendTo(clipPath);
+        }
+        let image = $(document.createElementNS('http://www.w3.org/2000/svg', 'image'))
+          .attr('x', xPos - imageRadius)
+          .attr('y', yPos - imageRadius)
+          .attr('href', operationIcon)
+          .attr('width', imageRadius * 2)
+          .appendTo(svg);
+        if (clipId !== undefined) {
+          image.attr('clip-path', `url(#${clipId})`);
+        }
+      }
+    }
+
+    setUpTooltip(svg, hoverArea, relativeTo, tooltipOffset, text, useCursorY) {
+      let self = this;
+      hoverArea.on("mouseenter", function(event) {
+        if (self.hoverTimeout != null) {
+          clearTimeout(self.hoverTimeout);
+          self.hoverTimeout = null;
+        }
+        self.hoverTimeout = setTimeout(function() {
+          self.hoverTimeout = null;
+          if (self.tooltip != null) {
+            self.tooltip.remove();
+            self.tooltip = null;
+          }
+          let rect = relativeTo[0].getBoundingClientRect();
+          let x = (rect.left + rect.right) / 2;
+          let y = (rect.top + rect.bottom) / 2;
+          if (useCursorY) {
+            y = event.clientY;
+          }
+          self.tooltip = $("<div></div>")
+            .css("left", x + tooltipOffset)
+            .addClass('recipe-tooltip')
+            .appendTo(svg.parent());
+          $("<div></div>")
+            .addClass('recipe-tooltip-triangle')
+            .appendTo(self.tooltip);
+          $("<div></div>")
+            .text(text)
+            .addClass('recipe-tooltip-inner')
+            .appendTo(self.tooltip);
+          self.tooltip.css("top", y - 0.5 * self.tooltip.outerHeight());
+        }, 300);
+
+        hoverArea.on("mouseleave", function() {
+          if (self.hoverTimeout != null) {
+            clearTimeout(self.hoverTimeout);
+            self.hoverTimeout = null;
+          }
+          if (self.tooltip != null) {
+            self.tooltip.remove();
+            self.tooltip = null;
+          }
+        });
+      });
+    }
+
+    drawBoundaryColumnName(svg, xPos, yPos, output, name) {
+      let angle = output ? 45 : -45;
+      let g = $(document.createElementNS('http://www.w3.org/2000/svg', 'g'))
+        .attr('transform', `rotate(${angle}, ${xPos}, ${yPos})`)
+        .appendTo(svg);
+      let txt = $(document.createElementNS('http://www.w3.org/2000/svg', 'text'))
+        .attr('x', xPos)
+        .attr('y', yPos)
+        .text(name)
+        .appendTo(g);
+    }
+
+    computeColumnPositions(operationsWithIds) {
+        // Do a topological sort
+        let unconstrainedColumns = new Set();
+        let positionMap = new Map();
+        for (let i = 0; i != operationsWithIds.columns.length; i++) {
+            unconstrainedColumns.add(i);
+            positionMap.set(i, 0);
+        }
+        // Index the constraints in bidirectional maps
+        let leftToRight = new Map();
+        let rightToLeft = new Map();
+        for (const constraint of operationsWithIds.constraints) {
+            addToMultiMap(leftToRight, constraint.left, constraint.right);
+            addToMultiMap(rightToLeft, constraint.right, constraint.left);
+            unconstrainedColumns.delete(constraint.right);
+        }
+
+        // main loop of the topological sort algorithm, greedily allocating
+        // positions to columns which are no longer constrained to be to the right of any column
+        let sorted = [];
+        while (unconstrainedColumns.size > 0) {
+            let id = unconstrainedColumns[Symbol.iterator]().next().value;
+            unconstrainedColumns.delete(id);
+            let position = positionMap.get(id);
+            sorted.push(id);
+            for(const rightId of leftToRight.get(id) || []) {
+                positionMap.set(rightId, Math.max(positionMap.get(rightId), position + 1));
+                let otherConstraints = rightToLeft.get(rightId);
+                let newConstraints = otherConstraints.filter(x => x != id);
+                rightToLeft.set(rightId, newConstraints);
+                if (newConstraints.length == 0) {
+                    unconstrainedColumns.add(rightId);
+                }
+            }
+        }
+        if (sorted.length < operationsWithIds.columns.length) {
+            throw new Error("invalid column constraints: loop detected");
+        }
+
+        return positionMap;
+    }
+  
+    computeColumnIds() {
+      // map from names of columns currently present to their id
+      let currentColumns = {};
+      // list of ids of columns currently present, in the order they appear
+      let currentColumnIds = [];
+      // list of order constraints between column ids, of the form {left: 2, right: 5},
+      // which means that the horizontal position of column 2 must be strictly less than that of column 5
+      let constraints = [];
+      // position of the slice where all columns were last reset (= position of the last opaque slice)
+      let lastColumnReset = 0;
+      // set of the rightmost columns since the columns were last reset
+      let rightmostSinceReset = new Set();
+      // list of column metadata (indices in this list are column ids)
+      let columns = [];
+      // operations translated to have their column dependencies as column ids
+      let translatedOperations = [];
+      for (let i = 0; i != this.analyzedOperations.length; i++) {
+        let operation = this.analyzedOperations[i];
+
+        let columnIds = {
+        };
+
+        columnIds.dependencies = [];
+        var fullDependencies = new Set(operation.dependencies || []);
+        if (operation.columnsDiff != null) {
+          for (let impliedDependency of operation.columnsDiff.impliedDependencies) {
+            fullDependencies = fullDependencies.add(impliedDependency);
+          }
+        }
+        for(const columnName of fullDependencies) {
+            if (currentColumns[columnName] === undefined) {
+                let columnId = columns.length;
+                currentColumns[columnName] = columnId;
+                currentColumnIds.push(columnId);
+                if (currentColumnIds.length > 1) {
+                    constraints.push({left: currentColumnIds[currentColumnIds.length - 2], right: columnId});
+                }
+                // make sure this column appears to the right of all of the previous rightmost columns
+                for (let rightmost of rightmostSinceReset) {
+                  constraints.push({left: rightmost, right: columnId});
+                }
+                rightmostSinceReset = new Set([ columnId ]);
+
+                columns.push({
+                    id: columnId,
+                    start: lastColumnReset,
+                    names: [{
+                      name: columnName,
+                      start: lastColumnReset
+                    }]
+                })
+            }
+            columnIds.dependencies.push(currentColumns[columnName]);
+        }
+
+        if (operation.columnsDiff === null) {
+            // make all current columns end here
+            for(const [name, id] of Object.entries(currentColumns)) {
+                columns[id].end = i;
+            }
+            currentColumns = {};
+            currentColumnIds = [];
+            lastColumnReset = i + 1;
+            rightmostSinceReset = new Set();
+        } else {
+            columnIds.added = [];
+            columnIds.deleted = [];
+            columnIds.modified = [];
+            for(const deletedColumn of operation.columnsDiff.deleted) {
+                let id = currentColumns[deletedColumn];
+                if (id !== undefined) {
+                    columnIds.deleted.push(id);
+                    // check if this column removal is part of a rename,
+                    // by checking if any column was added based on this column in the current slice
+                    let addedBasedOnThisColumn = operation.columnsDiff.added.find(added => added.afterName == deletedColumn);
+                    if (addedBasedOnThisColumn == undefined) {
+                      columns[id].end = i;
+                      delete currentColumns[deletedColumn];
+                      currentColumnIds = currentColumnIds.filter(x => x != id);
+                    } else {
+                      currentColumns[addedBasedOnThisColumn.name] = id;
+                      addedBasedOnThisColumn.isRename = true;
+                      let names = columns[id].names;
+                      names[names.length - 1].end = i;
+                      names.push({
+                        name: addedBasedOnThisColumn.name,
+                        start: i + 1
+                      });
+                    }
+                }
+            }
+            for (const addedColumn of operation.columnsDiff.added) {
+                // TODO check that it does not collide with existing column names
+                if (addedColumn.isRename) {
+                  continue;
+                }
+                let name = addedColumn.name;
+                let columnId = columns.length;
+                currentColumns[name] = columnId;
+                columns.push({
+                    id: columnId,
+                    start: i + 1,
+                    names: [{
+                      name,
+                      start: i + 1
+                    }]
+                });
+                let addedColumnAsId = {
+                    id: columnId
+                };
+                if (addedColumn.afterName != null) {
+                    let afterId = currentColumns[addedColumn.afterName];
+                    addedColumnAsId.afterId = afterId;
+                    let indexOfAfterId = currentColumnIds.indexOf(afterId);
+                    if (indexOfAfterId == -1) {
+                        indexOfAfterId = currentColumnIds.length - 1;
+                    } else {
+                        constraints.push({left: afterId, right: columnId});
+                    }
+                    currentColumnIds.splice(indexOfAfterId + 1, 0, columnId);
+                    if (indexOfAfterId + 2 < currentColumnIds.length) {
+                        constraints.push({left: columnId, right: currentColumnIds[indexOfAfterId + 2]});
+                    }
+                } else {
+                    // if no afterName is provided, the column gets added at the end of the list
+                    currentColumnIds.push(columnId);
+                    if (currentColumnIds.length > 1) {
+                        constraints.push({left: currentColumnIds[currentColumnIds.length - 2], right: columnId});
+                    }
+                }
+                columnIds.added.push(addedColumnAsId);
+            }
+            for (const modifiedColumn of operation.columnsDiff.modified) {
+                let id = currentColumns[modifiedColumn];
+                if (id !== undefined) {
+                    columnIds.modified.push(id);
+                }
+            }
+
+            if (currentColumnIds.length > 0) {
+              rightmostSinceReset.add(currentColumnIds[currentColumnIds.length - 1]);
+            }
+        }
+
+        translatedOperations.push({
+            operation,
+            columnIds,
+        });
+      }
+      // fill the end field on all columns that remain at the end
+      for(let column of columns) {
+        if (column.end === undefined) {
+            column.end = this.analyzedOperations.length;
+        }
+      }
+      return {
+        columns,
+        constraints,
+        translatedOperations,
+      };
+    }
+  
+  }

--- a/main/webapp/modules/core/styles/dialogs/extract-operations-dialog.css
+++ b/main/webapp/modules/core/styles/dialogs/extract-operations-dialog.css
@@ -1,0 +1,3 @@
+#recipe-extract-tabs {
+    border: none;
+}

--- a/main/webapp/modules/core/styles/dialogs/extract-operations-dialog.css
+++ b/main/webapp/modules/core/styles/dialogs/extract-operations-dialog.css
@@ -1,3 +1,5 @@
 #recipe-extract-tabs {
     border: none;
+    max-width: 80vw;
+    max-height: 80vh;
 }

--- a/main/webapp/modules/core/styles/project/sidebar.css
+++ b/main/webapp/modules/core/styles/project/sidebar.css
@@ -228,7 +228,7 @@ a.history-entry.filtered-out>* {
 
 .history-extract-dialog-panel {
   border: 1px solid var(--chrome-primary);
-  height: 400px;
+  height: 500px;
   overflow: auto;
 }
 

--- a/main/webapp/modules/core/styles/widgets/recipe-widget.css
+++ b/main/webapp/modules/core/styles/widgets/recipe-widget.css
@@ -11,7 +11,7 @@
     z-index: 20;
 }
 
-.recipe-tooltip-inner {
+.recipe-tooltip-inner, .recipe-tooltip-inner-embedded {
     background-color: white;
     border: 1px solid #888;
     padding: 3px;
@@ -20,9 +20,12 @@
     font-size: 0.9em;
     text-align: left;
     word-wrap: break-word;
-    max-width: 250px;
     display: inline-block;
     vertical-align: middle;
+}
+
+.recipe-tooltip-inner {
+    max-width: 250px;
 }
 
 .recipe-tooltip-triangle {
@@ -33,4 +36,4 @@
     border-right:7px solid #888;
     display: inline-block;
     vertical-align: middle;
-  }
+}

--- a/main/webapp/modules/core/styles/widgets/recipe-widget.css
+++ b/main/webapp/modules/core/styles/widgets/recipe-widget.css
@@ -1,0 +1,36 @@
+.recipe-svg-container {
+    text-align: center;
+    overflow: auto;
+    min-height: 100px;
+    max-height: 100%;
+    position: relative;
+}
+
+.recipe-tooltip {
+    position: fixed;
+    z-index: 20;
+}
+
+.recipe-tooltip-inner {
+    background-color: white;
+    border: 1px solid #888;
+    padding: 3px;
+    padding-left: 7px;
+    border-radius: 3px;
+    font-size: 0.9em;
+    text-align: left;
+    word-wrap: break-word;
+    max-width: 250px;
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.recipe-tooltip-triangle {
+    width: 0; 
+    height: 0; 
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent;
+    border-right:7px solid #888;
+    display: inline-block;
+    vertical-align: middle;
+  }

--- a/modules/core/src/main/java/com/google/refine/operations/Recipe.java
+++ b/modules/core/src/main/java/com/google/refine/operations/Recipe.java
@@ -58,6 +58,7 @@ public class Recipe {
             } catch (IllegalArgumentException e) {
                 throw new RecipeValidationException(index, e.getMessage());
             }
+            index++;
         }
 
         // currentColumnNames represents the current set of column names in the project,
@@ -70,6 +71,7 @@ public class Recipe {
         // columns created by the recipe
         newColumns = new HashSet<>();
 
+        index = 0;
         for (AbstractOperation op : operations) {
             if (currentColumnNames.isPresent()) {
                 Set<String> allDependencies = new HashSet<>();
@@ -90,7 +92,7 @@ public class Recipe {
                             // if this column has already been required before,
                             // but is no longer part of the current columns,
                             // that means it has since been deleted.
-                            throw new IllegalArgumentException(
+                            throw new RecipeValidationException(index,
                                     "Inconsistent list of operations: column '" + columnName + "' used after being deleted or renamed");
                         } else {
                             dependencies.add(columnName);
@@ -107,7 +109,7 @@ public class Recipe {
                 currentColumnNames.get().removeAll(columnsDiff.get().getDeletedColumns());
                 for (String addedColumn : columnsDiff.get().getAddedColumnNames()) {
                     if (currentColumnNames.get().contains(addedColumn)) {
-                        throw new IllegalArgumentException(
+                        throw new RecipeValidationException(index,
                                 "Creation of column '" + addedColumn + "' conflicts with an existing column with the same name");
                     }
                 }
@@ -115,6 +117,7 @@ public class Recipe {
                 newColumns.removeAll(columnsDiff.get().getDeletedColumns());
                 newColumns.addAll(columnsDiff.get().getAddedColumnNames());
             }
+            index++;
         }
     }
 


### PR DESCRIPTION
For #2253.

This introduces an experimental visualization of recipes in the Extract dialog, helping the user grasp the columnar dependencies of the operations they have selected for extraction. See the [forum thread](https://forum.openrefine.org/t/recipe-visualization-prototype/2069) on this.

I'm proposing to introduce this in the Extract dialog, because it seems to be the place where this is the most useful: when extracting a recipe, it's useful to understand how it will generalize to other projects, and get a bit of help selecting the operations as required.

The visualization is rendered as an SVG element, with some event listeners to enable tooltips when hovering.
The rendering of the SVG is done in a few steps:
* first, in `computeColumnIds()`, the recipe is scanned to list all columns involved at any point in the recipe. Constraints on the placement of those columns are also gathered in this pass: for instance, if a column is created based on another column, we require that the created column appears to the right of its base column (similarly to what happens when running the operation). At the end of this, we obtain a list of columns and constraints on their relative placement
* then, we do a topological sort to assign positions to each column
* finally, for the rendering itself, we draw all columns at their computed positions and then add the operations on top.

The positions of the columns in the visualization might differ from their original position in the project, since recipes don't provide sufficient information to recover that. In most cases, recipes are meant to generalize well regardless of column positions (apart from the first column defining the record boundaries).

![image](https://github.com/user-attachments/assets/c5849c57-a96f-46ba-8886-6bd3d0fcc8e5)
