### PR TITLE
never exceed viewport width

### DIFF
--- a/main/webapp/modules/core/styles/dialogs/expression-preview-dialog.css
+++ b/main/webapp/modules/core/styles/dialogs/expression-preview-dialog.css
@@ -63,6 +63,7 @@ textarea.expression-preview-code {
 #expression-preview-tabs-starred {
   height: 200px;
   overflow: auto;
+  max-width: 90vw;        /* never exceed viewport width */
 }
 
 #expression-preview-tabs-preview td, #expression-preview-tabs-preview th,


### PR DESCRIPTION
Fixes #7202 

Changes proposed in this pull request:
- never exceed viewport width for Large expression in history tab Custom Facet

Testing done on 
Firefox
<img width="3024" height="1890" alt="image" src="https://github.com/user-attachments/assets/24afd6c5-2ac4-48ed-8c04-b8f5bba307cf" />
Chrome 
<img width="3024" height="1890" alt="image" src="https://github.com/user-attachments/assets/edef2687-9455-4fe1-90c4-bf36ae44a294" />
Safari and brave with same results
