### PR TITLE
Remove unused parameter from AbstractOperation.createProcess(). Fixes #7527

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/commands/SaveWikibaseSchemaCommand.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/commands/SaveWikibaseSchemaCommand.java
@@ -29,7 +29,6 @@ import static org.openrefine.wikibase.commands.CommandUtilities.respondError;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -79,7 +78,7 @@ public class SaveWikibaseSchemaCommand extends Command {
             }
 
             AbstractOperation op = new SaveWikibaseSchemaOperation(schema);
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
 
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {

--- a/extensions/wikibase/src/org/openrefine/wikibase/operations/PerformWikibaseEditsOperation.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/operations/PerformWikibaseEditsOperation.java
@@ -170,7 +170,7 @@ public class PerformWikibaseEditsOperation extends EngineDependentOperation {
     }
 
     @Override
-    public Process createProcess(Project project, Properties options)
+    public Process createProcess(Project project)
             throws Exception {
         return new PerformEditsProcess(
                 project,

--- a/main/src/com/google/refine/commands/cell/JoinMultiValueCellsCommand.java
+++ b/main/src/com/google/refine/commands/cell/JoinMultiValueCellsCommand.java
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands.cell;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -65,7 +64,7 @@ public class JoinMultiValueCellsCommand extends Command {
 
             AbstractOperation op = new MultiValuedCellJoinOperation(columnName, keyColumnName, separator);
             op.validate();
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
 
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {

--- a/main/src/com/google/refine/commands/cell/KeyValueColumnizeCommand.java
+++ b/main/src/com/google/refine/commands/cell/KeyValueColumnizeCommand.java
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands.cell;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -66,7 +65,7 @@ public class KeyValueColumnizeCommand extends Command {
             AbstractOperation op = new KeyValueColumnizeOperation(
                     keyColumnName, valueColumnName, noteColumnName);
             op.validate();
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
 
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {

--- a/main/src/com/google/refine/commands/cell/SplitMultiValueCellsCommand.java
+++ b/main/src/com/google/refine/commands/cell/SplitMultiValueCellsCommand.java
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands.cell;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -87,7 +86,7 @@ public class SplitMultiValueCellsCommand extends Command {
                         regex);
             }
             op.validate();
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {
             respondException(response, e);

--- a/main/src/com/google/refine/commands/cell/TransposeColumnsIntoRowsCommand.java
+++ b/main/src/com/google/refine/commands/cell/TransposeColumnsIntoRowsCommand.java
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands.cell;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -83,7 +82,7 @@ public class TransposeColumnsIntoRowsCommand extends Command {
                         keyColumnName, valueColumnName);
             }
             op.validate();
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
 
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {

--- a/main/src/com/google/refine/commands/cell/TransposeRowsIntoColumnsCommand.java
+++ b/main/src/com/google/refine/commands/cell/TransposeRowsIntoColumnsCommand.java
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands.cell;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -65,7 +64,7 @@ public class TransposeRowsIntoColumnsCommand extends Command {
             AbstractOperation op = new TransposeRowsIntoColumnsOperation(
                     columnName, rowCount);
             op.validate();
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
 
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {

--- a/main/src/com/google/refine/commands/column/MoveColumnCommand.java
+++ b/main/src/com/google/refine/commands/column/MoveColumnCommand.java
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands.column;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -64,7 +63,7 @@ public class MoveColumnCommand extends Command {
 
             AbstractOperation op = new ColumnMoveOperation(columnName, index);
             op.validate();
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
 
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {

--- a/main/src/com/google/refine/commands/column/RemoveColumnCommand.java
+++ b/main/src/com/google/refine/commands/column/RemoveColumnCommand.java
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands.column;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -63,7 +62,7 @@ public class RemoveColumnCommand extends Command {
 
             AbstractOperation op = new ColumnRemovalOperation(columnName);
             op.validate();
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
 
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {

--- a/main/src/com/google/refine/commands/column/RenameColumnCommand.java
+++ b/main/src/com/google/refine/commands/column/RenameColumnCommand.java
@@ -35,7 +35,6 @@ package com.google.refine.commands.column;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -83,7 +82,7 @@ public class RenameColumnCommand extends Command {
 
             AbstractOperation op = new ColumnRenameOperation(oldColumnName, newColumnName);
             op.validate();
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
 
             HistoryEntry historyEntry = project.processManager.queueProcess(process);
             if (historyEntry != null) {

--- a/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
+++ b/main/src/com/google/refine/commands/history/ApplyOperationsCommand.java
@@ -37,7 +37,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -127,7 +126,7 @@ public class ApplyOperationsCommand extends Command {
             // Run all operations in sequence
             List<HistoryEntry> entries = new ArrayList<>(recipe.getOperations().size());
             for (AbstractOperation operation : recipe.getOperations()) {
-                Process process = operation.createProcess(project, new Properties());
+                Process process = operation.createProcess(project);
                 HistoryEntry entry = project.processManager.queueProcess(process);
                 if (entry != null) {
                     entries.add(entry);

--- a/main/src/com/google/refine/commands/row/AddRowsCommand.java
+++ b/main/src/com/google/refine/commands/row/AddRowsCommand.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -65,7 +64,7 @@ public class AddRowsCommand extends Command {
 
             AbstractOperation op = new RowAdditionOperation(rows, insertionIndex);
             op.validate();
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
 
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {

--- a/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
+++ b/main/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperation.java
@@ -251,7 +251,7 @@ public class ColumnAdditionByFetchingURLsOperation extends EngineDependentOperat
     }
 
     @Override
-    public Process createProcess(Project project, Properties options) throws Exception {
+    public Process createProcess(Project project) throws Exception {
         Engine engine = createEngine(project);
         engine.initializeFromConfig(_engineConfig);
 

--- a/main/src/com/google/refine/operations/recon/ExtendDataOperation.java
+++ b/main/src/com/google/refine/operations/recon/ExtendDataOperation.java
@@ -39,7 +39,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -138,7 +137,7 @@ public class ExtendDataOperation extends EngineDependentOperation {
     }
 
     @Override
-    public Process createProcess(Project project, Properties options) throws Exception {
+    public Process createProcess(Project project) throws Exception {
         return new ExtendDataProcess(
                 project,
                 getEngineConfig(),

--- a/main/src/com/google/refine/operations/recon/ReconOperation.java
+++ b/main/src/com/google/refine/operations/recon/ReconOperation.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -91,7 +90,7 @@ public class ReconOperation extends EngineDependentOperation {
     }
 
     @Override
-    public Process createProcess(Project project, Properties options) throws Exception {
+    public Process createProcess(Project project) throws Exception {
         return new ReconProcess(
                 project,
                 getEngineConfig(),

--- a/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/column/ColumnAdditionByFetchingURLsOperationTests.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -147,7 +146,7 @@ public class ColumnAdditionByFetchingURLsOperationTests extends RefineTest {
     @Test
     public void serializeUrlFetchingProcess() throws Exception {
         AbstractOperation op = ParsingUtilities.mapper.readValue(json, ColumnAdditionByFetchingURLsOperation.class);
-        Process process = op.createProcess(project, new Properties());
+        Process process = op.createProcess(project);
         TestUtils.isSerializedTo(process, String.format(processJson, process.hashCode()));
     }
 

--- a/main/tests/server/src/com/google/refine/operations/recon/ExtendDataOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ExtendDataOperationTests.java
@@ -245,7 +245,7 @@ public class ExtendDataOperationTests extends RefineTest {
     @Test
     public void serializeExtendDataProcess() throws Exception {
         Process p = ParsingUtilities.mapper.readValue(operationJsonLegacy, ExtendDataOperation.class)
-                .createProcess(project, new Properties());
+                .createProcess(project);
         TestUtils.isSerializedTo(p, String.format(processJson, p.hashCode()));
     }
 

--- a/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/recon/ReconOperationTests.java
@@ -45,7 +45,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -234,7 +233,7 @@ public class ReconOperationTests extends RefineTest {
     public void serializeReconProcess() throws Exception {
         ReconOperation op = ParsingUtilities.mapper.readValue(json, ReconOperation.class);
         Project project = mock(Project.class);
-        Process process = op.createProcess(project, new Properties());
+        Process process = op.createProcess(project);
         TestUtils.isSerializedTo(process, String.format(processJson, process.hashCode()));
     }
 
@@ -385,7 +384,7 @@ public class ReconOperationTests extends RefineTest {
                     "        ]}";
             StandardReconConfig config = StandardReconConfig.reconstruct(configJson);
             ReconOperation op = new ReconOperation(EngineConfig.defaultRowBased(), "director", config);
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
             ProcessManager pm = project.getProcessManager();
             process.startPerforming(pm);
             Assert.assertTrue(process.isRunning());
@@ -491,7 +490,7 @@ public class ReconOperationTests extends RefineTest {
                     "        ]}";
             StandardReconConfig config = StandardReconConfig.reconstruct(configJson);
             ReconOperation op = new ReconOperation(EngineConfig.defaultRowBased(), "director", config);
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
             ProcessManager pm = project.getProcessManager();
             process.startPerforming(pm);
             Assert.assertTrue(process.isRunning());

--- a/main/tests/server/src/com/google/refine/operations/row/RowKeepMatchedOperationTest.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowKeepMatchedOperationTest.java
@@ -58,7 +58,6 @@ public class RowKeepMatchedOperationTest extends RefineTest {
     }
 
     Project projectIssue567;
-    Properties options;
     EngineConfig engine_config;
     Engine engine;
     Properties bindings;
@@ -134,7 +133,7 @@ public class RowKeepMatchedOperationTest extends RefineTest {
         checkRowCounts(5, 4);
 
         EngineDependentOperation op = new RowKeepMatchedOperation(engine_config);
-        HistoryEntry historyEntry = op.createProcess(projectIssue567, options).performImmediate();
+        HistoryEntry historyEntry = op.createProcess(projectIssue567).performImmediate();
         // After keeping matched rows, we should have 4 rows (the ones with "a")
         checkRowCounts(4, 4);
 

--- a/main/tests/server/src/com/google/refine/operations/row/RowRemovalOperationTests.java
+++ b/main/tests/server/src/com/google/refine/operations/row/RowRemovalOperationTests.java
@@ -86,7 +86,6 @@ public class RowRemovalOperationTests extends RefineTest {
 
     // dependencies
     Project projectIssue567;
-    Properties options;
     EngineConfig engine_config;
     Engine engine;
     Properties bindings;
@@ -163,7 +162,7 @@ public class RowRemovalOperationTests extends RefineTest {
         checkRowCounts(5, 4);
 
         EngineDependentOperation op = new RowRemovalOperation(engine_config);
-        HistoryEntry historyEntry = op.createProcess(projectIssue567, options).performImmediate();
+        HistoryEntry historyEntry = op.createProcess(projectIssue567).performImmediate();
         checkRowCounts(1, 0);
 
         historyEntry.revert(projectIssue567);

--- a/modules/core/src/main/java/com/google/refine/commands/EngineDependentCommand.java
+++ b/modules/core/src/main/java/com/google/refine/commands/EngineDependentCommand.java
@@ -34,7 +34,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package com.google.refine.commands;
 
 import java.io.IOException;
-import java.util.Properties;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -75,7 +74,7 @@ abstract public class EngineDependentCommand extends Command {
 
             AbstractOperation op = createOperation(project, request, getEngineConfig(request));
             op.validate();
-            Process process = op.createProcess(project, new Properties());
+            Process process = op.createProcess(project);
 
             performProcessAndRespond(request, response, project, process);
         } catch (Exception e) {

--- a/modules/core/src/main/java/com/google/refine/model/AbstractOperation.java
+++ b/modules/core/src/main/java/com/google/refine/model/AbstractOperation.java
@@ -35,7 +35,6 @@ package com.google.refine.model;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -55,7 +54,7 @@ import com.google.refine.process.QuickHistoryEntryProcess;
  * the operation before it is carried out, such as the names of the columns it applies to, the configuration of any
  * facets to be observed by the operation, and so on. Any data obtained from executing the operation on the project
  * should be stored in a {@link Change} instead.
- * 
+ * <p>
  * Operations need to be (de)serializable in JSON via Jackson, used for project persistence and in the extract/apply
  * dialog of the history panel. Validation of the operation's parameters should not happen during deserialization, but
  * in the {@link #validate()} method.
@@ -67,7 +66,7 @@ abstract public class AbstractOperation {
     /**
      * Checks whether the parameters of this operation are suitably filled. Those checks should not happen in the
      * deserialization constructor as it would risk rejecting JSON certain representations at project loading time.
-     * 
+     *
      * @throws IllegalArgumentException
      *             if any parameter is missing or inconsistent
      */
@@ -75,7 +74,17 @@ abstract public class AbstractOperation {
 
     }
 
-    public Process createProcess(Project project, Properties options) throws Exception {
+    /**
+     * Create a background process for the current operation on the given project. This is used for long-running
+     * operations like Fetch URL.
+     *
+     * @param project
+     *            the project
+     * @return newly created process
+     * @throws Exception
+     *             if the process creation failed
+     */
+    public Process createProcess(Project project) throws Exception {
         return new QuickHistoryEntryProcess(project, getBriefDescription(null)) {
 
             @Override
@@ -98,6 +107,8 @@ abstract public class AbstractOperation {
         return OperationRegistry.s_opClassToName.get(this.getClass());
     }
 
+    // TODO: We don't really want to serialize the natural language description if we're going to support exchange among
+    // users
     @JsonProperty("description")
     public String getJsonDescription() {
         return getBriefDescription(null);
@@ -123,9 +134,9 @@ abstract public class AbstractOperation {
     }
 
     /**
-     * Compute a new version of this operation metadata, with renamed columns. This is a best-effort transformation:
-     * some column references might fail to be updated, for instance if they are embedded into expressions that cannot
-     * be fully analyzed. As a fall-back solution, the same operation can be returned.
+     * Compute a new version of this operation metadata with renamed columns. This is a best-effort transformation: some
+     * column references might fail to be updated, for instance, if they are embedded into expressions that cannot be
+     * fully analyzed. As a fall-back solution, the same operation can be returned.
      * 
      * @param newColumnNames
      *            a map from old to new column names

--- a/modules/core/src/main/java/com/google/refine/operations/UnknownOperation.java
+++ b/modules/core/src/main/java/com/google/refine/operations/UnknownOperation.java
@@ -13,11 +13,11 @@ import com.google.refine.model.AbstractOperation;
 import com.google.refine.model.Project;
 
 /**
- * An operation that is unknown to the current OpenRefine instance, but might be interpretable by another instance (for
+ * An operation that is unknown to the current OpenRefine instance but might be interpretable by another instance (for
  * instance, a later version of OpenRefine, or using an extension).
- * 
+ * <p>
  * This class holds the JSON serialization of the operation, in the interest of being able to serialize it later, hence
- * avoiding to discard it and lose metadata.
+ * avoiding discarding it and losing metadata.
  * 
  * @author Antonin Delpeuch
  *

--- a/modules/core/src/main/java/com/google/refine/process/Process.java
+++ b/modules/core/src/main/java/com/google/refine/process/Process.java
@@ -38,6 +38,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.google.refine.history.HistoryEntry;
 
+/**
+ * Processes come in two flavors:
+ * <ul>
+ * <li>Immediate - which get executed immediately in the foreground</li>
+ * <li>Long-running which get executed in the background on a separate thread and can be polled for status, completion,
+ * etc.</li>
+ * </ul>
+ */
 public abstract class Process {
 
     @JsonProperty("immediate")

--- a/modules/core/src/test/java/com/google/refine/RefineTest.java
+++ b/modules/core/src/test/java/com/google/refine/RefineTest.java
@@ -408,7 +408,7 @@ public class RefineTest {
         Set<String> columnNamesBefore = project.columnModel.columns.stream()
                 .map(column -> column.getName())
                 .collect(Collectors.toSet());
-        Process process = operation.createProcess(project, new Properties());
+        Process process = operation.createProcess(project);
         if (process.isImmediate()) {
             process.performImmediate();
         } else {


### PR DESCRIPTION
Fixes #7527 

Changes proposed in this pull request:
- removes unused Properties parameter from AbstractOperation.createProcess()

