### PR TITLE
Enable custom clustering for non-GREL expressions

### DIFF
--- a/extensions/jython/tests/src/com/google/refine/jython/JythonEvaluableTest.java
+++ b/extensions/jython/tests/src/com/google/refine/jython/JythonEvaluableTest.java
@@ -2,6 +2,7 @@
 package com.google.refine.jython;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -12,6 +13,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.refine.expr.CellTuple;
+import com.google.refine.expr.EvalError;
 import com.google.refine.expr.Evaluable;
 import com.google.refine.expr.ParsingException;
 import com.google.refine.model.Cell;
@@ -148,5 +150,34 @@ public class JythonEvaluableTest {
     @Test(expectedExceptions = ParsingException.class)
     public void testParseError() throws ParsingException {
         JythonEvaluable.createParser().parse("foo(", "jython");
+    }
+
+    @Test
+    public void testEvalErrorOnSomeBindings() {
+        String testKey = "columnName";
+        Properties bindings = createBindings();
+        assertTrue(bindings.containsKey(testKey), "Bindings should contain '" + testKey + "'.");
+
+        Evaluable evaluable = new JythonEvaluable("return " + testKey);
+        Object result = evaluable.evaluate(bindings);
+        assertTrue(result instanceof EvalError,
+                "Should produce an EvalError because '" + testKey + "' is not available.");
+        assertTrue(result.toString().contains(testKey),
+                "EvalError should contain the name '" + testKey + "' in the error message.");
+    }
+
+    @Test
+    public void testSpecialValuesForUserDefinedDistance() {
+        Properties bindings = createBindings();
+        String a = "aaaa";
+        String b = "bbb";
+        // special values used in custom clustering via UserDefinedDistance
+        bindings.put("value1", a);
+        bindings.put("value2", b);
+
+        long expectedLength = a.length() - b.length();
+        Evaluable evaluable = new JythonEvaluable("return len(value1) - len(value2)");
+        Object result = evaluable.evaluate(bindings);
+        assertEquals(result, expectedLength, "Length difference should be the same.");
     }
 }

--- a/main/src/com/google/refine/clustering/binning/UserDefinedKeyer.java
+++ b/main/src/com/google/refine/clustering/binning/UserDefinedKeyer.java
@@ -45,7 +45,7 @@ public class UserDefinedKeyer extends Keyer {
     private Properties bindings;
 
     public UserDefinedKeyer(String expression) throws ParsingException {
-        eval = MetaParser.parse("grel:" + expression);
+        eval = MetaParser.parse(expression);
         bindings = new Properties();
 
         bindings.put("true", true);

--- a/main/src/com/google/refine/clustering/knn/UserDefinedDistance.java
+++ b/main/src/com/google/refine/clustering/knn/UserDefinedDistance.java
@@ -46,7 +46,7 @@ public class UserDefinedDistance implements SimilarityDistance {
     private Properties bindings;
 
     public UserDefinedDistance(String expression) throws ParsingException {
-        eval = MetaParser.parse("grel:" + expression);
+        eval = MetaParser.parse(expression);
         bindings = new Properties();
 
         bindings.put("true", true);

--- a/main/src/com/google/refine/expr/ClojureParser.java
+++ b/main/src/com/google/refine/expr/ClojureParser.java
@@ -77,8 +77,7 @@ public class ClojureParser implements LanguageSpecificParser {
                                 bindings.get("row"),
                                 bindings.get("rowIndex"),
                                 bindings.get("value1"),
-                                bindings.get("value2")
-                                );
+                                bindings.get("value2"));
                     } catch (Exception e) {
                         return new EvalError(e.getMessage());
                     }

--- a/main/src/com/google/refine/expr/ClojureParser.java
+++ b/main/src/com/google/refine/expr/ClojureParser.java
@@ -50,7 +50,7 @@ public class ClojureParser implements LanguageSpecificParser {
 //                    RT.load("clojure/core"); // Make sure RT is initialized
             Object foo = RT.CURRENT_NS; // Make sure RT is initialized
             IFn fn = (IFn) clojure.lang.Compiler.load(new StringReader(
-                    "(fn [value cell cells row rowIndex] " + source + ")"));
+                    "(fn [value cell cells row rowIndex value1 value2] " + source + ")"));
 
             // TODO: We should to switch from using Compiler.load
             // because it's technically an internal interface
@@ -75,7 +75,10 @@ public class ClojureParser implements LanguageSpecificParser {
                                 bindings.get("cell"),
                                 bindings.get("cells"),
                                 bindings.get("row"),
-                                bindings.get("rowIndex"));
+                                bindings.get("rowIndex"),
+                                bindings.get("value1"),
+                                bindings.get("value2")
+                                );
                     } catch (Exception e) {
                         return new EvalError(e.getMessage());
                     }

