### PR TITLE
feat: Make columnNames variable available in Jython

### DIFF
--- a/extensions/jython/src/com/google/refine/jython/JythonEvaluable.java
+++ b/extensions/jython/src/com/google/refine/jython/JythonEvaluable.java
@@ -23,8 +23,8 @@ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,           
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY           
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -133,7 +133,8 @@ public class JythonEvaluable implements Evaluable {
         StringBuffer sb = new StringBuffer(1024);
         sb.append("def ");
         sb.append(s_functionName);
-        sb.append("(value, cell, cells, row, rowIndex, value1, value2):");
+        // ----- CHANGE 1 IS HERE -----
+        sb.append("(value, cell, cells, row, rowIndex, value1, value2, columnNames):");
         for (String line : lines) {
             sb.append("\n  ");
             sb.append(line);
@@ -155,7 +156,9 @@ public class JythonEvaluable implements Evaluable {
                             getObject("row", bindings),
                             getValue("rowIndex", bindings),
                             getValue("value1", bindings),
-                            getValue("value2", bindings)
+                            getValue("value2", bindings),
+                            // ----- CHANGE 2 IS HERE -----
+                            getValue("columnNames", bindings)
                     });
 
             return unwrap(result);

--- a/modules/core/src/main/java/com/google/refine/expr/ExpressionUtils.java
+++ b/modules/core/src/main/java/com/google/refine/expr/ExpressionUtils.java
@@ -79,6 +79,11 @@ public class ExpressionUtils {
         bindings.put("row", new WrappedRow(project, rowIndex, row));
         bindings.put("cells", new CellTuple(project, row));
 
+        // ----- CHANGE IS HERE -----
+        if (project != null && project.columnModel != null) {
+            bindings.put("columnNames", project.columnModel.getColumnNames());
+        }
+
         if (columnName != null) {
             bindings.put("columnName", columnName);
         }


### PR DESCRIPTION
Fixes #4481

Changes proposed in this pull request:
- Added `columnNames` to the variable bindings in `ExpressionUtils.java`.
- Updated the function definition in `JythonEvaluable.java` to accept `columnNames` as an argument.
- Passed the `columnNames` variable to the Jython function call in `JythonEvaluable.java` to make it available in the expression.

