### PR TITLE
fixes 7010: open file manager with headless Java

### DIFF
--- a/modules/core/src/main/java/com/google/refine/util/OpenDirectoryUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/util/OpenDirectoryUtilities.java
@@ -32,7 +32,8 @@ public class OpenDirectoryUtilities {
         } else if (SystemUtils.IS_OS_LINUX) {
             rt.exec(new String[] { "xdg-open", location });
         } else {
-            logger.warn(String.format("Java Desktop class not supported on this platform. Please open %s in your browser", location));
+            logger.warn(String.format("Java Desktop class not supported on this platform. Please open %s in your native application",
+                    location));
         }
     }
 }

--- a/modules/core/src/main/java/com/google/refine/util/OpenDirectoryUtilities.java
+++ b/modules/core/src/main/java/com/google/refine/util/OpenDirectoryUtilities.java
@@ -5,17 +5,34 @@ import java.awt.Desktop;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class OpenDirectoryUtilities {
+
+    final static Logger logger = LoggerFactory.getLogger("open-directory-utilities");
 
     public static void openDirectory(File dir) throws IOException {
         if (Desktop.isDesktopSupported()) {
             Desktop desktop = Desktop.getDesktop();
             desktop.open(dir);
-        } else /* if Mac */ {
-            Runtime.getRuntime().exec(
-                    "open .",
-                    new String[] {},
-                    dir);
+        } else {
+            openDirectoryFallback(String.valueOf(dir));
+        }
+    }
+
+    private static void openDirectoryFallback(String location) throws IOException {
+        Runtime rt = Runtime.getRuntime();
+
+        if (SystemUtils.IS_OS_WINDOWS) {
+            rt.exec(new String[] { "rundll32 ", "url.dll,FileProtocolHandler ", location });
+        } else if (SystemUtils.IS_OS_MAC_OSX) {
+            rt.exec(new String[] { "open ", location });
+        } else if (SystemUtils.IS_OS_LINUX) {
+            rt.exec(new String[] { "xdg-open", location });
+        } else {
+            logger.warn(String.format("Java Desktop class not supported on this platform. Please open %s in your browser", location));
         }
     }
 }


### PR DESCRIPTION


Fixes #7010

Changes proposed in this pull request:
- Some Java installations come without support for graphics libraries, on which OpenRefine relies to open the file manager for actions like opening extensions and opening the workspace directory. This change will fall back to running shell commands to open the file manager if certain operations (such as `java.awt.Desktop.open`) are not supported.