### PR TITLE
Fix/7715 dependency analyze

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -17,6 +17,16 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>grel</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>main</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -41,6 +51,10 @@
       <groupId>org.openrefine.dependencies</groupId>
       <artifactId>vicino</artifactId>
       <version>${vicino.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/extensions/jython/pom.xml
+++ b/extensions/jython/pom.xml
@@ -59,6 +59,12 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>main</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -73,6 +79,12 @@
       <groupId>org.python</groupId>
       <artifactId>jython-standalone</artifactId>
       <version>2.7.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- test dependencies -->

--- a/extensions/pc-axis/pom.xml
+++ b/extensions/pc-axis/pom.xml
@@ -55,6 +55,12 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>main</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -68,6 +74,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/extensions/wikibase/pom.xml
+++ b/extensions/wikibase/pom.xml
@@ -71,6 +71,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>grel</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <version>${servlet-api.version}</version>
@@ -112,6 +124,40 @@
       <version>${slf4j.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>${commons-lang3.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+      <version>${jsoup.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openrefine.dependencies</groupId>
+      <artifactId>butterfly</artifactId>
+      <version>${butterfly.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.poi</groupId>
+      <artifactId>poi</artifactId>
+      <version>${poi.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-jvm</artifactId>
+      <version>${okhttp.version}</version>
+    </dependency>
     <!-- downgrade wdtk's okhttp because it fails our tests for an unclear reason -->
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
@@ -144,6 +190,12 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+      <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver3</artifactId>
       <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>

--- a/extensions/wikibase/pom.xml
+++ b/extensions/wikibase/pom.xml
@@ -128,6 +128,7 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons-lang3.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -220,6 +220,10 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
@@ -230,6 +234,11 @@
       <artifactId>commons-lang3</artifactId>
       <version>${commons-lang3.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>commons-fileupload</groupId>
@@ -315,11 +324,28 @@
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
       <version>${httpclient5.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
       <version>${httpcore5.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>xtc</groupId>
+      <artifactId>rats-runtime</artifactId>
+      <version>1.15.0</version>
+    </dependency>
+    <dependency>
+      <groupId>de.fau.cs.osr.ptk</groupId>
+      <artifactId>ptk-common</artifactId>
+      <version>3.0.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+      <version>1.14.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.sweble.wikitext</groupId>
@@ -387,6 +413,24 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
       <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver3</artifactId>
+      <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-jvm</artifactId>
+      <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio-jvm</artifactId>
+      <version>3.16.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -429,7 +429,7 @@
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio-jvm</artifactId>
-      <version>3.16.4</version>
+      <version>${okio.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -324,7 +324,6 @@
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
       <version>${httpclient5.version}</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -88,6 +88,10 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jdk8</artifactId>
     </dependency>
@@ -96,6 +100,11 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -179,6 +188,11 @@
       <artifactId>jetty-servlets</artifactId>
       <version>${jetty.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.velocity</groupId>
+      <artifactId>velocity</artifactId>
+      <version>1.6.3</version>
+    </dependency>
 
     <!-- test dependencies -->
 
@@ -192,6 +206,18 @@
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver3</artifactId>
       <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-jvm</artifactId>
+      <version>${okhttp.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio-jvm</artifactId>
+      <version>3.16.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -190,8 +190,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.velocity</groupId>
-      <artifactId>velocity</artifactId>
-      <version>1.6.3</version>
+      <artifactId>velocity-engine-core</artifactId>
+      <version>${velocity.version}</version>
     </dependency>
 
     <!-- test dependencies -->
@@ -217,7 +217,7 @@
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio-jvm</artifactId>
-      <version>3.16.4</version>
+      <version>${okio.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/grel/pom.xml
+++ b/modules/grel/pom.xml
@@ -68,6 +68,11 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>

--- a/modules/grel/pom.xml
+++ b/modules/grel/pom.xml
@@ -133,7 +133,7 @@
     </dependency>
 
     <!-- test dependencies -->
-
+    
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>

--- a/modules/grel/pom.xml
+++ b/modules/grel/pom.xml
@@ -70,7 +70,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <log4j.version>2.25.4</log4j.version>
     <jetty.version>10.0.19</jetty.version>
     <okhttp.version>5.3.2</okhttp.version>
+    <okio.version>3.16.4</okio.version>
     <jena.version>5.6.0</jena.version>
     <poi.version>5.5.1</poi.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>


### PR DESCRIPTION
Fixes #7715 

Changes proposed in this pull request:

- adds explicit dependency declarations for items reported as **Used undeclared dependencies found**
- corrects scopes for items reported as **Non-test scoped test only dependencies found** (set to `test` where applicable)

## Out of scope (intentional)

- no removals for **Unused declared dependencies found** in this PR
- no plugin/config refactors unrelated to phase 1

Those are left for a follow-up PR, per maintainer guidance.

## Validation

- Ran iterative module checks:
  - `mvn -q -pl modules/core -am dependency:analyze`
  - `mvn -q -pl modules/grel -am dependency:analyze`
  - `mvn -q -pl main -am dependency:analyze`
  - `mvn -q -pl extensions/jython -am dependency:analyze`
  - `mvn -q -pl extensions/wikibase -am dependency:analyze`
  - `mvn -q -pl extensions/pc-axis -am dependency:analyze`
  - `mvn -q -pl benchmark -am dependency:analyze`
 
- Ran full analysis:
  - `mvn dependency:analyze`
  - Result: only **Unused declared dependencies found** warnings remain.

- Ran full verification:
  - `mvn verify`
  - Result: fails in existing Wikibase test `MediaInfoEditTest.testUploadNewFile` (timeout), unrelated to dependency declaration/scope changes.


## Notes for reviewers

This PR is intentionally phase-1 as recommended by reviewer, scoped to keep review focused and low risk.