### PR TITLE
fix: delete webapp/WEB-INF/classes on clean (#6745)

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -124,6 +124,9 @@
             <fileset>
               <directory>webapp/WEB-INF/lib</directory>
             </fileset>
+            <fileset>
+              <directory>webapp/WEB-INF/classes</directory>
+            </fileset>
           </filesets>
         </configuration>
       </plugin>


### PR DESCRIPTION
Fixes #6745

Changes proposed in this pull request:
- Configure `maven-clean-plugin` in `main/pom.xml` to include `webapp/WEB-INF/classes` in the filesets to be deleted on `mvn clean`.
- Ensures stale property files such as `OperationDescription.properties` output to `main/webapp/WEB-INF/classes` during IDE builds (e.g., IntelliJ) are properly cleaned up when executing `./refine clean` / `mvn clean`.