### PR TITLE
Prevent column mapping dialog from exceeding window

### DIFF
--- a/main/webapp/modules/core/styles/dialogs/column-mapping-dialog.css
+++ b/main/webapp/modules/core/styles/dialogs/column-mapping-dialog.css
@@ -18,7 +18,7 @@
 
 .column-mapping-form {
     max-height: 80vh;
-    overflow: scroll;
+    overflow: auto;
 
     div.grid-layout.layout-normal {
         margin: 0;


### PR DESCRIPTION
Fixes #7521

Changes proposed in this pull request:
- the column mapping dialog no longer exceeds the height of the window 
- the contents of the dialog will scroll instead of going off the page

Before:
<img width="1220" height="1079" alt="Screenshot from 2025-12-02 12-52-57" src="https://github.com/user-attachments/assets/ba9fb5ff-9015-44bb-aabd-23017b2c1a90" />

After:
<img width="1220" height="1079" alt="Screenshot from 2025-12-02 12-32-18" src="https://github.com/user-attachments/assets/1b14b5ea-7673-43be-80a7-d8eef0c2d291" />

