### PR TITLE
fix(wikibase): focus first input when statement-configuration dialog opens

### DIFF
--- a/extensions/wikibase/module/scripts/dialogs/statement-configuration-dialog.js
+++ b/extensions/wikibase/module/scripts/dialogs/statement-configuration-dialog.js
@@ -199,5 +199,8 @@ StatementConfigurationDialog.launch = function(statement) {
     }
   });
 
+  // Match the focus behavior of save-schema-dialog and perform-edits-dialog so
+  // the user can interact with the dialog immediately via the keyboard.
+  this._elmts.modeInput.focus();
 };
 

--- a/main/tests/cypress/cypress/e2e/extensions/wikibase/wikibase_schema.cy.js
+++ b/main/tests/cypress/cypress/e2e/extensions/wikibase/wikibase_schema.cy.js
@@ -33,7 +33,7 @@ describe('SchemaAlignment.setUpTabs', () => {
         // Check warnings
         cy.get('.schema-alignment-total-warning-count').should('to.contain', '1');
 
-        
+
         cy.get('#wikibase-schema-panel').click();
 
         // Add 2 items
@@ -44,6 +44,22 @@ describe('SchemaAlignment.setUpTabs', () => {
         cy.get('.schema-alignment-total-warning-count').should('to.contain', '2');
     });
 
-  
+    // Regression test for #7609: the statement-configuration dialog must focus
+    // its first input on open so the user can interact via the keyboard
+    // without having to click into the dialog first.
+    it('focuses the mode select when the statement configuration dialog opens', () => {
+        cy.visitOpenRefine();
+        cy.navigateTo('Import project');
+        cy.get('#project-tar-file-input').selectFile('cypress/fixtures/wikidata-schema.tar.gz.zip');
+        cy.get('#import-project-button').click();
+
+        cy.get('#extension-bar-menu-container').contains('Wikibase').click();
+        cy.get('.menu-container a').contains('Edit Wikibase schema').click();
+        cy.get('#wikibase-schema-panel').click();
+
+        cy.get('.wbs-configure').first().click();
+        cy.get('.dialog-frame').should('be.visible');
+        cy.focused().should('have.id', 'modeId');
+    });
+
   });
-  

--- a/main/tests/cypress/cypress/e2e/extensions/wikibase/wikibase_schema.cy.js
+++ b/main/tests/cypress/cypress/e2e/extensions/wikibase/wikibase_schema.cy.js
@@ -42,22 +42,21 @@ describe('SchemaAlignment.setUpTabs', () => {
     cy.get('.schema-alignment-total-warning-count').should('to.contain', '2');
   });
 
-    // Regression test for #7609: the statement-configuration dialog must focus
-    // its first input on open so the user can interact via the keyboard
-    // without having to click into the dialog first.
-    it('focuses the mode select when the statement configuration dialog opens', () => {
-        cy.visitOpenRefine();
-        cy.navigateTo('Import project');
-        cy.get('#project-tar-file-input').selectFile('cypress/fixtures/wikidata-schema.tar.gz.zip');
-        cy.get('#import-project-button').click();
+  // Regression test for #7609: the statement-configuration dialog must focus
+  // its first input on open so the user can interact via the keyboard
+  // without having to click into the dialog first.
+  it('focuses the mode select when the statement configuration dialog opens', () => {
+    cy.visitOpenRefine();
+    cy.navigateTo('Import project');
+    cy.get('#project-tar-file-input').selectFile('cypress/fixtures/wikidata-schema.tar.gz.zip');
+    cy.get('#import-project-button').click();
 
-        cy.get('#extension-bar-menu-container').contains('Wikibase').click();
-        cy.get('.menu-container a').contains('Edit Wikibase schema').click();
-        cy.get('#wikibase-schema-panel').click();
+    cy.get('#extension-bar-menu-container').contains('Wikibase').click();
+    cy.get('.menu-container a').contains('Edit Wikibase schema').click();
+    cy.get('#wikibase-schema-panel').click();
 
-        cy.get('.wbs-configure').first().click();
-        cy.get('.dialog-frame').should('be.visible');
-        cy.focused().should('have.id', 'modeId');
-    });
-
+    cy.get('.wbs-configure').first().click();
+    cy.get('.dialog-frame').should('be.visible');
+    cy.focused().should('have.id', 'modeId');
   });
+});

--- a/main/tests/cypress/cypress/e2e/extensions/wikibase/wikibase_schema.cy.js
+++ b/main/tests/cypress/cypress/e2e/extensions/wikibase/wikibase_schema.cy.js
@@ -41,4 +41,23 @@ describe('SchemaAlignment.setUpTabs', () => {
     // Check warnings
     cy.get('.schema-alignment-total-warning-count').should('to.contain', '2');
   });
-});
+
+    // Regression test for #7609: the statement-configuration dialog must focus
+    // its first input on open so the user can interact via the keyboard
+    // without having to click into the dialog first.
+    it('focuses the mode select when the statement configuration dialog opens', () => {
+        cy.visitOpenRefine();
+        cy.navigateTo('Import project');
+        cy.get('#project-tar-file-input').selectFile('cypress/fixtures/wikidata-schema.tar.gz.zip');
+        cy.get('#import-project-button').click();
+
+        cy.get('#extension-bar-menu-container').contains('Wikibase').click();
+        cy.get('.menu-container a').contains('Edit Wikibase schema').click();
+        cy.get('#wikibase-schema-panel').click();
+
+        cy.get('.wbs-configure').first().click();
+        cy.get('.dialog-frame').should('be.visible');
+        cy.focused().should('have.id', 'modeId');
+    });
+
+  });


### PR DESCRIPTION
When the dialog opens, no element receives keyboard focus, so the user must click into the dialog before they can interact with it. Match the behavior of save-schema-dialog and perform-edits-dialog by focusing the first input (the mode select) at the end of launch().

Fixes #7609
