### PR TITLE
Fix NullPointerException in FileNameScrutinizer

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
@@ -70,7 +70,7 @@ public class FileNameScrutinizer extends EditScrutinizer {
             return;
         }
 
-        if (edit.isMatched() && !edit.getFilePath().isEmpty()) {
+        if (edit.isMatched() && edit.getFilePath() != null && !edit.getFilePath().isEmpty()) {
             String normalizedFileName = normalizeFileNameSpaces(fileName);
             matchedFileNames.add(normalizedFileName);
             QAWarning issue = new QAWarning(uploadNewFileVersionType, null,


### PR DESCRIPTION
Fixes NullPointerException in FileNameScrutinizer during preview when filePath is null.

Added null check before calling isEmpty() to prevent crash.

