### PR TITLE
switch to new mysql connector coordinates

### DIFF
--- a/extensions/database/pom.xml
+++ b/extensions/database/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>com.mysql</groupId>
       <artifactId>mysql-connector-j</artifactId>
-      <version>8.0.33</version>
+      <version>8.2.0</version>
       <exclusions>
         <exclusion>
           <!-- Only needed for the X DevAPI features -->


### PR DESCRIPTION
fixes #7469 

Changes proposed in this pull request:
- switch to new maven coordinates for dependency `mysql-connector-j` 
(only went up 8.0.30 -> 8.0.33 to make sure there are no compatibility issues)
- additionally the mysql connector documentation notes that there is a possible exclusion of `protobuf-java` when xdevapi is not used (which is the case in db extension), so I excluded it 


Sources:
- announcement in mysql connector release notes:
https://dev.mysql.com/doc/relnotes/connector-j/en/news-8-0-31.html
- note about movement of artifact on maven repository website: 
https://mvnrepository.com/artifact/mysql/mysql-connector-java
- Installing Connector/J Using Maven (exclusion): 
https://dev.mysql.com/doc/connector-j/en/connector-j-installing-maven.html