### PR TITLE
Register Wikibase manifest schemas when schema UI initializes

### DIFF
--- a/extensions/wikibase/module/scripts/schema-alignment.js
+++ b/extensions/wikibase/module/scripts/schema-alignment.js
@@ -197,6 +197,11 @@ SchemaAlignment._rerenderTabs = function() {
   schemaElmts.saveNewTemplateButton.text($.i18n('wikibase-schema/save-button'));
 
   WikibaseTemplateManager.loadTemplates(function() {
+    // Make sure schema templates declared in the manifest of the currently
+    // selected Wikibase are available in the dropdown. Without this, the
+    // dropdown would be empty on a fresh project where the Wikibase was
+    // auto-selected from the saved schema's site IRI (issue #6939).
+    WikibaseManager.ensureManifestTemplatesRegistered(WikibaseManager.getSelectedWikibaseName());
     SchemaAlignment.updateAvailableTemplates();
   });
   schemaElmts.saveNewTemplateButton.on('click', function(e) {

--- a/extensions/wikibase/module/scripts/wikibase-manager.js
+++ b/extensions/wikibase/module/scripts/wikibase-manager.js
@@ -152,22 +152,32 @@ WikibaseManager.areStructuredMediaInfoFieldsDisabledForSelectedWikibase = functi
 WikibaseManager.selectWikibase = function (wikibaseName) {
   if (WikibaseManager.wikibases.hasOwnProperty(wikibaseName)) {
     WikibaseManager.selected = wikibaseName;
+    WikibaseManager.ensureManifestTemplatesRegistered(wikibaseName);
+  }
+};
 
-    // add any default templates that might not exist yet
-    let manifest = WikibaseManager.wikibases[wikibaseName];
-    if (manifest.schema_templates !== undefined) {
-      let templateAdded = false;
-      for (let template of manifest.schema_templates) {
-        if (WikibaseTemplateManager.getTemplate(template.name) === undefined) {
-          WikibaseTemplateManager.addTemplate(manifest.mediawiki.name, template.name, template.schema);
-          templateAdded = true;
-        }
-      }
-      if (templateAdded) {
-        WikibaseTemplateManager.saveTemplates();
-      }
+// Registers any schema_templates declared in the manifest of the given
+// Wikibase with the WikibaseTemplateManager, so that they appear in the
+// "Start from an existing schema" dropdown. Templates that are already
+// registered (e.g. previously saved to preferences) are left untouched.
+// This is called both when the user actively selects a Wikibase and when
+// the schema UI initializes with a Wikibase already selected (for instance
+// on project load), to avoid issue #6939 where the dropdown was empty
+// until the user manually switched Wikibase instances.
+WikibaseManager.ensureManifestTemplatesRegistered = function (wikibaseName) {
+  let manifest = WikibaseManager.wikibases[wikibaseName];
+  if (manifest === undefined || manifest.schema_templates === undefined) {
+    return;
+  }
+  let templateAdded = false;
+  for (let template of manifest.schema_templates) {
+    if (WikibaseTemplateManager.getTemplate(manifest.mediawiki.name, template.name) === undefined) {
+      WikibaseTemplateManager.addTemplate(manifest.mediawiki.name, template.name, template.schema);
+      templateAdded = true;
     }
-
+  }
+  if (templateAdded) {
+    WikibaseTemplateManager.saveTemplates();
   }
 };
 

--- a/main/tests/cypress/cypress/e2e/extensions/wikibase/wikibase_schema.cy.js
+++ b/main/tests/cypress/cypress/e2e/extensions/wikibase/wikibase_schema.cy.js
@@ -27,8 +27,7 @@ describe('SchemaAlignment.setUpTabs', () => {
   // opens with a Wikibase already auto-selected from the saved schema site IRI.
   it('should populate manifest schema templates without switching Wikibase', () => {
     const commonsSiteIri = 'https://commons.wikimedia.org/entity/';
-    const manifestTemplateName =
-      'Information (basic data for every Wikimedia Commons file)';
+    const manifestTemplateName = 'Information (basic data for every Wikimedia Commons file)';
     const commonsSchema = JSON.stringify({
       entityEdits: [],
       siteIri: commonsSiteIri,
@@ -36,45 +35,33 @@ describe('SchemaAlignment.setUpTabs', () => {
     });
 
     let savedTemplates;
-    cy.request(
-      Cypress.env('OPENREFINE_URL') +
-        '/command/core/get-preference?name=wikibase.templates'
-    ).then((response) => {
-      savedTemplates = response.body.value;
-    });
+    cy.request(Cypress.env('OPENREFINE_URL') + '/command/core/get-preference?name=wikibase.templates').then(
+      (response) => {
+        savedTemplates = response.body.value;
+      }
+    );
 
     cy.setPreference('wikibase.templates', JSON.stringify([{}]));
 
-    cy.loadProject('food.mini', Cypress.currentTest.title + '-' + Date.now()).then(
-      (projectId) => {
-        cy.get('@token', { log: false }).then((token) => {
-          cy.request({
-            method: 'POST',
-            url:
-              `${Cypress.env('OPENREFINE_URL')}/command/wikidata/save-wikibase-schema?project=${projectId}&csrf_token=${token}`,
-            form: true,
-            body: { schema: commonsSchema },
-          });
+    cy.loadProject('food.mini', Cypress.currentTest.title + '-' + Date.now()).then((projectId) => {
+      cy.get('@token', { log: false }).then((token) => {
+        cy.request({
+          method: 'POST',
+          url: `${Cypress.env('OPENREFINE_URL')}/command/wikidata/save-wikibase-schema?project=${projectId}&csrf_token=${token}`,
+          form: true,
+          body: { schema: commonsSchema },
         });
+      });
 
-        cy.visit(
-          Cypress.env('OPENREFINE_URL') + '/project?project=' + projectId
-        );
-        cy.waitForProjectTable();
+      cy.visit(Cypress.env('OPENREFINE_URL') + '/project?project=' + projectId);
+      cy.waitForProjectTable();
 
-        cy.get('#extension-bar-menu-container').contains('Wikibase').click();
-        cy.get('.menu-container a').contains('Edit Wikibase schema').click();
+      cy.get('#extension-bar-menu-container').contains('Wikibase').click();
+      cy.get('.menu-container a').contains('Edit Wikibase schema').click();
 
-        cy.get('#wikibase-instance-selector').should(
-          'have.value',
-          'Wikimedia Commons'
-        );
-        cy.get('#wikibase-template-select option').should(
-          'contain',
-          manifestTemplateName
-        );
-      }
-    );
+      cy.get('#wikibase-instance-selector').should('have.value', 'Wikimedia Commons');
+      cy.get('#wikibase-template-select option').should('contain', manifestTemplateName);
+    });
 
     cy.then(() => {
       if (savedTemplates === undefined || savedTemplates === null) {

--- a/main/tests/cypress/cypress/e2e/extensions/wikibase/wikibase_schema.cy.js
+++ b/main/tests/cypress/cypress/e2e/extensions/wikibase/wikibase_schema.cy.js
@@ -23,6 +23,68 @@ describe('SchemaAlignment.setUpTabs', () => {
     cy.get('.schema-alignment-total-warning-count').should('to.contain', '1');
   });
 
+  // Regression for #6939: manifest schema_templates must appear when the schema UI
+  // opens with a Wikibase already auto-selected from the saved schema site IRI.
+  it('should populate manifest schema templates without switching Wikibase', () => {
+    const commonsSiteIri = 'https://commons.wikimedia.org/entity/';
+    const manifestTemplateName =
+      'Information (basic data for every Wikimedia Commons file)';
+    const commonsSchema = JSON.stringify({
+      entityEdits: [],
+      siteIri: commonsSiteIri,
+      mediaWikiApiEndpoint: 'https://commons.wikimedia.org/w/api.php',
+    });
+
+    let savedTemplates;
+    cy.request(
+      Cypress.env('OPENREFINE_URL') +
+        '/command/core/get-preference?name=wikibase.templates'
+    ).then((response) => {
+      savedTemplates = response.body.value;
+    });
+
+    cy.setPreference('wikibase.templates', JSON.stringify([{}]));
+
+    cy.loadProject('food.mini', Cypress.currentTest.title + '-' + Date.now()).then(
+      (projectId) => {
+        cy.get('@token', { log: false }).then((token) => {
+          cy.request({
+            method: 'POST',
+            url:
+              `${Cypress.env('OPENREFINE_URL')}/command/wikidata/save-wikibase-schema?project=${projectId}&csrf_token=${token}`,
+            form: true,
+            body: { schema: commonsSchema },
+          });
+        });
+
+        cy.visit(
+          Cypress.env('OPENREFINE_URL') + '/project?project=' + projectId
+        );
+        cy.waitForProjectTable();
+
+        cy.get('#extension-bar-menu-container').contains('Wikibase').click();
+        cy.get('.menu-container a').contains('Edit Wikibase schema').click();
+
+        cy.get('#wikibase-instance-selector').should(
+          'have.value',
+          'Wikimedia Commons'
+        );
+        cy.get('#wikibase-template-select option').should(
+          'contain',
+          manifestTemplateName
+        );
+      }
+    );
+
+    cy.then(() => {
+      if (savedTemplates === undefined || savedTemplates === null) {
+        cy.deletePreference('wikibase.templates');
+      } else {
+        cy.setPreference('wikibase.templates', savedTemplates);
+      }
+    });
+  });
+
   // add 2 item in schema and check if issue count is updated
   it('should update the number of warnings', () => {
     cy.loadAndVisitProject('food.mini');


### PR DESCRIPTION
## Summary

Fixes https://github.com/OpenRefine/OpenRefine/issues/6939

On a fresh project where the Wikibase instance is auto-selected from the saved schema's site IRI, `WikibaseManager.selectWikibase()` never runs, so manifest `schema_templates` were never registered with `WikibaseTemplateManager`. The "Start from an existing schema" dropdown stayed empty until the user manually switched instances.

- Extract `ensureManifestTemplatesRegistered(wikibaseName)` from `selectWikibase`
- Call it from `SchemaAlignment._rerenderTabs` after templates load
- Fix the existing `getTemplate` call to pass both wikibase name and template name (API requires two arguments)

## Test plan

- [ ] Manual: new project → Manage Wikibase → Wikimedia Commons → Edit Wikibase schema → "Start from an existing schema" lists manifest templates without switching instances
- [ ] Manual: selecting a Wikibase in the management dialog still registers templates (no regression)

Made with [Cursor](https://cursor.com)