### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-servlets to 11.0.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <butterfly.version>1.2.6</butterfly.version>
     <slf4j.version>2.0.17</slf4j.version>
     <log4j.version>2.25.1</log4j.version>
-    <jetty.version>10.0.16</jetty.version>
+    <jetty.version>11.0.18</jetty.version>
     <okhttp.version>5.1.0</okhttp.version>
     <jena.version>4.10.0</jena.version>
     <poi.version>5.4.1</poi.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-servlets 10.0.16
- [CVE-2024-9823](https://www.oscs1024.com/hd/CVE-2024-9823)


### What did I do？
Upgrade org.eclipse.jetty:jetty-servlets from 10.0.16 to 11.0.18 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS