### PR TITLE
Resolve cypress test failures from language updates

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/all-column/collapse_all.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/all-column/collapse_all.cy.js
@@ -7,11 +7,11 @@ const fixture = [
       ];
   it('it collapses all columns', function () {
     cy.loadAndVisitProject(fixture);
-    cy.columnActionClick('All', ['View', 'Collapse all columns']);
+    cy.columnActionClick('All', ['Hide / Show', 'Hide all columns']);
 
-    cy.get('[title="Expand column \'a\'"]').should('to.contain', '');
-    cy.get('[title="Expand column \'b\'"]').should('to.contain', '');
-    cy.get('[title="Expand column \'c\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'a\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'b\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'c\'"]').should('to.contain', '');
 
   });
 });

--- a/main/tests/cypress/cypress/e2e/project/grid/all-column/view.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/all-column/view.cy.js
@@ -1,7 +1,7 @@
 describe(__filename, function () {
   it('it collapses all columns', function () {
     cy.loadAndVisitProject('food.mini');
-    cy.columnActionClick('All', ['View', 'Collapse all columns']);
+    cy.columnActionClick('All', ['Hide / Show', 'Hide all columns']);
 
     cy.get('.odd td:nth-child(4)').should('to.contain', '');
     cy.get('.odd td:nth-child(5)').should('to.contain', '');
@@ -15,12 +15,12 @@ describe(__filename, function () {
   });
   it('it expands all columns', function () {
     cy.loadAndVisitProject('food.mini');
-    cy.columnActionClick('All', ['View', 'Collapse all columns']);
+    cy.columnActionClick('All', ['Hide / Show', 'Hide all columns']);
 
     cy.get('.odd td:nth-child(4)').should('to.contain', '');
     cy.get('.even td:nth-child(7)').should('to.contain', '');
 
-    cy.columnActionClick('All', ['View', 'Expand all columns']);
+    cy.columnActionClick('All', ['Hide / Show', 'Show all columns']);
 
     cy.assertGridEquals([
       ['NDB_No', 'Shrt_Desc', 'Water', 'Energ_Kcal'],
@@ -31,14 +31,14 @@ describe(__filename, function () {
   it('it shows or hides null values', function () {
     cy.loadAndVisitProject('food.mini');
     cy.columnActionClick('Energ_Kcal', ['Edit cells', 'Common transforms', 'To null']);
-    cy.columnActionClick('All', ['View', 'Show / Hide null values in cells']);
+    cy.columnActionClick('All', ['Hide / Show', 'Show / Hide null values in cells']);
 
     cy.assertGridEquals([
       ['NDB_No', 'Shrt_Desc', 'Water', 'Energ_Kcal'],
       ['01001', 'BUTTER,WITH SALT', '15.87', null],
       ['01002', 'BUTTER,WHIPPED,WITH SALT', '15.87', null],
     ]);
-    cy.columnActionClick('All', ['View', 'Show / Hide null values in cells']);
+    cy.columnActionClick('All', ['Hide / Show', 'Show / Hide null values in cells']);
 
     cy.assertGridEquals([
       ['NDB_No', 'Shrt_Desc', 'Water', 'Energ_Kcal'],

--- a/main/tests/cypress/cypress/e2e/project/grid/column/view/collapse.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/view/collapse.cy.js
@@ -7,8 +7,8 @@ describe(__filename, function () {
       ];
   it('it collapses all columns', function () {
     cy.loadAndVisitProject(fixture);
-    cy.columnActionClick('a', ['View', 'Collapse this column']);
+    cy.columnActionClick('a', ['Hide / Show', 'Hide this column']);
 
-    cy.get('[title="Expand column \'a\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'a\'"]').should('to.contain', '');
   });
 });

--- a/main/tests/cypress/cypress/e2e/project/grid/column/view/collapse_left.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/view/collapse_left.cy.js
@@ -7,10 +7,10 @@ const fixture = [
       ];
   it('it collapses all columns to left', function () {
     cy.loadAndVisitProject(fixture);
-    cy.columnActionClick('c', ['View', 'Collapse all columns to left']);
+    cy.columnActionClick('c', ['Hide / Show', 'Hide all columns to left']);
 
-    cy.get('[title="Expand column \'a\'"]').should('to.contain', '');
-    cy.get('[title="Expand column \'b\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'a\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'b\'"]').should('to.contain', '');
 
   });
 });

--- a/main/tests/cypress/cypress/e2e/project/grid/column/view/collapse_right.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/view/collapse_right.cy.js
@@ -7,10 +7,10 @@ const fixture = [
       ];
   it('it collapses all columns to right', function () {
     cy.loadAndVisitProject(fixture);
-    cy.columnActionClick('a', ['View', 'Collapse all columns to right']);
+    cy.columnActionClick('a', ['Hide / Show', 'Hide all columns to right']);
 
-    cy.get('[title="Expand column \'b\'"]').should('to.contain', '');
-    cy.get('[title="Expand column \'c\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'b\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'c\'"]').should('to.contain', '');
 
   });
 });

--- a/main/tests/cypress/cypress/e2e/project/grid/column/view/expand-left.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/view/expand-left.cy.js
@@ -9,14 +9,14 @@ const fixture = [
   it('expands all columns to left', function () {
     cy.loadAndVisitProject(fixture);
     // Start by collapsing
-    cy.columnActionClick('c', ['View', 'Collapse all columns to left']);
+    cy.columnActionClick('c', ['Hide / Show', 'Hide all columns to left']);
 
     // Verify collapsed columns
-    cy.get('[title="Expand column \'a\'"]').should('to.contain', '');
-    cy.get('[title="Expand column \'b\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'a\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'b\'"]').should('to.contain', '');
 
     // Expand
-    cy.columnActionClick('c', ['View', 'Expand all columns to the left']);
+    cy.columnActionClick('c', ['Hide / Show', 'Show all columns to the left']);
 
     // Verify expanded columns
     cy.get('[title="a"]').should('to.contain', 'a');

--- a/main/tests/cypress/cypress/e2e/project/grid/column/view/expand-right.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/view/expand-right.cy.js
@@ -9,14 +9,14 @@ const fixture = [
   it('it collapses all columns to right', function () {
     cy.loadAndVisitProject(fixture);
     // Start by collapsing columns
-    cy.columnActionClick('a', ['View', 'Collapse all columns to right']);
+    cy.columnActionClick('a', ['Hide / Show', 'Hide all columns to right']);
 
     // Verify collapse
-    cy.get('[title="Expand column \'b\'"]').should('to.contain', '');
-    cy.get('[title="Expand column \'c\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'b\'"]').should('to.contain', '');
+    cy.get('[title="Show column \'c\'"]').should('to.contain', '');
 
-    // Expand columns
-    cy.columnActionClick('a', ['View', 'Expand all columns to the right']);
+    // Show columns
+    cy.columnActionClick('a', ['Hide / Show', 'Show all columns to the right']);
 
     // Verify expansion
     cy.get('[title="b"]').should('to.contain', 'b');


### PR DESCRIPTION
Changes proposed in this pull request:
- This aligns the cypress tests with the language updates made in #7193. I don't think the cypress tests run automatically on pull requests that update the language files, which might explain why these failures weren't noticed before merging the PR.
