### PR TITLE
Fix: override upstream tablesorter styles

### DIFF
--- a/main/webapp/modules/core/styles/index/open-project-ui.css
+++ b/main/webapp/modules/core/styles/index/open-project-ui.css
@@ -246,3 +246,11 @@ ul#tagsUl li a {
   text-align: center;
   font-size: x-large;
 }
+
+/* Tablesorter overrides */
+
+.tablesorter-blue {
+  border-width: 1px; /* fixes missing bottom border */
+  margin: 5px; /* aligns table with the tags bar and footer content */
+  max-width: calc(100% - 12px); /* prevents horizontal overflow */
+}


### PR DESCRIPTION
This commit overrides several upstream styles to:

1. ensure that the project table list is aligned with the project bar and footer content
2. ensure that the bottom of the table has a border
3. ensure that the table does not overflow horizontally

Before:
<img width="264" height="190" alt="Screenshot from 2026-02-27 19-07-17" src="https://github.com/user-attachments/assets/78b03d96-666c-41e1-9b4d-9300219f1028" />
<img width="264" height="190" alt="Screenshot from 2026-02-27 19-07-28" src="https://github.com/user-attachments/assets/e9681cf4-42a2-4fe7-a711-f8e7c2a00df8" />

After:
<img width="264" height="190" alt="Screenshot from 2026-02-27 19-07-49" src="https://github.com/user-attachments/assets/985368ae-5b50-4919-b103-487ade22076f" />
<img width="264" height="190" alt="Screenshot from 2026-02-27 19-07-36" src="https://github.com/user-attachments/assets/b306fb48-ab41-4ac5-85d4-6745d56b71d2" />
