### PR TITLE
Enable Unicode character classes in GREL regex and text filter

### DIFF
--- a/main/tests/server/src/com/google/refine/browsing/facets/TextSearchFacetTests.java
+++ b/main/tests/server/src/com/google/refine/browsing/facets/TextSearchFacetTests.java
@@ -186,6 +186,36 @@ public class TextSearchFacetTests extends RefineTest {
     }
 
     @Test
+    public void testUnicodeRegExFilter() throws Exception {
+        // Regression test for #1768: regex text filter must use Unicode-aware
+        // predefined character classes. \\w must match accented letters.
+        project = createProject("TextSearchFacetUnicode",
+                new String[] { "Value" },
+                new Serializable[][] {
+                        { "café" },
+                        { " Espresso" },
+                        { "123" },
+                        { "Ångström" }
+                });
+
+        // \w should match accented Unicode letters.
+        String filter = "{\"type\":\"text\","
+                + "\"name\":\"Value\","
+                + "\"columnName\":\"Value\","
+                + "\"mode\":\"regex\","
+                + "\"caseSensitive\":true,"
+                + "\"invert\":false,"
+                + "\"query\":\"\\\\w+\"}";
+
+        configureFilter(filter);
+
+        Assert.assertEquals(rowfilter.filterRow(project, 0, project.rows.get(0)), true); // "café"
+        Assert.assertEquals(rowfilter.filterRow(project, 1, project.rows.get(1)), true); // " Espresso"
+        Assert.assertEquals(rowfilter.filterRow(project, 2, project.rows.get(2)), true); // "123"
+        Assert.assertEquals(rowfilter.filterRow(project, 3, project.rows.get(3)), true); // "Ångström"
+    }
+
+    @Test
     public void testCaseSensitiveFilter() throws Exception {
         // Apply case-sensitive filter "A"
 

--- a/modules/core/src/main/java/com/google/refine/browsing/facets/TextSearchFacet.java
+++ b/modules/core/src/main/java/com/google/refine/browsing/facets/TextSearchFacet.java
@@ -93,7 +93,8 @@ public class TextSearchFacet implements Facet {
                 try {
                     Pattern.compile(
                             _query,
-                            _caseSensitive ? 0 : Pattern.CASE_INSENSITIVE);
+                            Pattern.UNICODE_CHARACTER_CLASS
+                                    | (_caseSensitive ? 0 : Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
                 } catch (java.util.regex.PatternSyntaxException e) {
                     throw new IllegalArgumentException(e);
                 }
@@ -176,7 +177,8 @@ public class TextSearchFacet implements Facet {
                 try {
                     _pattern = Pattern.compile(
                             _query,
-                            _config._caseSensitive ? 0 : Pattern.CASE_INSENSITIVE);
+                            Pattern.UNICODE_CHARACTER_CLASS
+                                    | (_config._caseSensitive ? 0 : Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE));
                 } catch (java.util.regex.PatternSyntaxException e) {
                     PatternSyntaxExceptionParser err = new PatternSyntaxExceptionParser(e);
                     throw new IllegalArgumentException(err.getUserMessage());

--- a/modules/grel/src/main/java/com/google/refine/expr/functions/strings/Match.java
+++ b/modules/grel/src/main/java/com/google/refine/expr/functions/strings/Match.java
@@ -53,7 +53,9 @@ public class Match implements Function {
 
             if (s != null && p != null && (p instanceof String || p instanceof Pattern)) {
 
-                Pattern pattern = (p instanceof String) ? Pattern.compile((String) p) : (Pattern) p;
+                Pattern pattern = (p instanceof String)
+                        ? Pattern.compile((String) p, Pattern.UNICODE_CHARACTER_CLASS)
+                        : (Pattern) p;
 
                 Matcher matcher = pattern.matcher(s.toString());
 

--- a/modules/grel/src/main/java/com/google/refine/expr/functions/strings/Match.java
+++ b/modules/grel/src/main/java/com/google/refine/expr/functions/strings/Match.java
@@ -54,7 +54,8 @@ public class Match implements Function {
             if (s != null && p != null && (p instanceof String || p instanceof Pattern)) {
 
                 Pattern pattern = (p instanceof String)
-                        ? Pattern.compile((String) p, Pattern.UNICODE_CHARACTER_CLASS)
+                        ? Pattern.compile((String) p,
+                                Pattern.UNICODE_CHARACTER_CLASS | Pattern.UNICODE_CASE)
                         : (Pattern) p;
 
                 Matcher matcher = pattern.matcher(s.toString());

--- a/modules/grel/src/main/java/com/google/refine/grel/Parser.java
+++ b/modules/grel/src/main/java/com/google/refine/grel/Parser.java
@@ -184,7 +184,10 @@ public class Parser {
             RegexToken t = (RegexToken) _token;
 
             try {
-                Pattern pattern = Pattern.compile(_token.text, t.caseInsensitive ? Pattern.CASE_INSENSITIVE : 0);
+                Pattern pattern = Pattern.compile(
+                        _token.text,
+                        Pattern.UNICODE_CHARACTER_CLASS
+                                | (t.caseInsensitive ? Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE : 0));
                 eval = new LiteralExpr(pattern, t.fullSource());
                 next(false);
             } catch (Exception e) {

--- a/modules/grel/src/test/java/com/google/refine/expr/functions/strings/MatchTests.java
+++ b/modules/grel/src/test/java/com/google/refine/expr/functions/strings/MatchTests.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (C) 2018, OpenRefine contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ ******************************************************************************/
+
+package com.google.refine.expr.functions.strings;
+
+import java.util.regex.Pattern;
+
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.google.refine.RefineServlet;
+import com.google.refine.grel.GrelTestBase;
+
+/**
+ * Test cases for the match function, including Unicode-aware regex (#1768).
+ */
+public class MatchTests extends GrelTestBase {
+
+    @Override
+    @BeforeTest
+    public void init() {
+        logger = LoggerFactory.getLogger(this.getClass());
+    }
+
+    // dependencies
+    RefineServlet servlet;
+
+    @Test
+    public void matchFunctionLiteralStringTest() throws Exception {
+        // Plain ASCII still matches end-to-end.
+        Assert.assertEquals(((String[]) invoke("match", "hello", "h(e)llo"))[0], "e");
+    }
+
+    @Test
+    public void matchFunctionUnicodeStringRegexTest() throws Exception {
+        // String-form regex: \w must cover Unicode letters (#1768). "café" should match \\w+ as a whole word.
+        String[] groups = (String[]) invoke("match", "café", "\\w+");
+        Assert.assertNotNull(groups, "expected a match for 'café' against \\w+ with Unicode character class");
+        Assert.assertEquals(groups.length, 0, "no capture groups expected for \\w+");
+    }
+
+    @Test
+    public void matchFunctionUnicodeStringRegexWithGroupTest() throws Exception {
+        // Capture groups work and Unicode word characters are matched by \\w.
+        String[] groups = (String[]) invoke("match", "Ångström", "(\\w+)");
+        Assert.assertNotNull(groups);
+        Assert.assertEquals(groups[0], "Ångström");
+    }
+
+    @Test
+    public void matchFunctionUnicodePatternRegexTest() throws Exception {
+        // Pattern-form regex compiled with the flag should also see Unicode word characters.
+        Pattern p = Pattern.compile("\\w+", Pattern.UNICODE_CHARACTER_CLASS);
+        String[] groups = (String[]) invoke("match", "café", p);
+        Assert.assertNotNull(groups);
+    }
+
+    @Test
+    public void matchFunctionUnicodeDigitsTest() throws Exception {
+        // Arabic-Indic digits should be matched by \\d under UNICODE_CHARACTER_CLASS.
+        String[] groups = (String[]) invoke("match", "١٢٣", "\\d+");
+        Assert.assertNotNull(groups, "expected \\d to match Arabic-Indic digits under Unicode flag");
+    }
+
+    @Test
+    public void matchFunctionNoMatchReturnsNullTest() throws Exception {
+        Assert.assertNull(invoke("match", "abc", "\\d+"));
+    }
+}

--- a/modules/grel/src/test/java/com/google/refine/expr/functions/strings/MatchTests.java
+++ b/modules/grel/src/test/java/com/google/refine/expr/functions/strings/MatchTests.java
@@ -82,6 +82,13 @@ public class MatchTests extends GrelTestBase {
     }
 
     @Test
+    public void matchFunctionUnicodeCaseInsensitiveTest() throws Exception {
+        // (?i) must use Unicode case folding so É matches é (#1768).
+        String[] groups = (String[]) invoke("match", "École", "(?i)école");
+        Assert.assertNotNull(groups, "expected (?i) to match É/é with Unicode case folding");
+    }
+
+    @Test
     public void matchFunctionUnicodeDigitsTest() throws Exception {
         // Arabic-Indic digits should be matched by \\d under UNICODE_CHARACTER_CLASS.
         String[] groups = (String[]) invoke("match", "١٢٣", "\\d+");

--- a/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
+++ b/modules/grel/src/test/java/com/google/refine/grel/GrelTests.java
@@ -344,6 +344,26 @@ public class GrelTests extends GrelTestBase {
         }
     }
 
+    // Regression test for #1768: Unicode-aware predefined character classes in GREL regex literals.
+    @Test
+    public void testUnicodeRegexLiterals() throws ParsingException {
+        String tests[][] = {
+                // \w covers Unicode letters in regex literals consumed by find/match/replace/split.
+                { "'café'.find(/\\w+/).join('|')", "café" },
+                // Unicode digits (Arabic-Indic) matched by \d.
+                { "'١٢٣'.find(/\\d+/).join('|')", "١٢٣" },
+                // Case-insensitive regex literal folds Unicode case (É -> é).
+                { "'Élysée'.find(/élysée/i).join('|')", "Élysée" },
+                // Split on Unicode whitespace (NBSP between b and c).
+                { "'a b\u00A0c'.split(/\\s+/).join(',')", "a,b,c" },
+                // replace() honors Unicode \w through the regex literal path.
+                { "'café'.replace(/\\w/, 'X')", "XXXX" },
+        };
+        for (String[] test : tests) {
+            parseEval(bindings, test);
+        }
+    }
+
     @Test
     public void testGetters() throws ParsingException {
         Evaluable evaluable = MetaParser.parse("grel:value + \" foo\"");


### PR DESCRIPTION
## Summary

Fixes https://github.com/OpenRefine/OpenRefine/issues/1768

Java's default regex `\w` / `\d` / `\s` are ASCII-only unless `Pattern.UNICODE_CHARACTER_CLASS` is set. GREL regex literals, `match()` with a string pattern, and the text-search facet regex mode now compile with that flag (and `UNICODE_CASE` whenever case-insensitive matching is requested), matching the approach already used in `MultiValuedCellSplitOperation`.

## Test plan

- [x] `mvn -pl modules/grel -am test -Dtest='MatchTests,GrelTests'` — Unicode `\w`/`\d`/`\s` / case-fold coverage
- [x] `mvn -pl main -am test -Dtest='TextSearchFacetTests'` — Unicode regex facet regression

Made with [Cursor](https://cursor.com)