### PR TITLE
Fix #7330: Make stop words editable via preferences

### DIFF
--- a/modules/core/src/main/java/com/google/refine/ProjectManager.java
+++ b/modules/core/src/main/java/com/google/refine/ProjectManager.java
@@ -654,5 +654,6 @@ public abstract class ProjectManager {
     static protected void preparePreferenceStore(PreferenceStore ps) {
         ps.put("scripting.expressions", new TopList(EXPRESSION_HISTORY_MAX));
         ps.put("scripting.starred-expressions", new TopList(Integer.MAX_VALUE));
+        ps.put("stopwords", "the,a,and,of,on,in,at,by");
     }
 }

--- a/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
@@ -755,16 +755,16 @@ public class StandardReconConfig extends ReconConfig {
 
     static protected Set<String> getStopWords() {
 
-            Object prefValue = (ProjectManager.singleton.getPreferenceStore().get("stopwords"));
-            String stopwordsPref = (prefValue != null) ? prefValue.toString() : null;
-            if(stopwordsPref == null) {
-                stopwordsPref = "the,a,and,of,on,in,at,by";
-            }
-            Set<String> stopWords= new HashSet<>();
-            for(String stopWord: stopwordsPref.split(",")) {
-                stopWords.add(stopWord.trim().toLowerCase());
-            }
-            return stopWords;
+        Object prefValue = (ProjectManager.singleton.getPreferenceStore().get("stopwords"));
+        String stopwordsPref = (prefValue != null) ? prefValue.toString() : null;
+        if (stopwordsPref == null) {
+            stopwordsPref = "the,a,and,of,on,in,at,by";
+        }
+        Set<String> stopWords = new HashSet<>();
+        for (String stopWord : stopwordsPref.split(",")) {
+            stopWords.add(stopWord.trim().toLowerCase());
+        }
+        return stopWords;
     }
 
     static protected Set<String> breakWords(String s) {

--- a/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
@@ -61,6 +61,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.refine.ProjectManager;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
@@ -739,26 +740,41 @@ public class StandardReconConfig extends ReconConfig {
         return common / longWords.size();
     }
 
-    static final protected Set<String> s_stopWords = new HashSet<String>();
-    static {
-        // FIXME: This is English specific - needs i18n
-        s_stopWords.add("the");
-        s_stopWords.add("a");
-        s_stopWords.add("and");
-        s_stopWords.add("of");
-        s_stopWords.add("on");
-        s_stopWords.add("in");
-        s_stopWords.add("at");
-        s_stopWords.add("by");
+//    static final protected Set<String> s_stopWords = new HashSet<String>();
+//    static {
+//        // FIXME: This is English specific - needs i18n
+//        s_stopWords.add("the");
+//        s_stopWords.add("a");
+//        s_stopWords.add("and");
+//        s_stopWords.add("of");
+//        s_stopWords.add("on");
+//        s_stopWords.add("in");
+//        s_stopWords.add("at");
+//        s_stopWords.add("by");
+//    }
+
+    static protected Set<String> getStopWords() {
+
+            Object prefValue = (ProjectManager.singleton.getPreferenceStore().get("stopwords"));
+            String stopwordsPref = (prefValue != null) ? prefValue.toString() : null;
+            if(stopwordsPref == null) {
+                stopwordsPref = "the,a,and,of,on,in,at,by";
+            }
+            Set<String> stopWords= new HashSet<>();
+            for(String stopWord: stopwordsPref.split(",")) {
+                stopWords.add(stopWord.trim().toLowerCase());
+            }
+            return stopWords;
     }
 
     static protected Set<String> breakWords(String s) {
         // TODO: This needs i18n
         String[] words = s.toLowerCase().split("\\s+");
 
+        Set<String> stopWords = getStopWords();
         Set<String> set = new HashSet<String>(words.length);
         for (String word : words) {
-            if (!s_stopWords.contains(word)) {
+            if (!stopWords.contains(word)) {
                 set.add(word);
             }
         }

--- a/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
@@ -740,19 +740,6 @@ public class StandardReconConfig extends ReconConfig {
         return common / longWords.size();
     }
 
-//    static final protected Set<String> s_stopWords = new HashSet<String>();
-//    static {
-//        // FIXME: This is English specific - needs i18n
-//        s_stopWords.add("the");
-//        s_stopWords.add("a");
-//        s_stopWords.add("and");
-//        s_stopWords.add("of");
-//        s_stopWords.add("on");
-//        s_stopWords.add("in");
-//        s_stopWords.add("at");
-//        s_stopWords.add("by");
-//    }
-
     static protected Set<String> getStopWords() {
 
         Object prefValue = (ProjectManager.singleton.getPreferenceStore().get("stopwords"));

--- a/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
@@ -740,18 +740,35 @@ public class StandardReconConfig extends ReconConfig {
         return common / longWords.size();
     }
 
-    static protected Set<String> getStopWords() {
+    private static final String STOPWORDS_PREF_KEY = "stopwords";
+    private static final String DEFAULT_STOPWORDS_PREF = "the,a,and,of,on,in,at,by";
+    private static volatile String cachedStopwordsPref;
+    private static volatile Set<String> cachedStopWords;
 
-        Object prefValue = (ProjectManager.singleton.getPreferenceStore().get("stopwords"));
-        String stopwordsPref = (prefValue != null) ? prefValue.toString() : null;
+    static protected Set<String> getStopWords() {
+        Object prefValue = ProjectManager.singleton.getPreferenceStore().get(STOPWORDS_PREF_KEY);
+        String stopwordsPref = prefValue != null ? prefValue.toString() : null;
         if (stopwordsPref == null) {
-            stopwordsPref = "the,a,and,of,on,in,at,by";
+            stopwordsPref = DEFAULT_STOPWORDS_PREF;
         }
+
+        Set<String> cached = cachedStopWords;
+        if (cached != null && stopwordsPref.equals(cachedStopwordsPref)) {
+            return cached;
+        }
+
         Set<String> stopWords = new HashSet<>();
-        for (String stopWord : stopwordsPref.split(",")) {
-            stopWords.add(stopWord.trim().toLowerCase());
+        for (String rawStopWord : stopwordsPref.split(",")) {
+            String stopWord = rawStopWord.trim().toLowerCase();
+            if (!stopWord.isEmpty()) {
+                stopWords.add(stopWord);
+            }
         }
-        return stopWords;
+
+        Set<String> immutable = Set.copyOf(stopWords);
+        cachedStopwordsPref = stopwordsPref;
+        cachedStopWords = immutable;
+        return immutable;
     }
 
     static protected Set<String> breakWords(String s) {

--- a/modules/core/src/test/java/com/google/refine/io/FileProjectManagerTests.java
+++ b/modules/core/src/test/java/com/google/refine/io/FileProjectManagerTests.java
@@ -84,7 +84,8 @@ public class FileProjectManagerTests {
                 "             \"class\" : \"com.google.refine.preference.TopList\",\n" +
                 "             \"list\" : [ ],\n" +
                 "             \"top\" : 2147483647\n" +
-                "           }\n" +
+                "           },\n" +
+                "           \"stopwords\" : \"the,a,and,of,on,in,at,by\"\n" +
                 "         }\n" +
                 "       },\n" +
                 "       \"projectIDs\" : [ 5555 ]\n" +

--- a/modules/core/src/test/java/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/modules/core/src/test/java/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -679,13 +679,12 @@ public class StandardReconConfigTests extends RefineTest {
         assertNotNull(recon.features);
     }
 
-
     @Test
     public void testBreakWordsUsesStopWordsPreference() {
         StandardReconConfigStub stub = new StandardReconConfigStub();
         ProjectManager.singleton.getPreferenceStore()
                 .put("stopwords", "the,a,and,of,on,in,at,by,le");
-        Set<String> words =stub.breakWords("Le Petit Prince");
+        Set<String> words = stub.breakWords("Le Petit Prince");
         Assert.assertEquals(Set.of("petit", "prince"), words);
         Assert.assertFalse(words.contains("le"));
         Assert.assertTrue(words.contains("petit"));
@@ -697,7 +696,7 @@ public class StandardReconConfigTests extends RefineTest {
         StandardReconConfigStub stub = new StandardReconConfigStub();
         ProjectManager.singleton.getPreferenceStore()
                 .put("stopwords", "the, a, and, of, on,in,at,by, le");
-        Set<String> words =stub.breakWords("Le Petit Prince");
+        Set<String> words = stub.breakWords("Le Petit Prince");
         Assert.assertEquals(Set.of("petit", "prince"), words);
         Assert.assertFalse(words.contains("le"));
         Assert.assertTrue(words.contains("petit"));
@@ -709,7 +708,7 @@ public class StandardReconConfigTests extends RefineTest {
         StandardReconConfigStub stub = new StandardReconConfigStub();
         ProjectManager.singleton.getPreferenceStore()
                 .put("stopwords", null);
-        Set<String> words =stub.breakWords("The Lord of the Rings");
+        Set<String> words = stub.breakWords("The Lord of the Rings");
         Assert.assertEquals(Set.of("lord", "rings"), words);
         Assert.assertFalse(words.contains("the"));
         Assert.assertFalse(words.contains("of"));

--- a/modules/core/src/test/java/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/modules/core/src/test/java/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -54,6 +54,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import com.google.refine.ProjectManager;
 import com.google.refine.RefineTest;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
@@ -676,5 +677,43 @@ public class StandardReconConfigTests extends RefineTest {
         Recon recon = stub.createNewRecon(2384738L);
         stub.computeFeatures(recon, null);
         assertNotNull(recon.features);
+    }
+
+
+    @Test
+    public void testBreakWordsUsesStopWordsPreference() {
+        StandardReconConfigStub stub = new StandardReconConfigStub();
+        ProjectManager.singleton.getPreferenceStore()
+                .put("stopwords", "the,a,and,of,on,in,at,by,le");
+        Set<String> words =stub.breakWords("Le Petit Prince");
+        Assert.assertEquals(Set.of("petit", "prince"), words);
+        Assert.assertFalse(words.contains("le"));
+        Assert.assertTrue(words.contains("petit"));
+        Assert.assertTrue(words.contains("prince"));
+    }
+
+    @Test
+    public void testBreakWordsUsesStopWordsTrimWhitespace() {
+        StandardReconConfigStub stub = new StandardReconConfigStub();
+        ProjectManager.singleton.getPreferenceStore()
+                .put("stopwords", "the, a, and, of, on,in,at,by, le");
+        Set<String> words =stub.breakWords("Le Petit Prince");
+        Assert.assertEquals(Set.of("petit", "prince"), words);
+        Assert.assertFalse(words.contains("le"));
+        Assert.assertTrue(words.contains("petit"));
+        Assert.assertTrue(words.contains("prince"));
+    }
+
+    @Test
+    public void testBreakWordsDefaultStopWords() {
+        StandardReconConfigStub stub = new StandardReconConfigStub();
+        ProjectManager.singleton.getPreferenceStore()
+                .put("stopwords", null);
+        Set<String> words =stub.breakWords("The Lord of the Rings");
+        Assert.assertEquals(Set.of("lord", "rings"), words);
+        Assert.assertFalse(words.contains("the"));
+        Assert.assertFalse(words.contains("of"));
+        Assert.assertTrue(words.contains("lord"));
+        Assert.assertTrue(words.contains("rings"));
     }
 }

--- a/modules/core/src/test/java/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/modules/core/src/test/java/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -681,10 +681,9 @@ public class StandardReconConfigTests extends RefineTest {
 
     @Test
     public void testBreakWordsUsesStopWordsPreference() {
-        StandardReconConfigStub stub = new StandardReconConfigStub();
         ProjectManager.singleton.getPreferenceStore()
                 .put("stopwords", "the,a,and,of,on,in,at,by,le");
-        Set<String> words = stub.breakWords("Le Petit Prince");
+        Set<String> words = StandardReconConfig.breakWords("Le Petit Prince");
         Assert.assertEquals(Set.of("petit", "prince"), words);
         Assert.assertFalse(words.contains("le"));
         Assert.assertTrue(words.contains("petit"));


### PR DESCRIPTION
Fixes #7330

Changes proposed in this pull request:
- Added a default stopwords preference with the value: the,a,and,of,on,in,at,by
- Updated StandardReconConfig to load stop words from preferences instead of a hardcoded set.
- Trims whitespace around configured stop words.
- The default stop word list is used when no preference is configured.
- Added Unit tests for for custom stop words, whitespace trimming and default stop word list is used when no preference is configured.