### PR TITLE
Fix #6697: Enable middle-click and Cmd+Click on reconciliation candidates

### DIFF
--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -331,8 +331,18 @@ Refine.OpenProjectUI.prototype._renderProjects = function(data) {
       .addClass("searchable")
       .text(project.name)
       .attr("href", "project?project=" + project.id)
-      .attr("target", "_blank")
       .appendTo($(tr.insertCell(tr.cells.length)));
+
+       nameLink.on("click", function (e) {
+       // If user middle-clicks OR Ctrl/Cmd-click → allow default behavior (new tab)
+       if (e.which === 2 || e.metaKey || e.ctrlKey) {
+        return;
+       }
+
+       e.preventDefault();
+       window.location = $(this).attr("href");
+       });
+
 
       
     var tagsCell = $(tr.insertCell(tr.cells.length));
@@ -472,3 +482,4 @@ Refine.actionAreas.push({
   label: $.i18n('core-index-open/open-proj'),
   uiClass: Refine.OpenProjectUI
 });
+


### PR DESCRIPTION
Implements the requested behavior from issue #6697.

Users can now open the Wikibase entity page in a new browser tab without selecting it:
- Cmd + Click (macOS)
- Ctrl + Click (Windows/Linux)
- Middle click

Normal click continues to select the candidate as expected.
<img width="1512" height="982" alt="Screenshot 2025-12-12 at 12 08 19 AM" src="https://github.com/user-attachments/assets/b5424318-831e-485d-9891-a3df8fb8946b" />


