### PR TITLE
Fix: Add check before looping over archive/filename columns (#7319)

### DIFF
--- a/modules/core/src/main/java/com/google/refine/importers/ImportingParserBase.java
+++ b/modules/core/src/main/java/com/google/refine/importers/ImportingParserBase.java
@@ -153,17 +153,18 @@ abstract public class ImportingParserBase implements ImportingParser {
 
                 // Fill in filename and archive name column for all rows added from this file
                 if (archiveColumnIndex >= 0 || filenameColumnIndex >= 0) {
-                int endingRowCount = project.rows.size(); 
+                int endingRowCount = project.rows.size();
                 for (int i = startingRowCount; i < endingRowCount; i++) {
                 Row row = project.rows.get(i);
                 if (archiveColumnIndex >= 0) {
-                   row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
+                row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
                 }
-                if (filenameColumnIndex >= 0) {
-                row.setCell(filenameColumnIndex, new Cell(fileSource, null));
-        }
-    }
-}
+               if (filenameColumnIndex >= 0) {
+               row.setCell(filenameColumnIndex, new Cell(fileSource, null));
+               }
+               }
+               }
+
 
 
                 ObjectNode fileOptions = options.deepCopy();

--- a/modules/core/src/main/java/com/google/refine/importers/ImportingParserBase.java
+++ b/modules/core/src/main/java/com/google/refine/importers/ImportingParserBase.java
@@ -153,19 +153,17 @@ abstract public class ImportingParserBase implements ImportingParser {
 
                 // Fill in filename and archive name column for all rows added from this file
                 if (archiveColumnIndex >= 0 || filenameColumnIndex >= 0) {
-                int endingRowCount = project.rows.size();
-                for (int i = startingRowCount; i < endingRowCount; i++) {
-                Row row = project.rows.get(i);
-                if (archiveColumnIndex >= 0) {
-                row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
+                    int endingRowCount = project.rows.size();
+                    for (int i = startingRowCount; i < endingRowCount; i++) {
+                        Row row = project.rows.get(i);
+                        if (archiveColumnIndex >= 0) {
+                            row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
+                        }
+                        if (filenameColumnIndex >= 0) {
+                            row.setCell(filenameColumnIndex, new Cell(fileSource, null));
+                        }
+                    }
                 }
-               if (filenameColumnIndex >= 0) {
-               row.setCell(filenameColumnIndex, new Cell(fileSource, null));
-               }
-               }
-               }
-
-
 
                 ObjectNode fileOptions = options.deepCopy();
                 JSONUtilities.safePut(fileOptions, "fileSource", fileSource);

--- a/modules/core/src/main/java/com/google/refine/importers/ImportingParserBase.java
+++ b/modules/core/src/main/java/com/google/refine/importers/ImportingParserBase.java
@@ -152,16 +152,19 @@ abstract public class ImportingParserBase implements ImportingParser {
                 }
 
                 // Fill in filename and archive name column for all rows added from this file
-                int endingRowCount = project.rows.size();
+                if (archiveColumnIndex >= 0 || filenameColumnIndex >= 0) {
+                int endingRowCount = project.rows.size(); 
                 for (int i = startingRowCount; i < endingRowCount; i++) {
-                    Row row = project.rows.get(i);
-                    if (archiveColumnIndex >= 0) {
-                        row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
-                    }
-                    if (filenameColumnIndex >= 0) {
-                        row.setCell(filenameColumnIndex, new Cell(fileSource, null));
-                    }
+                Row row = project.rows.get(i);
+                if (archiveColumnIndex >= 0) {
+                   row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
                 }
+                if (filenameColumnIndex >= 0) {
+                row.setCell(filenameColumnIndex, new Cell(fileSource, null));
+        }
+    }
+}
+
 
                 ObjectNode fileOptions = options.deepCopy();
                 JSONUtilities.safePut(fileOptions, "fileSource", fileSource);

--- a/modules/core/src/main/java/com/google/refine/importers/tree/TreeImportingParserBase.java
+++ b/modules/core/src/main/java/com/google/refine/importers/tree/TreeImportingParserBase.java
@@ -142,19 +142,19 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
                             rootColumnGroup, limit, options, exceptions);
                 }
 
