### PR TITLE
Add Unix domain socket support to RefineServer

### DIFF
--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -72,10 +72,6 @@ jobs:
           npm i -g yarn
           yarn install
 
-      - name: Test Unix Domain Socket connectivity
-        run: | 
-          ./refine uds_tests
-
       - name: Test with Cypress on ${{ matrix.browser }}
         run: | 
           echo REFINE_MIN_MEMORY=1400M >> ./refine.ini
@@ -88,3 +84,22 @@ jobs:
           CYPRESS_CI_BUILD_ID: '${{ github.run_id }}'
           CYPRESS_SPECS: ${{ matrix.specs.paths }}
           CYPRESS_GROUP: ${{ matrix.specs.group }}
+  misc_integration_test:
+    name: Misc integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: 'maven'
+
+      - name: Build OpenRefine
+        run: ./refine build
+
+      - name: Test Unix Domain Socket connectivity
+        run: | 
+          ./refine uds_tests

--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -72,6 +72,10 @@ jobs:
           npm i -g yarn
           yarn install
 
+      - name: Test Unix Domain Socket connectivity
+        run: | 
+          ./refine uds_tests
+
       - name: Test with Cypress on ${{ matrix.browser }}
         run: | 
           echo REFINE_MIN_MEMORY=1400M >> ./refine.ini

--- a/refine
+++ b/refine
@@ -93,8 +93,24 @@ check_downloaders() {
 
 check_running() {
     check_downloaders
-    URL="http://${REFINE_HOST_INTERNAL}:${REFINE_PORT}/"
+
     CHECK_STR="<title>OpenRefine</title>"
+    URL="http://${REFINE_HOST_INTERNAL}:${REFINE_PORT}/"
+
+    if [ -n "$REFINE_SOCKET" ] ; then
+        if [ "$CURL" ] ; then
+            RUNNING=`curl --unix-socket $REFINE_SOCKET --noproxy 127.0.0.1 -s http://localhost | grep "$CHECK_STR"`
+        else
+            # wget does not support connecting to unix domain sockets
+            # instead use a simple filesystem check to determine whether a file exists at the socket path
+            if [ -e "$REFINE_SOCKET" ] ; then
+                RUNNING="0"
+            else
+                RUNNING=""
+            fi
+        fi
+        return
+    fi
 
     if [ "$CURL" ] ; then
         curl --noproxy 127.0.0.1 -s -S -f $URL > /dev/null 2>&1
@@ -107,7 +123,7 @@ check_running() {
         if [ "$?" = "4" ] ; then
             NOT_RUNNING="1"
         fi
-    fi    
+    fi
 
     if [ -z "${NOT_RUNNING}" ] ; then
         if [ "$CURL" ] ; then
@@ -361,6 +377,36 @@ test() {
     $MVN test
 }
 
+uds_tests() {
+    add_option "-Drefine.headless=true"
+    add_option "-Drefine.socket=/tmp/openrefine_test.sock"
+    REFINE_SOCKET="/tmp/openrefine_test.sock"
+    check_running
+
+    if [ "$RUNNING" ] ; then
+        echo "An OpenRefine server is already running. Please shut it down so that we can start a test server."
+        exit
+    fi
+    echo "Starting OpenRefine server"
+
+    run fork > /dev/null
+
+    echo "Waiting for OpenRefine to load..."
+    sleep 5
+    check_running
+
+    if [ ! "$RUNNING" ] ; then
+        fail "OpenRefine failed to start on Unix Domain Socket."
+    else
+        echo ""
+        echo "Killing OpenRefine"
+        /bin/kill $REFINE_PID
+        echo "Cleaning up"
+        rm -rf "$REFINE_DATA_DIR"
+        return 0
+    fi
+}
+
 
 e2e_tests() {
     get_revision
@@ -435,8 +481,6 @@ e2e_tests() {
     echo ""
     echo "Killing OpenRefine"
     /bin/kill -9 $REFINE_PID
-    echo "Cleaning up"
-    rm -rf "$REFINE_DATA_DIR"
 
     if [ "$UI_TEST_SUCCESS" = "0" ] ; then
         error "The UI test suite failed."
@@ -748,6 +792,7 @@ case "$ACTION" in
   test) test $1;;
   tests) test $1;;
   e2e_tests) e2e_tests;;
+  uds_tests) uds_tests;;
   server_test) server_test $1;;  
   server_tests) server_test $1;;  
   extensions_test) extensions_test $1;;

