### PR TITLE
Feature/Add Editing results facet button to extensions menu

### DIFF
--- a/extensions/wikibase/module/MOD-INF/controller.js
+++ b/extensions/wikibase/module/MOD-INF/controller.js
@@ -77,6 +77,7 @@ function init() {
         "scripts/preview-renderer.js",
         "scripts/wikibase-suggest.js",
         "scripts/schema-alignment.js",
+        "scripts/wikibase-ui.js",
         "scripts/wikidata-extension-manager.js",
         "scripts/dialogs/manage-account-dialog.js",
         "scripts/dialogs/perform-edits-dialog.js",

--- a/extensions/wikibase/module/langs/translation-en.json
+++ b/extensions/wikibase/module/langs/translation-en.json
@@ -5,6 +5,7 @@
     "wikibase-extension/import-wikibase-schema": "Import schema…",
     "wikibase-extension/manage-wikibase-account": "Manage Wikibase account…",
     "wikibase-extension/perform-edits-on-wikibase": "Upload edits to Wikibase…",
+    "wikibase-extension/editing-results-facet": "Editing results facet",
     "wikibase-extension/export-to-qs": "Export to QuickStatements",
     "wikibase-extension/qs-file": "QuickStatements file",
     "wikibase-extension/wikibase-edits": "Wikibase edits…",

--- a/extensions/wikibase/module/scripts/menu-bar-extension.js
+++ b/extensions/wikibase/module/scripts/menu-bar-extension.js
@@ -121,6 +121,13 @@ $(function () {
             }
           },
           {
+            id: "wikidata/editing-results-facet",
+            label: $.i18n('wikibase-extension/editing-results-facet'),
+            click: function () {
+              WikibaseUI.createEditingResultsFacet();
+            }
+          },
+          {
             id: "wikidata/export-qs",
             label: $.i18n('wikibase-extension/export-to-qs'),
             click: function () {

--- a/extensions/wikibase/module/scripts/wikibase-ui.js
+++ b/extensions/wikibase/module/scripts/wikibase-ui.js
@@ -1,0 +1,20 @@
+var WikibaseUI = {};
+
+WikibaseUI.createEditingResultsFacet = function () {
+    const columnName = "Wikibase editing results";
+
+    const column = theProject.columnModel.columns.find(col => col.name === columnName);
+    if (!column) {
+        alert(`${columnName} column not found.`);
+        return;
+    }
+
+    ui.browsingEngine.addFacet(
+        "list",
+        {
+            "name": columnName,
+            "columnName": columnName,
+            "expression": "if(isError(value), 'failed edit', if(isBlank(value), 'no edit', 'successful edit'))"
+        }
+    );
+};


### PR DESCRIPTION
Fixes #{6864}

Changes proposed in this pull request:
- add Editing results facet option in menu-bar-extensions.js
- create wikibase-ui.js file for the buttons functionality
- put the file in the controller.js file
- add the text for the button in the translation-en.json (other json language files needs to add this)
