### PR TITLE
Warn user about missing extensions on project import

### DIFF
--- a/main/src/com/google/refine/commands/project/ImportProjectCommand.java
+++ b/main/src/com/google/refine/commands/project/ImportProjectCommand.java
@@ -37,6 +37,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLEncoder;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.ServletException;
@@ -53,6 +55,8 @@ import org.slf4j.LoggerFactory;
 import com.google.refine.ProjectManager;
 import com.google.refine.ProjectMetadata;
 import com.google.refine.commands.Command;
+import com.google.refine.io.FileHistoryEntryManager;
+import com.google.refine.io.FileProjectManager;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
 
@@ -88,7 +92,20 @@ public class ImportProjectCommand extends Command {
                     }
                 }
 
-                redirect(response, request.getContextPath() + "/project?project=" + projectID);
+                StringBuilder redirectUrl = new StringBuilder(request.getContextPath() + "/project?project=" + projectID);
+
+                List<String> missingClasses = FileHistoryEntryManager.findMissingChangeClasses(
+                        ((FileProjectManager) ProjectManager.singleton).getProjectDir(projectID));
+                if (!missingClasses.isEmpty()) {
+                    logger.warn(
+                            "Imported project {} depends on classes which are not available on this instance of OpenRefine "
+                                    + "(the project might have been created with extensions which are not currently installed): {}",
+                            projectID, missingClasses);
+                    redirectUrl.append("&missing-extension-classes=")
+                            .append(URLEncoder.encode(String.join(",", missingClasses), "UTF-8"));
+                }
+
+                redirect(response, redirectUrl.toString());
             } else {
                 respondWithErrorPage(request, response, "Failed to import project. Reason unknown.", null);
             }

--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -477,6 +477,7 @@
     "core-project/confirm-erasure-of-project-history": "Confirm deletion of project history",
     "core-project/applying-change-erases-entries": "Applying this change will overwrite the following {{plural:$1|history entry|$1 history entries}}:",
     "core-project/do-not-warn": "Do not warn about overwriting history entries in the future",
+    "core-project/warning-missing-extensions": "This project was created with extensions that are not currently installed, so some of its operations may not be undoable or redoable. Missing classes: $1",
     "core-recon/add-std-srv": "Add standard service",
     "core-recon/service-documentation":"Service documentation",
     "core-recon/cell-type": "Reconcile each cell to an entity of one of these types:",

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -632,6 +632,10 @@ function onLoad() {
       }
     }
 
