### PR TITLE
fix(open-project): clear search input when switching tags

### DIFF
--- a/main/tests/cypress/cypress/e2e/open-project/filter_projects.cy.js
+++ b/main/tests/cypress/cypress/e2e/open-project/filter_projects.cy.js
@@ -37,6 +37,29 @@ describe(__filename, function () {
     cy.get('#projects-list table').contains(project1).should('not.be.visible');
   });
 
+  it('Clears the search input when a tag (including "All") is selected', function () {
+    // Regression test for #7632: the search box should not retain text after
+    // the user switches to a tag filter, otherwise the visible rows and the
+    // input contents disagree.
+    const project1 = 'Project A';
+    const project2 = 'Project B';
+    cy.loadProject('food.mini', project1, 'TestTagOne');
+    cy.loadProject('food.mini', project2, 'TestTagTwo');
+    cy.visitOpenRefine();
+    cy.navigateTo('Open project');
+
+    cy.get('#search-icon').click();
+    cy.get('#search-input').type('Project A');
+    cy.wait(800); // typing timeout is 500 msec
+    cy.get('#projects-list table').contains(project2).should('not.be.visible');
+
+    // Click the "All" tag — search input should be cleared and all rows shown.
+    cy.get('#projectTags ul').children().contains('All').click();
+    cy.get('#search-input').should('have.value', '');
+    cy.get('#projects-list table').contains(project1).should('be.visible');
+    cy.get('#projects-list table').contains(project2).should('be.visible');
+  });
+
   it('Ensure projects are being filtered through search', function () {
     const project1 = 'Project A';
     const project2 = 'Project B';

--- a/main/tests/cypress/cypress/e2e/open-project/filter_projects.cy.js
+++ b/main/tests/cypress/cypress/e2e/open-project/filter_projects.cy.js
@@ -50,7 +50,6 @@ describe(__filename, function () {
 
     cy.get('#search-icon').click();
     cy.get('#search-input').type('Project A');
-    cy.wait(800); // typing timeout is 500 msec
     cy.get('#projects-list table').contains(project2).should('not.be.visible');
 
     // Click the "All" tag — search input should be cleared and all rows shown.

--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -116,6 +116,13 @@ Refine.OpenProjectUI._filterTags = function(tag) {
   // this function can run even if the open project UI is not visible to the user, so only update the URL if it is
   if (window.hash === "#open-project") window.history.pushState("", "", "?tag=" + tag + "#open-project");
 
+  // Reset the search filter so the visible state matches the active tag.
+  const searchInput = $('#search-input');
+  if (searchInput.length && searchInput.val() !== '') {
+    searchInput.val('');
+    $("#tableBody").filterListSearch('');
+  }
+
   $('#tagsUl').children().each(function() {
     $(this).removeClass('current');
   });

--- a/main/webapp/modules/core/scripts/index/open-project-ui.js
+++ b/main/webapp/modules/core/scripts/index/open-project-ui.js
@@ -119,6 +119,10 @@ Refine.OpenProjectUI._filterTags = function(tag) {
   // Reset the search filter so the visible state matches the active tag.
   const searchInput = $('#search-input');
   if (searchInput.length && searchInput.val() !== '') {
+    // Cancel any pending debounced search update (see _searchInput typingTimer)
+    // so it can't re-apply after the tag filter runs.
+    searchInput.trigger('keydown');
+
     searchInput.val('');
     $("#tableBody").filterListSearch('');
   }


### PR DESCRIPTION
When the user typed into the search box on the Open Project page and then clicked a tag (including "All"), the search input retained its text but the row visibility was reset, so the visible state no longer matched the input. Reset the search filter inside _filterTags so the tag class, the list filter, and the input box are always consistent.

Adds a Cypress regression test in filter_projects.cy.js.

Fixes #7632
