### PR TITLE
Fix build warnings related to annotation processing as per issue #7354

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -51,6 +51,11 @@
     <jmh.version>1.37</jmh.version>
     <javac.target>${java.minversion}</javac.target>
     <uberjar.name>openrefine-benchmarks</uberjar.name>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jmh.version>1.37</jmh.version>
+    <uberjar.name>openrefine-benchmarks</uberjar.name>
+    <maven.compiler.source>${java.minversion}</maven.compiler.source>
+    <maven.compiler.target>${java.minversion}</maven.compiler.target>
   </properties>
 
   <build>
@@ -60,11 +65,11 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.14.0</version>
         <configuration>
-          <compilerVersion>${javac.target}</compilerVersion>
-          <source>${javac.target}</source>
-          <target>${javac.target}</target>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
         </configuration>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
       <url>https://github.com/OpenRefine/OpenRefine/graphs/contributors</url>
       <roles>
         <role>Contributor</role>
-      </roles>  
+      </roles>
     </developer>
   </developers>
 
@@ -129,6 +129,7 @@
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <license-plugin.version>2.6.0</license-plugin.version>
     <org-jvnet-localizer-plugin.version>1.31</org-jvnet-localizer-plugin.version>
+    <skipTests>false</skipTests>
   </properties>
 
 


### PR DESCRIPTION
Fixes #7349

### Changes proposed in this pull request:
-  **Removed deprecated** usage of <compilerVersion> in benchmark/pom.xml.
-  **Added standard Maven properties** <maven.compiler.source> and <maven.compiler.target> to specify the Java version.
- These changes align the project with modern Maven practices and avoid potential build issues with future Java versions.

### Warnings Resolved
**Deprecated Compiler Property:**

- Removed: 'compilerVersion' (user property 'maven.compiler.compilerVersion') is deprecated...
- Solution: Switched to standard properties <maven.compiler.source> and <maven.compiler.target>.
