### PR TITLE
ExporterManager: add an explicite extension point

### DIFF
--- a/extensions/wikibase/module/scripts/menu-bar-extension.js
+++ b/extensions/wikibase/module/scripts/menu-bar-extension.js
@@ -3,28 +3,29 @@ I18NUtil.init("wikidata");
 OperationIconRegistry.setIcon('wikidata/save-wikibase-schema', 'extension/wikidata/images/wikibase-black-icon.svg');
 OperationIconRegistry.setIcon('wikidata/perform-wikibase-edits', 'extension/wikidata/images/wikibase-upload-icon.svg');
 
-ExporterManager.MenuItems.push({});
-ExporterManager.MenuItems.push({
-  id: "performWikibaseEdits",
-  label: $.i18n('wikibase-extension/wikibase-edits'),
-  click: function () {
+ExporterManager.addMenuSpacerAfter();
+
+ExporterManager.addMenuItemAfter(
+  "performWikibaseEdits",
+  $.i18n('wikibase-extension/wikibase-edits'),
+  function () {
     PerformEditsDialog.checkAndLaunch();
   }
-});
-ExporterManager.MenuItems.push({
-  id: "exportQuickStatements",
-  label: $.i18n('wikibase-extension/qs-file'),
-  click: function () {
+);
+ExporterManager.addMenuItemAfter(
+  "exportQuickStatements",
+  $.i18n('wikibase-extension/qs-file'),
+  function () {
     WikibaseExporterMenuBar.checkSchemaAndExport("quickstatements");
   }
-});
-ExporterManager.MenuItems.push({
-  id: "exportWikibaseSchema",
-  label: $.i18n('wikibase-extension/wikibase-schema'),
-  click: function () {
+);
+ExporterManager.addMenuItemAfter(
+  "exportWikibaseSchema",
+  $.i18n('wikibase-extension/wikibase-schema'),
+  function () {
     WikibaseExporterMenuBar.checkSchemaAndExport("wikibase-schema");
   }
-});
+);
 
 WikibaseExporterMenuBar = {};
 

--- a/main/webapp/modules/core/scripts/project/exporters.js
+++ b/main/webapp/modules/core/scripts/project/exporters.js
@@ -105,6 +105,29 @@ ExporterManager.prototype._initializeUI = function() {
   });
 };
 
+/**
+ * Adds a menu item to the end of the ExporterManager menu.
+ * @public
+ * @param {string} id - The item ID.
+ * @param {string} label - The item Label.
+ * @param {function} click - The function which is called upon an item click.
+ */
+ExporterManager.addMenuItemAfter = function(id, label, click) {
+    ExporterManager.MenuItems.push({
+        'id': id,
+        'label': label,
+        'click': click,
+    });
+}
+
+/**
+ * Adds a separator item to the end of the menu.
+ * @public
+ */
+ExporterManager.addMenuSpacerAfter = function() {
+    ExporterManager.MenuItems.push({});
+}
+
 ExporterManager.stripNonFileChars = function(name) {
     // prohibited characters in file name of linux (/) and windows (\/:*?"<>|)
     // and MacOS https://stackoverflow.com/a/47455094/167425


### PR DESCRIPTION
Prior to this change one would extend the export menu by pushing directly to an array. This comes with several issues:

 - The interface isn't actually controlled by us and is incredibly large.
 - We can't document the interface in a structured way(with for example JSDoc).
 - Extensions ability to modify the menu isn't limited.

This change does not break existing interfaces as the underlying array  is untouched. Some extensions do more than pushing to the array, however, that could be considered a side effect of the interface rather than an intended feature. If there are legitime use-cases beyond pushing additional extension points could be added.