### PR TITLE
Fix "Edit all columns" menu

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/all-column/edit-all-columns.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/all-column/edit-all-columns.cy.js
@@ -1,0 +1,16 @@
+describe(__filename, function () {
+  it('Ensure columns are filled down', function () {
+    cy.loadAndVisitProject([
+      ['Column A', 'Column B'],
+      ['&lt;html&gt;&lt;body&gt;', '&lt;html&gt;&lt;head&gt;'],
+    ]);
+
+    cy.columnActionClick('All', ['Edit all columns', 'Unescape HTML entities…']);
+    cy.get('.dialog-footer button').contains('OK').click();
+
+    cy.assertGridEquals([
+      ['Column A', 'Column B'],
+      ['<html><body>', '<html><head>'],
+    ]);
+  });
+});

--- a/main/webapp/modules/core/scripts/dialogs/common-transform-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/common-transform-dialog.js
@@ -90,7 +90,6 @@ commonTransformDialog.prototype._createDialog = function(expression,label) {
 
     this._elmts.okButton.on('click',function() {
       self._commit(expression);
-      self._dismiss();
     });
     this._elmts.cancelButton.on('click',function() {
       self._dismiss();
@@ -114,24 +113,20 @@ commonTransformDialog.prototype._commit = function(expression) {
       columnNames.push(name);
     }
   });
-  var doTextTransform = function(index, expression, onError, repeat, repeatCount) {
-    if (index < columnNames.length) {
-      Refine.postCoreProcess(
-        "text-transform",
-        {
-          columnName: columnNames[index], 
-          expression: expression, 
-          onError: onError,
-          repeat: repeat,
-          repeatCount: repeatCount
-        },
-        null,
-        { cellsChanged: true, rowIdsPreserved: true },
-        { onDone: function() { doTextTransform(index + 1, expression, onError, repeat, repeatCount) } }
-      );
-    } else {
-      self._dismiss();
-    }
-  };
-  doTextTransform(0, expression, "keep-original", false, "");
+  let operations = columnNames.map(columnName => { return {
+    op: "core/text-transform",
+    onError: "keep-original",
+    repeat: false,
+    repeatCount: 0,
+    engineConfig: ui.browsingEngine.getJSON(),
+    columnName,
+    expression
+  }});
+  Refine.postCoreProcess(
+    "apply-operations",
+    {},
+    { operations: JSON.stringify(operations) },
+    { modelsChanged: true, rowIdsPreserved: true },
+    { onDone: function() { self._dismiss(); } }
+  );
 };


### PR DESCRIPTION
Fixes #7212.

It turns out that all actions in the "All" -> "Edit all columns" menu didn't work if there were undone operations in the history, a bug caused by my introduction of the history erasure confirmation dialog.
This fixes it by simplifying the way those actions are implemented, making a single request to execute all operations on selected columns at once.

I intend to backport this to 3.9, to be released in 3.9.2.