### PR TITLE
Add operation icons to the dialog warning of history erasure

### DIFF
--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -492,6 +492,10 @@ Refine._confirmHistoryErasure = function(entries, onDone) {
     var entryDom = $(DOM.loadHTML("core", "scripts/project/history-entry.html")).appendTo(elmts.entryList);
     var entryElmts = DOM.bind(entryDom);
     entryElmts.entryDescription.text(entry.description);
+    if (entry.operation_id !== undefined && OperationIconRegistry.getIcon(entry.operation_id) !== undefined) {
+      entryElmts.operationIcon.append($('<img>')
+        .attr('src', OperationIconRegistry.getIcon(entry.operation_id)));
+    }
   }
 
   var updateWarnPreferences = function () {


### PR DESCRIPTION
So far the operations were listed simply with their description, not their icon. This introduces the icons as shown below.

### Screenshot

![image](https://github.com/user-attachments/assets/49824e66-1285-4817-a19e-78bcc31e0818)
