### PR TITLE
Add confirmation dialog before removing facets

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
@@ -109,12 +109,36 @@ describe(__filename, function () {
     cy.getFacetContainer('Water').contains('Cluster');
   });
 
-  it('Delete a facet', function () {
+  it('Delete a facet with confirmation dialog', function () {
+
     cy.loadAndVisitProject('food.small');
+
     cy.columnActionClick('Water', ['Facet', 'Text facet']);
 
-    cy.getFacetContainer('Water').find('a.facet-title-remove').click();
-    cy.get('#refine-tabs-facets > div.browsing-panel-help').should('be.visible');
+    cy.getFacetContainer('Water').should('exist');
+
+    cy.on('window:confirm', (text) => {
+      expect(text).to.eq(
+        'Are you sure you want to remove this facet?'
+      );
+      return false;
+    });
+
+    cy.getFacetContainer('Water')
+      .find('a.facet-title-remove')
+      .click();
+
+    cy.getFacetContainer('Water')
+      .should('exist');
+
+    cy.on('window:confirm', () => true);
+
+    cy.getFacetContainer('Water')
+      .find('a.facet-title-remove')
+      .click();
+
+    cy.getFacetContainer('Water')
+      .should('not.exist');
   });
 
   it('Test editing a facet ("change")', function () {

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -379,6 +379,7 @@
     "core-dialogs/remove-duplicate-rows-col-select": "Select columns used to identify duplicate rows",
     "core-buttons/no-criteria-selected": "At least one column needs to be selected to identify duplicates.",
     "core-facets/remove-facet": "Remove this facet",
+    "core-facets/confirm-remove-facet": "Are you sure you want to remove this facet?",
     "core-facets/minimize-facet": "Toggle between the minimization and maximization of this facet",
     "core-facets/reset": "reset",
     "core-facets/invert": "invert",

--- a/main/webapp/modules/core/scripts/facets/facet.js
+++ b/main/webapp/modules/core/scripts/facets/facet.js
@@ -59,17 +59,19 @@ class Facet {
   };
 
   _remove() {
-  	ui.browsingEngine.removeFacet(this);
+	if (!window.confirm($.i18n('core-facets/confirm-remove-facet'))) {
+		return;
+		}
+	ui.browsingEngine.removeFacet(this);
+	this._div = null;
+	this._config = null;
+	this._selection = null;
+	this._blankChoice = null;
+	this._errorChoice = null;
+	this._data = null;
+	this._options = null;
+	};
 
-  	this._div = null;
-  	this._config = null;
-
-  	this._selection = null;
-  	this._blankChoice = null;
-  	this._errorChoice = null;
-  	this._data = null;
-  	this._options = null;
-  };
 
   // Method to be overriden by subclasses to return a value which
   // should generally be unique among all facets currently open. This is to


### PR DESCRIPTION
## What

Adds a confirmation dialog before removing a facet.

## Why

Users can accidentally remove a facet with a single click. This change adds a confirmation step to prevent accidental removal.

## Testing

- Added Cypress test coverage.
- Verified Cancel keeps the facet.
- Verified OK removes the facet.