### PR TITLE
fix typo in path to operation icon

### DIFF
--- a/main/webapp/modules/core/scripts/project/operation-icons.js
+++ b/main/webapp/modules/core/scripts/project/operation-icons.js
@@ -52,7 +52,7 @@ OperationIconRegistry.setIcon('core/recon', 'images/operations/reconcile.svg');
 OperationIconRegistry.setIcon('core/recon-mark-new-topics', 'images/operations/recon-mark-new-topics.svg');
 OperationIconRegistry.setIcon('core/recon-match-best-candidates', 'images/operations/recon-match-best-candidates.svg');
 OperationIconRegistry.setIcon('core/recon-discard-judgments', 'images/operations/recon-discard-judgments.svg');
-OperationIconRegistry.setIcon('core/recon-match-specific-topic-to-cells', 'images/operation/recon-match-specific-topic-to-cells.svg');
+OperationIconRegistry.setIcon('core/recon-match-specific-topic-to-cells', 'images/operations/recon-match-specific-topic-to-cells.svg');
 OperationIconRegistry.setIcon('core/recon-judge-similar-cells', 'images/operations/recon-match-specific-topic-to-cells.svg');
 OperationIconRegistry.setIcon('core/recon-clear-similar-cells', 'images/operations/delete.svg');
 OperationIconRegistry.setIcon('core/recon-copy-across-columns', 'images/operations/recon-copy-across-columns.svg');


### PR DESCRIPTION
minimal fix, no associated issue

### Status quo
- when opening a project, one gets the following failing http request (404)
<img width="858" height="243" alt="typo-in-operations-path" src="https://github.com/user-attachments/assets/dd87f2b9-c4cb-48b2-ad46-3441c438941d" />

In the failing GET request notice the typo in URL path "images/operation/recon-match-specific-topic-to-cells.svg" 
 -> missing "s" at the end of  "operations".

### Reproduce 
The error is thrown when pre-loading the images (happens in same file)
https://github.com/OpenRefine/OpenRefine/blob/873965f16f23ac45b36c7acc556527602b03948d/main/webapp/modules/core/scripts/project/operation-icons.js#L9-L11

Test/reproduce on master by modifying the code like this and opening a project
```js
  // this will cause the image to load so that once it is added to the DOM it will already be in the browser cache
  var image = new Image();
  image.onerror = function () {
    console.error("Failed to load image:", image.src);
  };
  image.src = iconPath;
```

### Changes proposed in this pull request:
- fix typo in path to operation icon
