### PR TITLE
Update snapshot repository URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -391,7 +391,7 @@
   <distributionManagement>
      <snapshotRepository>
        <id>ossrh</id>
-       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+       <url>https://central.sonatype.com/repository/maven-snapshots/</url>
      </snapshotRepository>
      <repository>
        <id>ossrh</id>


### PR DESCRIPTION
Fixes #7390 

Changes proposed in this pull request:
- Update the snapshot repository URL to point to the currently-supported Maven Central Repository. Snapshot releases have been enabled in the `org.openrefine` namespace.