### PR TITLE
Include `contextPath` when returning a redirect response

### DIFF
--- a/main/src/com/google/refine/commands/project/CreateProjectCommand.java
+++ b/main/src/com/google/refine/commands/project/CreateProjectCommand.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.refine.ProjectManager;
 import com.google.refine.commands.Command;
-import com.google.refine.commands.HttpUtilities;
 import com.google.refine.importing.ImportingJob;
 import com.google.refine.importing.ImportingManager;
 import com.google.refine.importing.ImportingManager.Format;
@@ -129,7 +128,7 @@ public class CreateProjectCommand extends Command {
 
             long projectId = ImportingUtilities.createProject(job, format, optionObj, exceptions, true);
 
-            HttpUtilities.redirect(response, "/project?project=" + projectId);
+            redirect(response, request.getContextPath() + "/project?project=" + projectId);
         } catch (Exception e) {
             respondWithErrorPage(request, response, "Failed to import file", e);
         } finally {

--- a/main/src/com/google/refine/commands/project/ImportProjectCommand.java
+++ b/main/src/com/google/refine/commands/project/ImportProjectCommand.java
@@ -88,7 +88,7 @@ public class ImportProjectCommand extends Command {
                     }
                 }
 
-                redirect(response, "/project?project=" + projectID);
+                redirect(response, request.getContextPath() + "/project?project=" + projectID);
             } else {
                 respondWithErrorPage(request, response, "Failed to import project. Reason unknown.", null);
             }

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -120,6 +120,7 @@ public class Refine {
 
         RefineServer server = new RefineServer();
         server.init(iface, port, host);
+        String contextPath = server.getURI().getPath();
 
         boolean headless = Configurations.getBoolean("refine.headless", false);
         if (headless) {
@@ -131,12 +132,12 @@ public class Refine {
                 if ("*".equals(host)) {
                     if ("0.0.0.0".equals(iface)) {
                         logger.warn("No refine.host specified while binding to interface 0.0.0.0, guessing localhost.");
-                        client.init("localhost", port);
+                        client.init("localhost", port, contextPath);
                     } else {
-                        client.init(iface, port);
+                        client.init(iface, port, contextPath);
                     }
                 } else {
-                    client.init(host, port);
+                    client.init(host, port, contextPath);
                 }
             } catch (Exception e) {
                 logger.warn("Sorry, some error prevented us from launching the browser for you.\n\n Point your browser to http://" + host
@@ -492,8 +493,8 @@ class RefineClient extends JFrame implements ActionListener {
 
     private URI uri;
 
-    public void init(String host, int port) throws Exception {
-        uri = new URI("http://" + host + ":" + port + "/");
+    public void init(String host, int port, String contextPath) throws Exception {
+        uri = new URI("http://" + host + ":" + port + contextPath);
         openBrowser();
     }
 


### PR DESCRIPTION
Fixes #7231 

Changes proposed in this pull request:
- Includes the server's `contextPath` as a prefix when redirecting after creating or importing a project. 
- Include `contextPath` when opening the browser on startup.
