### PR TITLE
feat(exporter): add Markdown table export

### DIFF
--- a/main/src/com/google/refine/exporters/MarkdownExporter.java
+++ b/main/src/com/google/refine/exporters/MarkdownExporter.java
@@ -1,0 +1,105 @@
+/*
+
+Copyright 2010, Google Inc.
+Copyright 2024, OpenRefine contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+package com.google.refine.exporters;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+import java.util.Properties;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.google.refine.browsing.Engine;
+import com.google.refine.model.Project;
+
+public class MarkdownExporter implements WriterExporter {
+
+    @Override
+    public String getContentType() {
+        return "text/markdown";
+    }
+
+    @Override
+    public void export(final Project project, Properties params, Engine engine, final Writer writer)
+            throws IOException {
+
+        TabularSerializer serializer = new TabularSerializer() {
+
+            @Override
+            public void startFile(JsonNode options) {
+                // A Markdown table has no preamble; output begins with the header row.
+            }
+
+            @Override
+            public void endFile() {
+                // A Markdown table has no trailer.
+            }
+
+            @Override
+            public void addRow(List<CellData> cells, boolean isHeader) {
+                try {
+                    writer.write("|");
+                    for (CellData cellData : cells) {
+                        writer.write(" ");
+                        writer.write((cellData != null && cellData.text != null) ? escapeMarkdown(cellData.text) : "");
+                        writer.write(" |");
+                    }
+                    writer.write("\n");
+
+                    if (isHeader) {
+                        writer.write("|");
+                        for (int i = 0; i < cells.size(); i++) {
+                            writer.write(" --- |");
+                        }
+                        writer.write("\n");
+                    }
+                } catch (IOException e) {
+                    // Ignore
+                }
+            }
+        };
+
+        CustomizableTabularExporterUtilities.exportRows(
+                project, engine, params, serializer);
+    }
+
+    /**
+     * Escapes characters that would otherwise break a Markdown table cell: pipes are the cell delimiter, and a cell may
+     * not span multiple lines.
+     */
+    static private String escapeMarkdown(String text) {
+        return text.replace("|", "\\|").replaceAll("[\r\n]+", " ");
+    }
+}

