### PR TITLE
Disable Wikibase reconciliation tests. Refs #7589

### DIFF
--- a/main/tests/cypress/cypress/e2e/extensions/wikibase/select_wikibase_instance.cy.js
+++ b/main/tests/cypress/cypress/e2e/extensions/wikibase/select_wikibase_instance.cy.js
@@ -3,7 +3,7 @@
  * Delete all previously added Wikibase test instances
  * They are shared across project, therefore some cleanup is required to ensure a Wikibase instance doesn't come from another test
  */
-describe(__filename, function () {
+describe.skip(__filename, function () {
     const WIKIBASE_TEST_NAME = 'OpenRefine Wikibase Cypress Test';
     const WIKIBASE_TEST_NAME2 = 'OpenRefine Wikibase Test';
 


### PR DESCRIPTION
Temporary patch to get CI working again. Refs #7589

Changes proposed in this pull request:
- disable Wikibase tests which use remote test Wikibase instance
