### PR TITLE
Fix scatterplot facet. Fixes #4926

### DIFF
--- a/main/src/com/google/refine/commands/browsing/GetScatterplotCommand.java
+++ b/main/src/com/google/refine/commands/browsing/GetScatterplotCommand.java
@@ -44,7 +44,6 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,18 +85,12 @@ public class GetScatterplotCommand extends Command {
 
             response.setHeader("Content-Type", "image/png");
 
-            ServletOutputStream sos = null;
-
-            try {
-                sos = response.getOutputStream();
+            try (ServletOutputStream sos = response.getOutputStream()) {
                 draw(sos, project, engine, conf);
-            } finally {
-                sos.close();
             }
 
             logger.trace("Drawn scatterplot in {} ms", Long.toString(System.currentTimeMillis() - start));
         } catch (Exception e) {
-            e.printStackTrace();
             respondException(response, e);
         }
     }
@@ -108,14 +101,14 @@ public class GetScatterplotCommand extends Command {
         public int size = 100;
         @JsonProperty(ScatterplotFacet.DOT)
         double dot = 100;
-        @JsonIgnore
-        public int dim_x = ScatterplotFacet.LIN;
-        @JsonIgnore
-        public int dim_y = ScatterplotFacet.LIN;
+        @JsonProperty(ScatterplotFacet.DIM_X)
+        public ScatterplotFacet.LinLog dim_x = ScatterplotFacet.LinLog.LIN;
+        @JsonProperty(ScatterplotFacet.DIM_Y)
+        public ScatterplotFacet.LinLog dim_y = ScatterplotFacet.LinLog.LIN;
         @JsonProperty(ScatterplotFacet.ROTATION)
-        public int rotation = ScatterplotFacet.NO_ROTATION;
+        public ScatterplotFacet.Rotation rotation = ScatterplotFacet.Rotation.NO_ROTATION;
         @JsonProperty(ScatterplotFacet.COLOR)
-        public String color_str = "000000";
+        public String color_str = "000000"; // TODO: Can this be simplified to set color directly (if we keep it)?
         @JsonProperty(ScatterplotFacet.BASE_COLOR)
         public String base_color_str = null;
         @JsonProperty(ScatterplotFacet.X_COLUMN_NAME)
@@ -127,31 +120,6 @@ public class GetScatterplotCommand extends Command {
         @JsonProperty(ScatterplotFacet.Y_EXPRESSION)
         public String expression_y = "value";
 
-        @JsonProperty(ScatterplotFacet.DIM_X)
-        public String getDimX() {
-            return dim_x == ScatterplotFacet.LIN ? "lin" : "log";
-        }
-
-        @JsonProperty(ScatterplotFacet.DIM_Y)
-        public String getDimY() {
-            return dim_y == ScatterplotFacet.LIN ? "lin" : "log";
-        }
-
-        @JsonProperty(ScatterplotFacet.DIM_X)
-        public void setDimX(String dim) {
-            dim_x = dim.equals("lin") ? ScatterplotFacet.LIN : ScatterplotFacet.LOG;
-        }
-
-        @JsonProperty(ScatterplotFacet.DIM_Y)
-        public void setDimY(String dim) {
-            dim_y = dim.equals("lin") ? ScatterplotFacet.LIN : ScatterplotFacet.LOG;
-        }
-
-        // rotation can be set to "none" (a JSON string) in which case it should be ignored
-        @JsonProperty(ScatterplotFacet.ROTATION)
-        public void setRotation(Object rotation) {
-            this.rotation = ScatterplotFacet.ScatterplotFacetConfig.getRotation(rotation.toString());
-        }
     }
 
     public void draw(OutputStream output, Project project, Engine engine, PlotterConfig o) throws IOException {
@@ -171,7 +139,7 @@ public class GetScatterplotCommand extends Command {
 
         Color base_color = o.base_color_str != null ? new Color(Integer.parseInt(o.base_color_str, 16)) : null;
 
-        if (o.columnName_x.length() > 0) {
+        if (!o.columnName_x.isEmpty()) {
             Column x_column = project.columnModel.getColumnByName(o.columnName_x);
             if (x_column != null) {
                 columnIndex_x = x_column.getCellIndex();
@@ -186,7 +154,7 @@ public class GetScatterplotCommand extends Command {
             logger.warn("error parsing expression", e);
         }
 
-        if (o.columnName_y.length() > 0) {
+        if (!o.columnName_y.isEmpty()) {
             Column y_column = project.columnModel.getColumnByName(o.columnName_y);
             if (y_column != null) {
                 columnIndex_y = y_column.getCellIndex();

--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/scatterplot-facet.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/scatterplot-facet.cy.js
@@ -1,7 +1,47 @@
 /**
- * Those tests are generic test to ensure the general behavior of the various facets components
- * It's using "text facet" as it is the most simple facet
+ * Test the scatterplot facet.
  */
+
+/**
+ * Helper that posts to the get-rows API with a scatterplot facet config and returns the filtered count.
+ * @param {string} projectId - The OpenRefine project ID
+ * @param {string} openRefineUrl - Base URL of the OpenRefine instance
+ * @param {string} csrfToken - CSRF token for the request
+ * @param {object} facetConfig - Partial scatterplot facet configuration (merged with base config)
+ */
+function getScatterplotFilteredCount(projectId, openRefineUrl, csrfToken, facetConfig) {
+  const engine = {
+    facets: [
+      {
+        type: 'scatterplot',
+        name: 'Water (x) vs. Energ_Kcal (y)',
+        cx: 'Water',
+        ex: 'value',
+        cy: 'Energ_Kcal',
+        ey: 'value',
+        l: 150,
+        dot: 1,
+        ...facetConfig,
+      },
+    ],
+    mode: 'row-based',
+  };
+  return cy
+    .request({
+      method: 'POST',
+      url: `${openRefineUrl}/command/core/get-rows`,
+      form: true,
+      body: {
+        project: projectId,
+        engine: JSON.stringify(engine),
+        start: 0,
+        limit: 0,
+        csrf_token: csrfToken,
+      },
+    })
+    .then((resp) => resp.body.filtered);
+}
+
 describe(__filename, function () {
   it('Verify the scatterplot matrix order of elements', function () {
     cy.loadAndVisitProject('food.small', 'food-small');
@@ -44,5 +84,63 @@ describe(__filename, function () {
     cy.get('label[title="Regular dot size"]').should('to.exist');
     cy.get('label[title="Big dot size"]').should('to.exist');
     cy.get('.scatterplot-export-plot > a').contains('Export plot').should('to.exist');
+    cy.get('#summary-bar').should('to.contain', '199 rows');
   });
+
+  it('Rotation and log scale filters different rows for the same selection', function () {
+    cy.loadAndVisitProject('food.small', 'food-small');
+    cy.castColumnTo('Water', 'number');
+    cy.castColumnTo('Energ_Kcal', 'number');
+
+    // TODO: We'd really like to do this using mouse selection rather than
+    // protocol requests, but we've been unable to get it working with the
+    // jQuery imgareaselect widget
+    cy.url().then((url) => {
+      const projectId = url.split('=').slice(-1)[0];
+      const openRefineUrl = Cypress.env('OPENREFINE_URL');
+
+      cy.request(openRefineUrl + '/command/core/get-csrf-token').then(
+        (tokenResp) => {
+          const csrfToken = tokenResp.body.token;
+
+          getScatterplotFilteredCount(projectId, openRefineUrl, csrfToken, {
+            from_x: 0.0,
+            to_x: 0.5,
+            from_y: 0.0,
+            to_y: 1.0,
+            dim_x: 'lin',
+            dim_y: 'lin',
+          }).as('noRotationCount');
+
+          getScatterplotFilteredCount(projectId, openRefineUrl, csrfToken, {
+            from_x: 0.0,
+            to_x: 0.5,
+            from_y: 0.0,
+            to_y: 1.0,
+            dim_x: 'log',
+            dim_y: 'log',
+          }).as('logCount');
+
+          getScatterplotFilteredCount(projectId, openRefineUrl, csrfToken, {
+            from_x: 0.0,
+            to_x: 0.5,
+            from_y: 0.0,
+            to_y: 1.0,
+            dim_x: 'lin',
+            dim_y: 'lin',
+            r: 'cw',
+          }).as('cwCount');
+        }
+      );
+    });
+
+    cy.then(function () {
+      // With CW rotation or log scale, the same rectangular pixel selection maps
+      // to a different region of the data space, so the filtered count differs
+      expect(this.cwCount).to.equal(198);
+      expect(this.noRotationCount).to.equal(76);
+      expect(this.logCount).to.equal(29);
+    });
+  });
+
 });

--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/scatterplot-facet.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/scatterplot-facet.cy.js
@@ -99,41 +99,40 @@ describe(__filename, function () {
       const projectId = url.split('=').slice(-1)[0];
       const openRefineUrl = Cypress.env('OPENREFINE_URL');
 
-      cy.request(openRefineUrl + '/command/core/get-csrf-token').then(
-        (tokenResp) => {
-          const csrfToken = tokenResp.body.token;
+      cy.request(openRefineUrl + '/command/core/get-csrf-token').then((tokenResp) => {
+        const csrfToken = tokenResp.body.token;
 
-          getScatterplotFilteredCount(projectId, openRefineUrl, csrfToken, {
-            from_x: 0.0,
-            to_x: 0.5,
-            from_y: 0.0,
-            to_y: 1.0,
-            dim_x: 'lin',
-            dim_y: 'lin',
-          }).as('noRotationCount');
+        getScatterplotFilteredCount(projectId, openRefineUrl, csrfToken, {
+          from_x: 0.0,
+          to_x: 0.5,
+          from_y: 0.0,
+          to_y: 1.0,
+          dim_x: 'lin',
+          dim_y: 'lin',
+        }).as('noRotationCount');
 
-          getScatterplotFilteredCount(projectId, openRefineUrl, csrfToken, {
-            from_x: 0.0,
-            to_x: 0.5,
-            from_y: 0.0,
-            to_y: 1.0,
-            dim_x: 'log',
-            dim_y: 'log',
-          }).as('logCount');
+        getScatterplotFilteredCount(projectId, openRefineUrl, csrfToken, {
+          from_x: 0.0,
+          to_x: 0.5,
+          from_y: 0.0,
+          to_y: 1.0,
+          dim_x: 'log',
+          dim_y: 'log',
+        }).as('logCount');
 
-          getScatterplotFilteredCount(projectId, openRefineUrl, csrfToken, {
-            from_x: 0.0,
-            to_x: 0.5,
-            from_y: 0.0,
-            to_y: 1.0,
-            dim_x: 'lin',
-            dim_y: 'lin',
-            r: 'cw',
-          }).as('cwCount');
-        }
-      );
+        getScatterplotFilteredCount(projectId, openRefineUrl, csrfToken, {
+          from_x: 0.0,
+          to_x: 0.5,
+          from_y: 0.0,
+          to_y: 1.0,
+          dim_x: 'lin',
+          dim_y: 'lin',
+          r: 'cw',
+        }).as('cwCount');
+      });
     });
 
+    /* eslint no-invalid-this: "warn"*/
     cy.then(function () {
       // With CW rotation or log scale, the same rectangular pixel selection maps
       // to a different region of the data space, so the filtered count differs
@@ -142,5 +141,4 @@ describe(__filename, function () {
       expect(this.logCount).to.equal(29);
     });
   });
-
 });

--- a/main/tests/server/src/com/google/refine/browsing/facets/ScatterplotFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/ScatterplotFacetTests.java
@@ -73,6 +73,24 @@ public class ScatterplotFacetTests extends RefineTest {
             "          \"name\": \"my column (x) vs. e (y)\"\n" +
             "        }";
 
+    public static String configJsonLog = "{\n" +
+            "          \"to_x\": 1,\n" +
+            "          \"to_y\": 1,\n" +
+            "          \"dot\": 1,\n" +
+            "          \"from_x\": 0.21333333333333335,\n" +
+            "          \"l\": 150,\n" +
+            "          \"type\": \"scatterplot\",\n" +
+            "          \"from_y\": 0.26666666666666666,\n" +
+            "          \"dim_y\": \"log\",\n" +
+            "          \"ex\": \"value\",\n" +
+            "          \"dim_x\": \"log\",\n" +
+            "          \"r\": \"cw\",\n" +
+            "          \"ey\": \"value\",\n" +
+            "          \"cx\": \"my column\",\n" +
+            "          \"cy\": \"e\",\n" +
+            "          \"name\": \"my column (x) vs. e (y)\"\n" +
+            "        }";
+
     public static String configJsonRenamed = "{\n" +
             "          \"to_x\": 1,\n" +
             "          \"to_y\": 1,\n" +
@@ -115,9 +133,8 @@ public class ScatterplotFacetTests extends RefineTest {
             + "\"ey\":\"value\","
             + "\"l\":150,"
             + "\"dot\":1,"
-            + "\"r\":0,"
-            + "\"dim_x\":0,"
-            + "\"dim_y\":0,"
+            + "\"dim_x\":\"lin\","
+            + "\"dim_y\":\"lin\","
             + "\"color\":\"000000\","
             + "\"from_x\":0.21333333333333335,"
             + "\"to_x\":1,"
@@ -139,6 +156,15 @@ public class ScatterplotFacetTests extends RefineTest {
     public void serializeScatterplotFacetConfig() throws JsonParseException, JsonMappingException, IOException {
         ScatterplotFacetConfig config = ParsingUtilities.mapper.readValue(configJson, ScatterplotFacetConfig.class);
         TestUtils.isSerializedTo(config, configJson);
+    }
+
+    @Test
+    public void deserializeLogAndRotationConfig() throws JsonParseException, JsonMappingException, IOException {
+        ScatterplotFacetConfig config = ParsingUtilities.mapper.readValue(configJsonLog, ScatterplotFacetConfig.class);
+        assertEquals(config.dim_x, ScatterplotFacet.LinLog.LOG);
+        assertEquals(config.dim_y, ScatterplotFacet.LinLog.LOG);
+        assertEquals(config.rotation, ScatterplotFacet.Rotation.ROTATE_CW);
+        TestUtils.isSerializedTo(config, configJsonLog);
     }
 
     @Test

--- a/main/tests/server/src/com/google/refine/commands/browsing/ScatterplotDrawCommandTests.java
+++ b/main/tests/server/src/com/google/refine/commands/browsing/ScatterplotDrawCommandTests.java
@@ -104,31 +104,32 @@ public class ScatterplotDrawCommandTests extends CommandTestBase {
     public void testParseConfig() throws JsonParseException, JsonMappingException, IOException {
         GetScatterplotCommand.PlotterConfig config = ParsingUtilities.mapper.readValue(configJson,
                 GetScatterplotCommand.PlotterConfig.class);
-        Assert.assertEquals("a", config.columnName_x);
-        Assert.assertEquals("b", config.columnName_y);
-        Assert.assertEquals(ScatterplotFacet.LOG, config.dim_x);
-        Assert.assertEquals(ScatterplotFacet.LIN, config.dim_y);
+        Assert.assertEquals(config.columnName_x, "a");
+        Assert.assertEquals(config.columnName_y, "b");
+        // In reality both axes always match as either LIN or LOG
+        Assert.assertEquals(config.dim_x, ScatterplotFacet.LinLog.LOG);
+        Assert.assertEquals(config.dim_y, ScatterplotFacet.LinLog.LIN);
     }
 
     @Test
     public void testParseConfigWithNone() throws JsonParseException, JsonMappingException, IOException {
         GetScatterplotCommand.PlotterConfig config = ParsingUtilities.mapper.readValue(configJsonWithNone,
                 GetScatterplotCommand.PlotterConfig.class);
-        Assert.assertEquals(ScatterplotFacet.NO_ROTATION, config.rotation);
+        Assert.assertEquals(config.rotation, ScatterplotFacet.Rotation.NO_ROTATION);
     }
 
     @Test
     public void testParseConfigWithCW() throws JsonParseException, JsonMappingException, IOException {
         GetScatterplotCommand.PlotterConfig config = ParsingUtilities.mapper.readValue(configJsonWithCW,
                 GetScatterplotCommand.PlotterConfig.class);
-        Assert.assertEquals(ScatterplotFacet.ROTATE_CW, config.rotation);
+        Assert.assertEquals(config.rotation, ScatterplotFacet.Rotation.ROTATE_CW);
     }
 
     @Test
     public void testParseConfigWithCCW() throws JsonParseException, JsonMappingException, IOException {
         GetScatterplotCommand.PlotterConfig config = ParsingUtilities.mapper.readValue(configJsonWithCCW,
                 GetScatterplotCommand.PlotterConfig.class);
-        Assert.assertEquals(ScatterplotFacet.ROTATE_CCW, config.rotation);
+        Assert.assertEquals(config.rotation, ScatterplotFacet.Rotation.ROTATE_CCW);
     }
 
 }

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotDrawingRowVisitor.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotDrawingRowVisitor.java
@@ -54,8 +54,8 @@ public class ScatterplotDrawingRowVisitor implements RowVisitor, RecordVisitor {
 
     int col_x;
     int col_y;
-    int dim_x;
-    int dim_y;
+    ScatterplotFacet.LinLog dim_x;
+    ScatterplotFacet.LinLog dim_y;
 
     double l;
     double dot;
@@ -72,7 +72,8 @@ public class ScatterplotDrawingRowVisitor implements RowVisitor, RecordVisitor {
 
     public ScatterplotDrawingRowVisitor(
             int col_x, int col_y, double min_x, double max_x, double min_y, double max_y,
-            int size, int dim_x, int dim_y, int rotation, double dot, Color color) {
+            int size, ScatterplotFacet.LinLog dim_x, ScatterplotFacet.LinLog dim_y, ScatterplotFacet.Rotation rotation, double dot,
+            Color color) {
         this.col_x = col_x;
         this.col_y = col_y;
         this.min_x = min_x;

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
@@ -135,7 +135,7 @@ public class ScatterplotFacet implements Facet {
         protected LinLog dim_y = LinLog.LIN;
 
         @JsonProperty(value = ROTATION)
-        protected Rotation rotation;
+        protected Rotation rotation = Rotation.NO_ROTATION; // Default value "none" if missing
 
         @JsonProperty(value = ROTATION)
         @JsonInclude(Include.NON_NULL)
@@ -638,12 +638,12 @@ public class ScatterplotFacet implements Facet {
     }
 
     private static double scale(double value, double min, double max, LinLog dim, double size) {
-        double relative_x = value - min;
-        double range_x = max - min;
+        double relative = value - min;
+        double range = max - min;
         if (dim == LinLog.LOG) {
-            value = Math.log10(relative_x + 1) * size / Math.log10(range_x + 1);
+            value = Math.log10(relative + 1) * size / Math.log10(range + 1);
         } else {
-            value = relative_x * size / range_x;
+            value = relative * size / range;
         }
         return value;
     }

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
@@ -48,6 +48,7 @@ import java.util.Set;
 
 import javax.imageio.ImageIO;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -75,15 +76,42 @@ import com.google.refine.util.NotImplementedException;
 
 public class ScatterplotFacet implements Facet {
 
-    public static final int LIN = 0;
-    public static final int LOG = 1;
+    // @formatter:off
+    public enum LinLog {
+        @JsonInclude(Include.ALWAYS) @JsonEnumDefaultValue @JsonProperty("lin") LIN,
+        @JsonProperty("log") LOG;
+    }
 
-    public static final int NO_ROTATION = 0;
-    public static final int ROTATE_CW = 1;
-    public static final int ROTATE_CCW = 2;
+    // NOTE: legacy values of right (cw) & left (ccw) no longer supported
+    public enum Rotation {
+        @JsonEnumDefaultValue @JsonProperty("none") NO_ROTATION,
+        @JsonProperty("cw") ROTATE_CW,
+        @JsonProperty("ccw") ROTATE_CCW;
+    }
+    // @formatter:on
 
     /*
      * Configuration, from the client side
+     * @formatter:off
+     * An example of the JSON representation of the configuration:
+      * {
+          "name": "Water (x) vs. Energ_Kcal (y)",
+          "cx": "Water",
+          "cy": "Energ_Kcal",
+          "l": 150,
+          "ex": "value",
+          "ey": "value",
+          "dot": 0.8,
+          "dim_x": "lin",
+          "dim_y": "lin",
+          "r": "ccw",
+          "type": "scatterplot",
+          "from_x": 0.8,
+          "to_x": 1,
+          "from_y": 0.3933333333333333,
+          "to_y": 0.5933333333333334
+       }
+       * @formatter:on
      */
     public static class ScatterplotFacetConfig implements FacetConfig {
 
@@ -101,23 +129,28 @@ public class ScatterplotFacet implements Facet {
 
         @JsonProperty(SIZE)
         protected int size;
-        @JsonIgnore
-        protected int dim_x;
-        @JsonIgnore
-        protected int dim_y;
-        @JsonIgnore
-        protected String rotation_str;
-        @JsonIgnore
-        protected int rotation;
+        @JsonProperty(DIM_X)
+        protected LinLog dim_x = LinLog.LIN;
+        @JsonProperty(DIM_Y)
+        protected LinLog dim_y = LinLog.LIN;
 
-        @JsonIgnore
-        protected double l = 1.;
+        @JsonProperty(value = ROTATION)
+        protected Rotation rotation;
+
+        @JsonProperty(value = ROTATION)
+        @JsonInclude(Include.NON_NULL)
+        public Rotation getRotation() {
+            // Don't serialize default value
+            return rotation == Rotation.NO_ROTATION ? null : rotation;
+        }
+
         @JsonProperty(DOT)
         protected double dot;
 
         @JsonIgnore
         protected String color_str = "000000";
 
+        // FIXME: color support was never used, so this is dead code
         @JsonIgnore
         protected Color getColor() {
             return new Color(Integer.parseInt(color_str, 16));
@@ -138,32 +171,11 @@ public class ScatterplotFacet implements Facet {
             return from_x > 0 || to_x < 1 || from_y > 0 || to_y < 1;
         }
 
-        @JsonProperty(DIM_X)
-        public String getDimX() {
-            return dim_x == LIN ? "lin" : "log";
-        }
-
-        @JsonProperty(DIM_Y)
-        public String getDimY() {
-            return dim_y == LIN ? "lin" : "log";
-        }
-
         @Override
         public ScatterplotFacet apply(Project project) {
             ScatterplotFacet facet = new ScatterplotFacet();
             facet.initializeFromConfig(this, project);
             return facet;
-        }
-
-        public static int getRotation(String rotation) {
-            rotation = rotation.toLowerCase();
-            if ("cw".equals(rotation) || "right".equals(rotation)) {
-                return ScatterplotFacet.ROTATE_CW;
-            } else if ("ccw".equals(rotation) || "left".equals(rotation)) {
-                return ScatterplotFacet.ROTATE_CCW;
-            } else {
-                return NO_ROTATION;
-            }
         }
 
         @Override
@@ -231,9 +243,7 @@ public class ScatterplotFacet implements Facet {
             newConfig.size = size;
             newConfig.dim_x = dim_x;
             newConfig.dim_y = dim_y;
-            newConfig.rotation_str = rotation_str;
             newConfig.rotation = rotation;
-            newConfig.l = l;
             newConfig.dot = dot;
             newConfig.color_str = color_str;
             newConfig.from_x = from_x;
@@ -276,16 +286,12 @@ public class ScatterplotFacet implements Facet {
 
     public static final String X_COLUMN_NAME = "cx";
     public static final String X_EXPRESSION = "ex";
-    public static final String MIN_X = "min_x";
-    public static final String MAX_X = "max_x";
     public static final String TO_X = "to_x";
     public static final String FROM_X = "from_x";
     public static final String ERROR_X = "error_x";
 
     public static final String Y_COLUMN_NAME = "cy";
     public static final String Y_EXPRESSION = "ey";
-    public static final String MIN_Y = "min_y";
-    public static final String MAX_Y = "max_y";
     public static final String TO_Y = "to_y";
     public static final String FROM_Y = "from_y";
     public static final String ERROR_Y = "error_y";
@@ -335,12 +341,12 @@ public class ScatterplotFacet implements Facet {
     }
 
     @JsonProperty(DIM_X)
-    public int getDimX() {
+    public LinLog getDimX() {
         return config.dim_x;
     }
 
-    @JsonProperty(DIM_Y)
-    public int getDimY() {
+    @JsonProperty(value = DIM_Y)
+    public LinLog getDimY() {
         return config.dim_y;
     }
 
@@ -349,9 +355,10 @@ public class ScatterplotFacet implements Facet {
         return config.dot;
     }
 
-    @JsonProperty(ROTATION)
-    public double getRotation() {
-        return config.rotation;
+    @JsonProperty(value = ROTATION)
+    @JsonInclude(Include.NON_NULL)
+    public Rotation getRotation() {
+        return config.rotation == Rotation.NO_ROTATION ? null : config.rotation;
     }
 
     @JsonProperty(COLOR)
@@ -419,9 +426,9 @@ public class ScatterplotFacet implements Facet {
     public void initializeFromConfig(ScatterplotFacetConfig configuration, Project project) {
         config = configuration;
 
-        t = createRotationMatrix(config.rotation, config.l);
+        t = createRotationMatrix(config.rotation, config.size);
 
-        if (config.columnName_x.length() > 0) {
+        if (!config.columnName_x.isEmpty()) {
             Column x_column = project.columnModel.getColumnByName(config.columnName_x);
             if (x_column != null) {
                 columnIndex_x = x_column.getCellIndex();
@@ -442,7 +449,7 @@ public class ScatterplotFacet implements Facet {
             errorMessage_x = e.getMessage();
         }
 
-        if (config.columnName_y.length() > 0) {
+        if (!config.columnName_y.isEmpty()) {
             Column y_column = project.columnModel.getColumnByName(config.columnName_y);
             if (y_column != null) {
                 columnIndex_y = y_column.getCellIndex();
@@ -473,15 +480,15 @@ public class ScatterplotFacet implements Facet {
             return new DualExpressionsNumberComparisonRowFilter(
                     eval_x, config.columnName_x, columnIndex_x, eval_y, config.columnName_y, columnIndex_y) {
 
-                double from_x_pixels = config.from_x * config.l;
-                double to_x_pixels = config.to_x * config.l;
-                double from_y_pixels = config.from_y * config.l;
-                double to_y_pixels = config.to_y * config.l;
+                double from_x_pixels = config.from_x * config.size;
+                double to_x_pixels = config.to_x * config.size;
+                double from_y_pixels = config.from_y * config.size;
+                double to_y_pixels = config.to_y * config.size;
 
                 @Override
                 protected boolean checkValues(double x, double y) {
                     Point2D.Double p = new Point2D.Double(x, y);
-                    p = translateCoordinates(p, min_x, max_x, min_y, max_y, config.dim_x, config.dim_y, config.l, t);
+                    p = translateCoordinates(p, min_x, max_x, min_y, max_y, config.dim_x, config.dim_y, config.size, t);
                     return p.x >= from_x_pixels && p.x <= to_x_pixels && p.y >= from_y_pixels && p.y <= to_y_pixels;
                 };
             };
@@ -573,10 +580,6 @@ public class ScatterplotFacet implements Facet {
         return url;
     }
 
-    public static int getAxisDim(String type) {
-        return ("log".equals(type.toLowerCase())) ? LOG : LIN;
-    }
-
     public static NumericBinIndex getBinIndex(Project project, Column column, Evaluable eval, String expression) {
         return getBinIndex(project, column, eval, expression, "row-based");
     }
@@ -603,13 +606,13 @@ public class ScatterplotFacet implements Facet {
 
     private static double s_rotateScale = 1 / Math.sqrt(2.0);
 
-    public static AffineTransform createRotationMatrix(int rotation, double l) {
-        if (rotation == ScatterplotFacet.ROTATE_CW) {
+    public static AffineTransform createRotationMatrix(Rotation rotation, double l) {
+        if (rotation == Rotation.ROTATE_CW) {
             AffineTransform t = AffineTransform.getTranslateInstance(0, l / 2);
             t.scale(s_rotateScale, s_rotateScale);
             t.rotate(-Math.PI / 4);
             return t;
-        } else if (rotation == ScatterplotFacet.ROTATE_CCW) {
+        } else if (rotation == Rotation.ROTATE_CCW) {
             AffineTransform t = AffineTransform.getTranslateInstance(l / 2, 0);
             t.scale(s_rotateScale, s_rotateScale);
             t.rotate(Math.PI / 4);
@@ -622,14 +625,14 @@ public class ScatterplotFacet implements Facet {
     public static Point2D.Double translateCoordinates(
             Point2D.Double p,
             double min_x, double max_x, double min_y, double max_y,
-            int dim_x, int dim_y, double l, AffineTransform t) {
+            LinLog dim_x, LinLog dim_y, double l, AffineTransform t) {
 
         double x = p.x;
         double y = p.y;
 
         double relative_x = x - min_x;
         double range_x = max_x - min_x;
-        if (dim_x == ScatterplotFacet.LOG) {
+        if (dim_x == LinLog.LOG) {
             x = Math.log10(relative_x + 1) * l / Math.log10(range_x + 1);
         } else {
             x = relative_x * l / range_x;
@@ -637,7 +640,7 @@ public class ScatterplotFacet implements Facet {
 
         double relative_y = y - min_y;
         double range_y = max_y - min_y;
-        if (dim_y == ScatterplotFacet.LOG) {
+        if (dim_y == LinLog.LOG) {
             y = Math.log10(relative_y + 1) * l / Math.log10(range_y + 1);
         } else {
             y = relative_y * l / range_y;

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
@@ -128,7 +128,7 @@ public class ScatterplotFacet implements Facet {
         protected String columnName_y; // column to base the y expression on, if any
 
         @JsonProperty(SIZE)
-        protected int size;
+        protected int size; // Default value 100 if missing
         @JsonProperty(DIM_X)
         protected LinLog dim_x = LinLog.LIN;
         @JsonProperty(DIM_Y)
@@ -145,7 +145,7 @@ public class ScatterplotFacet implements Facet {
         }
 
         @JsonProperty(DOT)
-        protected double dot;
+        protected double dot; // Default value if missing 0.5
 
         @JsonIgnore
         protected String color_str = "000000";
@@ -157,13 +157,13 @@ public class ScatterplotFacet implements Facet {
         }
 
         @JsonProperty(FROM_X)
-        protected double from_x; // the numeric selection for the x axis, from 0 to 1
+        protected double from_x; // the numeric selection for the x axis, from 0 to 1. Default value 0 if missing
         @JsonProperty(TO_X)
-        protected double to_x;
+        protected double to_x; // Default value 1 if missing
         @JsonProperty(FROM_Y)
-        protected double from_y; // the numeric selection for the y axis, from 0 to 1
+        protected double from_y; // the numeric selection for the y axis, from 0 to 1. Default value 0 if missing
         @JsonProperty(TO_Y)
-        protected double to_y;
+        protected double to_y; // Default value 1 if missing
 
         // false if we're certain that all rows will match
         // and there isn't any filtering to do

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/ScatterplotFacet.java
@@ -627,32 +627,25 @@ public class ScatterplotFacet implements Facet {
             double min_x, double max_x, double min_y, double max_y,
             LinLog dim_x, LinLog dim_y, double l, AffineTransform t) {
 
-        double x = p.x;
-        double y = p.y;
+        p.x = scale(p.x, min_x, max_x, dim_x, l);
+        p.y = scale(p.y, min_y, max_y, dim_y, l);
 
-        double relative_x = x - min_x;
-        double range_x = max_x - min_x;
-        if (dim_x == LinLog.LOG) {
-            x = Math.log10(relative_x + 1) * l / Math.log10(range_x + 1);
-        } else {
-            x = relative_x * l / range_x;
-        }
-
-        double relative_y = y - min_y;
-        double range_y = max_y - min_y;
-        if (dim_y == LinLog.LOG) {
-            y = Math.log10(relative_y + 1) * l / Math.log10(range_y + 1);
-        } else {
-            y = relative_y * l / range_y;
-        }
-
-        p.x = x;
-        p.y = y;
         if (t != null) {
             t.transform(p, p);
         }
 
         return p;
+    }
+
+    private static double scale(double value, double min, double max, LinLog dim, double size) {
+        double relative_x = value - min;
+        double range_x = max - min;
+        if (dim == LinLog.LOG) {
+            value = Math.log10(relative_x + 1) * size / Math.log10(range_x + 1);
+        } else {
+            value = relative_x * size / range_x;
+        }
+        return value;
     }
 
 }


### PR DESCRIPTION
Fixes #4926

Fixes the facet configuration for both log/linear and rotation settings as well as simplifying some of the handling to let Jackson do more of the work instead of hand converting values. Now uses Java enums instead of constants to make code more readable and support Jackson.

Other minor changes:
- Remove redundant size field which there were both double and int versions of
- Use correct parameter order for assert calls in tests to make failures easier to interpret
- extracted a scaling helper to dry up scaling code
- document expected defaults based on the original implementation code (but didn't actually reimplement them)