--- a/main/tests/server/src/com/google/refine/exporters/MarkdownExporterTests.java
+++ b/main/tests/server/src/com/google/refine/exporters/MarkdownExporterTests.java
@@ -1,0 +1,181 @@
+/*
+
+Copyright 2010, Google Inc.
+Copyright 2024, OpenRefine contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+package com.google.refine.exporters;
+
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Properties;
+
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.google.refine.ProjectManager;
+import com.google.refine.ProjectManagerStub;
+import com.google.refine.ProjectMetadata;
+import com.google.refine.RefineTest;
+import com.google.refine.browsing.Engine;
+import com.google.refine.model.Cell;
+import com.google.refine.model.Column;
+import com.google.refine.model.ModelException;
+import com.google.refine.model.Project;
+import com.google.refine.model.Row;
+
+public class MarkdownExporterTests extends RefineTest {
+
+    private static final String TEST_PROJECT_NAME = "markdown table exporter test project";
+
+    @Override
+    @BeforeTest
+    public void init() {
+        logger = LoggerFactory.getLogger(this.getClass());
+    }
+
+    // dependencies
+    StringWriter writer;
+    ProjectMetadata projectMetadata;
+    Project project;
+    Engine engine;
+    Properties options;
+
+    // System Under Test
+    WriterExporter SUT;
+
+    @BeforeMethod
+    public void SetUp() {
+        SUT = new MarkdownExporter();
+        writer = new StringWriter();
+        ProjectManager.singleton = new ProjectManagerStub();
+        projectMetadata = new ProjectMetadata();
+        project = new Project();
+        projectMetadata.setName(TEST_PROJECT_NAME);
+        ProjectManager.singleton.registerProject(project, projectMetadata);
+        engine = new Engine(project);
+        options = mock(Properties.class);
+    }
+
+    @AfterMethod
+    public void TearDown() {
+        SUT = null;
+        writer = null;
+        ProjectManager.singleton.deleteProject(project.id);
+        project = null;
+        projectMetadata = null;
+        engine = null;
+        options = null;
+    }
+
+    @Test
+    public void exportSimpleMarkdownTable() {
+        CreateGrid(2, 2);
+
+        try {
+            SUT.export(project, options, engine, writer);
+        } catch (IOException e) {
+            Assert.fail();
+        }
+
+        Assert.assertEquals(writer.toString(), "| column0 | column1 |\n" +
+                "| --- | --- |\n" +
+                "| row0cell0 | row0cell1 |\n" +
+                "| row1cell0 | row1cell1 |\n");
+    }
+
+    @Test
+    public void exportMarkdownTableWithEmptyCells() {
+        CreateGrid(3, 3);
+
+        project.rows.get(1).cells.set(1, null);
+        project.rows.get(2).cells.set(0, null);
+        try {
+            SUT.export(project, options, engine, writer);
+        } catch (IOException e) {
+            Assert.fail();
+        }
+
+        Assert.assertEquals(writer.toString(), "| column0 | column1 | column2 |\n" +
+                "| --- | --- | --- |\n" +
+                "| row0cell0 | row0cell1 | row0cell2 |\n" +
+                "| row1cell0 |  | row1cell2 |\n" +
+                "|  | row2cell1 | row2cell2 |\n");
+    }
+
+    @Test
+    public void exportMarkdownTableWithSpecialCharacters() {
+        CreateGrid(2, 2);
+
+        project.rows.get(0).cells.set(1, new Cell("a | b", null));
+        project.rows.get(1).cells.set(0, new Cell("line1\nline2", null));
+        try {
+            SUT.export(project, options, engine, writer);
+        } catch (IOException e) {
+            Assert.fail();
+        }
+
+        Assert.assertEquals(writer.toString(), "| column0 | column1 |\n" +
+                "| --- | --- |\n" +
+                "| row0cell0 | a \\| b |\n" +
+                "| line1 line2 | row1cell1 |\n");
+    }
+
+    // helper methods
+
+    protected void CreateColumns(int noOfColumns) {
+        for (int i = 0; i < noOfColumns; i++) {
+            try {
+                project.columnModel.addColumn(i, new Column(i, "column" + i), true);
+            } catch (ModelException e1) {
+                Assert.fail("Could not create column");
+            }
+        }
+    }
+
+    protected void CreateGrid(int noOfRows, int noOfColumns) {
+        CreateColumns(noOfColumns);
+
+        for (int i = 0; i < noOfRows; i++) {
+            Row row = new Row(noOfColumns);
+            for (int j = 0; j < noOfColumns; j++) {
+                row.cells.add(new Cell("row" + i + "cell" + j, null));
+            }
+            project.rows.add(row);
+        }
+    }
+}

--- a/main/webapp/modules/core/MOD-INF/controller.js
+++ b/main/webapp/modules/core/MOD-INF/controller.js
@@ -341,6 +341,7 @@ function registerExporters() {
    ER.registerExporter("xlsx", new Packages.com.google.refine.exporters.XlsExporter(true));
    ER.registerExporter("ods", new Packages.com.google.refine.exporters.OdsExporter());
    ER.registerExporter("html", new Packages.com.google.refine.exporters.HtmlTableExporter());
+   ER.registerExporter("md", new Packages.com.google.refine.exporters.MarkdownExporter());
    ER.registerExporter("template", new Packages.com.google.refine.exporters.TemplatingExporter());
    ER.registerExporter("sql", new Packages.com.google.refine.exporters.sql.SqlExporter());
 }

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -442,6 +442,7 @@
     "core-project/tab-value": "Tab-separated value",
     "core-project/comma-sep": "Comma-separated value",
     "core-project/html-table": "HTML table",
+    "core-project/markdown-table": "Markdown table",
     "core-project/excel": "Excel (.xls)",
     "core-project/excel-xml": "Excel 2007+ (.xlsx)",
     "core-project/odf": "ODF spreadsheet",

--- a/main/webapp/modules/core/scripts/project/exporters.js
+++ b/main/webapp/modules/core/scripts/project/exporters.js
@@ -60,6 +60,11 @@ ExporterManager.MenuItems = [
     "click": function() { ExporterManager.handlers.exportRows("html", "html"); }
   },
   {
+    "id" : "core/export-markdown",
+    "label": $.i18n('core-project/markdown-table'),
+    "click": function() { ExporterManager.handlers.exportRows("md", "md"); }
+  },
+  {
     "id" : "core/export-excel",
     "label": $.i18n('core-project/excel'),
     "click": function() { ExporterManager.handlers.exportRows("xls", "xls"); }


### PR DESCRIPTION
Changes proposed in this pull request:

- Add a new `MarkdownExporter` for exporting the current project view as a GitHub-flavored Markdown table.
- Register the `md` export format in the exporter registry and add it to the Export menu as `Markdown table`.
- Add unit tests covering normal table output, empty cells, escaped pipe characters, and newline handling inside cells.

Tests run:

- `mvn -pl main -Dtest=MarkdownExporterTests test`