### PR TITLE
fix mysql driver class

### DIFF
--- a/extensions/database/src/com/google/refine/extension/database/mysql/MySQLDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/mysql/MySQLDatabaseService.java
@@ -52,7 +52,7 @@ public class MySQLDatabaseService extends DatabaseService {
 
     private static final Logger logger = LoggerFactory.getLogger("MySQLDatabaseService");
     public static final String DB_NAME = "mysql";
-    public static final String DB_DRIVER = "com.mysql.cj.jdbc.Driver";
+    public static final String DB_DRIVER = com.mysql.cj.jdbc.Driver.class.getCanonicalName();
 
     private static MySQLDatabaseService instance;
 


### PR DESCRIPTION
fixes #5794

### Changes proposed in this pull request:
- change class name of mysql driver from "com.mysql.jdbc.Driver" to "com.mysql.cj.jdbc.Driver"
- the warning is triggered by this line in `MySQLConnectionManager`:
https://github.com/OpenRefine/OpenRefine/blob/b3693e0e564f1f287c8907f076d396e3ef21e72e/extensions/database/src/com/google/refine/extension/database/mysql/MySQLConnectionManager.java#L133
To have a quick way to reproduce the warning and see that it disappears after the change I added the "test", but the commit "reproduce warning" can be dropped before merging.

### Source
> The name of the class that implements java.sql.Driver in MySQL Connector/J has changed from com.mysql.jdbc.Driver to com.mysql.cj.jdbc.Driver. The old class name has been deprecated. 

Source: https://dev.mysql.com/doc/connectors/en/connector-j-upgrading-to-8.0.html