-         //     Fill in filename and archive name column for all rows added from this file
-                if (archiveColumnIndex >= 0 || filenameColumnIndex >= 0) {
-                int endingRowCount = project.rows.size(); 
-                for (int i = startingRowCount; i < endingRowCount; i++) {
-                Row row = project.rows.get(i);
-                if (archiveColumnIndex >= 0) {
-                row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
-                }
-                if (filenameColumnIndex >= 0) {
-                row.setCell(filenameColumnIndex, new Cell(fileSource, null));
-                }
-                }
-               }
+         // Fill in filename and archive name column for all rows added from this file
+         if (archiveColumnIndex >= 0 || filenameColumnIndex >= 0) {
+         int endingRowCount = project.rows.size();
+         for (int i = startingRowCount; i < endingRowCount; i++) {
+         Row row = project.rows.get(i);
+         if (archiveColumnIndex >= 0) {
+            row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
+          }
+         if (filenameColumnIndex >= 0) {
+            row.setCell(filenameColumnIndex, new Cell(fileSource, null));
+         }
+         }
+         }
 
 
                 ObjectNode fileOptions = options.deepCopy();

--- a/modules/core/src/main/java/com/google/refine/importers/tree/TreeImportingParserBase.java
+++ b/modules/core/src/main/java/com/google/refine/importers/tree/TreeImportingParserBase.java
@@ -142,20 +142,19 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
                             rootColumnGroup, limit, options, exceptions);
                 }
 
-         // Fill in filename and archive name column for all rows added from this file
-         if (archiveColumnIndex >= 0 || filenameColumnIndex >= 0) {
-         int endingRowCount = project.rows.size();
-         for (int i = startingRowCount; i < endingRowCount; i++) {
-         Row row = project.rows.get(i);
-         if (archiveColumnIndex >= 0) {
-            row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
-          }
-         if (filenameColumnIndex >= 0) {
-            row.setCell(filenameColumnIndex, new Cell(fileSource, null));
-         }
-         }
-         }
-
+                // Fill in filename and archive name column for all rows added from this file
+                if (archiveColumnIndex >= 0 || filenameColumnIndex >= 0) {
+                    int endingRowCount = project.rows.size();
+                    for (int i = startingRowCount; i < endingRowCount; i++) {
+                        Row row = project.rows.get(i);
+                        if (archiveColumnIndex >= 0) {
+                            row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
+                        }
+                        if (filenameColumnIndex >= 0) {
+                            row.setCell(filenameColumnIndex, new Cell(fileSource, null));
+                        }
+                    }
+                }
 
                 ObjectNode fileOptions = options.deepCopy();
                 JSONUtilities.safePut(fileOptions, "fileSource", fileSource);

--- a/modules/core/src/main/java/com/google/refine/importers/tree/TreeImportingParserBase.java
+++ b/modules/core/src/main/java/com/google/refine/importers/tree/TreeImportingParserBase.java
@@ -142,17 +142,20 @@ abstract public class TreeImportingParserBase extends ImportingParserBase {
                             rootColumnGroup, limit, options, exceptions);
                 }
 
-//                 Fill in filename and archive name column for all rows added from this file
-                int endingRowCount = project.rows.size();
+         //     Fill in filename and archive name column for all rows added from this file
+                if (archiveColumnIndex >= 0 || filenameColumnIndex >= 0) {
+                int endingRowCount = project.rows.size(); 
                 for (int i = startingRowCount; i < endingRowCount; i++) {
-                    Row row = project.rows.get(i);
-                    if (archiveColumnIndex >= 0) {
-                        row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
-                    }
-                    if (filenameColumnIndex >= 0) {
-                        row.setCell(filenameColumnIndex, new Cell(fileSource, null));
-                    }
+                Row row = project.rows.get(i);
+                if (archiveColumnIndex >= 0) {
+                row.setCell(archiveColumnIndex, new Cell(archiveFileName, null));
                 }
+                if (filenameColumnIndex >= 0) {
+                row.setCell(filenameColumnIndex, new Cell(fileSource, null));
+                }
+                }
+               }
+
 
                 ObjectNode fileOptions = options.deepCopy();
                 JSONUtilities.safePut(fileOptions, "fileSource", fileSource);


### PR DESCRIPTION
Issue 7319 resolved

Fixes #7319

This change adds a condition to avoid unnecessary looping over project rows if both archiveColumnIndex and filenameColumnIndex are not set. Improves performance as suggested in issue #7319.
