### PR TITLE
Fix: enable middle click to open project in new tab

### DIFF
--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -331,7 +331,9 @@ Refine.OpenProjectUI.prototype._renderProjects = function(data) {
       .addClass("searchable")
       .text(project.name)
       .attr("href", "project?project=" + project.id)
+      .attr("target", "_blank")
       .appendTo($(tr.insertCell(tr.cells.length)));
+
       
     var tagsCell = $(tr.insertCell(tr.cells.length));
     var tags = project.tags;


### PR DESCRIPTION
This PR adds a helpful improvement to the reconciliation UI.
Users can now open a reconciliation suggestion in a new browser tab without actually selecting it.

What’s new

Middle-click (Windows/Linux) opens the entity page in a new tab

Command + click (macOS) does the same

A normal click still selects the suggestion as before

The browser’s default behavior and context menu continue to work normally

This makes it easier for users to quickly preview Wikidata (or other service) pages before deciding which suggestion to pick.

Closes #6697