### PR TITLE
Make GitHub syntax highlight and index .vt files as Velocity templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,6 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+# Make GitHub syntax-highlight and index .vt files as Velocity templates
+*.vt linguist-language=velocity


### PR DESCRIPTION
This PR makes GitHub detect our Velocity files correctly, as a result they will have syntax highlighting and appear correctly in the languages statistics. 

Documentation:

 - https://github.com/github-linguist/linguist/blob/main/docs/overrides.md
 - https://github.com/github-linguist/linguist/blob/1cc4b1a09f0bb64266386728966c1f839e386803/lib/linguist/languages.yml#L7832-L7844

**Changes proposed in this pull request:**

- Make GitHub syntax-highlight and index .vt files as Velocity templates
