### PR TITLE
Re-enable text selection on column headers

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/all-column/edit-columns.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/all-column/edit-columns.cy.js
@@ -20,6 +20,20 @@ describe(__filename, function () {
       ['BUTTER,WHIPPED,WITH SALT', '01002', '717', '15.87'],
     ]);
   });
+
+  it('Ensure columns can be reordered from the project grid via drag and drop', function () {
+    cy.loadAndVisitProject('food.mini');
+
+    cy.dragAndDrop('th[data-col-name="Shrt_Desc"]', 'th[data-col-name="NDB_No"]', 'top', 'top');
+    cy.dragAndDrop('th[data-col-name="Energ_Kcal"]', 'th[data-col-name="Water"]', 'top', 'top');
+
+    cy.assertGridEquals([
+      ['Shrt_Desc', 'NDB_No', 'Energ_Kcal', 'Water'],
+      ['BUTTER,WITH SALT', '01001', '717', '15.87'],
+      ['BUTTER,WHIPPED,WITH SALT', '01002', '717', '15.87'],
+    ]);
+  });
+
   it('Ensure columns are removed using remove column', function () {
     cy.loadAndVisitProject('food.mini');
     cy.columnActionClick('All', [

--- a/main/tests/cypress/cypress/support/commands.js
+++ b/main/tests/cypress/cypress/support/commands.js
@@ -324,8 +324,10 @@ Cypress.Commands.add(
  * targetSelector - jquery selector for the element to be dropped on
  * position - position relative to the target element to perform the drop
  */
-Cypress.Commands.add('dragAndDrop', (sourceSelector, targetSelector, position = 'center') => {
-  cy.get(sourceSelector).trigger('mousedown', { which: 1 });
+Cypress.Commands.add(
+  'dragAndDrop',
+  (sourceSelector, targetSelector, position = 'center', sourcePosition = 'center') => {
+  cy.get(sourceSelector).trigger('mousedown', sourcePosition, { which: 1 });
 
   cy.get(targetSelector) // eslint-disable-line
     .trigger('mousemove',position)

--- a/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
+++ b/main/webapp/modules/core/scripts/views/data-table/data-table-view.js
@@ -619,7 +619,7 @@ DataTableView.prototype._enableHeaderDrag = function() {
     axis: "x",
     containment: "parent",
     items: "> th:not(:first-child)", // skip the "All" column
-    cancel: ".column-header-menu, .column-header-resizer-left, .column-header-resizer-right",
+    cancel: ".column-header-menu, .column-header-name, .column-header-resizer-left, .column-header-resizer-right",
     helper: "clone",
     start: function(_, ui) {
       ui.placeholder.width(ui.helper.width());
@@ -635,7 +635,7 @@ DataTableView.prototype._enableHeaderDrag = function() {
         { modelsChanged: true }
       );
     }
-  }).disableSelection();
+  });
 };
 
 DataTableView.prototype._addResizingControls = function(th, index) {


### PR DESCRIPTION
Fixes #7338

Changes proposed in this pull request:
- Adds a class name to the jQuery sortable element which would allow users to select the text. Previously, this capability was overridden by the drag and drop functionality provided by the sortable call.
- Adds a Cypress test to ensure that drag and drop still works (the `dragAndDrop` Cypress function was updated to be able to specify where on the source element to click; the default is `center` which is now selectable text and is no longer a valid drag and drop click target)


I wanted to add a test to ensure that the text was selectable, but several different methods of simulating text highlighting were not properly testing this interaction so I decided to open the pull request without such a test.