### PR TITLE
add upload button to preview tab

### DIFF
--- a/extensions/wikibase/module/scripts/preview-tab.html
+++ b/extensions/wikibase/module/scripts/preview-tab.html
@@ -1,5 +1,8 @@
 <div id="schema-preview-tab">
-    <p class="panel-explanation" bind="previewExplanation"></p>
+    <div id="schema-preview-divided-header">
+        <p class="panel-explanation" bind="previewExplanation"></p>
+        <button class="button button-primary" bind="uploadEditsButton"></button>
+    </div>
     <p class="invalid-schema-warning" bind="invalidSchemaWarningPreview"></p>
     <div class="schema-validation-errors" bind="schemaValidationErrors"></div>
     <div class="schema-alignment-dialog-preview"></div>

--- a/extensions/wikibase/module/scripts/schema-alignment.js
+++ b/extensions/wikibase/module/scripts/schema-alignment.js
@@ -228,6 +228,10 @@ SchemaAlignment._rerenderTabs = function() {
   previewElmts.invalidSchemaWarningPreview.text($.i18n('wikibase-schema/invalid-schema-warning'));
   this.schemaValidationErrorsInPreview = previewElmts.schemaValidationErrors;
   this._previewPanes = $(".schema-alignment-dialog-preview");
+  previewElmts.uploadEditsButton.text($.i18n('wikibase-extension/perform-edits-on-wikibase'));
+  previewElmts.uploadEditsButton.on('click', function(evt) {
+    PerformEditsDialog.checkAndLaunch();
+  });
 
   // add all recon services for all the entity types of the Wikibase instance
   var entityTypes = WikibaseManager.getSelectedWikibaseAvailableEntityTypes();

--- a/extensions/wikibase/module/styles/schema-alignment.css
+++ b/extensions/wikibase/module/styles/schema-alignment.css
@@ -17,6 +17,18 @@
   height: 100%;
 }
 
+#schema-preview-divided-header {
+  max-width: 900px;
+  padding: 0px 10px 0px 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+#schema-preview-divided-header .panel-explanation {
+  margin-left: 0em;
+}
+
 .schema-alignment-tab-content {
   max-width: 70em;
 }


### PR DESCRIPTION
closes #6305 

### Status quo
After checking edits in the preview tab, user has to go through the extension menu to upload them (see issue description)

### Changes proposed in this pull request
- adds a button directly at the top of the preview tab that refers to the same functionality as directly selecting "Upload edits to Wikibase..." in the extension's dropdown menu

Before:
![preview-tab-header-before](https://github.com/user-attachments/assets/001a0527-f38c-4aba-95a0-b1055380e42a)

After:
![preview-tab-header-after](https://github.com/user-attachments/assets/40ece269-e947-4771-bb34-87e830b7d26d)

_Note_:
the CSS for `#schema-preview-divided-header` (max-width & padding) corresponds to the CSS for `schema-alignment-dialog-preview` so both elements align