### PR TITLE
Enable middle-click and Cmd-click to open reconciliation suggestions …

### DIFF
--- a/main/webapp/modules/core/externals/suggest/suggest-4_3a.js
+++ b/main/webapp/modules/core/externals/suggest/suggest-4_3a.js
@@ -1303,17 +1303,30 @@
       // If we know of a view URL for this suggest service,
       // clicking with the middle button sends the user to
       // the view page.
-      if('view_url' in this.options && data.id) {
-        var view_url = this.options.view_url.replace('{{id}}', data.id).replace('${id}', data.id);
-        li.on('mousedown', function(e) {
-           if (e.which == 2) {
-              var win = window.open(view_url, '_blank');
-              win.focus();
-              e.preventDefault();
-           }
-        });
-      }
+      if ('view_url' in this.options && data.id) {
+    var view_url = this.options.view_url
+        .replace('{{id}}', data.id)
+        .replace('${id}', data.id);
 
+    li.on('mousedown', function(e) {
+
+        // Middle click (Windows/Linux)
+        if (e.which === 2) {
+            e.preventDefault();
+            e.stopPropagation();
+            window.open(view_url, '_blank');
+            return false;
+        }
+
+        // Cmd + Click (Mac)
+        if (e.metaKey) {
+            e.preventDefault();
+            e.stopPropagation();
+            window.open(view_url, '_blank');
+            return false;
+        }
+    });
+}
       //console.log("create_item", li);
       return li;
     },


### PR DESCRIPTION
This PR fixes #6697 by enabling opening reconciliation suggestion links in a new tab.

Changes
1.Middle-click (Linux/Windows) opens the suggestion link in a new tab
2.Ctrl + Click (Windows/Linux) opens the link in a new tab
3.Cmd + Click (MacOS) is supported

Tested locally on Windows:
1.Middle-click opens the correct Wikidata page in a new tab
2.Ctrl + Click opens the correct Wikidata page in a new tab

Demo
<img width="1910" height="1029" alt="image" src="https://github.com/user-attachments/assets/1d47e471-b39b-4042-8816-3c36897c8e5f" />

https://github.com/user-attachments/assets/32e27bc6-34bb-48d2-b1b4-2618f5611191



