### PR TITLE
Deprecate before delete

### DIFF
--- a/extensions/database/src/com/google/refine/extension/database/DBQueryResultPreviewReader.java
+++ b/extensions/database/src/com/google/refine/extension/database/DBQueryResultPreviewReader.java
@@ -47,7 +47,7 @@ import com.google.refine.importing.ImportingJob;
 /**
  * @deprecated use {@link DBQueryResultImportReader} instead.
  */
-@Deprecated(since = "3.9")
+@Deprecated(since = "3.10")
 public class DBQueryResultPreviewReader implements TableDataReader {
 
     private static final Logger logger = LoggerFactory.getLogger("DBQueryResultPreviewReader");

--- a/extensions/database/src/com/google/refine/extension/database/DatabaseModuleImpl.java
+++ b/extensions/database/src/com/google/refine/extension/database/DatabaseModuleImpl.java
@@ -99,7 +99,7 @@ public class DatabaseModuleImpl extends ButterflyModuleImpl {
     /**
      * @deprecated use {@link #getCreateBatchSize()} instead.
      */
-    @Deprecated(since = "3.9")
+    @Deprecated(since = "3.10")
     public static String getImportCreateBatchSize() {
         return String.valueOf(getCreateBatchSize());
     }
@@ -107,7 +107,7 @@ public class DatabaseModuleImpl extends ButterflyModuleImpl {
     /**
      * @deprecated use {@link #getPreviewBatchSize()} instead.
      */
-    @Deprecated(since = "3.9")
+    @Deprecated(since = "3.10")
     public static String getImportPreviewBatchSize() {
         return String.valueOf(getPreviewBatchSize());
     }

--- a/extensions/database/src/com/google/refine/extension/database/DatabaseUtils.java
+++ b/extensions/database/src/com/google/refine/extension/database/DatabaseUtils.java
@@ -58,7 +58,7 @@ public class DatabaseUtils {
     /**
      * @deprecated as it is unused. Determine size of {@link #getSavedConnections()} result instead.
      */
-    @Deprecated(since = "3.9")
+    @Deprecated(since = "3.10")
     public static int getSavedConnectionsSize() {
         List<DatabaseConfiguration> scList = getSavedConnections();
         if (scList == null || scList.isEmpty()) {
@@ -147,7 +147,7 @@ public class DatabaseUtils {
     /**
      * @deprecated as it is unused. Use {@link #decrypt(String)} instead.
      */
-    @Deprecated(since = "3.9")
+    @Deprecated(since = "3.10")
     public static List<DatabaseConfiguration> decryptAll(List<DatabaseConfiguration> savedConnections) {
         List<DatabaseConfiguration> dbConfigs = new ArrayList<DatabaseConfiguration>(savedConnections.size());
 
@@ -190,7 +190,7 @@ public class DatabaseUtils {
     /**
      * @deprecated as it is unused. Use {@link #deleteSavedConnections(String)} instead.
      */
-    @Deprecated(since = "3.9")
+    @Deprecated(since = "3.10")
     public static void deleteAllSavedConnections() {
         if (logger.isDebugEnabled()) {
             logger.debug("delete All Saved Connections called...");

--- a/modules/core/src/main/java/com/google/refine/importers/TabularImportingParserBase.java
+++ b/modules/core/src/main/java/com/google/refine/importers/TabularImportingParserBase.java
@@ -229,7 +229,7 @@ abstract public class TabularImportingParserBase extends ImportingParserBase {
      *
      * @deprecated 2025-05-23 Use {@link ImporterUtilities#deleteColumns(Project, List)}
      */
-    @Deprecated(since = "3.9")
+    @Deprecated(since = "3.10")
     static public void deleteEmptyColumns(List<Boolean> columnsHasData, Project project) throws ModelException {
         project.columnModel.update(); // make sure all our cell indexes are up to date
         for (int c = 0; c < columnsHasData.size(); c++) {


### PR DESCRIPTION
Fixes #7519
and additionally reverts the removal of public methods/classes and instead deprecates them.

Changes proposed in this pull request:
- deprecate unused methods in `DatabaseUtils` 
->#7519
- deprecate public methods `getImportCreateBatchSize` and `getImportPreviewBatchSize` in `DatabaseModuleImpl` instead of deleting them
->https://github.com/OpenRefine/OpenRefine/pull/7446
- deprecate class `DBQueryResultPreviewReader` instead of deleting it
Note I used the last version before its removal : https://github.com/OpenRefine/OpenRefine/pull/7507/commits/c14b133b04e4d436bebbed28e2ea01ab2a97ef12
->  https://github.com/OpenRefine/OpenRefine/pull/7507
- and one more deprecated annotation I missed a while back for `TabularImportingParserBase.deleteEmptyColumns`


All these instances were oversights of mine, sorry! Now that they accumulated I can pack them all together in one PR.
If you deem some of the commits unnecessary, feel free to drop them.

-- 
Note: None of the reversed code deletions have been released yet.