--- a/refine
+++ b/refine
@@ -116,9 +116,9 @@ check_running() {
             RUNNING=`no_proxy=127.0.0.1 wget -O - $URL| grep "$CHECK_STR"` 
         fi    
         
-        # if [ -z "${RUNNING}" ] ; then
-        #     error "OpenRefine isn't running on $URL. Maybe a proxy issue?"
-        # fi
+        if [ -z "${RUNNING}" ] ; then
+            error "OpenRefine isn't running on $URL. Maybe a proxy issue?"
+        fi
     else
         RUNNING=""
     fi

--- a/refine
+++ b/refine
@@ -35,7 +35,7 @@ Options
     -i <interface>                The network interface OpenRefine should bind to. Default: 127.0.0.1.
     -m <memory>                   JVM min and max memory heap size. Default: 1400M.
     -p <port>                     Port that OpenRefine will listen to. Default: 3333.
-    -s <path>                     Path to unix domain socket at which the server will listen (interface and port will be ignored).
+    -s <path>                     Path to Unix domain socket at which the server will listen
     -v <level>                    Verbosity level [error,warn,info,debug,trace]. Default: info.
     -w <path>                     Path to the webapp. Default: main/webapp.
     -x <name=value>               Additional configuration parameters to pass to OpenRefine.

--- a/refine
+++ b/refine
@@ -35,6 +35,7 @@ Options
     -i <interface>                The network interface OpenRefine should bind to. Default: 127.0.0.1.
     -m <memory>                   JVM min and max memory heap size. Default: 1400M.
     -p <port>                     Port that OpenRefine will listen to. Default: 3333.
+    -s <path>                     Path to unix domain socket at which the server will listen (interface and port will be ignored).
     -v <level>                    Verbosity level [error,warn,info,debug,trace]. Default: info.
     -w <path>                     Path to the webapp. Default: main/webapp.
     -x <name=value>               Additional configuration parameters to pass to OpenRefine.
@@ -115,9 +116,9 @@ check_running() {
             RUNNING=`no_proxy=127.0.0.1 wget -O - $URL| grep "$CHECK_STR"` 
         fi    
         
-        if [ -z "${RUNNING}" ] ; then
-            error "OpenRefine isn't running on $URL. Maybe a proxy issue?"
-        fi
+        # if [ -z "${RUNNING}" ] ; then
+        #     error "OpenRefine isn't running on $URL. Maybe a proxy issue?"
+        # fi
     else
         RUNNING=""
     fi
@@ -503,6 +504,10 @@ run() {
         add_option "-Drefine.webapp=$REFINE_WEBAPP"
     fi
 
+    if [ "$REFINE_SOCKET" ] ; then
+        add_option "-Drefine.socket=$REFINE_SOCKET"
+    fi
+
     if [ "$REFINE_PORT" ] ; then
         add_option "-Drefine.port=$REFINE_PORT"
     fi
@@ -603,6 +608,7 @@ for ((i=0; i<${#args[@]}; i+=1)); do
   arg="${args[i]}"
   case "$arg" in
     -h) usage;;
+    -s) ((i+=1)); REFINE_SOCKET="${args[i]}"; continue;;
     -p) ((i+=1)); REFINE_PORT="${args[i]}"; continue;;
     -H) ((i+=1)); REFINE_HOST="${args[i]}"; continue;;
     -i) ((i+=1)); REFINE_INTERFACE="${args[i]}"; continue;;
@@ -664,27 +670,29 @@ if [ -z "$REFINE_MAX_FORM_CONTENT_SIZE" ] ; then
 fi
 add_option "-Drefine.max_form_content_size=$REFINE_MAX_FORM_CONTENT_SIZE"
 
-if [ -z "$REFINE_PORT" ] ; then
-    REFINE_PORT="3333"
-fi
-
-if [ -z "$REFINE_INTERFACE" ] ; then
-    REFINE_INTERFACE="127.0.0.1"
-fi
-
-if [ -z "$REFINE_HOST" ] ; then
-    if [ "$REFINE_INTERFACE" = "0.0.0.0" ] ; then
-        REFINE_HOST='*'
-    else
-        REFINE_HOST="$REFINE_INTERFACE"
+if [ -z "$REFINE_SOCKET" ] ; then
+    if [ -z "$REFINE_PORT" ] ; then
+        REFINE_PORT="3333"
     fi
-fi
-
-if [ "$REFINE_HOST" = '*' ] ; then
-    echo No host specified while binding to interface 0.0.0.0, guessing localhost.
-    REFINE_HOST_INTERNAL="localhost"
-else
-    REFINE_HOST_INTERNAL="$REFINE_HOST"
+    
+    if [ -z "$REFINE_INTERFACE" ] ; then
+        REFINE_INTERFACE="127.0.0.1"
+    fi
+    
+    if [ -z "$REFINE_HOST" ] ; then
+        if [ "$REFINE_INTERFACE" = "0.0.0.0" ] ; then
+            REFINE_HOST='*'
+        else
+            REFINE_HOST="$REFINE_INTERFACE"
+        fi
+    fi
+    
+    if [ "$REFINE_HOST" = '*' ] ; then
+        echo No host specified while binding to interface 0.0.0.0, guessing localhost.
+        REFINE_HOST_INTERNAL="localhost"
+    else
+        REFINE_HOST_INTERNAL="$REFINE_HOST"
+    fi
 fi
 
 if [ -z "$REFINE_WEBAPP" ] ; then

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -166,6 +166,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-unixdomain-server</artifactId>
+      <version>${jetty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
       <version>${jetty.version}</version>
     </dependency>

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -183,6 +183,10 @@ class RefineServer extends Server {
 
     private ThreadPoolExecutor threadPool;
 
+    public void init(String iface, int port, String host) throws Exception {
+        this.init(iface, port, host, null);
+    }
+
     public void init(String iface, int port, String host, String socket) throws Exception {
         logger.info("Java runtime version {} from java.home: {}", Runtime.version().toString(), System.getProperty("java.home", ""));
         logger.info("Java VM: {} {} {} {}", System.getProperty("java.vm.vendor", ""), System.getProperty("java.vm.name", ""),

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -41,6 +41,7 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.net.BindException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -62,6 +63,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.unixdomain.server.UnixDomainServerConnector;
 import org.eclipse.jetty.util.Scanner;
 import org.eclipse.jetty.util.thread.ThreadPool;
 import org.eclipse.jetty.webapp.WebAppContext;
@@ -80,6 +82,7 @@ public class Refine {
     static private int port;
     static private String host;
     static private String iface;
+    static private String socket;
 
     final static Logger logger = LoggerFactory.getLogger("refine");
 
@@ -106,6 +109,7 @@ public class Refine {
         port = Configurations.getInteger("refine.port", DEFAULT_PORT);
         iface = Configurations.get("refine.interface", DEFAULT_IFACE);
         host = Configurations.get("refine.host", iface);
+        socket = Configurations.get("refine.socket", null);
         if ("0.0.0.0".equals(host)) {
             host = "*";
         }
@@ -119,29 +123,35 @@ public class Refine {
     public void init(String[] args) throws Exception {
 
         RefineServer server = new RefineServer();
-        server.init(iface, port, host);
-        String contextPath = server.getURI().getPath();
+        server.init(iface, port, host, socket);
 
-        boolean headless = Configurations.getBoolean("refine.headless", false);
-        if (headless) {
-            System.setProperty("java.awt.headless", "true");
-            logger.info("Running in headless mode");
-        } else {
-            try {
-                RefineClient client = new RefineClient();
-                if ("*".equals(host)) {
-                    if ("0.0.0.0".equals(iface)) {
-                        logger.warn("No refine.host specified while binding to interface 0.0.0.0, guessing localhost.");
-                        client.init("localhost", port, contextPath);
+        // if a Unix domain socket was defined, don't try to launch a client
+        // most browsers don't know how to open a UDS.
+        if (socket == null) {
+            String contextPath = server.getURI().getPath();
+
+            boolean headless = Configurations.getBoolean("refine.headless", false);
+            if (headless) {
+                System.setProperty("java.awt.headless", "true");
+                logger.info("Running in headless mode");
+            } else {
+                try {
+                    RefineClient client = new RefineClient();
+                    if ("*".equals(host)) {
+                        if ("0.0.0.0".equals(iface)) {
+                            logger.warn("No refine.host specified while binding to interface 0.0.0.0, guessing localhost.");
+                            client.init("localhost", port, contextPath);
+                        } else {
+                            client.init(iface, port, contextPath);
+                        }
                     } else {
-                        client.init(iface, port, contextPath);
+                        client.init(host, port, contextPath);
                     }
-                } else {
-                    client.init(host, port, contextPath);
+                } catch (Exception e) {
+                    logger.warn(
+                            "Sorry, some error prevented us from launching the browser for you.\n\n Point your browser to http://" + host
+                                    + ":" + port + "/ to start using Refine.");
                 }
-            } catch (Exception e) {
-                logger.warn("Sorry, some error prevented us from launching the browser for you.\n\n Point your browser to http://" + host
-                        + ":" + port + "/ to start using Refine.");
             }
         }
 
@@ -173,22 +183,32 @@ class RefineServer extends Server {
 
     private ThreadPoolExecutor threadPool;
 
-    public void init(String iface, int port, String host) throws Exception {
+    public void init(String iface, int port, String host, String socket) throws Exception {
         logger.info("Java runtime version {} from java.home: {}", Runtime.version().toString(), System.getProperty("java.home", ""));
         logger.info("Java VM: {} {} {} {}", System.getProperty("java.vm.vendor", ""), System.getProperty("java.vm.name", ""),
                 System.getProperty("java.vm.version", ""), System.getProperty("java.vm.info", ""));
-        logger.info("Starting Server bound to http://{}:{}", iface, port);
         logger.info("refine.memory size: {} JVM Max heap: {} MBytes", Configurations.get("refine.memory", "<default>"),
                 Runtime.getRuntime().maxMemory() / 1024 / 1024.0);
 
         HttpConfiguration httpConfig = new HttpConfiguration();
         httpConfig.setSendServerVersion(false);
         HttpConnectionFactory httpFactory = new HttpConnectionFactory(httpConfig);
-        ServerConnector connector = new ServerConnector(this, httpFactory);
-        connector.setPort(port);
-        connector.setHost(iface);
-        connector.setIdleTimeout(Configurations.getInteger("server.connection.max_idle_time", 60000));
-        this.addConnector(connector);
+
+        int maxIdleTime = Configurations.getInteger("server.connection.max_idle_time", 60000);
+        if (socket == null) {
+            ServerConnector connector = new ServerConnector(this, httpFactory);
+            connector.setPort(port);
+            connector.setHost(iface);
+            connector.setIdleTimeout(maxIdleTime);
+            this.addConnector(connector);
+            logger.info("Starting Server bound to http://{}:{}", iface, port);
+        } else {
+            UnixDomainServerConnector connector = new UnixDomainServerConnector(this, httpFactory);
+            connector.setUnixDomainPath(Path.of(socket));
+            connector.setIdleTimeout(maxIdleTime);
+            this.addConnector(connector);
+            logger.info("Starting Server bound to Unix domain socket at {}", socket);
+        }
 
         File webapp = new File(Configurations.get("refine.webapp", "main/webapp"));
 

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -125,33 +125,32 @@ public class Refine {
         RefineServer server = new RefineServer();
         server.init(iface, port, host, socket);
 
-        // if a Unix domain socket was defined, don't try to launch a client
-        // most browsers don't know how to open a UDS.
-        if (socket == null) {
-            String contextPath = server.getURI().getPath();
+        String contextPath = server.getURI().getPath();
 
-            boolean headless = Configurations.getBoolean("refine.headless", false);
-            if (headless) {
-                System.setProperty("java.awt.headless", "true");
-                logger.info("Running in headless mode");
-            } else {
-                try {
-                    RefineClient client = new RefineClient();
-                    if ("*".equals(host)) {
-                        if ("0.0.0.0".equals(iface)) {
-                            logger.warn("No refine.host specified while binding to interface 0.0.0.0, guessing localhost.");
-                            client.init("localhost", port, contextPath);
-                        } else {
-                            client.init(iface, port, contextPath);
-                        }
+        boolean headless = Configurations.getBoolean("refine.headless", false);
+        if (headless) {
+            System.setProperty("java.awt.headless", "true");
+            logger.info("Running in headless mode");
+        } else if (socket != null) {
+            logger.info(
+                    "Server is bound to a Unix Domain Socket, most browsers don't know how to connect to one. Skipping launching a browser.");
+        } else {
+            try {
+                RefineClient client = new RefineClient();
+                if ("*".equals(host)) {
+                    if ("0.0.0.0".equals(iface)) {
+                        logger.warn("No refine.host specified while binding to interface 0.0.0.0, guessing localhost.");
+                        client.init("localhost", port, contextPath);
                     } else {
-                        client.init(host, port, contextPath);
+                        client.init(iface, port, contextPath);
                     }
-                } catch (Exception e) {
-                    logger.warn(
-                            "Sorry, some error prevented us from launching the browser for you.\n\n Point your browser to http://" + host
-                                    + ":" + port + "/ to start using Refine.");
+                } else {
+                    client.init(host, port, contextPath);
                 }
+            } catch (Exception e) {
+                logger.warn(
+                        "Sorry, some error prevented us from launching the browser for you.\n\n Point your browser to http://" + host
+                                + ":" + port + "/ to start using Refine.");
             }
         }
 

--- a/server/src/com/google/refine/Refine.java
+++ b/server/src/com/google/refine/Refine.java
@@ -125,8 +125,6 @@ public class Refine {
         RefineServer server = new RefineServer();
         server.init(iface, port, host, socket);
 
-        String contextPath = server.getURI().getPath();
-
         boolean headless = Configurations.getBoolean("refine.headless", false);
         if (headless) {
             System.setProperty("java.awt.headless", "true");
@@ -137,6 +135,7 @@ public class Refine {
         } else {
             try {
                 RefineClient client = new RefineClient();
+                String contextPath = server.getURI().getPath();
                 if ("*".equals(host)) {
                     if ("0.0.0.0".equals(iface)) {
                         logger.warn("No refine.host specified while binding to interface 0.0.0.0, guessing localhost.");


### PR DESCRIPTION
Closes #7700

This implements support for Unix domain sockets (see e.g. https://jetty.org/docs/jetty/10/programming-guide/server/io-arch.html), which is valuable when using OpenRefine on a shared machine (e.g. an HPC system) with multiple users -- in that case, running on a TCP socket is not secure, as any user on the system can connect to the socket.

Our use case is launching OpenRefine via JupyterHub and a reverse proxy, spawning an instance for each user, on a shared cloud VM.

This PR modifies RefineServer's `init` to take a `socket` parameter. This can be passed in via the `refine` script using the `-s` switch. If `socket` is `null`, normal TCP socket with options (port, host, interface) will be used.

This doesn't yet add support to `refine.bat`, as I'm not able to test on Windows. I'm also not sure in what cases UDS support on Windows makes sense.