### PR TITLE
Fail build on error. Refs #7671

### DIFF
--- a/.github/workflows/release/add_apple_keys.sh
+++ b/.github/workflows/release/add_apple_keys.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+set -e
 
 # Create a custom keychain
 security create-keychain -p gh_actions refine-build.keychain

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -7,7 +7,7 @@ on:
     paths-ignore:
       - 'docs/**'
   release:
-    types: [created, published]
+    types: [ published ]
 
 jobs:
   prepare_e2e_test_matrix:

--- a/packaging/apple_certs/codesign.sh
+++ b/packaging/apple_certs/codesign.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+set -e
 
 # Adapted from https://github.com/gephi/gephi/blob/6ac653758063f74c56a7b93db800978ead3ea95d/modules/application/src/main/app-resources/codesign.sh
 # Author: Mathieu Bastian
-# License: https://opensource.org/licenses/CDDL-1.0
+# License: https://opensource.org/licenses/CDDL-1.0
 
 function codesignJarsInDir {
   local dir="$1"
@@ -27,7 +28,7 @@ function codesignJarsInDir {
 
             # Issue 4568: replace "libjffi-1.2.jnilib" by a version of it that
             # was compiled on a newer Xcode SDK.
-            # This is a temporary measure until this is fixed upstream:
+            # This is a temporary measure until this is fixed upstream (still open July 2026):
             # https://github.com/jnr/jffi/issues/123
             if [ $(basename "${libfile}") == "libjffi-1.2.jnilib" ]; then
                 local our_libjffi="$(dirname ${BASH_SOURCE})/libjffi-1.2.jnilib" 

--- a/packaging/apple_certs/codesign.sh
+++ b/packaging/apple_certs/codesign.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Adapted from https://github.com/gephi/gephi/blob/6ac653758063f74c56a7b93db800978ead3ea95d/modules/application/src/main/app-resources/codesign.sh
 # Author: Mathieu Bastian

--- a/packaging/apple_certs/codesign.sh
+++ b/packaging/apple_certs/codesign.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # Adapted from https://github.com/gephi/gephi/blob/6ac653758063f74c56a7b93db800978ead3ea95d/modules/application/src/main/app-resources/codesign.sh
 # Author: Mathieu Bastian
@@ -26,7 +25,8 @@ function codesignJarsInDir {
         # Codesign all all relevant files
         while IFS= read -r -d $'\0' libfile; do
             echo "Codesigning file $(basename "${libfile}")"
-            codesign --verbose --entitlements "$3" --deep --force --timestamp --sign "$2" --options runtime $libfile
+            # Exit with error if codesigning fails
+            codesign --verbose --entitlements "$3" --deep --force --timestamp --sign "$2" --options runtime $libfile || exit $?
         done < <(find -E "$folder" -regex '.*\.(dylib|jnilib)' -print0)
 
         # Create updated JAR

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -330,7 +330,7 @@
                 </exec>
 
                 <!-- Codesign JRE -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="codesign">
+                <exec dir="${project.build.directory}" os="Mac OS X" executable="codesign" failonerror="true">
                     <arg value="--entitlements" />
                     <arg value="../Entitlements.plist" />
                     <arg value="--sign"/>
@@ -344,7 +344,7 @@
                 </exec>
 
                 <!-- Codesign jars with native code in them -->
-                <exec executable="/bin/bash" os="Mac OS X" dir="${project.build.directory}/${mac.build.directory}">
+                <exec executable="/bin/bash" os="Mac OS X" dir="${project.build.directory}/${mac.build.directory}"  failonerror="true">
                     <arg value="${basedir}/apple_certs/codesign.sh" />
                     <arg value="OpenRefine.app" />
                     <arg value="${mac.signing.identity}" />
@@ -352,7 +352,7 @@
                 </exec>
 
                 <!-- Codesign app -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="codesign">
+                <exec dir="${project.build.directory}" os="Mac OS X" executable="codesign" failonerror="true">
                     <arg value="--entitlements" />
                     <arg value="../Entitlements.plist" />
                     <arg value="--sign"/>
@@ -366,7 +366,7 @@
                 </exec>
 
                 <!-- Create DMG (Mac OS X) -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="python3">
+                <exec dir="${project.build.directory}" os="Mac OS X" executable="python3" failonerror="true">
                     <arg value="-m"/>
                     <arg value="dmgbuild"/>
                     <arg value="-s"/>
@@ -397,7 +397,7 @@
                 </exec>
 
                 <!-- Send DMG file to Apple's notarization service -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="xcrun">
+                <exec dir="${project.build.directory}" os="Mac OS X" executable="xcrun" failonerror="true">
                     <arg value="notarytool"/>
                     <arg value="submit"/>
                     <arg value="${mac.dmg.path}"/>
@@ -413,7 +413,7 @@
                 </exec>
 
                 <!-- Staple the notarization ticket to the DMG bundle -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="xcrun">
+                <exec dir="${project.build.directory}" os="Mac OS X" executable="xcrun" failonerror="true">
                     <arg value="stapler"/>
                     <arg value="staple"/>
                     <arg value="${mac.dmg.path}"/>
@@ -536,7 +536,7 @@
           <version>1.2.0</version>
           <dependencies>
             <dependency>
-              <!-- dependency upgraded to >4.0 to fix runtime issues with some JRE versions:
+              <!-- dependency upgraded to >4.0 to fix runtime issues with some JRE versions:
                    https://stackoverflow.com/questions/53696439/appbundle-maven-plugin-fails-on-mac-osx-with-java-10 -->
               <groupId>org.codehaus.plexus</groupId>
               <artifactId>plexus-archiver</artifactId>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -144,7 +144,7 @@
                             <target name="notarizeDMG" description="Notarize DMG">
 
                                 <!-- Send DMG file to Apple's notarization service -->
-                                <exec dir="${project.build.directory}" os="Mac OS X" executable="xcrun">
+                                <exec dir="${project.build.directory}" os="Mac OS X" executable="xcrun" failonerror="true">
                                     <arg value="notarytool"/>
                                     <arg value="submit"/>
                                     <arg value="${mac.dmg.path}"/>
@@ -160,7 +160,7 @@
                                 </exec>
 
                                 <!-- Staple the notarization ticket to the DMG bundle -->
-                                <exec dir="${project.build.directory}" os="Mac OS X" executable="xcrun">
+                                <exec dir="${project.build.directory}" os="Mac OS X" executable="xcrun" failonerror="true">
                                     <arg value="stapler"/>
                                     <arg value="staple"/>
                                     <arg value="${mac.dmg.path}"/>
@@ -391,7 +391,7 @@
                 </exec>
 
                 <!-- Codesign JRE -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="codesign">
+                <exec dir="${project.build.directory}" os="Mac OS X" executable="codesign" failonerror="true">
                     <arg value="--entitlements" />
                     <arg value="../Entitlements.plist" />
                     <arg value="--sign"/>
@@ -405,7 +405,7 @@
                 </exec>
 
                 <!-- Codesign jars with native code in them -->
-                <exec executable="/bin/bash" os="Mac OS X" dir="${project.build.directory}/${mac.build.directory}">
+                <exec executable="/bin/bash" os="Mac OS X" dir="${project.build.directory}/${mac.build.directory}"  failonerror="true">
                     <arg value="${basedir}/apple_certs/codesign.sh" />
                     <arg value="OpenRefine.app" />
                     <arg value="${mac.signing.identity}" />
@@ -413,7 +413,7 @@
                 </exec>
 
                 <!-- Codesign app -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="codesign">
+                <exec dir="${project.build.directory}" os="Mac OS X" executable="codesign" failonerror="true">
                     <arg value="--entitlements" />
                     <arg value="../Entitlements.plist" />
                     <arg value="--sign"/>
@@ -427,7 +427,7 @@
                 </exec>
 
                 <!-- Create DMG (Mac OS X) -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="python3">
+                <exec dir="${project.build.directory}" os="Mac OS X" executable="python3" failonerror="true">
                     <arg value="-m"/>
                     <arg value="dmgbuild"/>
                     <arg value="-s"/>


### PR DESCRIPTION
Refs #7671 #7692

Attempt to fix build that silently fails to notarize DMG.

- Make sure shell scripts exit immediately on error.
- Fail any critical tasks which error to abort the build.
