### PR TITLE
Fix: Align operations dialog columns. Fixes #7573.

### DIFF
--- a/main/webapp/modules/core/styles/dialogs/column-mapping-dialog.css
+++ b/main/webapp/modules/core/styles/dialogs/column-mapping-dialog.css
@@ -23,5 +23,13 @@
     div.grid-layout.layout-normal {
         margin: 0;
     }
+    div.grid-layout.layout-normal>table {
+        width: 100%;
+    }
+    div.grid-layout.layout-normal>table>thead>tr>th, div.grid-layout.layout-normal>table>tbody>tr>td:first-child  {
+        width: 65%;
+        white-space: normal !important;
+        word-break: break-word;
+    }
 }
 


### PR DESCRIPTION
Fixes #7573

Changes proposed in this pull request:
- First column's content now wraps to prevent misalignment of other columns.
- Table layout is consistent to ensure Created columns section at the bottom is aligned.

Before:
<img width="1035" height="347" alt="image" src="https://github.com/user-attachments/assets/7315e900-8b04-4529-8215-0e4f56b0d9b1" />

After:
<img width="798" height="273" alt="image" src="https://github.com/user-attachments/assets/9b9e7ec3-7ec8-488c-939d-878c49a26513" />

