### PR TITLE
don't inject defaults encoding into the client

### DIFF
--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -773,7 +773,6 @@ function process(path, request, response) {
           }
           
           context.encodingJson = JSON.stringify(encodings);
-          context.defaultEncoding = JSON.stringify(Packages.java.nio.charset.Charset.defaultCharset().name());
         }
         
         send(request, response, path + ".vt", context);

--- a/main/webapp/modules/core/index.vt
+++ b/main/webapp/modules/core/index.vt
@@ -40,7 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   <script type="text/javascript" src="wirings.js"></script>
   $scriptInjection
   $styleInjection
-  <script>Refine.encodings = $encodingJson; Refine.defaultEncoding = $defaultEncoding;</script>
+  <script>Refine.encodings = $encodingJson;</script>
 </head>
 <body>
   <div id="header">

--- a/main/webapp/modules/core/project.vt
+++ b/main/webapp/modules/core/project.vt
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     </script>
     <script type="text/javascript" src="wirings.js"></script>
     $scriptInjection
-    <script>Refine.encodings = $encodingJson; Refine.defaultEncoding = $defaultEncoding;</script>
+    <script>Refine.encodings = $encodingJson;</script>
   </head>
   <body>
     <div id="header">


### PR DESCRIPTION
Slightly random cleanup incoming.

`Refine.encodings` is not accessed by any scripts in core nor any known extensions. It appears like it was once introduced for debugging purposes but has since ended up as dead code.
