### PR TITLE
feat(api): add support for flat array response in get-all-project-tags

### DIFF
--- a/main/src/com/google/refine/commands/workspace/GetAllProjectTagsCommand.java
+++ b/main/src/com/google/refine/commands/workspace/GetAllProjectTagsCommand.java
@@ -57,6 +57,13 @@ public class GetAllProjectTagsCommand extends Command {
 
         Map<String, Integer> tagMap = ProjectManager.singleton.getAllProjectsTags();
         Set<String> tags = tagMap == null ? Collections.emptySet() : tagMap.keySet();
-        respondJSON(response, new AllProjectsTags(tags));
+
+        String format = request.getParameter("format"); // e.g., ?format=flat
+
+        if ("flat".equalsIgnoreCase(format)) {
+            respondJSON(response, tags); // Simplified array
+        } else {
+            respondJSON(response, new AllProjectsTags(tags)); // Old format with "tags" key
+        }
     }
 }


### PR DESCRIPTION
feat(api): add support for flat array response in `get-all-project-tags`

Fixes #7295 

Changes proposed in this pull request:

This pull request introduces an optional `format=flat` query parameter to the `get-all-project-tags` API endpoint. When specified, the API returns a flat JSON array of tags instead of the default object with a "tags" key.

Example:
```
GET /...?format=flat
Response: ["tag1", "tag2", "tag3"]
```

This enhancement maintains backward compatibility and provides clients with a simplified response format when desired.
