### PR TITLE
Use aria-labelledby over aria-labeledby

### DIFF
--- a/main/webapp/modules/core/scripts/util/dialog.js
+++ b/main/webapp/modules/core/scripts/util/dialog.js
@@ -79,7 +79,7 @@ DialogSystem.showDialog = function(elmt, onCancel) {
   elmt.attr("role", "dialog");
   var dialogHeader = elmt.find(".dialog-header");
   if (dialogHeader.length && dialogHeader[0].id) {
-    elmt.attr("aria-labeledby", dialogHeader[0].id);
+    elmt.attr("aria-labelledby", dialogHeader[0].id);
   }
 
   elmt.attr("tabindex", -1);


### PR DESCRIPTION
This PR changes `aria-labeledby` to `aria-labelledby`.

I'm making this change because the `aria-labeledby` (with a single `l` in the middle) is the alternate spelling to the correct `aria-labelledby` (with two `l`s in the middle). The two `l`s version is preferred over the single `l` version. Some browsers will only respect the version with two `l`s. 

I discovered this repository by performing a code search for uses of `aria-labeledby` and sending PRs to replace them. (I'm not a bot but someone who is working on fixing this issue). For more on this you could read https://github.com/w3c/aria/issues/2093.