### PR TITLE
fix db import progress updates

### DIFF
--- a/extensions/database/src/com/google/refine/extension/database/DBQueryResultImportReader.java
+++ b/extensions/database/src/com/google/refine/extension/database/DBQueryResultImportReader.java
@@ -118,11 +118,6 @@ public class DBQueryResultImportReader implements TableDataReader {
                     if (processedRows % 100 == 0) {
                         setProgress(job, querySource, progress++);
                     }
-                    if (processedRows % 10000 == 0) {
-                        if (logger.isDebugEnabled()) {
-                            logger.debug("[[ {} rows processed... ]]", processedRows);
-                        }
-                    }
                 }
                 return result;
             } else {

--- a/extensions/database/src/com/google/refine/extension/database/DatabaseImportController.java
+++ b/extensions/database/src/com/google/refine/extension/database/DatabaseImportController.java
@@ -390,6 +390,7 @@ public class DatabaseImportController implements ImportingController {
 
         List<DatabaseColumn> columns = databaseService.getColumns(dbQueryInfo.getDbConfig(), dbQueryInfo.getQuery());
 
+        Integer count = databaseService.getCount(dbQueryInfo.getDbConfig(), dbQueryInfo.getQuery());
         setProgress(job, querySource, -1);
 
         JSONUtilities.safePut(options, "ignoreLines", 0); // number of blank lines at the beginning to ignore
@@ -413,7 +414,6 @@ public class DatabaseImportController implements ImportingController {
         }
 
         setProgress(job, querySource, 100);
-
     }
 
     private static int getCreateBatchSize() {

--- a/extensions/database/src/com/google/refine/extension/database/DatabaseImportController.java
+++ b/extensions/database/src/com/google/refine/extension/database/DatabaseImportController.java
@@ -402,7 +402,7 @@ public class DatabaseImportController implements ImportingController {
                 project,
                 metadata,
                 job,
-                new DBQueryResultImportReader(job, databaseService, querySource, columns, dbQueryInfo, getCreateBatchSize()),
+                new DBQueryResultImportReader(job, databaseService, querySource, columns, dbQueryInfo, getCreateBatchSize(), count),
                 querySource,
                 limit,
                 options,

--- a/extensions/database/src/com/google/refine/extension/database/DatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/DatabaseService.java
@@ -149,6 +149,45 @@ public abstract class DatabaseService {
         return parsedQueryOut;
     }
 
+    String buildCountQuery(String query) {
+        if (logger.isDebugEnabled()) {
+            logger.info("<<< original input query::{} >>>", query);
+        }
+
+        String trimmedQuery = query.trim();
+        final int len = trimmedQuery.length();
+        String parsedQuery = trimmedQuery.endsWith(";") ? trimmedQuery.substring(0, len - 1) : trimmedQuery;
+
+        String parsedQueryOut = String.format("SELECT COUNT(*) FROM (%s) AS TOTAL;", parsedQuery.trim());
+
+        if (logger.isDebugEnabled()) {
+            logger.info("<<<Final input query::{} >>>", parsedQueryOut);
+        }
+
+        return parsedQueryOut;
+    }
+
+    Integer getCount(DatabaseConfiguration dbConfig, String query) {
+        String countQuery = buildCountQuery(query);
+
+        try {
+            List<DatabaseRow> dbRows = getRows(dbConfig, countQuery);
+
+            if (dbRows != null && !dbRows.isEmpty()) {
+                DatabaseRow row = dbRows.get(0);
+                List<String> rowValues = row.getValues();
+
+                if (rowValues != null && !rowValues.isEmpty()) {
+                    return Integer.parseInt(rowValues.get(0));
+                }
+            }
+        } catch (DatabaseServiceException | NumberFormatException e) {
+            logger.error("Error when retrieving count from db: {}", e.getMessage());
+        }
+
+        return null;
+    }
+
     public abstract List<DatabaseColumn> getColumns(DatabaseConfiguration dbConfig, String query) throws DatabaseServiceException;
 
     public abstract List<DatabaseRow> getRows(DatabaseConfiguration dbConfig, String query) throws DatabaseServiceException;

--- a/extensions/database/tests/src/com/google/refine/extension/database/DatabaseServiceTest.java
+++ b/extensions/database/tests/src/com/google/refine/extension/database/DatabaseServiceTest.java
@@ -124,6 +124,24 @@ public class DatabaseServiceTest extends DBExtensionTests {
         Assert.assertEquals(limitQuery, "SELECT * FROM (SELECT * FROM " + testTable + ") data LIMIT " + 100 + " OFFSET " + 0 + ";");
     }
 
+    @Test
+    public void testBuildCountQuery() {
+        DatabaseService dbService = DatabaseService.get(testDbConfig.getDatabaseType());
+        String basicSelectQuery = "SELECT * FROM " + testTable + ";";
+        String countQuery = dbService.buildCountQuery(basicSelectQuery);
+        Assert.assertNotNull(countQuery);
+        Assert.assertEquals(countQuery, "SELECT COUNT(*) FROM (SELECT * FROM " + testTable + ") AS TOTAL;");
+    }
+
+    @Test
+    public void testBuildCountQueryFromSpaciousBasicQuery() {
+        DatabaseService dbService = DatabaseService.get(testDbConfig.getDatabaseType());
+        String basicSelectQuery = " SELECT * FROM " + testTable + "  ;   ";
+        String countQuery = dbService.buildCountQuery(basicSelectQuery);
+        Assert.assertNotNull(countQuery);
+        Assert.assertEquals(countQuery, "SELECT COUNT(*) FROM (SELECT * FROM " + testTable + ") AS TOTAL;");
+    }
+
     @Test(groups = { "requiresMySQL" })
     public void testGetColumns() throws DatabaseServiceException {
         List<DatabaseColumn> dbColumns;
@@ -146,4 +164,12 @@ public class DatabaseServiceTest extends DBExtensionTests {
         Assert.assertEquals(dbRows.size(), 1);
     }
 
+    @Test(groups = { "requiresMySQL" })
+    public void testGetCount() {
+        DatabaseService dbService = DatabaseService.get(testDbConfig.getDatabaseType());
+        Integer count = dbService.getCount(testDbConfig, "SELECT * FROM " + testTable);
+
+        Assert.assertNotNull(count);
+        Assert.assertEquals(count, 1);
+    }
 }

--- a/main/webapp/modules/core/scripts/index/create-project-progress-panel.html
+++ b/main/webapp/modules/core/scripts/index/create-project-progress-panel.html
@@ -3,6 +3,7 @@
     <tr><td colspan="3" id="create-project-progress-message"></td></tr>
     <tr><td colspan="3">
       <div id="create-project-progress-bar-frame"><div id="create-project-progress-bar-body"></div></div>
+      <img id="create-project-progress-spinner" src="images/small-spinner.gif" alt="loading spinner"/>
     </td></tr>
     <tr><td colspan="3">
       <button class="button" id="create-project-progress-cancel-button"></button>

--- a/main/webapp/modules/core/scripts/index/create-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/create-project-ui.js
@@ -157,11 +157,22 @@ Refine.actionAreas.push({
   uiClass: Refine.CreateProjectUI
 });
 
+Refine.CreateProjectUI.prototype.setProgressKnown = function(known) {
+  if (known) {
+    $('#create-project-progress-spinner').hide();
+    $('#create-project-progress-bar-frame').show();
+  } else {
+    $('#create-project-progress-bar-frame').hide();
+    $('#create-project-progress-spinner').show();
+  }
+};
+
 Refine.CreateProjectUI.prototype.showImportProgressPanel = function(progressMessage, onCancel) {
   var self = this;
 
   this.showCustomPanel(this._progressPanel);
 
+  self.setProgressKnown(false);
   $('#create-project-progress-message').text(progressMessage);
   $('#create-project-progress-bar-body').css("width", "0%");
   $('#create-project-progress-message-left').text($.i18n('core-index-create/starting'));
@@ -194,6 +205,7 @@ Refine.CreateProjectUI.prototype.pollImportJob = function(start, jobID, timerID,
         
         onError(job);
       } else if (checkDone(job)) {
+        $('#create-project-progress-bar-body').removeClass('indefinite').css("width", "100%"); // show progress as done
         $('#create-project-progress-message').text($.i18n('core-index-create/done'));
 
         window.clearInterval(timerID);
@@ -206,6 +218,7 @@ Refine.CreateProjectUI.prototype.pollImportJob = function(start, jobID, timerID,
           var secondsSpent = (new Date().getTime() - start.getTime()) / 1000;
           var secondsRemaining = (100 / progress.percent) * secondsSpent - secondsSpent;
 
+          self.setProgressKnown(true);
           $('#create-project-progress-bar-body')
           .removeClass('indefinite')
           .css("width", progress.percent + "%");
@@ -222,6 +235,7 @@ Refine.CreateProjectUI.prototype.pollImportJob = function(start, jobID, timerID,
             $('#create-project-progress-timing').text($.i18n('core-index-create/almost-done'));
           }
         } else {
+          self.setProgressKnown(false);
           $('#create-project-progress-bar-body').addClass('indefinite');
           $('#create-project-progress-timing').empty();
         }


### PR DESCRIPTION
Fixes #6654 

**Problem**:
DB import uses a counter instead of percentage to track its progress (see corresponding issue)

**Changes proposed in this pull request:**
- before starting the db import, we query the db for the `COUNT(*)` of the specified query, similar to the existing functionality for querying batches using `LIMIT` and `OFFSET`
- case count available: 
we use the total count and an additional counter variable to track progress of the db import and calculate the percentage for the UI
- case count not available:
 (e.g. query failed or an extension uses constructor of `DBQueryResultImportReader` that does not include count) then we switch to not showing the progress bar but a spinner instead.

In any case we additionally add the absolute progress "(currentcount / totalCount)" to the progress message so the user can still see progress happening.

**Screenshots**:
<img width="954" height="458" alt="or-db-import-progress" src="https://github.com/user-attachments/assets/33285adf-a21e-4593-ac96-3518dfe2273c" />
<img width="946" height="402" alt="or-db-import-progress-unknown" src="https://github.com/user-attachments/assets/af4ec645-4c06-4b28-8886-4011a74b22ee" />


**Notes**:
- additionally removed one log statement, which is already printed 5 lines prior so code is less cluttered (first commit)
- the variable `processedRows` in `DBQueryResultImportReader` is not needed and can be replaced by `currentCount` but lets focus on the correct progress implementation in this PR (no change in import functionality)
- building the sql statement is basically adapted from the limit query and has so much potential to go wrong but this needs to be handled in a separate PR where both query builders / query validation should be addressed  (if the query fails, we switch to the spinner and absolute progress so for this PR should be fine)