### PR TITLE
Add resizable facet/filter panel (#7106)

### DIFF
--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -179,10 +179,13 @@ resizer.hover(
 
 let isDragging = false;
 
+// ✅ MOUSEDOWN
 resizer.on('mousedown', function () {
   isDragging = true;
+  $('body').css('user-select', 'none');
 });
 
+// ✅ MOUSEMOVE
 $(document).on('mousemove', function (e) {
   if (!isDragging) return;
 
@@ -192,14 +195,25 @@ $(document).on('mousemove', function (e) {
   if (newWidth > 500) newWidth = 500;
 
   Refine.setPreference("ui.browsing.facetsHistoryPanelWidth", newWidth);
-  resizeAll();
-});
 
+  // Layout update
+  resize();
+  resizeTabs();
+
+  // 🔥 ONLY THIS WORKS PROPERLY
+  Refine.update({ engineChanged: true });
+});
+// ✅ MOUSEUP
 $(document).on('mouseup', function () {
   isDragging = false;
+  $('body').css('user-select', 'auto');
+
+  resizeAll(); // final alignment
 });
 
+// Add resizer to DOM
 $('body').append(resizer);
+
 // === Facet Panel Resizer END ===
 
   resize();

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -100,6 +100,12 @@ function resize() {
   ui.processPanelDiv
   .css("width", processPanelWidth + "px")
   .css("left", Math.floor((width - processPanelWidth) / 2) + "px");
+  // Position resizer
+$('#facet-resizer').css({
+  left: leftPanelWidth + 'px',
+  top: top + 'px',
+  height: height + 'px'
+});
 }
 
 function resizeTabs() {
@@ -153,6 +159,49 @@ function initializeUI(uiState) {
   ui.exporterManager = new ExporterManager($("#export-button"));
 
   ui.leftPanelTabs.tabs();
+
+// === Facet Panel Resizer START ===
+const resizer = $('<div id="facet-resizer"></div>');
+
+resizer.css({
+  position: 'absolute',
+  width: '8px',
+  cursor: 'col-resize',
+  background: 'rgba(0,0,0,0.1)',
+  zIndex: 1000
+});
+
+// Hover effect
+resizer.hover(
+  function() { $(this).css('background', 'rgba(0,0,0,0.3)'); },
+  function() { $(this).css('background', 'rgba(0,0,0,0.1)'); }
+);
+
+let isDragging = false;
+
+resizer.on('mousedown', function () {
+  isDragging = true;
+});
+
+$(document).on('mousemove', function (e) {
+  if (!isDragging) return;
+
+  let newWidth = e.clientX;
+
+  if (newWidth < 200) newWidth = 200;
+  if (newWidth > 500) newWidth = 500;
+
+  Refine.setPreference("ui.browsing.facetsHistoryPanelWidth", newWidth);
+  resizeAll();
+});
+
+$(document).on('mouseup', function () {
+  isDragging = false;
+});
+
+$('body').append(resizer);
+// === Facet Panel Resizer END ===
+
   resize();
   resizeTabs();
 


### PR DESCRIPTION
Fixes #7106

### 🚀 Summary
This PR adds the ability to resize the Facet/Filter panel using a draggable vertical resizer.

### ✨ Changes
- Added a draggable resizer element to adjust panel width
- Enforced min/max width limits (200px – 500px)
- Persisted panel width using user preferences
- Updated UI dynamically on resize

### 🧪 Testing
- Verified drag resizing works smoothly
- Confirmed layout updates correctly
- No UI breakage observed

### 📌 Notes
- Resizer position updates dynamically with window resize
- Minimal UI styling added for visibility and usability