### PR TITLE
Update Jetty to 10.0.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <butterfly.version>1.2.6</butterfly.version>
     <slf4j.version>2.0.17</slf4j.version>
     <log4j.version>2.25.2</log4j.version>
-    <jetty.version>10.0.16</jetty.version>
+    <jetty.version>10.0.19</jetty.version>
     <okhttp.version>5.1.0</okhttp.version>
     <jena.version>4.10.0</jena.version>
     <poi.version>5.4.1</poi.version>


### PR DESCRIPTION
Replaces #7427

Fixes [CVE-2024-9823](https://nvd.nist.gov/vuln/detail/CVE-2024-9823)