### PR TITLE
Switch to OSSRH Staging API. Refs #7390

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -134,7 +134,7 @@ jobs:
         distribution: 'temurin'
         java-version: 11
         cache: 'maven'
-        server-id: ossrh
+        server-id: ossrh-staging-api
         server-username: OSSRH_USER
         server-password: OSSRH_PASS
         
@@ -192,7 +192,7 @@ jobs:
         distribution: 'temurin'
         java-version: 17
         cache: 'maven'
-        server-id: ossrh
+        server-id: ossrh-staging-api
         server-username: OSSRH_USER
         server-password: OSSRH_PASS
         gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -239,7 +239,7 @@ jobs:
 
     - name: Package and upload to OSSRH
       run: |
-        mvn -B deploy -DskipTests=true -DrepositoryId=ossrh -Dapple.notarization.username=$APPLE_USERNAME -Dapple.notarization.password=$APPLE_PASSWORD -Dapple.notarization.team.id=$APPLE_TEAM_ID -Dgpg.signer=bc
+        mvn -B deploy -DskipTests=true -DrepositoryId=ossrh-staging-api -Dapple.notarization.username=$APPLE_USERNAME -Dapple.notarization.password=$APPLE_PASSWORD -Dapple.notarization.team.id=$APPLE_TEAM_ID -Dgpg.signer=bc
       env:
         OSSRH_USER: ${{ secrets.OSSRH_USER }}
         OSSRH_PASS: ${{ secrets.OSSRH_PASS }}

--- a/pom.xml
+++ b/pom.xml
@@ -331,8 +331,8 @@
         <version>1.7.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <serverId>ossrh-staging-api</serverId>
+          <nexusUrl>https://ossrh-staging-api.central.sonatype.com</nexusUrl>
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
@@ -366,7 +366,7 @@
   <repositories>
     <repository>
       <id>snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -390,12 +390,12 @@
   <!-- Locations of the artifacts published -->
   <distributionManagement>
      <snapshotRepository>
-       <id>ossrh</id>
-       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+       <id>ossrh-staging-api</id>
+       <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
      </snapshotRepository>
      <repository>
-       <id>ossrh</id>
-       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+       <id>ossrh-staging-api</id>
+       <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
      </repository>
   </distributionManagement>
 


### PR DESCRIPTION
This addresses #7390, but may not be a complete solution, but it's a starting point.

Fixes #{issue number here}

Changes proposed in this pull request:
-  Change the server ID from ossrh to ossrh-staging-api
-  Switch URLs from oss.sonatype.org to ossrh-staging-api.sonatype.com

I suspect this will fail due to the use of the OSSRH token, but we'll see ...
