### PR TITLE
fix(wikibase): do not show required statement warnings for existing items

### DIFF
--- a/.github/workflows/codeql_java.yml
+++ b/.github/workflows/codeql_java.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: 'maven'
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:

--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/ItemRequiresScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/ItemRequiresScrutinizer.java
@@ -80,6 +80,10 @@ public class ItemRequiresScrutinizer extends EditScrutinizer {
     }
 
     public void scrutinizeStatementEdit(StatementEntityEdit update) {
+        if (!update.isNew()) {
+            return;
+        }
+
         Map<PropertyIdValue, Set<Value>> propertyIdValueValueMap = new HashMap<>();
         for (Statement statement : update.getAddedStatements()) {
             Snak mainSnak = statement.getClaim().getMainSnak();

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/commands/PreviewWikibaseSchemaCommandTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/commands/PreviewWikibaseSchemaCommandTest.java
@@ -27,6 +27,7 @@ package org.openrefine.wikibase.commands;
 import static org.mockito.Mockito.when;
 import static org.openrefine.wikibase.testing.TestingData.jsonFromFile;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -167,7 +168,7 @@ public class PreviewWikibaseSchemaCommandTest extends SchemaCommandTest {
                 existingitemrequirescertainotherstatement_P633P18 = true;
             }
         }
-        assertEquals(existingitemrequirescertainotherstatementwithsuggestedvalue_P633P17, true);
-        assertEquals(existingitemrequirescertainotherstatement_P633P18, true);
+        assertFalse(existingitemrequirescertainotherstatementwithsuggestedvalue_P633P17);
+        assertFalse(existingitemrequirescertainotherstatement_P633P18);
     }
 }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ItemRequiresScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/ItemRequiresScrutinizerTest.java
@@ -61,7 +61,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         setFetcher(fetcher);
 
         scrutinize(updateA);
-        assertWarningsRaised(ItemRequiresScrutinizer.existingItemRequireValueswithSuggestedValueType);
+        assertNoWarningRaised();
     }
 
     @Test
@@ -87,7 +87,7 @@ public class ItemRequiresScrutinizerTest extends ScrutinizerTest {
         setFetcher(fetcher);
 
         scrutinize(updateA);
-        assertWarningsRaised(ItemRequiresScrutinizer.existingItemRequireValueswithSuggestedValueType);
+        assertNoWarningRaised();
     }
 
     @Test


### PR DESCRIPTION
Fixes #6767

Changes proposed in this pull request:
- Stop generating Wikibase required statement constraint warnings for edits on existing entities.
- Keep required statement checks for new entities.
- Update unit and preview-command tests to reflect the new behavior.

Validation:
- RED: `mvn -pl extensions/wikibase -Dtest=ItemRequiresScrutinizerTest test` failed because an existing entity still produced `existing-item-requires-property-to-have-certain-values-with-suggested-value`.
- GREEN: `mvn -pl extensions/wikibase -Dtest=ItemRequiresScrutinizerTest test` passed.
- `mvn -pl extensions/wikibase test` passed: 575 tests, 0 failures.
- `git diff --check` passed.