### PR TITLE
Defensively reject null or blank Host headers

### DIFF
--- a/server/src/com/google/refine/ValidateHostHandler.java
+++ b/server/src/com/google/refine/ValidateHostHandler.java
@@ -64,6 +64,13 @@ class ValidateHostHandler extends HandlerWrapper {
 
     public boolean isValidHost(String host) {
 
+        // Defensive check: the Host header can be null or blank in malformed
+        // or non-browser HTTP requests. Such requests must be rejected to
+        // avoid unexpected behavior or bypassing host validation.
+        if (host == null || host.isBlank()) {
+            return false;
+        }
+
         // Allow loopback IPv4 and IPv6 addresses, as well as localhost
         if (LOOPBACK_PATTERN.matcher(host).find()) {
             return true;


### PR DESCRIPTION
While reviewing host validation logic, I noticed that the Host header
can be null or blank in malformed or non-browser HTTP requests, which
could lead to unexpected behavior.

This change adds an early defensive check to reject such requests,
ensuring host validation remains robust without altering existing
behavior for valid requests.
