### PR TITLE
feat(GREL): add collapseWhitespace GREL function

### DIFF
--- a/modules/grel/src/main/java/com/google/refine/expr/functions/strings/CollapseWhitespace.java
+++ b/modules/grel/src/main/java/com/google/refine/expr/functions/strings/CollapseWhitespace.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (C) 2026, OpenRefine contributors
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+package com.google.refine.expr.functions.strings;
+
+import java.util.Properties;
+
+import com.google.common.base.CharMatcher;
+
+import com.google.refine.expr.EvalError;
+import com.google.refine.grel.ControlFunctionRegistry;
+import com.google.refine.grel.EvalErrorMessage;
+import com.google.refine.grel.Function;
+import com.google.refine.grel.FunctionDescription;
+
+public class CollapseWhitespace implements Function {
+
+    @Override
+    public Object call(Properties bindings, Object[] args) {
+        if (args.length == 1) {
+            Object s = args[0];
+            if (s != null && s instanceof String) {
+                return CharMatcher.whitespace().trimAndCollapseFrom((String) s, ' ');
+            }
+        }
+        return new EvalError(EvalErrorMessage.expects_one_string(ControlFunctionRegistry.getFunctionName(this)));
+    }
+
+    @Override
+    public String getDescription() {
+        return FunctionDescription.str_collapse_whitespace();
+    }
+
+    @Override
+    public String getParams() {
+        return "string s";
+    }
+
+    @Override
+    public String getReturns() {
+        return "string";
+    }
+}

--- a/modules/grel/src/main/java/com/google/refine/grel/ControlFunctionRegistry.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/ControlFunctionRegistry.java
@@ -102,6 +102,7 @@ import com.google.refine.expr.functions.math.Sum;
 import com.google.refine.expr.functions.math.Tan;
 import com.google.refine.expr.functions.math.Tanh;
 import com.google.refine.expr.functions.strings.Chomp;
+import com.google.refine.expr.functions.strings.CollapseWhitespace;
 import com.google.refine.expr.functions.strings.Contains;
 import com.google.refine.expr.functions.strings.Decode;
 import com.google.refine.expr.functions.strings.DetectLanguage;
@@ -259,6 +260,7 @@ public class ControlFunctionRegistry {
         registerFunction("unicodeType", new UnicodeType());
         registerFunction("diff", new Diff());
         registerFunction("chomp", new Chomp());
+        registerFunction("collapseWhitespace", new CollapseWhitespace());
         registerFunction("fingerprint", new Fingerprint());
         registerFunction("ngramFingerprint", new NGramFingerprint());
         registerFunction("phonetic", new Phonetic());

--- a/modules/grel/src/main/resources/com/google/refine/grel/FunctionDescription.properties
+++ b/modules/grel/src/main/resources/com/google/refine/grel/FunctionDescription.properties
@@ -61,6 +61,7 @@ math_tanh=Returns the hyperbolic tangent of an angle.
 
 # 6. Strings
 str_chomp=Returns a copy of string s with string sep removed from the end if s ends with sep; otherwise, returns s.
+str_collapse_whitespace=Returns a copy of string s with leading and trailing whitespace removed and internal whitespace runs collapsed to one space.
 str_contains=Returns a boolean indicating whether s contains sub, which is either a substring or a regex pattern. For example, "food".contains("oo") returns true.
 str_decode=Decodes a string using the specified encoding. Encodings include Base16, Base32Hex, Base32, Base64, and Base64Url.
 str_detect_language=Detects the language of the given string and provides the language code.

--- a/modules/grel/src/test/java/com/google/refine/expr/functions/strings/CollapseWhitespaceTests.java
+++ b/modules/grel/src/test/java/com/google/refine/expr/functions/strings/CollapseWhitespaceTests.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (C) 2026, OpenRefine contributors
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+package com.google.refine.expr.functions.strings;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.refine.expr.EvalError;
+import com.google.refine.grel.GrelTestBase;
+
+public class CollapseWhitespaceTests extends GrelTestBase {
+
+    @Test
+    public void testInvalidParams() {
+        Assert.assertTrue(invoke("collapseWhitespace") instanceof EvalError);
+        Assert.assertTrue(invoke("collapseWhitespace", (Object) null) instanceof EvalError);
+        Assert.assertTrue(invoke("collapseWhitespace", 1) instanceof EvalError);
+        Assert.assertTrue(invoke("collapseWhitespace", "one", "two") instanceof EvalError);
+    }
+
+    @Test
+    public void testCollapseWhitespace() {
+        Assert.assertEquals(invoke("collapseWhitespace", "  New   York  City  "), "New York City");
+        Assert.assertEquals(invoke("collapseWhitespace", "\tNew\tYork\nCity\r\n"), "New York City");
+        Assert.assertEquals(invoke("collapseWhitespace", "New York City"), "New York City");
+        Assert.assertEquals(invoke("collapseWhitespace", ""), "");
+        Assert.assertEquals(invoke("collapseWhitespace", " \t\n "), "");
+    }
+
+    @Test
+    public void testCollapseUnicodeWhitespace() {
+        Assert.assertEquals(invoke("collapseWhitespace", "\u00A0New\u2003York\u3000City\u00A0"), "New York City");
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a new GREL `collapseWhitespace` function for trimming text and collapsing whitespace runs to a single space.
- Register the function in `ControlFunctionRegistry` and add its English function description.
- Add unit tests covering normal whitespace, tabs/newlines, Unicode whitespace, empty input, and invalid arguments.

Tests run:
- `mvn -pl modules/grel -Dtest=com.google.refine.expr.functions.strings.CollapseWhitespaceTests test`