### PR TITLE
Change release manager to Rory

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -57,7 +57,7 @@ The Release Manager is responsible to
 * Coordinate with the community to select which issues and pull requests are part of new releases
 * Prepare and coordinate publishing new releases
 
-The current Release Manager is [Antonin Delpeuch](https://github.com/wetneb).
+The current Release Manager is [Rory Sawyer](https://github.com/SoryRawyer).
 
 ### Steering Committee
 The steering committee oversees the general direction of the project and initiates connections and collaborations with other organizations and projects.


### PR DESCRIPTION
As I am transitioning out of the project, I'd like to pass on the release manager hat.
Rory, feel free to reach out if you need any sort of help, I intend to remain reachable in the coming months.

On a similar note, I will no longer feel responsible for keeping the PR backlog under control, so I encourage you to merge things :) For that also, if you are unsure about something in a PR, feel free to request my review, I will be happy to give opinions :)