### PR TITLE
Fix typo in OpenRefine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ like Spanish, Brazilian Portuguese, and French could use help.
 When browsing our [user manual](https://openrefine.org/docs/) or other documentation, feel free to use the edit button to suggest improvements.
 For large changes, you might want to first discuss your proposed changes on the forum and then [prepare your changes locally](https://openrefine.org/docs/technical-reference/documentation-contributions).
 
-##  Contribute code 
+##  Contribute code
 
 You can contribute code in various ways:
 - Fix bugs or implement new features. Follow [our guide towards your first code contribution](https://openrefine.org/docs/technical-reference/code-contributions)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -116,7 +116,7 @@ The results must be positive for the person to be elected.
 
 # Policies
 This section does NOT cover OpenRefine project governance. It is currently maintained in this `GOVERNANCE.md` file temporarily until another document or location can hold this information and make it transparent to the community.
- 
+
 The **Code of Conduct Committee, Advisory Committee, and Core Developer Group** hold greater authority within the OpenRefine project, with the ability to represent and make commitments on its behalf. To maintain the community’s trust, these groups are held to a higher standard of transparency and accountability in their decision-making processes.
 This includes transparent and open practices for:
 - Requesting and managing funds
@@ -140,7 +140,7 @@ Unrestricted funds are not linked to a specific deliverable or usage and usually
 Restricted funds are attached to specific deliverables or budget assignments from the grantors and usually come from grant applications. The Advisory Committee must approve grant applications by formal vote before submitting them.
 
 Any contributor can initiate a grant application as a Principal Investigator (PI). The PI
-- Must start a new thread with a subject line starting with `[Grant Opportunity:]` on the forum section named [Community Feedback](https://forum.openrefine.org/c/community/feedback/2) to collect feedback from the community. 
+- Must start a new thread with a subject line starting with `[Grant Opportunity:]` on the forum section named [Community Feedback](https://forum.openrefine.org/c/community/feedback/2) to collect feedback from the community.
 - Must be coordinated with the Advisory Committee.
 - Will hire and supervise the contractors with the support of the Advisory Committee.
 - Must collaborate with other OpenRefine Members (and related working groups) regarding the grant scope.

--- a/conf/openrefine.l4j.ini
+++ b/conf/openrefine.l4j.ini
@@ -8,7 +8,7 @@
 
 # Use system defined HTTP proxies
 -Djava.net.useSystemProxies=true
-# You should probably define the properties below, if they are not already 
+# You should probably define the properties below, if they are not already
 # defined in the environment variable JAVA_TOOL_OPTIONS.
 # Refer to the Java documentation (for example, at
 # https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html

--- a/extensions/database/licenses/jdbc-client.LICENSE.txt
+++ b/extensions/database/licenses/jdbc-client.LICENSE.txt
@@ -11,7 +11,7 @@ Copyright 2006 Google
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
                                Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/extensions/database/module/langs/translation-en.json
+++ b/extensions/database/module/langs/translation-en.json
@@ -61,5 +61,5 @@
     "database-source/alert-db-host-invalid-character": "Database Host Error: Illegal Character in Input. Only Alphanumeric characters allowed",
     "database-source/alert-db-user-invalid-character": "Database User Error: Illegal Character in Input. Only Alphanumeric characters allowed",
     "database-source/alert-db-port-invalid-character": "Database Port Error: Illegal Character in Input. Only Numeric values allowed."
-    
+
 }

--- a/extensions/wikibase/credits.txt
+++ b/extensions/wikibase/credits.txt
@@ -1,16 +1,16 @@
 #-------------------------------------------------------------------------------
 # Copyright (C) 2018 Antonin Delpeuch
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,6 +27,6 @@ The following images were obtained from Wikimedia Commons:
 - Warning.svg by User:Ezekiel63745 (CC BY-SA)
   https://commons.wikimedia.org/wiki/File:Information_orange.svg
 - Important.svg originally from David Vignoni (GNU LGPL)
-  https://commons.wikimedia.org/wiki/File:Nuvola_apps_important.svg 
+  https://commons.wikimedia.org/wiki/File:Nuvola_apps_important.svg
 - Critical.svg by User:Stannered (CC BY-SA)
   https://commons.wikimedia.org/wiki/File:Stop_x_nuvola.svg


### PR DESCRIPTION
I fixed a small set of formatting issues that were easy to clean up without touching behavior.