### PR TITLE
Assign version data to the global `OpenRefineVersion` variable instead of shadowing it in a smaller scope

### DIFF
--- a/main/webapp/modules/core/scripts/index.js
+++ b/main/webapp/modules/core/scripts/index.js
@@ -87,7 +87,7 @@ $(function() {
         "command/core/get-version",
         null,
         function(data) {
-          var OpenRefineVersion = data;
+          OpenRefineVersion = data;
 
           $("#openrefine-version").prepend($.i18n('core-index/refine-version', OpenRefineVersion.full_version));
           $("#openrefine-extensions").text($.i18n('core-index/refine-extensions', OpenRefineVersion.module_names.join(", ")));


### PR DESCRIPTION
Fixes #7576 

Changes proposed in this pull request:
- Removes `var` from `OpenRefineVersion` assignment so it is globally accessible