### PR TITLE
Send absolute row index in request when "last" pagination button is clicked

### DIFF
--- a/main/src/com/google/refine/commands/row/GetRowsCommand.java
+++ b/main/src/com/google/refine/commands/row/GetRowsCommand.java
@@ -293,7 +293,7 @@ public class GetRowsCommand extends Command {
             JsonResult result = new JsonResult(engine.getMode(),
                     rwv.results, rwv.total,
                     engine.getMode() == Mode.RowBased ? project.rows.size() : project.recordModel.getRecordCount(),
-                    rwv.totalRows, start, end, limit, pool, previousPageEnd, nextPageStart);
+                    project.rows.size(), start, end, limit, pool, previousPageEnd, nextPageStart);
 
             respondJSON(response, result);
         } catch (IllegalJsonpException e2) {

--- a/main/src/com/google/refine/commands/row/GetRowsCommand.java
+++ b/main/src/com/google/refine/commands/row/GetRowsCommand.java
@@ -277,7 +277,7 @@ public class GetRowsCommand extends Command {
                 if (start > 0) {
                     previousPageEnd = start;
                 }
-                if (!wrappedRows.isEmpty()) {
+                if (!wrappedRows.isEmpty() && ((wrappedRows.size() >= limit))) {
                     nextPageStart = wrappedRows.get(wrappedRows.size() - 1).paginationIndex + 1;
                 }
             } else {

--- a/main/tests/server/src/com/google/refine/commands/row/GetRowsCommandTest.java
+++ b/main/tests/server/src/com/google/refine/commands/row/GetRowsCommandTest.java
@@ -44,6 +44,8 @@ import org.testng.annotations.Test;
 
 import com.google.refine.RefineTest;
 import com.google.refine.commands.Command;
+import com.google.refine.expr.MetaParser;
+import com.google.refine.grel.Parser;
 import com.google.refine.model.Project;
 import com.google.refine.util.TestUtils;
 
@@ -82,6 +84,8 @@ public class GetRowsCommandTest extends RefineTest {
                 + "}]}";
         when(request.getParameter("project")).thenReturn(String.valueOf(project.id));
         when(response.getWriter()).thenReturn(new PrintWriter(writer));
+
+        MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
     }
 
     @Test
@@ -304,6 +308,114 @@ public class GetRowsCommandTest extends RefineTest {
         when(request.getParameter("end")).thenReturn("2");
         when(request.getParameter("limit")).thenReturn("3");
         when(request.getParameter("sorting")).thenReturn(sortingConfigJson);
+        command.doPost(request, response);
+        TestUtils.assertEqualsAsJson(writer.toString(), rowJson);
+    }
+
+    @Test
+    public void testOutputFacetedRowsStart() throws ServletException, IOException {
+        String rowJson = "{\n" +
+                "       \"filtered\" : 1,\n" +
+                "       \"limit\" : 2,\n" +
+                "       \"mode\" : \"row-based\",\n" +
+                "       \"pool\" : {\n" +
+                "         \"recons\" : { }\n" +
+                "       },\n" +
+                "       \"rows\" : [ {\n" +
+                "         \"cells\" : [ {\n" +
+                "           \"v\" : \"a\"\n" +
+                "         }, {\n" +
+                "           \"v\" : \"b\"\n" +
+                "         } ],\n" +
+                "         \"flagged\" : false,\n" +
+                "         \"i\" : 0,\n" +
+                "         \"k\" : 0,\n" +
+                "         \"starred\" : false\n" +
+                "       } ],\n" +
+                "       \"start\" : 0,\n" +
+                "       \"total\" : 5,\n" +
+                "       \"totalRows\" : 5\n" +
+                "     }";
+
+        String engineConfig = "{\n"
+                + "  \"facets\": [ \n"
+                + "    {"
+                + "      \"type\":\"list\", \n"
+                + "      \"name\":\"bar\", \n"
+                + "      \"columnName\":\"bar\", \n"
+                + "      \"expression\":\"value\", \n"
+                + "      \"omitBlank\":false, \n"
+                + "      \"omitError\":false, \n"
+                + "      \"selection\":[{ \n"
+                + "        \"v\":{  \n"
+                + "          \"v\":\"b\", \n"
+                + "          \"l\":\"b\" \n"
+                + "        } \n"
+                + "      }], \n"
+                + "      \"selectBlank\":false, \n"
+                + "      \"selectError\":false, \n"
+                + "      \"invert\":false \n"
+                + "  }], \n"
+                + "  \"mode\":\"row-based\" \n"
+                + "}";
+
+        when(request.getParameter("engine")).thenReturn(engineConfig);
+        when(request.getParameter("start")).thenReturn("0");
+        when(request.getParameter("limit")).thenReturn("2");
+        command.doPost(request, response);
+        TestUtils.assertEqualsAsJson(writer.toString(), rowJson);
+    }
+
+    @Test
+    public void testOutputFacetedRowsEnd() throws ServletException, IOException {
+        String rowJson = "{\n" +
+                "       \"filtered\" : 1,\n" +
+                "       \"limit\" : 1,\n" +
+                "       \"mode\" : \"row-based\",\n" +
+                "       \"pool\" : {\n" +
+                "         \"recons\" : { }\n" +
+                "       },\n" +
+                "       \"rows\" : [ {\n" +
+                "         \"cells\" : [ {\n" +
+                "           \"v\" : \"a\"\n" +
+                "         }, {\n" +
+                "           \"v\" : \"b\"\n" +
+                "         } ],\n" +
+                "         \"flagged\" : false,\n" +
+                "         \"i\" : 0,\n" +
+                "         \"k\" : 0,\n" +
+                "         \"starred\" : false\n" +
+                "       } ],\n" +
+                "       \"end\" : 5,\n" +
+                "       \"total\" : 5,\n" +
+                "       \"totalRows\" : 5\n" +
+                "     }";
+
+        String engineConfig = "{\n"
+                + "  \"facets\": [ \n"
+                + "    {"
+                + "      \"type\":\"list\", \n"
+                + "      \"name\":\"bar\", \n"
+                + "      \"columnName\":\"bar\", \n"
+                + "      \"expression\":\"value\", \n"
+                + "      \"omitBlank\":false, \n"
+                + "      \"omitError\":false, \n"
+                + "      \"selection\":[{ \n"
+                + "        \"v\":{  \n"
+                + "          \"v\":\"b\", \n"
+                + "          \"l\":\"b\" \n"
+                + "        } \n"
+                + "      }], \n"
+                + "      \"selectBlank\":false, \n"
+                + "      \"selectError\":false, \n"
+                + "      \"invert\":false \n"
+                + "  }], \n"
+                + "  \"mode\":\"row-based\" \n"
+                + "}";
+
+        when(request.getParameter("engine")).thenReturn(engineConfig);
+        when(request.getParameter("end")).thenReturn("5");
+        when(request.getParameter("limit")).thenReturn("1");
         command.doPost(request, response);
         TestUtils.assertEqualsAsJson(writer.toString(), rowJson);
     }

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -657,7 +657,7 @@ DataTableView.prototype._onClickFirstPage = function(elmt, evt) {
 };
 
 DataTableView.prototype._onClickLastPage = function(elmt, evt) {
-  this._showRows({end: theProject.rowModel.total});
+  this._showRows({end: theProject.rowModel.totalRows});
 };
 
 DataTableView.prototype._onChangeMinRow = function(elmt, evt) {

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -657,7 +657,7 @@ DataTableView.prototype._onClickFirstPage = function(elmt, evt) {
 };
 
 DataTableView.prototype._onClickLastPage = function(elmt, evt) {
-  this._showRows({end: theProject.rowModel.totalRows});
+  this._showRows({end: theProject.rowModel.total});
 };
 
 DataTableView.prototype._onChangeMinRow = function(elmt, evt) {


### PR DESCRIPTION
Fixes #7207

Changes proposed in this pull request:
- This change addresses how the "last" pagination navigation button sends the ending point. The current behavior is that it sends the index of the last row relative to a faceted search, and this change is to send the index of the absolute last row in the project.
- This also includes a change to omit the `nextPageStart` variable if there are fewer than `limit` elements in the response. This will cause the `next` and `last` pagination buttons to be marked as inactive, as there are no more elements to paginate through.
