### PR TITLE
Don't escape backslashes for TSV export. Fixes #7704

### DIFF
--- a/main/src/com/google/refine/exporters/CsvExporter.java
+++ b/main/src/com/google/refine/exporters/CsvExporter.java
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package com.google.refine.exporters;
 
+import java.io.FilterWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.List;
@@ -45,7 +46,6 @@ import com.univocity.parsers.common.AbstractWriter;
 import com.univocity.parsers.csv.CsvFormat;
 import com.univocity.parsers.csv.CsvWriter;
 import com.univocity.parsers.csv.CsvWriterSettings;
-import com.univocity.parsers.tsv.TsvFormat;
 import com.univocity.parsers.tsv.TsvWriter;
 import com.univocity.parsers.tsv.TsvWriterSettings;
 import org.slf4j.Logger;
@@ -58,8 +58,6 @@ import com.google.refine.util.ParsingUtilities;
 public class CsvExporter implements WriterExporter {
 
     static CsvFormat DEFAULT_FORMAT = new CsvWriterSettings().getFormat();
-    static TsvFormat TSV_FORMAT = new TsvWriterSettings().getFormat();
-    static char DEFAULT_SEPARATOR = DEFAULT_FORMAT.getDelimiter();
     static String DEFAULT_LINE_ENDING = DEFAULT_FORMAT.getLineSeparatorString();
 
     final static Logger logger = LoggerFactory.getLogger("CsvExporter");
@@ -94,7 +92,7 @@ public class CsvExporter implements WriterExporter {
                 options = ParsingUtilities.mapper.readValue(optionsString, Configuration.class);
             } catch (IOException e) {
                 // Ignore and keep options null.
-                e.printStackTrace();
+                logger.warn("Invalid options string ignored: {}", optionsString, e);
             }
         }
         if (options.separator == null) {
@@ -115,7 +113,8 @@ public class CsvExporter implements WriterExporter {
             tsvSettings.setIgnoreLeadingWhitespaces(false);
             tsvSettings.setIgnoreTrailingWhitespaces(false);
             tsvSettings.getFormat().setLineSeparator(lineSeparator);
-            csvWriter = new TsvWriter(writer, tsvSettings);
+            // TODO: We need an export setting to control whether we escape output
+            csvWriter = new TsvWriter(new DoubleBackslashFilterWriter(writer), tsvSettings);
         } else {
             CsvWriterSettings settings = new CsvWriterSettings();
             settings.setIgnoreLeadingWhitespaces(false);
@@ -161,4 +160,70 @@ public class CsvExporter implements WriterExporter {
     public String getContentType() {
         return "text/plain";
     }
+
+    /**
+     * A hacky filter class to work around the fact that the TSV writer doesn't have a setting to not escape backlashes,
+     * so we have to filter the doubled up backslashes after the fact, leaving escaped \t \n \r alone.
+     */
+    private static class DoubleBackslashFilterWriter extends FilterWriter {
+
+        private boolean pendingBackslash = false;
+
+        protected DoubleBackslashFilterWriter(Writer out) {
+            super(out);
+        }
+
+        @Override
+        public void write(int c) throws IOException {
+            writeChar((char) c);
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            for (int i = off; i < off + len; i++) {
+                writeChar(cbuf[i]);
+            }
+        }
+
+        @Override
+        public void write(String str, int off, int len) throws IOException {
+            for (int i = off; i < off + len; i++) {
+                writeChar(str.charAt(i));
+            }
+        }
+
+        @Override
+        public void flush() throws IOException {
+            flushPendingBackslash();
+            super.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            flushPendingBackslash();
+            super.close();
+        }
+
+        private void writeChar(char c) throws IOException {
+            if (c == '\\') {
+                if (pendingBackslash) {
+                    out.write('\\');
+                    pendingBackslash = false;
+                } else {
+                    pendingBackslash = true;
+                }
+            } else {
+                flushPendingBackslash();
+                out.write(c);
+            }
+        }
+
+        private void flushPendingBackslash() throws IOException {
+            if (pendingBackslash) {
+                out.write('\\');
+                pendingBackslash = false;
+            }
+        }
+    }
+
 }

--- a/main/src/com/google/refine/exporters/CsvExporter.java
+++ b/main/src/com/google/refine/exporters/CsvExporter.java
@@ -162,8 +162,8 @@ public class CsvExporter implements WriterExporter {
     }
 
     /**
-     * Filter to work around the fact that the TSV writer doesn't offer a setting to avoid escaping backslashes,
-     * so we collapse doubled backslashes after the fact while leaving {@code \t}, {@code \n}, and {@code \r} alone.
+     * Filter to work around the fact that the TSV writer doesn't offer a setting to avoid escaping backslashes, so we
+     * collapse doubled backslashes after the fact while leaving {@code \t}, {@code \n}, and {@code \r} alone.
      */
     private static class DoubleBackslashFilterWriter extends FilterWriter {
 

--- a/main/src/com/google/refine/exporters/CsvExporter.java
+++ b/main/src/com/google/refine/exporters/CsvExporter.java
@@ -162,14 +162,14 @@ public class CsvExporter implements WriterExporter {
     }
 
     /**
-     * A hacky filter class to work around the fact that the TSV writer doesn't have a setting to not escape backlashes,
-     * so we have to filter the doubled up backslashes after the fact, leaving escaped \t \n \r alone.
+     * Filter to work around the fact that the TSV writer doesn't offer a setting to avoid escaping backslashes,
+     * so we collapse doubled backslashes after the fact while leaving {@code \t}, {@code \n}, and {@code \r} alone.
      */
     private static class DoubleBackslashFilterWriter extends FilterWriter {
 
         private boolean pendingBackslash = false;
 
-        protected DoubleBackslashFilterWriter(Writer out) {
+        private DoubleBackslashFilterWriter(Writer out) {
             super(out);
         }
 

--- a/main/tests/server/src/com/google/refine/exporters/CsvExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/CsvExporterTests.java
@@ -209,22 +209,6 @@ public class CsvExporterTests extends RefineTest {
                 ",row2cell1,row2cell2\n");
     }
 
-    // all date type cells are in unified format
-    /**
-     * @Ignore
-     * @Test public void exportDateColumnsPreVersion28(){ CreateGrid(1,2); Calendar calendar = Calendar.getInstance();
-     *       Date date = new Date();
-     * 
-     *       when(options.getProperty("printColumnHeader")).thenReturn("false"); project.rows.get(0).cells.set(0, new
-     *       Cell(calendar, null)); project.rows.get(0).cells.set(1, new Cell(date, null));
-     * 
-     *       try { SUT.export(project, options, engine, writer); } catch (IOException e) { Assert.fail(); }
-     * 
-     *       String expectedOutput = ParsingUtilities.instantToLocalDateTimeString(calendar.toInstant()) + "," +
-     *       ParsingUtilities.instantToLocalDateTimeString(date.toInstant()) + "\n";
-     * 
-     *       assertEqualsSystemLineEnding(writer.toString(), expectedOutput); }
-     */
     // helper methods
 
     protected void CreateColumns(int noOfColumns) {

--- a/main/tests/server/src/com/google/refine/exporters/TsvExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/TsvExporterTests.java
@@ -143,7 +143,6 @@ public class TsvExporterTests extends RefineTest {
                 "row2cell0\trow2cell1\trow2cell2\n");
     }
 
-
     @Test
     public void exportTsvWithBackslash() throws IOException {
         CreateGrid(3, 3);
@@ -152,12 +151,11 @@ public class TsvExporterTests extends RefineTest {
         project.rows.get(1).cells.set(1, new Cell(testCell, null));
         SUT.export(project, options, engine, writer);
 
-        assertEqualsSystemLineEnding(writer.toString(), "column0,column1,column2\n" +
+        assertEqualsSystemLineEnding(writer.toString(), "column0\tcolumn1\tcolumn2\n" +
                 "row0cell0\trow0cell1\trow0cell2\n" +
                 "row1cell0\t" + testCell + "\trow1cell2\n" +
                 "row2cell0\trow2cell1\trow2cell2\n");
     }
-
 
     @Test
     public void exportTsvWithQuote() throws IOException {

--- a/main/tests/server/src/com/google/refine/exporters/TsvExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/TsvExporterTests.java
@@ -131,7 +131,7 @@ public class TsvExporterTests extends RefineTest {
     }
 
     @Test
-    public void exportTsvWithComma() throws IOException {
+    public void exportTsvWithTab() throws IOException {
         CreateGrid(3, 3);
 
         project.rows.get(1).cells.set(1, new Cell("with\t tab", null));
@@ -142,6 +142,22 @@ public class TsvExporterTests extends RefineTest {
                 "row1cell0\twith\\t tab\trow1cell2\n" +
                 "row2cell0\trow2cell1\trow2cell2\n");
     }
+
+
+    @Test
+    public void exportTsvWithBackslash() throws IOException {
+        CreateGrid(3, 3);
+
+        String testCell = "cell has a \\ backslash";
+        project.rows.get(1).cells.set(1, new Cell(testCell, null));
+        SUT.export(project, options, engine, writer);
+
+        assertEqualsSystemLineEnding(writer.toString(), "column0,column1,column2\n" +
+                "row0cell0\trow0cell1\trow0cell2\n" +
+                "row1cell0\t" + testCell + "\trow1cell2\n" +
+                "row2cell0\trow2cell1\trow2cell2\n");
+    }
+
 
     @Test
     public void exportTsvWithQuote() throws IOException {


### PR DESCRIPTION
Fixes #7704

Changes proposed in this pull request:
- Add a test to cover the case mentioned in the issue
- Add a FilterWriter which takes the output of TsvWriter and filters the escaped backslashes (\\) back to single backslashs (\) leaving the other escaped characters (\t, \n, \r) alone.

This is something that we probably want to have an export setting to control, but for now I'm just restoring the original behavior.
