### PR TITLE
Automatic wikibase property suggestions based on statement property

### DIFF
--- a/extensions/wikibase/module/scripts/schema-alignment.js
+++ b/extensions/wikibase/module/scripts/schema-alignment.js
@@ -1132,7 +1132,7 @@ SchemaAlignment._statementToJSON = function (statement) {
  **************/
 
 SchemaAlignment._addQualifier = function(container, json, context) {
-  context = context || 'qualifier';
+  context = context || 'qualifier';// this will make sense later when we use it
   var property = null;
   var value = null;
   if (json) {
@@ -1154,6 +1154,8 @@ SchemaAlignment._addQualifier = function(container, json, context) {
   var statementContainer = $('<div></div>').addClass('wbs-statement-container').appendTo(right);
 
   var getMainsnakPid = function() {
+    // this function will get the pid of the statement's property
+
     var propInput = container.closest('.wbs-statement-group').find('.wbs-prop-input').first();
     var mainsnakValue = propInput.data('jsonValue');
     return (mainsnakValue && mainsnakValue.pid) ? mainsnakValue.pid : null;
@@ -1161,6 +1163,7 @@ SchemaAlignment._addQualifier = function(container, json, context) {
 
 
   SchemaAlignment._initPropertyField(inputContainer, statementContainer, property, context, getMainsnakPid);
+
   if (value && property) {
     SchemaAlignment._addStatement(statementContainer, property.datatype, {value:value});
   } else {
@@ -1217,7 +1220,7 @@ SchemaAlignment._addReference = function(container, json) {
   var toolbar2 = $('<div></div>').addClass('wbs-toolbar').appendTo(right);
   var addSnakButton = $('<a></a>').addClass('wbs-add-qualifier')
         .on('click',function(e) {
-      SchemaAlignment._addQualifier(qualifierContainer, null, 'reference');
+      SchemaAlignment._addQualifier(qualifierContainer, null, 'reference');// context set to 'reference'
       e.preventDefault();
   }).appendTo(toolbar2);
   SchemaAlignment._plusButton($.i18n('wikibase-schema/add-reference-snak'), addSnakButton);
@@ -1297,8 +1300,9 @@ SchemaAlignment._initPropertyField = function(inputContainer, targetContainer, i
     language: $.i18n("core-recon/wd-recon-lang"),
     view_url: WikibaseManager.getSelectedWikibaseSiteIriForEntityType('property')+'{{id}}'
   };
-  var widgetName = 'suggestWikibase';
+  var widgetName = 'suggestWikibase';// default widget
   if (context === 'qualifier' || context === 'reference') {
+    // basically if context is not null, we switch to 'suggestWikibaseProperty', else we use 'suggestWikibase'
     widgetName = 'suggestWikibaseProperty';
     suggestConfig.context = context;
     suggestConfig.get_mainsnak_pid = getMainsnakPid;
@@ -1306,16 +1310,22 @@ SchemaAlignment._initPropertyField = function(inputContainer, targetContainer, i
 
   var suggestWidget = input[widgetName](suggestConfig);
   var showSuggestionsIfEmpty = function() {
+    // this will show suggestions when property fields are empty
     if (!input.val() && !input.data('dont_hide')) {
       var widgetInstance = input.data(widgetName);
+      // probably won't need this if statement, might remove it later
       if (widgetInstance && typeof widgetInstance.request === 'function') {
+        // we pass in an empty search string
         widgetInstance.request('', 0);
       }
     }
   };
 
   if (widgetName === 'suggestWikibaseProperty') {
+    // when user clicks on the empty field, lets show the suggestions
     input.on('focus', showSuggestionsIfEmpty);
+
+    // what if user clears a property? then property field becomes empty again, so we need to show the suggestions again
     input.on('fb-textchange', function() {
       setTimeout(showSuggestionsIfEmpty, 0);
     });

--- a/extensions/wikibase/module/scripts/schema-alignment.js
+++ b/extensions/wikibase/module/scripts/schema-alignment.js
@@ -1305,15 +1305,19 @@ SchemaAlignment._initPropertyField = function(inputContainer, targetContainer, i
   }
 
   var suggestWidget = input[widgetName](suggestConfig);
+  var showSuggestionsIfEmpty = function() {
+    if (!input.val() && !input.data('dont_hide')) {
+      var widgetInstance = input.data(widgetName);
+      if (widgetInstance && typeof widgetInstance.request === 'function') {
+        widgetInstance.request('', 0);
+      }
+    }
+  };
 
   if (widgetName === 'suggestWikibaseProperty') {
-    input.one('focus', function() {
-      if (!input.val()) {
-        var widgetInstance = input.data(widgetName);
-        if (widgetInstance && typeof widgetInstance.request === 'function') {
-          widgetInstance.request('', 0);
-        }
-      }
+    input.on('focus', showSuggestionsIfEmpty);
+    input.on('fb-textchange', function() {
+      setTimeout(showSuggestionsIfEmpty, 0);
     });
   }
 

--- a/extensions/wikibase/module/scripts/schema-alignment.js
+++ b/extensions/wikibase/module/scripts/schema-alignment.js
@@ -1131,7 +1131,8 @@ SchemaAlignment._statementToJSON = function (statement) {
  * QUALIFIERS *
  **************/
 
-SchemaAlignment._addQualifier = function(container, json) {
+SchemaAlignment._addQualifier = function(container, json, context) {
+  context = context || 'qualifier';
   var property = null;
   var value = null;
   if (json) {
@@ -1151,7 +1152,15 @@ SchemaAlignment._addQualifier = function(container, json) {
     e.preventDefault();
   });
   var statementContainer = $('<div></div>').addClass('wbs-statement-container').appendTo(right);
-  SchemaAlignment._initPropertyField(inputContainer, statementContainer, property);
+
+  var getMainsnakPid = function() {
+    var propInput = container.closest('.wbs-statement-group').find('.wbs-prop-input').first();
+    var mainsnakValue = propInput.data('jsonValue');
+    return (mainsnakValue && mainsnakValue.pid) ? mainsnakValue.pid : null;
+  };
+
+
+  SchemaAlignment._initPropertyField(inputContainer, statementContainer, property, context, getMainsnakPid);
   if (value && property) {
     SchemaAlignment._addStatement(statementContainer, property.datatype, {value:value});
   } else {
@@ -1208,17 +1217,17 @@ SchemaAlignment._addReference = function(container, json) {
   var toolbar2 = $('<div></div>').addClass('wbs-toolbar').appendTo(right);
   var addSnakButton = $('<a></a>').addClass('wbs-add-qualifier')
         .on('click',function(e) {
-      SchemaAlignment._addQualifier(qualifierContainer, null);
+      SchemaAlignment._addQualifier(qualifierContainer, null, 'reference');
       e.preventDefault();
   }).appendTo(toolbar2);
   SchemaAlignment._plusButton($.i18n('wikibase-schema/add-reference-snak'), addSnakButton);
 
   if (snaks) {
      for (var i = 0; i != snaks.length; i++) {
-        SchemaAlignment._addQualifier(qualifierContainer, snaks[i]);
+        SchemaAlignment._addQualifier(qualifierContainer, snaks[i], 'reference');
      }
   } else {
-     SchemaAlignment._addQualifier(qualifierContainer, null);
+     SchemaAlignment._addQualifier(qualifierContainer, null, 'reference');
   }
 };
 
@@ -1277,7 +1286,7 @@ SchemaAlignment._getPropertyType = function(pid, callback) {
      }});
 };
 
-SchemaAlignment._initPropertyField = function(inputContainer, targetContainer, initialValue) {
+SchemaAlignment._initPropertyField = function(inputContainer, targetContainer, initialValue, context, getMainsnakPid) {
   var input = $('<input></input>').appendTo(inputContainer);
   input.attr("placeholder", $.i18n('wikibase-schema/property-placeholder'));
 
@@ -1288,8 +1297,28 @@ SchemaAlignment._initPropertyField = function(inputContainer, targetContainer, i
     language: $.i18n("core-recon/wd-recon-lang"),
     view_url: WikibaseManager.getSelectedWikibaseSiteIriForEntityType('property')+'{{id}}'
   };
-  
-  input.suggestWikibase(suggestConfig).on("fb-select", function(evt, data) {
+  var widgetName = 'suggestWikibase';
+  if (context === 'qualifier' || context === 'reference') {
+    widgetName = 'suggestWikibaseProperty';
+    suggestConfig.context = context;
+    suggestConfig.get_mainsnak_pid = getMainsnakPid;
+  }
+
+  var suggestWidget = input[widgetName](suggestConfig);
+
+  if (widgetName === 'suggestWikibaseProperty') {
+    input.one('focus', function() {
+      if (!input.val()) {
+        var widgetInstance = input.data(widgetName);
+        if (widgetInstance && typeof widgetInstance.request === 'function') {
+          widgetInstance.request('', 0);
+        }
+      }
+    });
+  }
+
+  suggestWidget.on("fb-select", function(evt, data) {
+    
       SchemaAlignment._getPropertyType(data.id, function(datatype) {
         inputContainer.data("jsonValue", {
           type : "wbpropconstant",

--- a/extensions/wikibase/module/scripts/schema-alignment.js
+++ b/extensions/wikibase/module/scripts/schema-alignment.js
@@ -1156,7 +1156,7 @@ SchemaAlignment._addQualifier = function(container, json, context) {
   var getMainsnakPid = function() {
     // this function will get the pid of the statement's property
 
-    var propInput = container.closest('.wbs-statement-group').find('.wbs-prop-input').first();
+    var propInput = container.closest('.wbs-statement-group').children('.wbs-prop-input').first();
     var mainsnakValue = propInput.data('jsonValue');
     return (mainsnakValue && mainsnakValue.pid) ? mainsnakValue.pid : null;
   };
@@ -1313,12 +1313,10 @@ SchemaAlignment._initPropertyField = function(inputContainer, targetContainer, i
     // this will show suggestions when property fields are empty
     if (!input.val() && !input.data('dont_hide')) {
       var widgetInstance = input.data(widgetName);
-      // probably won't need this if statement, might remove it later
       if (widgetInstance && typeof widgetInstance.request === 'function') {
-        // we pass in an empty search string
-        widgetInstance.request('', 0);
+        widgetInstance.request('');
       }
-    }
+    } 
   };
 
   if (widgetName === 'suggestWikibaseProperty') {

--- a/extensions/wikibase/module/scripts/wikibase-suggest.js
+++ b/extensions/wikibase/module/scripts/wikibase-suggest.js
@@ -149,6 +149,11 @@
     {},
     $.suggest.suggestWikibase.prototype,
     {
+      focus: function(e) {
+        // need this otherwise user can't select if field is empty
+        this.focus_hook(e);
+      },
+
       request: function(val, cursor) {
         var self = this,
             o = this.options;

--- a/extensions/wikibase/module/scripts/wikibase-suggest.js
+++ b/extensions/wikibase/module/scripts/wikibase-suggest.js
@@ -142,6 +142,107 @@
     }
   );
 
+  $.suggest(
+  "suggestWikibaseProperty",
+  $.extend(
+    true,
+    {},
+    $.suggest.suggestWikibase.prototype,
+    {
+      request: function(val, cursor) {
+        var self = this,
+            o = this.options;
+
+        var mainsnakPid = o.get_mainsnak_pid ? o.get_mainsnak_pid() : null;
+
+        if (!mainsnakPid || o._suggesterUnavailable) {
+          return $.suggest.suggestWikibase.prototype.request.call(this, val, cursor);
+        }
+
+        var data = {
+          action: 'wbsgetsuggestions',
+          properties: mainsnakPid,
+          context: o.context,
+          search: val || '',
+          language: o.language,
+          format: 'json',
+          origin: '*',
+          uselang: o.language
+        };
+
+        if (cursor) {
+          data['continue'] = cursor;
+        }
+
+        var url = o.mediawiki_endpoint + "?" + $.param(data, true);
+        var cached = $.suggest.cache[url];
+        if (cached) {
+          this.response(cached, cursor ? cursor : -1, true);
+          return;
+        }
+
+        clearTimeout(this.request.timeout);
+
+        var ajax_options = {
+          url: o.mediawiki_endpoint,
+          data: data,
+          traditional: true,
+          beforeSend: function(xhr) {
+            var calls = self.input.data("request.count.suggest") || 0;
+            if (!calls) {
+              self.trackEvent(self.name, "start_session");
+            }
+            calls += 1;
+            self.trackEvent(self.name, "request", "count", calls);
+            self.input.data("request.count.suggest", calls);
+          },
+          success: function(data) {
+            var translated = {
+                prefix: val,
+                result: (data.search || []).map(result => { return {
+                    id: result.id,
+                    name: result.label,
+                    description: result.description};})
+            };
+            $.suggest.cache[url] = translated;
+            self.response(translated, cursor ? cursor : -1);
+          },
+          error: function(xhr) {
+            o._suggesterUnavailable = true;
+            self.status_error();
+            self.trackEvent(self.name, "request", "error", {
+              url: this.url,
+              response: xhr ? xhr.responseText : ''
+            });
+            $.suggest.suggestWikibase.prototype.request.call(self, val, cursor);
+          },
+          complete: function(xhr) {
+            if (xhr) {
+              self.trackEvent(self.name, "request", "tid",
+              xhr.getResponseHeader("X-Metaweb-TID"));
+            }
+          },
+          dataType: "json",
+          cache: true
+        };
+
+        this.request.timeout = setTimeout(function() {
+          $.ajax(ajax_options);
+        }, o.xhr_delay);
+      }
+    }));
+
+  $.extend(
+    $.suggest.suggestWikibaseProperty,
+    {
+      defaults: $.extend(
+        true,
+        {},
+        $.suggest.suggestWikibase.defaults
+      )
+    }
+  );
+
 })();
 
 

--- a/extensions/wikibase/module/scripts/wikibase-suggest.js
+++ b/extensions/wikibase/module/scripts/wikibase-suggest.js
@@ -150,7 +150,7 @@
     $.suggest.suggestWikibase.prototype,
     {
       focus: function(e) {
-        // need this otherwise user can't select if field is empty
+        // need this otherwise user will not be able select items if field is empty, even if suggestions are being shown
         this.focus_hook(e);
       },
 
@@ -161,13 +161,14 @@
         var mainsnakPid = o.get_mainsnak_pid ? o.get_mainsnak_pid() : null;
 
         if (!mainsnakPid || o._suggesterUnavailable) {
+          // if we don't find a main snak pid, just use suggestWikibase widget's request()
           return $.suggest.suggestWikibase.prototype.request.call(this, val, cursor);
         }
 
         var data = {
           action: 'wbsgetsuggestions',
-          properties: mainsnakPid,
-          context: o.context,
+          properties: mainsnakPid,// pass in the statement's main property pid here
+          context: o.context,// add context
           search: val || '',
           language: o.language,
           format: 'json',
@@ -219,6 +220,7 @@
               url: this.url,
               response: xhr ? xhr.responseText : ''
             });
+            // fallback to suggestWikibase request()
             $.suggest.suggestWikibase.prototype.request.call(self, val, cursor);
           },
           complete: function(xhr) {


### PR DESCRIPTION
This PR implements the feature requested in #6814

When adding a qualifier or a reference in the Wikibase schema editor, the property field performed a generic search. It also required the user to start typing before anything was suggested. Wikidata does suggest relevant properties by ranking suggestions against the statement's main property, so it could be used to get the automatic suggestions.

### Changes proposed in this pull request:

I modified the 2 files `schema-alignment.js` and `wikibase-suggest.js` to make automatic suggestions based on the statement's main property.

- `_addQualifier` now takes a `context` argument ("qualifier" or "reference")
- `getMainsnakPid()` closure is used to resolve the statement's main property PID.
- `suggestWikibaseProperty` calls the `wbsgetsuggestions` API action with the main property PID and context, which returns the property suggestions.
- `suggestWikibaseProperty` overrides `focus()` to call `focus_hook()`. Suggestions are now requested automatically when: an empty qualifier or reference property field receives focus, or when the field is cleared back to empty, by using the `fb-textchange` event


After the changes, suggestions automatically show up based on the statement's property:

<img width="1036" height="751" alt="snap_2026-07-13_13-14-08" src="https://github.com/user-attachments/assets/b2fd39cf-3a41-433b-a6c4-26aae5a6ba28" />
<br><br>
I hope this works and addresses the issue well. I would like any suggestions to improve the code. If I made some mistakes or did something wrong, please let me know. Thanks!