### PR TITLE
fix: JSON deserialization of RowAdditionOperation

### DIFF
--- a/main/src/com/google/refine/operations/row/RowAdditionOperation.java
+++ b/main/src/com/google/refine/operations/row/RowAdditionOperation.java
@@ -76,7 +76,7 @@ public class RowAdditionOperation extends AbstractOperation {
     public RowAdditionOperation(
             @JsonProperty("addedRows") List<Row> addedRows,
             @JsonProperty("rows") List<Object> rows,
-            @JsonProperty("insertionIndex") int insertionIndex) {
+            @JsonProperty("index") int insertionIndex) {
         _rows = addedRows != null ? addedRows
                 : (rows == null ? List.of() : rows.stream().map(r -> new Row(0)).collect(Collectors.toList()));
         _insertionIndex = insertionIndex;

--- a/main/tests/server/src/com/google/refine/operations/row/RowAdditionOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowAdditionOperationTests.java
@@ -59,6 +59,7 @@ public class RowAdditionOperationTests extends RefineTest {
 
     String legacyJson;
     String newJson;
+    String jsonAppend;
     RowAdditionOperation op;
 
     @BeforeSuite
@@ -80,6 +81,11 @@ public class RowAdditionOperationTests extends RefineTest {
                 + "\"op\":\"core/row-addition\","
                 + "\"addedRows\":[{\"starred\":false,\"flagged\":false,\"cells\":[]},{\"starred\":false,\"flagged\":false,\"cells\":[]}],"
                 + "\"index\":0,"
+                + "\"description\":" + new TextNode(OperationDescription.row_addition_brief()).toString() + "}";
+        jsonAppend = "{"
+                + "\"op\":\"core/row-addition\","
+                + "\"addedRows\":[{\"starred\":false,\"flagged\":false,\"cells\":[]},{\"starred\":false,\"flagged\":false,\"cells\":[]}],"
+                + "\"index\":15,"
                 + "\"description\":" + new TextNode(OperationDescription.row_addition_brief()).toString() + "}";
 
         List<Row> rows = new ArrayList<>(2);
@@ -106,6 +112,12 @@ public class RowAdditionOperationTests extends RefineTest {
     public void testNewDeserialization() throws IOException {
         RowAdditionOperation op = ParsingUtilities.mapper.readValue(newJson, RowAdditionOperation.class);
         TestUtils.isSerializedTo(op, newJson);
+    }
+
+    @Test
+    public void testDeserializationAppend() throws IOException {
+        RowAdditionOperation op = ParsingUtilities.mapper.readValue(jsonAppend, RowAdditionOperation.class);
+        TestUtils.isSerializedTo(op, jsonAppend);
     }
 
     @Test


### PR DESCRIPTION
I realized that the serialization and deserialization code of RowAdditionOperation were inconsistent: the index at which the rows should be inserted was called `index` in serialization, but `insertionIndex` in deserialization.

This fixes deserialization. Since any serialized versions of this operation in workspaces will use the `index` field, there shouldn't be any need to keep supporting `insertionIndex`.

This PR conflicts with #7224: depending on which one gets merged first, the other one will need to be adapted to change the frontend to submit `index` instead of `insertionIndex`.