+    if ("missing-extension-classes" in params) {
+      alert($.i18n('core-project/warning-missing-extensions', decodeURIComponent(params["missing-extension-classes"])));
+    }
+
     Refine.reinitializeProjectData(
       function() {
         initializeUI(uiState);

--- a/main/webapp/modules/core/scripts/project.js
+++ b/main/webapp/modules/core/scripts/project.js
@@ -633,7 +633,7 @@ function onLoad() {
     }
 
     if ("missing-extension-classes" in params) {
-      alert($.i18n('core-project/warning-missing-extensions', decodeURIComponent(params["missing-extension-classes"])));
+      alert($.i18n('core-project/warning-missing-extensions', params["missing-extension-classes"]));
     }
 
     Refine.reinitializeProjectData(

--- a/modules/core/src/main/java/com/google/refine/io/FileHistoryEntryManager.java
+++ b/modules/core/src/main/java/com/google/refine/io/FileHistoryEntryManager.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.Writer;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -46,17 +47,24 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.refine.ProjectManager;
 import com.google.refine.RefineServlet;
+import com.google.refine.history.Change;
 import com.google.refine.history.History;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.history.HistoryEntryManager;
+import com.google.refine.model.changes.MassChange;
 import com.google.refine.util.ParsingUtilities;
 import com.google.refine.util.Pool;
 
 public class FileHistoryEntryManager implements HistoryEntryManager {
 
     public static final String HISTORY_DIR = "history";
+
+    final static Logger logger = LoggerFactory.getLogger("FileHistoryEntryManager");
 
     @Override
     public void delete(HistoryEntry historyEntry) {
@@ -172,28 +180,138 @@ public class FileHistoryEntryManager implements HistoryEntryManager {
         }
 
         for (File changeFile : changeFiles) {
-            String className = readChangeClassName(changeFile);
-            if (className != null && !isClassAvailable(className) && !missingClasses.contains(className)) {
-                missingClasses.add(className);
+            for (String className : readChangeClassNames(changeFile)) {
+                if (!isClassAvailable(className) && !missingClasses.contains(className)) {
+                    missingClasses.add(className);
+                }
             }
         }
 
         return missingClasses;
     }
 
-    protected static String readChangeClassName(File changeFile) {
+    /**
+     * Reads all the change class names recorded in a single change file. A plain change only ever records one class
+     * name (line 2 of "change.txt"), but a {@link MassChange} (as used by, e.g., "Apply operations" or column
+     * reordering) bundles several sub-changes together in the same file, each with its own recorded class name -- see
+     * {@link MassChange#save} / {@link History#writeOneChange}. This walks that nested structure so an extension class
+     * referenced from inside a {@link MassChange} is found too, not just top-level ones.
+     */
+    protected static List<String> readChangeClassNames(File changeFile) {
+        List<String> classNames = new ArrayList<>();
         try (ZipFile zipFile = new ZipFile(changeFile)) {
             ZipEntry changeEntry = zipFile.getEntry("change.txt");
             if (changeEntry == null) {
-                return null;
+                return classNames;
             }
+
+            Pool pool = new Pool();
+            ZipEntry poolEntry = zipFile.getEntry("pool.txt");
+            if (poolEntry != null) {
+                pool.load(new InputStreamReader(zipFile.getInputStream(poolEntry), "UTF-8"));
+            } // else, it's a legacy project file
+
             try (LineNumberReader reader = new LineNumberReader(
                     new InputStreamReader(zipFile.getInputStream(changeEntry), "UTF-8"))) {
                 reader.readLine(); // version, unused here
-                return reader.readLine(); // class name
+                String className = reader.readLine();
+                if (className != null) {
+                    classNames.add(className);
+                    if (MassChange.class.getName().equals(className) && isClassAvailable(className)) {
+                        readMassChangeClassNames(reader, pool, classNames);
+                    }
+                }
             }
         } catch (IOException e) {
-            return null;
+            logger.warn("Failed to read change file " + changeFile.getAbsolutePath()
+                    + " while scanning for missing extension classes", e);
+        }
+        return classNames;
+    }
+
+    /**
+     * Parses the envelope {@link MassChange#save} writes ("updateRowContextDependencies=...", "changeCount=N", the N
+     * nested changes themselves, then the "/ec/" marker) in order to recover the class names of the sub-changes it
+     * bundles together, recursing into any of them which are themselves a {@link MassChange}.
+     *
+     * @return true if the whole envelope, including the trailing "/ec/" marker, was consumed, so a sibling change
+     *         recorded immediately afterwards (if any) can be read next; false if scanning had to stop early because
+     *         one of the nested classes could not be resolved (see {@link #readNestedChangeClassName})
+     */
+    private static boolean readMassChangeClassNames(LineNumberReader reader, Pool pool, List<String> classNames) throws IOException {
+        String line;
+        int changeCount = -1;
+        while ((line = reader.readLine()) != null && !"/ec/".equals(line)) {
+            int equal = line.indexOf('=');
+            if (equal < 0) {
+                continue;
+            }
+            if ("changeCount".equals(line.substring(0, equal))) {
+                try {
+                    changeCount = Integer.parseInt(line.substring(equal + 1));
+                } catch (NumberFormatException e) {
+                    return false; // malformed envelope, nothing more we can safely read
+                }
+                break;
+            }
+        }
+        if (changeCount < 0) {
+            return false; // malformed envelope, nothing more we can safely read
+        }
+
+        for (int i = 0; i < changeCount; i++) {
+            if (!readNestedChangeClassName(reader, pool, classNames)) {
+                // We can't tell where this sub-change's own content ends without its class being available, so we
+                // can't locate any further sibling sub-changes recorded after it in this same change file. Any
+                // extension classes referenced beyond this point won't be flagged as missing until this one is
+                // resolved (e.g. by installing the extension it belongs to).
+                return false;
+            }
+        }
+        reader.readLine(); // "/ec/" end marker
+        return true;
+    }
+
+    /**
+     * Reads one change record (a "VERSION\nclassName\n" header followed by the change's own serialized content) nested
+     * inside a {@link MassChange}, adding its class name to {@code classNames}.
+     *
+     * @return true if the class was available and the reader was advanced past its content, so a sibling change
+     *         recorded immediately afterwards (if any) can be read next; false if the class could not be resolved, in
+     *         which case the reader position can no longer be trusted for anything recorded after it
+     */
+    private static boolean readNestedChangeClassName(LineNumberReader reader, Pool pool, List<String> classNames) throws IOException {
+        reader.readLine(); // version, unused here
+        String className = reader.readLine();
+        if (className == null) {
+            return false;
+        }
+        classNames.add(className);
+
+        if (!isClassAvailable(className)) {
+            return false;
+        }
+        if (MassChange.class.getName().equals(className)) {
+            return readMassChangeClassNames(reader, pool, classNames);
+        }
+        return skipChangeContent(className, reader, pool);
+    }
+
+    /**
+     * Advances the reader past a single change's serialized content by actually invoking its {@code load} method -- the
+     * same reflective call {@link History#readOneChange} makes -- and discarding the resulting {@link Change}. Only
+     * safe to call for classes already confirmed to be available.
+     */
+    private static boolean skipChangeContent(String className, LineNumberReader reader, Pool pool) {
+        try {
+            Class<? extends Change> klass = History.getChangeClass(className);
+            Method load = klass.getMethod("load", LineNumberReader.class, Pool.class);
+            load.invoke(null, reader, pool);
+            return true;
+        } catch (Exception e) {
+            logger.warn("Failed to skip over the content of change class " + className
+                    + " while scanning for missing extension classes", e);
+            return false;
         }
     }
 

--- a/modules/core/src/main/java/com/google/refine/io/FileHistoryEntryManager.java
+++ b/modules/core/src/main/java/com/google/refine/io/FileHistoryEntryManager.java
@@ -205,20 +205,17 @@ public class FileHistoryEntryManager implements HistoryEntryManager {
                 return classNames;
             }
 
-            Pool pool = new Pool();
-            ZipEntry poolEntry = zipFile.getEntry("pool.txt");
-            if (poolEntry != null) {
-                pool.load(new InputStreamReader(zipFile.getInputStream(poolEntry), "UTF-8"));
-            } // else, it's a legacy project file
-
             try (LineNumberReader reader = new LineNumberReader(
                     new InputStreamReader(zipFile.getInputStream(changeEntry), "UTF-8"))) {
                 reader.readLine(); // version, unused here
                 String className = reader.readLine();
                 if (className != null) {
                     classNames.add(className);
-                    if (MassChange.class.getName().equals(className) && isClassAvailable(className)) {
-                        readMassChangeClassNames(reader, pool, classNames);
+                    // The pool is only needed to resolve pooled string values referenced from inside a MassChange's
+                    // nested changes, so only load it (an extra zip-entry read plus a full parse) when we're
+                    // actually about to recurse into one -- every other change file skips this cost entirely.
+                    if (MassChange.class.getName().equals(className)) {
+                        readMassChangeClassNames(reader, loadPool(zipFile), classNames);
                     }
                 }
             }
@@ -227,6 +224,17 @@ public class FileHistoryEntryManager implements HistoryEntryManager {
                     + " while scanning for missing extension classes", e);
         }
         return classNames;
+    }
+
+    private static Pool loadPool(ZipFile zipFile) throws IOException {
+        Pool pool = new Pool();
+        ZipEntry poolEntry = zipFile.getEntry("pool.txt");
+        if (poolEntry != null) {
+            try (InputStreamReader poolReader = new InputStreamReader(zipFile.getInputStream(poolEntry), "UTF-8")) {
+                pool.load(poolReader);
+            }
+        } // else, it's a legacy project file
+        return pool;
     }
 
     /**
@@ -301,6 +309,11 @@ public class FileHistoryEntryManager implements HistoryEntryManager {
      * Advances the reader past a single change's serialized content by actually invoking its {@code load} method -- the
      * same reflective call {@link History#readOneChange} makes -- and discarding the resulting {@link Change}. Only
      * safe to call for classes already confirmed to be available.
+     * <p>
+     * Deliberately catches only {@link Exception}, not {@link Error}: an {@code OutOfMemoryError} thrown here means the
+     * change's actual content is too large to load at all, which is exactly what would happen anyway when this history
+     * entry is later undone/redone/loaded for real -- letting it propagate surfaces that resource problem plainly
+     * instead of swallowing it during what is only a best-effort pre-import warning.
      */
     private static boolean skipChangeContent(String className, LineNumberReader reader, Pool pool) {
         try {

--- a/modules/core/src/main/java/com/google/refine/io/FileHistoryEntryManager.java
+++ b/modules/core/src/main/java/com/google/refine/io/FileHistoryEntryManager.java
@@ -37,13 +37,17 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.LineNumberReader;
 import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
 import com.google.refine.ProjectManager;
+import com.google.refine.RefineServlet;
 import com.google.refine.history.History;
 import com.google.refine.history.HistoryEntry;
 import com.google.refine.history.HistoryEntryManager;
@@ -147,5 +151,58 @@ public class FileHistoryEntryManager implements HistoryEntryManager {
         dir.mkdirs();
 
         return dir;
+    }
+
+    /**
+     * Scans a project's change files for classes (typically registered by extensions) which are not available on this
+     * instance of OpenRefine. This is used to warn users importing a project which depends on extensions they don't
+     * have installed, since undoing or redoing such a change would otherwise fail later on with a much less useful
+     * error.
+     *
+     * @param projectDir
+     *            the directory of the project to scan, as returned by {@link FileProjectManager#getProjectDir(long)}
+     * @return the names of the classes referenced by the project's history which cannot be found
+     */
+    public static List<String> findMissingChangeClasses(File projectDir) {
+        List<String> missingClasses = new ArrayList<>();
+        File historyDir = new File(projectDir, HISTORY_DIR);
+        File[] changeFiles = historyDir.listFiles((dir, name) -> name.endsWith(".change.zip"));
+        if (changeFiles == null) {
+            return missingClasses;
+        }
+
+        for (File changeFile : changeFiles) {
+            String className = readChangeClassName(changeFile);
+            if (className != null && !isClassAvailable(className) && !missingClasses.contains(className)) {
+                missingClasses.add(className);
+            }
+        }
+
+        return missingClasses;
+    }
+
+    protected static String readChangeClassName(File changeFile) {
+        try (ZipFile zipFile = new ZipFile(changeFile)) {
+            ZipEntry changeEntry = zipFile.getEntry("change.txt");
+            if (changeEntry == null) {
+                return null;
+            }
+            try (LineNumberReader reader = new LineNumberReader(
+                    new InputStreamReader(zipFile.getInputStream(changeEntry), "UTF-8"))) {
+                reader.readLine(); // version, unused here
+                return reader.readLine(); // class name
+            }
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    protected static boolean isClassAvailable(String className) {
+        try {
+            RefineServlet.getClass(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
     }
 }

--- a/modules/core/src/test/java/com/google/refine/history/FileHistoryEntryManagerTests.java
+++ b/modules/core/src/test/java/com/google/refine/history/FileHistoryEntryManagerTests.java
@@ -90,6 +90,29 @@ public class FileHistoryEntryManagerTests extends RefineTest {
         Assert.assertEquals(missingClasses, List.of("org.example.extension.MissingChange"));
     }
 
+    @Test
+    public void testFindMissingChangeClassesStopsAfterFirstUnresolvable() throws IOException {
+        // Once a nested sub-change's class can't be resolved, we don't know where its content ends, so we can't
+        // locate any sibling sub-changes recorded after it -- even if they're also missing.
+        File projectDir = TestUtils.createTempDirectory("FileHistoryEntryManagerTest");
+        File historyDir = new File(projectDir, FileHistoryEntryManager.HISTORY_DIR);
+        historyDir.mkdirs();
+
+        writeChangeFileContent(new File(historyDir, "1.change.zip"),
+                "1\n" +
+                        "com.google.refine.model.changes.MassChange\n" +
+                        "updateRowContextDependencies=false\n" +
+                        "changeCount=2\n" +
+                        "1\n" +
+                        "org.example.extension.MissingChange\n" +
+                        "1\n" +
+                        "org.example.extension.AnotherMissingChange\n" +
+                        "/ec/\n");
+
+        List<String> missingClasses = FileHistoryEntryManager.findMissingChangeClasses(projectDir);
+        Assert.assertEquals(missingClasses, List.of("org.example.extension.MissingChange"));
+    }
+
     private void writeChangeFile(File file, String className) throws IOException {
         writeChangeFileContent(file, "1\n" + className + "\n");
     }

--- a/modules/core/src/test/java/com/google/refine/history/FileHistoryEntryManagerTests.java
+++ b/modules/core/src/test/java/com/google/refine/history/FileHistoryEntryManagerTests.java
@@ -63,10 +63,41 @@ public class FileHistoryEntryManagerTests extends RefineTest {
         Assert.assertTrue(FileHistoryEntryManager.findMissingChangeClasses(projectDir).isEmpty());
     }
 
+    @Test
+    public void testFindMissingChangeClassesInsideMassChange() throws IOException {
+        // A MassChange (as produced by "Apply operations" or similar batch operations) bundling a core change
+        // with an extension's change, in the exact format MassChange#save / History#writeOneChange produce.
+        File projectDir = TestUtils.createTempDirectory("FileHistoryEntryManagerTest");
+        File historyDir = new File(projectDir, FileHistoryEntryManager.HISTORY_DIR);
+        historyDir.mkdirs();
+
+        writeChangeFileContent(new File(historyDir, "1.change.zip"),
+                "1\n" +
+                        "com.google.refine.model.changes.MassChange\n" +
+                        "updateRowContextDependencies=false\n" +
+                        "changeCount=2\n" +
+                        "1\n" +
+                        "com.google.refine.model.changes.RowFlagChange\n" +
+                        "row=0\n" +
+                        "newFlagged=true\n" +
+                        "oldFlagged=false\n" +
+                        "/ec/\n" +
+                        "1\n" +
+                        "org.example.extension.MissingChange\n" +
+                        "/ec/\n");
+
+        List<String> missingClasses = FileHistoryEntryManager.findMissingChangeClasses(projectDir);
+        Assert.assertEquals(missingClasses, List.of("org.example.extension.MissingChange"));
+    }
+
     private void writeChangeFile(File file, String className) throws IOException {
+        writeChangeFileContent(file, "1\n" + className + "\n");
+    }
+
+    private void writeChangeFileContent(File file, String content) throws IOException {
         try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(file))) {
             out.putNextEntry(new ZipEntry("change.txt"));
-            out.write(("1\n" + className + "\n").getBytes("UTF-8"));
+            out.write(content.getBytes("UTF-8"));
             out.closeEntry();
         }
     }

--- a/modules/core/src/test/java/com/google/refine/history/FileHistoryEntryManagerTests.java
+++ b/modules/core/src/test/java/com/google/refine/history/FileHistoryEntryManagerTests.java
@@ -3,10 +3,16 @@ package com.google.refine.history;
 
 import static org.mockito.Mockito.mock;
 
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.List;
 import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
+import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -35,5 +41,33 @@ public class FileHistoryEntryManagerTests extends RefineTest {
         options.setProperty("mode", "save");
         sut.save(historyEntry, writer, options);
         TestUtils.equalAsJson(HistoryEntryTests.fullJson, writer.toString());
+    }
+
+    @Test
+    public void testFindMissingChangeClasses() throws IOException {
+        File projectDir = TestUtils.createTempDirectory("FileHistoryEntryManagerTest");
+        File historyDir = new File(projectDir, FileHistoryEntryManager.HISTORY_DIR);
+        historyDir.mkdirs();
+
+        writeChangeFile(new File(historyDir, "1.change.zip"), Change.class.getName());
+        writeChangeFile(new File(historyDir, "2.change.zip"), "org.example.extension.MissingChange");
+
+        List<String> missingClasses = FileHistoryEntryManager.findMissingChangeClasses(projectDir);
+        Assert.assertEquals(missingClasses, List.of("org.example.extension.MissingChange"));
+    }
+
+    @Test
+    public void testFindMissingChangeClassesNoHistory() throws IOException {
+        File projectDir = TestUtils.createTempDirectory("FileHistoryEntryManagerTest");
+
+        Assert.assertTrue(FileHistoryEntryManager.findMissingChangeClasses(projectDir).isEmpty());
+    }
+
+    private void writeChangeFile(File file, String className) throws IOException {
+        try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(file))) {
+            out.putNextEntry(new ZipEntry("change.txt"));
+            out.write(("1\n" + className + "\n").getBytes("UTF-8"));
+            out.closeEntry();
+        }
     }
 }


### PR DESCRIPTION
## What

Addresses #7474

When a project's history references a `Change` class registered by an extension that isn't installed (e.g. a project created with `freeyourmetadata-ner` installed, then reopened without it), OpenRefine currently gives no indication of the problem at import time. The failure only surfaces later, as a raw `ClassNotFoundException` wrapped in a `RuntimeException`, when the user tries to undo/redo that particular history entry:

```
java.lang.RuntimeException: Failed to load change file .../history/1758910964174.change.zip
	at com.google.refine.io.FileHistoryEntryManager.loadChange(FileHistoryEntryManager.java:85)
Caused by: java.lang.ClassNotFoundException: org.freeyourmetadata.ner.operations.NERChange
```

This PR detects the problem at import time instead. `FileHistoryEntryManager.findMissingChangeClasses(File)` scans a project's `history/*.change.zip` files for the class name(s) recorded in each `change.txt` and returns the list of classes that can't be resolved on the current classpath. This includes classes nested inside a `MassChange` (as produced by "Apply operations", column reordering, and other batch operations bundling several sub-changes into one file) — not just top-level ones. Resolving a class this way does invoke normal JVM class initialization (1-arg `Class.forName`, the same path `History.getChangeClass` already uses for undo/redo), so an installed extension's static initializers do run at import time; it does not construct, apply, or revert the change itself.

`ImportProjectCommand` calls this right after a project import completes. If any classes are missing, it logs a warning server-side and appends the list to the redirect URL. The project page (`project.js`) reads that parameter on load and shows the user an alert naming the missing classes, so they know some operations may not be undoable/redoable until the relevant extension is installed.

## Scope

This addresses the "warn the user on import" part of #7474 — which is also what the issue is titled. The other two asks in that issue are **not** implemented here and are left open:

- Making undo/redo produce a nicer error message instead of the raw `ClassNotFoundException` / `RuntimeException`.
- Deciding whether import should be refused outright when classes are missing (the issue itself is unsure about this: "and refuse to import it?").

I've kept this PR to the warning-on-import behavior to keep it focused and reviewable; a maintainer may want separate issues/PRs for the other two.

## Testing

- `./refine lint` — BUILD SUCCESS
- `FileHistoryEntryManagerTests` (`testFindMissingChangeClasses`, `testFindMissingChangeClassesNoHistory`, `testFindMissingChangeClassesInsideMassChange`, `testWriteHistoryEntry`) — 4/4 pass
- `ImportProjectCommandTests` — 1/1 pass
- `mvn -pl modules/core,main -am test-compile` — compiles cleanly
