### PR TITLE
Fix SchemaExporter to throw ExporterException when Wikibase schema is missing

### DIFF
--- a/extensions/wikibase/src/org/openrefine/wikibase/exporters/SchemaExporter.java
+++ b/extensions/wikibase/src/org/openrefine/wikibase/exporters/SchemaExporter.java
@@ -6,6 +6,7 @@ import java.io.Writer;
 import java.util.Properties;
 
 import com.google.refine.browsing.Engine;
+import com.google.refine.exporters.ExporterException;
 import com.google.refine.exporters.WriterExporter;
 import com.google.refine.model.Project;
 import com.google.refine.util.ParsingUtilities;
@@ -13,6 +14,8 @@ import com.google.refine.util.ParsingUtilities;
 import org.openrefine.wikibase.schema.WikibaseSchema;
 
 public class SchemaExporter implements WriterExporter {
+
+    public static final String noSchemaErrorMessage = "No schema was provided. You need to align your project with Wikibase first.";
 
     @Override
     public String getContentType() {
@@ -23,7 +26,7 @@ public class SchemaExporter implements WriterExporter {
     public void export(Project project, Properties options, Engine engine, Writer writer) throws IOException {
         WikibaseSchema schema = (WikibaseSchema) project.overlayModels.get("wikibaseSchema");
         if (schema == null) {
-            schema = new WikibaseSchema();
+            throw new ExporterException(noSchemaErrorMessage);
         }
         ParsingUtilities.mapper.writeValue(writer, schema);
     }

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/SchemaExporterTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/exporters/SchemaExporterTest.java
@@ -1,6 +1,8 @@
 
 package org.openrefine.wikibase.exporters;
 
+import static org.testng.Assert.assertThrows;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringWriter;
@@ -9,8 +11,8 @@ import java.util.Properties;
 import org.testng.annotations.Test;
 
 import com.google.refine.browsing.Engine;
+import com.google.refine.exporters.ExporterException;
 import com.google.refine.model.Project;
-import com.google.refine.util.TestUtils;
 
 import org.openrefine.wikibase.testing.WikidataRefineTest;
 
@@ -19,9 +21,7 @@ public class SchemaExporterTest extends WikidataRefineTest {
     private SchemaExporter exporter = new SchemaExporter();
 
     @Test
-    public void testNoSchema()
-            throws IOException {
-        // TODO instead of returning an empty (and invalid) schema, we should just return an error
+    public void testNoSchema() throws IOException {
         Project project = this.createProject(
                 new String[] { "a", "b" },
                 new Serializable[][] {
@@ -30,9 +30,7 @@ public class SchemaExporterTest extends WikidataRefineTest {
         Engine engine = new Engine(project);
         StringWriter writer = new StringWriter();
         Properties properties = new Properties();
-        exporter.export(project, properties, engine, writer);
-        TestUtils.assertEqualsAsJson(writer.toString(),
-                "{\"entityEdits\":[],\"siteIri\":null,\"mediaWikiApiEndpoint\":null,\"entityTypeSiteIRI\":{}}");
+        assertThrows(ExporterException.class, () -> exporter.export(project, properties, engine, writer));
     }
 
 }


### PR DESCRIPTION
Fixes #7872
Changes proposed in this pull request:
- Update `SchemaExporter` to throw `ExporterException` when no Wikibase schema is configured for a project, matching standard exporter error handling.
- Prevent `SchemaExporter` from outputting an invalid JSON schema payload containing null fields when an unconfigured schema is exported.
- Update `SchemaExporterTest` to assert that `ExporterException` is thrown when exporting a project without a Wikibase schema.
