### PR TITLE
Identify syntax errors in Python expressions

### DIFF
--- a/extensions/jython/src/com/google/refine/jython/JythonEvaluable.java
+++ b/extensions/jython/src/com/google/refine/jython/JythonEvaluable.java
@@ -50,6 +50,7 @@ import org.python.core.PyLong;
 import org.python.core.PyNone;
 import org.python.core.PyObject;
 import org.python.core.PyString;
+import org.python.core.PySyntaxError;
 import org.python.util.PythonInterpreter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,7 +70,11 @@ public class JythonEvaluable implements Evaluable {
 
             @Override
             public Evaluable parse(String source, String languagePrefix) throws ParsingException {
-                return new JythonEvaluable(source, languagePrefix);
+                try {
+                    return new JythonEvaluable(source, languagePrefix);
+                } catch (PySyntaxError e) {
+                    throw new ParsingException("Syntax error");
+                }
             }
 
         };

--- a/extensions/jython/tests/src/com/google/refine/jython/JythonEvaluableTest.java
+++ b/extensions/jython/tests/src/com/google/refine/jython/JythonEvaluableTest.java
@@ -13,6 +13,7 @@ import org.testng.annotations.Test;
 
 import com.google.refine.expr.CellTuple;
 import com.google.refine.expr.Evaluable;
+import com.google.refine.expr.ParsingException;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
 import com.google.refine.model.Row;
@@ -142,5 +143,10 @@ public class JythonEvaluableTest {
 
         assertEquals(evaluable.getSource(), "return (1,2)");
         assertEquals(evaluable.getLanguagePrefix(), "jython");
+    }
+
+    @Test(expectedExceptions = ParsingException.class)
+    public void testParseError() throws ParsingException {
+        JythonEvaluable.createParser().parse("foo(", "jython");
     }
 }

--- a/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/misc/expressions.cy.js
@@ -77,7 +77,7 @@ describe(__filename, function () {
     loadExpressionPanel();
     cy.selectPython();
     cy.typeExpression('(;)');
-    cy.get('.expression-preview-parsing-status').contains('Internal error');
+    cy.get('.expression-preview-parsing-status').contains('Syntax error');
   });
 
   it('Test a Clojure syntax error', function () {

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -205,7 +205,7 @@ Cypress.Commands.add('selectPython', () => {
   cy.get('textarea.expression-preview-code').clear()
   cy.get('select[bind="expressionPreviewLanguageSelect"]').select('jython');
   // Wait for Jython interpreter to load (as indicated by changed error message)
-  cy.get('.expression-preview-parsing-status').contains('Internal error');
+  cy.get('.expression-preview-parsing-status').contains('Syntax error');
 });
 
 /**


### PR DESCRIPTION
This addresses #3012, though I'm not sure if I can say it entirely fixes it.

Changes proposed in this pull request:
- This change will catch a `PySyntaxError` when initializing a new `JythonEvaluable` object and will return the string "Syntax error" instead of the current "Internal error". It is a small change but I feel it is at least somewhat more helpful in guiding the user towards resolving the issue.

This is the existing error message:
![Screenshot from 2025-03-21 10-24-13](https://github.com/user-attachments/assets/63cf876d-d652-4fd1-b7a2-71feffeaa00a)

And this is the error message after this change:
![Screenshot from 2025-03-21 10-22-41](https://github.com/user-attachments/assets/d1caad53-2776-4a7b-a3f2-426040c0826a)

I realize this is a relatively small change, so please feel free to reject if you think it's unhelpful, but I feel it at least distinguishes between an internal error specific to OpenRefine and an error that a user could potentially resolve on their own.