### PR TITLE
Update to MacOS 15 Intel runner

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -178,7 +178,7 @@ jobs:
 
   mac_test_and_deploy:
     if: github.repository == 'OpenRefine/OpenRefine'
-    runs-on: macos-13
+    runs-on: macos-15-intel
 
     outputs: 
       version_number_string: ${{ steps.version_string_variable.outputs.output_value }}


### PR DESCRIPTION
Fixes #7540

Changes proposed in this pull request:
- Update to MacOS 15 Intel runner

This will be the last Intel architecture runner available, but it will be available until August 2027.
https://github.com/actions/runner-images/issues/13045

Note that because Java doesn't support multi-architecture builds, we currently provide Intel architecture builds for use on both Intel and ARM. We won't be able to do this after August 2027 using the Github CI release build pipeline.