--- a/main/tests/server/src/com/google/refine/clustering/binning/UserDefinedKeyerTests.java
+++ b/main/tests/server/src/com/google/refine/clustering/binning/UserDefinedKeyerTests.java
@@ -31,69 +31,110 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.clustering.binning;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import com.google.refine.expr.Evaluable;
+import com.google.refine.expr.LanguageSpecificParser;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
 import com.google.refine.grel.Parser;
 
 public class UserDefinedKeyerTests {
 
-    private Keyer keyer;
+    private List<String> testStrings = List.of("hello", "new", "fantastic");
+
+    @Mock
+    private LanguageSpecificParser testParser;
+
+    @Mock
+    private Evaluable testEvaluable;
+
     // some sample test cases taken from KeyerTests
-    private static final String[][] testStrings = {
-            { " école ÉCole ecoLe ", "ecole" },
-            { " d c b a ", "a b c d" },
-            { "\tABC \t DEF ", "abc def" }, // test leading and trailing whitespace
-            { "bbb\taaa", "aaa bbb" },
-//        {"å","aa"}, // Requested by issue #650, but conflicts with diacritic folding
-            { "æø", "aeoe" }, // Norwegian replacements from #650
-            { "©ß", "css" }, // issue #409 esszet
-    };
+    @DataProvider(name = "user-defined-keyer-test-cases")
+    private String[][] userDefinedKeyerTestCases() {
+        return new String[][] {
+                { " école ÉCole ecoLe ", "ecole" },
+                { " d c b a ", "a b c d" },
+                { "\tABC \t DEF ", "abc def" }, // test leading and trailing whitespace
+                { "bbb\taaa", "aaa bbb" },
+                // {"å","aa"}, // Requested by issue #650, but conflicts with diacritic folding
+                { "æø", "aeoe" }, // Norwegian replacements from #650
+                { "©ß", "css" }, // issue #409 esszet
+        };
+    }
+
+    @DataProvider(name = "user-defined-keyer-expressions")
+    private String[][] userDefinedKeyerExpressions() {
+        return new String[][] {
+                { "value + ' world'", },
+                { "grel:value + ' world'", },
+                { "testparser:value + world" },
+        };
+    }
 
     @BeforeMethod
-    public void registerGRELParser() {
+    public void setupMocks() throws ParsingException {
+        MockitoAnnotations.openMocks(this);
+        when(testParser.parse(anyString(), eq("testparser"))).thenReturn(testEvaluable);
+        when(testEvaluable.evaluate(any())).thenAnswer(AdditionalAnswers
+                .returnsElementsOf(testStrings.stream().map(s -> s + " world").collect(Collectors.toList())));
+    }
+
+    @BeforeMethod
+    public void registerParser() {
         MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+        MetaParser.registerLanguageParser("testparser", "Test Parser", testParser, "return value");
     }
 
     @AfterMethod
-    public void unregisterGRELParser() {
+    public void unregisterParser() {
         MetaParser.unregisterLanguageParser("grel");
+        MetaParser.unregisterLanguageParser("testparser");
     }
 
-    @Test
-    public void testUserDefinedKeyer1() {
+    @Test(dataProvider = "user-defined-keyer-test-cases")
+    public void testGenericCases(String testString, String expectedString) {
+        UserDefinedKeyer keyer;
         try {
             String expression = "value.fingerprint()";
             keyer = new UserDefinedKeyer(expression);
         } catch (ParsingException e) {
             throw new RuntimeException(e);
         }
-        for (String[] ss : testStrings) {
-            Assert.assertEquals(ss.length, 2, "Invalid test"); // Not a valid test
-            Assert.assertEquals(keyer.key(ss[0]), ss[1],
-                    "User defined keying for string: " + ss[0] + " failed");
-        }
+        Assert.assertEquals(keyer.key(testString), expectedString,
+                "User defined keying for string: " + testString + " failed");
     }
 
-    @Test
-    public void testUserDefinedKeyer2() {
+    @Test(dataProvider = "user-defined-keyer-expressions")
+    public void testDifferentExpressions(String expression) {
+        UserDefinedKeyer keyer;
         try {
-            String expression = "value + ' world'";
             keyer = new UserDefinedKeyer(expression);
         } catch (ParsingException e) {
+            e.printStackTrace();
+            Assert.fail("Could not parse expression " + expression);
             throw new RuntimeException(e);
         }
 
-        String[] strs = { "hello", "new", "fantastic" };
-        for (String s : strs) {
+        for (String s : testStrings) {
             String output = keyer.key(s);
             Assert.assertEquals(output, s + " world",
                     "User defined keying for string: " + s + " failed");
         }
     }
-
 }

--- a/main/tests/server/src/com/google/refine/clustering/knn/DistanceTests.java
+++ b/main/tests/server/src/com/google/refine/clustering/knn/DistanceTests.java
@@ -33,44 +33,74 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.clustering.knn;
 
-import org.slf4j.LoggerFactory;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.google.refine.RefineTest;
+import com.google.refine.expr.Evaluable;
+import com.google.refine.expr.LanguageSpecificParser;
 import com.google.refine.expr.MetaParser;
 import com.google.refine.expr.ParsingException;
 import com.google.refine.grel.Parser;
 
-public class DistanceTests extends RefineTest {
+public class DistanceTests {
 
-    private static SimilarityDistance _distance;
+    private List<Integer> testLengths = List.of(1, 3, 5);
 
-    @Override
-    @BeforeTest
-    public void init() {
-        logger = LoggerFactory.getLogger(this.getClass());
+    @Mock
+    private LanguageSpecificParser testParser;
+
+    @Mock
+    private Evaluable testEvaluable;
+
+    @DataProvider(name = "user-defined-distance-expressions")
+    private String[][] userDefinedKeyerExpressions() {
+        return new String[][] {
+                { "value1.length() - value2.length()", },
+                { "grel:value1.length() - value2.length()", },
+                { "testparser:value1.length() - value2.length()" },
+        };
     }
 
     @BeforeMethod
-    public void registerGRELParser() {
+    public void setupMocks() throws ParsingException {
+        MockitoAnnotations.openMocks(this);
+        when(testParser.parse(anyString(), eq("testparser"))).thenReturn(testEvaluable);
+        when(testEvaluable.evaluate(any())).thenAnswer(AdditionalAnswers.returnsElementsOf(testLengths));
+    }
+
+    @BeforeMethod
+    public void registerParser() {
         MetaParser.registerLanguageParser("grel", "GREL", Parser.grelParser, "value");
+        MetaParser.registerLanguageParser("testparser", "Test Parser", testParser, "return value");
     }
 
     @AfterMethod
-    public void unregisterGRELParser() {
+    public void unregisterParser() {
         MetaParser.unregisterLanguageParser("grel");
+        MetaParser.unregisterLanguageParser("testparser");
     }
 
     @Test
     public void testUserDefinedDistance() {
         String expression = "value1.length() - value2.length()";
 
+        SimilarityDistance distance;
         try {
-            _distance = new UserDefinedDistance(expression);
+            distance = new UserDefinedDistance(expression);
         } catch (ParsingException e) {
             throw new RuntimeException(e);
         }
@@ -78,9 +108,31 @@ public class DistanceTests extends RefineTest {
         String[] testString = { "Ahmed", "Mohamed", "Omar", "Othman", "Aly", "Eleraky" };
         for (int i = 0; i < testString.length; i++) {
             for (int j = i + 1; j < testString.length; j++) {
-                Assert.assertEquals(testString[i].length() - testString[j].length(), _distance.compute(testString[i], testString[j]),
+                Assert.assertEquals(testString[i].length() - testString[j].length(),
+                        distance.compute(testString[i], testString[j]),
                         "User defined distance for strings: " + testString[i] + ", " + testString[j] + " failed");
             }
+        }
+    }
+
+    @Test(dataProvider = "user-defined-distance-expressions")
+    public void testUserDefinedDistanceWithDifferentExpressions(String expression) {
+        SimilarityDistance distance;
+        try {
+            distance = new UserDefinedDistance(expression);
+        } catch (ParsingException e) {
+            e.printStackTrace();
+            Assert.fail("Could not parse expression " + expression);
+            throw new RuntimeException(e);
+        }
+
+        for (int expectedDistance : testLengths) {
+            int baseLength = 10;
+            String testString1 = StringUtils.repeat("*", baseLength);
+            String testString2 = StringUtils.repeat("*", baseLength - expectedDistance);
+            double computedDistance = distance.compute(testString1, testString2);
+            Assert.assertEquals(computedDistance, expectedDistance,
+                    "User defined distance for strings: " + testString1 + ", " + testString2 + " failed");
         }
     }
 }

--- a/main/tests/server/src/com/google/refine/expr/ClojureParserTest.java
+++ b/main/tests/server/src/com/google/refine/expr/ClojureParserTest.java
@@ -1,3 +1,4 @@
+
 package com.google.refine.expr;
 
 import static org.testng.Assert.assertEquals;

--- a/main/tests/server/src/com/google/refine/expr/ClojureParserTest.java
+++ b/main/tests/server/src/com/google/refine/expr/ClojureParserTest.java
@@ -1,0 +1,72 @@
+package com.google.refine.expr;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import java.util.Properties;
+
+import org.testng.annotations.Test;
+
+import com.google.refine.model.Cell;
+import com.google.refine.model.Project;
+import com.google.refine.model.Row;
+
+public class ClojureParserTest {
+
+    private Properties createBindings() {
+        Project project = new Project();
+        Row row = new Row(2);
+        row.setCell(0, new Cell("one", null));
+        row.setCell(0, new Cell("1", null));
+        Properties bindings = new Properties();
+        bindings.put("columnName", "number");
+        bindings.put("true", "true");
+        bindings.put("false", "false");
+        bindings.put("rowIndex", "0");
+        bindings.put("value", 1);
+        bindings.put("project", project);
+        bindings.put("call", "number");
+        bindings.put("PI", "3.141592654");
+        bindings.put("cells", new CellTuple(project, row));
+        return bindings;
+    }
+
+    @Test
+    public void testBasicClojureExpression() throws ParsingException {
+        Properties bindings = createBindings();
+        // just make sure that value is a number
+        bindings.put("value", 1);
+
+        Evaluable evaluable = (new ClojureParser()).parse("(+ 0 value)", "clojure");
+        Object result = evaluable.evaluate(bindings);
+        assertEquals(new BigDecimal((long) result), new BigDecimal((int) bindings.get("value")),
+                "Adding 0 to a number should keep the number.");
+    }
+
+    @Test(expectedExceptions = ParsingException.class)
+    public void testEvalErrorOnSomeBindings() throws ParsingException {
+        String testKey = "columnName";
+        Properties bindings = createBindings();
+        assertTrue(bindings.containsKey(testKey), "Bindings should contain '" + testKey + "'.");
+
+        Evaluable evaluable = (new ClojureParser()).parse("(count " + testKey + ")", "clojure");
+        evaluable.evaluate(bindings);
+    }
+
+    @Test
+    public void testSpecialValuesForUserDefinedDistance() throws ParsingException {
+        Properties bindings = createBindings();
+        String a = "aaaa";
+        String b = "bbb";
+        // special values used in custom clustering via UserDefinedDistance
+        bindings.put("value1", a);
+        bindings.put("value2", b);
+
+        long expectedLength = a.length() - b.length();
+
+        Evaluable evaluable = (new ClojureParser()).parse("(- (count value1) (count value2))", "clojure");
+        Object result = evaluable.evaluate(bindings);
+        assertEquals(result, expectedLength, "Length difference should be the same.");
+    }
+}

--- a/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-dialog.js
@@ -226,7 +226,7 @@ ClusteringDialog.prototype._renderClusteringFunctions = function() {
                     var option = $('<option></option>')
                         .val("UserDefinedKeyer")
                         .text(functions[i].name)
-                        .data('expression', functions[i].expression)
+                        .data('expression', functions[i].expressionLang + ':' + functions[i].expression)
                         .appendTo(self._elmts.keyingFunctionSelector);
 
                 }
@@ -243,7 +243,7 @@ ClusteringDialog.prototype._renderClusteringFunctions = function() {
                     var option = $('<option></option>')
                         .val("UserDefinedDistance")
                         .text(functions[i].name)
-                        .data('expression', functions[i].expression)
+                        .data('expression', functions[i].expressionLang + ':' + functions[i].expression)
                         .appendTo(self._elmts.distanceFunctionSelector);
                 }
             },

--- a/main/webapp/modules/core/scripts/dialogs/clustering-functions-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/clustering-functions-dialog.js
@@ -223,7 +223,7 @@ ClusteringFunctionsDialog.prototype._addFunction = function (column) {
                             }),
                             data: {
                                 "value": JSON.stringify(_functions),
-                                csrf_token: token
+                                "csrf_token": token
                             },
                             success: function (data) {
                                 self._renderTable();
@@ -313,7 +313,7 @@ ClusteringFunctionsDialog.prototype._editFunction = function (column, functionsT
                             }),
                             data: {
                                 "value": JSON.stringify(_functions),
-                                csrf_token: token
+                                "csrf_token": token
                             },
                             success: function (data) {
                                 self._renderTable();
@@ -352,7 +352,7 @@ ClusteringFunctionsDialog.prototype._deleteFunction = function (index) {
                             }),
                             data: {
                                 "value": JSON.stringify(_functions),
-                                csrf_token: token
+                                "csrf_token": token
                             },
                             success: function (data) {
                                 self._renderTable();

--- a/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
+++ b/main/webapp/modules/core/scripts/dialogs/expression-preview-dialog.js
@@ -468,12 +468,12 @@ ExpressionPreviewDialog.Widget.prototype.update = function() {
         );
 
         self._params = {
-            "expression" : expression,
+            "expression" : this._getLanguage() + ":" + expression,
             "radius" : Number(document.getElementById('radius').value),
             "blocking-ngram-size" : Number(document.getElementById('blockingChars').value)
         };
 
-        $.post(
+        Refine.postCSRF(
             "command/core/compute-clusters?" + $.param({ project: theProject.id }),
             {
                 engine: JSON.stringify(ui.browsingEngine.getJSON()),
@@ -664,7 +664,7 @@ ExpressionPreviewDialog.Widget.prototype._renderDistancePreview = function(first
         let newExpression = expression.replace(/value1/g, '"' + value1.toString().replaceAll(' ', '\xa0') + '"')
                                 .replace(/value2/g, '"' + value2.toString().replaceAll(' ', '\xa0') + '"')
                                 .replace(/value/g,"");
-        $.post(
+        Refine.postCSRF(
             "command/core/preview-expression?" + $.param(params), 
             {
                 expression: self._getLanguage() + ":" + newExpression,


### PR DESCRIPTION
Fixes #7234 

In #6612 we introduced custom clustering functions.
But with non-GREL expressions like Jython and Clojure the clustering failed on multiple levels.

1. Several post requests in the new clustering dialogs were missing csrf tokens.
2. Several post requests did only sent the plain expression without the language code.
3. The GREL language code was hard coded in `UserDefinedKeyer.java` and `UserDefinedDistance.java`.
4. The new variables `value1` and `value2` were not made available in Jython and Clojure expressions.

The last one is probably the most problematic.

In GREL all variables in `bindings` are basically available as globals. But in Jython and Clojure we encapsulate the expressions in functions and only pass certain variables as parameters (`value, cell, cells, row, rowIndex`).

This means that in Jython and Clojure expressions we can not access variables like `columnName`. This also means that we somehow have to make the new variables `value1` and `value2` accessible to Jython and Clojure expressions.

Without rewriting the whole Jython and Clojure integration it felt most idiomatic to also introduce the new variables as parameters to the Jython and Clojure functions that encapsulate the expressions. But it is still somewhat unsatisfying that we have a different pool of available variables in GREL and (possibly) each other language integration.

**Note:** for the custom clustering a separate set of `bindings` is created. This means we basically only have access to `value` and `value1, value2` respectively. Usually available variables like `cell, cells, row, rowIndex, ...` are not available (not even in GREL). As this seems to be a deliberate choice I did not touch this part. But we should also document this behavior e.g. on [Custom clustering methods](https://openrefine.org/docs/manual/cellediting#custom-clustering-methods) to avoid further confusion.