### PR TITLE
Restore exporter error reporting and clean up XLS/XLSX error handling

### DIFF
--- a/main/src/com/google/refine/exporters/sql/SqlExporterException.java
+++ b/main/src/com/google/refine/exporters/sql/SqlExporterException.java
@@ -27,7 +27,9 @@
 
 package com.google.refine.exporters.sql;
 
-public class SqlExporterException extends RuntimeException {
+import com.google.refine.exporters.ExporterException;
+
+public class SqlExporterException extends ExporterException {
 
     /**
      * 
@@ -36,7 +38,6 @@ public class SqlExporterException extends RuntimeException {
 
     public SqlExporterException(String message) {
         super(message);
-        // TODO Auto-generated constructor stub
     }
 
 }

--- a/main/tests/cypress/cypress/e2e/project/project-header/export_project.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/project-header/export_project.cy.js
@@ -144,7 +144,7 @@ describe(__filename, function () {
     const TALL_FIXTURE = [
       ["column"],
       ["cell value too long".padEnd(32768, ".")]
-    ]
+    ];
 
     cy.loadAndVisitProject(TALL_FIXTURE, Date.now());
 

--- a/main/tests/cypress/cypress/e2e/project/project-header/export_project.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/project-header/export_project.cy.js
@@ -108,6 +108,55 @@ describe(__filename, function () {
     });
 
   });
+  it('Test error for wide (>256col) project to XLS format', function () {
+    const WIDTH = 257;
+    const WIDE_FIXTURE = [
+      Array.from({length: WIDTH}, (e, i)=> "column"+i),
+      Array.from({length: WIDTH}, (e, i)=> "row0cell"+i),
+    ];
+    cy.loadAndVisitProject(WIDE_FIXTURE, Date.now());
+
+    cy.get('#export-button').click();
+    triggerLoadEvent();
+    cy.get('.menu-container a')
+      .contains('Excel (.xls)')
+      .click();
+
+    cy.get('body').contains('HTTP ERROR 400 Maximum number of columns exceeded for export format (256)');
+
+  });
+  it('Test too many rows error for export to XLS format', function () {
+    // zero-th row contains column names, so +1
+    const TALL_FIXTURE = Array.from({length: 65536+1}, (e, i)=> ["row"+i]);
+
+    cy.loadAndVisitProject(TALL_FIXTURE, Date.now());
+
+    cy.get('#export-button').click();
+    triggerLoadEvent();
+    cy.get('.menu-container a')
+      .contains('Excel (.xls)')
+      .click();
+
+    cy.get('body').contains('HTTP ERROR 400 Maximum number of rows exceeded for export format (65536)');
+
+  });
+  it('Test cell value too long error for export to XLS format', function () {
+    const TALL_FIXTURE = [
+      ["column"],
+      ["cell value too long".padEnd(32768, ".")]
+    ]
+
+    cy.loadAndVisitProject(TALL_FIXTURE, Date.now());
+
+    cy.get('#export-button').click();
+    triggerLoadEvent();
+    cy.get('.menu-container a')
+      .contains('Excel (.xls)')
+      .click();
+
+    cy.get('body').contains('HTTP ERROR 400 Maximum size (32767) of cell');
+
+  });
   it('Export a project through "Excel 2007+ (.xlsx)"', function () {
 
     cy.loadAndVisitProject(fixture, Date.now());

--- a/modules/core/src/main/java/com/google/refine/exporters/ExporterException.java
+++ b/modules/core/src/main/java/com/google/refine/exporters/ExporterException.java
@@ -1,0 +1,14 @@
+
+package com.google.refine.exporters;
+
+/**
+ * Exception thrown by exporters to indicate a failure or error condition during export to distinguish them from
+ * completely unexpected/unhandled errors. These might include things like row or column limits exceeded. Exceptions
+ * thrown during the export which are not instances or subclasses of this will cause HTTP 500 server error.
+ */
+public class ExporterException extends RuntimeException {
+
+    public ExporterException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Fixes #7368. Fixes #352. Refs #351

This includes a fix for the specific XLS row limit exceeded error (#7368) as well as better error reporting for exporters in general, which we seem to have broken sometime in the recent past. It also fixes #352 (silent truncation of large cells) and provides a better fix for #351 (almost silent truncation of sheets with too many columns).

1. Fix exporter error handling
    -  Fix HTTP response headers for error case, so HTML error page gets rendered again. This could be improved, but at least restores the previous behavior.
    - Refactor `ExportRowsCommand` so that it doesn't have SQL exporter specific handing by introducing `ExporterException`, which it handles and making SQL exception a subclass of it
    - remove obsolete CSRF comment (unrelated non-functional change)
2. Fix XLS/XLSX exporter to throw exceptions when limits are exceeded for number of columns, number of rows, or size of cell. This includes BEHAVIOR CHANGES:
    - Previously sheets wider than 256 columns would be truncated and the right most columns cell contents replaced with an error message, which was easy to miss and basically a silent form of data corruption
    - Previously cells with contents greater than 32767 characters were silently truncated with no warning at all (!)
    - Previously sheets with more than 65535 rows would trigger an IllegalArgumentException deep inside the Apache library which would percolate up as general ServletException (causing a HTTP 500 status)

All of the XLS/XLSX errors will now generated a 400 Bad Request error with a specific (unlocalized) error message indicating what the problem is and what limit was exceeded. Unhandled exporter exceptions (those which are not an instance/subclass of `ExporterException` will again render the catch all servlet exception page with a 500 status.