### PR TITLE
Make references to JDBC driver classes explicit. Fixes #7504

### DIFF
--- a/extensions/database/src/com/google/refine/extension/database/mariadb/MariaDBDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/mariadb/MariaDBDatabaseService.java
@@ -53,7 +53,7 @@ public class MariaDBDatabaseService extends DatabaseService {
 
     private static final Logger logger = LoggerFactory.getLogger("MariaDBDatabaseService");
     public static final String DB_NAME = "mariadb";
-    public static final String DB_DRIVER = "org.mariadb.jdbc.Driver";
+    public static final String DB_DRIVER = org.mariadb.jdbc.Driver.class.getCanonicalName();
     private static MariaDBDatabaseService instance;
 
     private MariaDBDatabaseService() {

--- a/extensions/database/src/com/google/refine/extension/database/pgsql/PgSQLDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/pgsql/PgSQLDatabaseService.java
@@ -53,7 +53,7 @@ public class PgSQLDatabaseService extends DatabaseService {
 
     private static final Logger logger = LoggerFactory.getLogger("PgSQLDatabaseService");
     public static final String DB_NAME = "postgresql";
-    public static final String DB_DRIVER = "org.postgresql.Driver";
+    public static final String DB_DRIVER = org.postgresql.Driver.class.getCanonicalName();
     private static PgSQLDatabaseService instance;
 
     private PgSQLDatabaseService() {

--- a/extensions/database/src/com/google/refine/extension/database/sqlite/SQLiteDatabaseService.java
+++ b/extensions/database/src/com/google/refine/extension/database/sqlite/SQLiteDatabaseService.java
@@ -52,7 +52,7 @@ import com.google.refine.extension.database.model.DatabaseRow;
 public class SQLiteDatabaseService extends DatabaseService {
 
     public static final String DB_NAME = "sqlite";
-    public static final String DB_DRIVER = "org.sqlite.JDBC";
+    public static final String DB_DRIVER = org.sqlite.JDBC.class.getCanonicalName();
     private static final Logger logger = LoggerFactory.getLogger("SQLiteDatabaseService");
     private static SQLiteDatabaseService instance;
 


### PR DESCRIPTION
Fixes #7504

Changes proposed in this pull request:
- Reference classes directly instead of burying them in opaque strings

