### PR TITLE
Fix NullPointerException in FileNameScrutinizer when previewing MediaInfo SDC-only schema

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizer.java
@@ -70,7 +70,7 @@ public class FileNameScrutinizer extends EditScrutinizer {
             return;
         }
 
-        if (edit.isMatched() && !edit.getFilePath().isEmpty()) {
+        if (edit.isMatched() && edit.getFilePath() != null && !edit.getFilePath().isEmpty()) {
             String normalizedFileName = normalizeFileNameSpaces(fileName);
             matchedFileNames.add(normalizedFileName);
             QAWarning issue = new QAWarning(uploadNewFileVersionType, null,

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/qa/scrutinizers/FileNameScrutinizerTest.java
@@ -241,4 +241,16 @@ public class FileNameScrutinizerTest extends ScrutinizerTest {
 
         assertWarningsRaised(FileNameScrutinizer.uploadNewFileVersionType);
     }
+
+    @Test
+    public void testMatchedMediaInfoWithoutFilePath() {
+        MediaInfoEdit edit = new MediaInfoEditBuilder(TestingData.matchedMid)
+                .addFileName("Matched.png")
+                .addContributingRowId(123)
+                .build();
+
+        scrutinize(edit);
+
+        assertNoWarningRaised();
+    }
 }


### PR DESCRIPTION
Fixes #7808

Changes proposed in this pull request:
- Add null check for `edit.getFilePath()` in `FileNameScrutinizer` before checking `.isEmpty()`.
- Prevent `NullPointerException` when previewing MediaInfo schema edits on existing Wikimedia Commons files without a local file upload.
- Add unit test `testMatchedMediaInfoWithoutFilePath` in `FileNameScrutinizerTest` to cover matched MediaInfo edits with a null file path.

