### PR TITLE
Make reconciliation stop words configurable via preferences (fixes #<…

### DIFF
--- a/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
+++ b/modules/core/src/main/java/com/google/refine/model/recon/StandardReconConfig.java
@@ -61,6 +61,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.refine.ProjectManager;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.model.Cell;
 import com.google.refine.model.Project;
@@ -70,6 +71,7 @@ import com.google.refine.model.ReconCandidate;
 import com.google.refine.model.ReconType;
 import com.google.refine.model.RecordModel.RowDependency;
 import com.google.refine.model.Row;
+import com.google.refine.preference.PreferenceStore;
 import com.google.refine.util.HttpClient;
 import com.google.refine.util.ParsingUtilities;
 
@@ -739,17 +741,27 @@ public class StandardReconConfig extends ReconConfig {
         return common / longWords.size();
     }
 
-    static final protected Set<String> s_stopWords = new HashSet<String>();
-    static {
-        // FIXME: This is English specific - needs i18n
-        s_stopWords.add("the");
-        s_stopWords.add("a");
-        s_stopWords.add("and");
-        s_stopWords.add("of");
-        s_stopWords.add("on");
-        s_stopWords.add("in");
-        s_stopWords.add("at");
-        s_stopWords.add("by");
+    protected static Set<String> getStopWords() {
+
+        PreferenceStore ps = ProjectManager.singleton.getPreferenceStore();
+
+        Object pref = ps.get("stopwords");
+
+        String stopWords = pref == null
+                ? "the,a,and,of,on,in,at,by"
+                : pref.toString();
+
+        String[] words = stopWords.split(",");
+
+        Set<String> stopWordSet = new HashSet<>();
+
+        for (String word : words) {
+            String trimmed = word.trim();
+            if (!trimmed.isEmpty()) {
+                stopWordSet.add(trimmed.toLowerCase());
+            }
+        }
+        return stopWordSet;
     }
 
     static protected Set<String> breakWords(String s) {
@@ -757,8 +769,10 @@ public class StandardReconConfig extends ReconConfig {
         String[] words = s.toLowerCase().split("\\s+");
 
         Set<String> set = new HashSet<String>(words.length);
+        Set<String> stopWords = getStopWords();
+
         for (String word : words) {
-            if (!s_stopWords.contains(word)) {
+            if (!stopWords.contains(word)){
                 set.add(word);
             }
         }

--- a/modules/core/src/test/java/com/google/refine/model/recon/StandardReconConfigTests.java
+++ b/modules/core/src/test/java/com/google/refine/model/recon/StandardReconConfigTests.java
@@ -50,10 +50,12 @@ import mockwebserver3.SocketEffect;
 import okhttp3.HttpUrl;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import com.google.refine.ProjectManager;
 import com.google.refine.RefineTest;
 import com.google.refine.model.Project;
 import com.google.refine.model.Recon;
@@ -676,5 +678,71 @@ public class StandardReconConfigTests extends RefineTest {
         Recon recon = stub.createNewRecon(2384738L);
         stub.computeFeatures(recon, null);
         assertNotNull(recon.features);
+    }
+
+    @AfterMethod
+    public void resetStopWordsPreference() {
+        ProjectManager.singleton.getPreferenceStore().put("stopwords", null);
+    }
+
+    @Test
+    public void testBreakWordsUsesDefaultStopWordsWhenPreferenceUnset() {
+        ProjectManager.singleton.getPreferenceStore().put("stopwords", null);
+
+        Set<String> result = StandardReconConfig.breakWords("The quick fox jumps on the log");
+
+        assertTrue(!result.contains("the"));
+        assertTrue(!result.contains("on"));
+        assertTrue(result.contains("quick"));
+        assertTrue(result.contains("fox"));
+        assertTrue(result.contains("jumps"));
+        assertTrue(result.contains("log"));
+    }
+
+    @Test
+    public void testBreakWordsUsesCustomPreference() {
+        ProjectManager.singleton.getPreferenceStore().put("stopwords", " le , la , et ");
+
+        Set<String> result = StandardReconConfig.breakWords("Le chat et la souris");
+
+        assertTrue(result.contains("chat"));
+        assertTrue(result.contains("souris"));
+
+        assertTrue(!result.contains("le"));
+        assertTrue(!result.contains("et"));
+        assertTrue(!result.contains("la"));
+    }
+
+    @Test
+    public void testGetStopWordsIsCaseInsensitiveToPreference() {
+        ProjectManager.singleton.getPreferenceStore().put("stopwords", "The,A,And,Of");
+
+        Set<String> stopWords = StandardReconConfig.getStopWords();
+
+        assertTrue(stopWords.contains("the"));
+        assertTrue(stopWords.contains("a"));
+        assertTrue(stopWords.contains("and"));
+        assertTrue(stopWords.contains("of"));
+    }
+
+    @Test
+    public void testGetStopWordsTrimsWhitespace() {
+        ProjectManager.singleton.getPreferenceStore().put("stopwords", " the , a , and ");
+
+        Set<String> stopWords = StandardReconConfig.getStopWords();
+
+        assertEquals(stopWords.size(), 3);
+        assertTrue(stopWords.contains("the"));
+        assertTrue(stopWords.contains("a"));
+        assertTrue(stopWords.contains("and"));
+    }
+
+    @Test
+    public void testGetStopWordsHandlesEmptyPreference() {
+        ProjectManager.singleton.getPreferenceStore().put("stopwords", "");
+
+        Set<String> stopWords = StandardReconConfig.getStopWords();
+
+        assertTrue(stopWords.isEmpty());
     }
 }


### PR DESCRIPTION
Fixes #7330

Changes proposed in this pull request:
- Added a "stopwords" preference (default: "the,a,and,of,on,in,at,by") so the reconciliation stop word list is no longer hardcoded and English-only
- Modified StandardReconConfig to read this preference, split on commas, trim whitespace, and lowercase each entry before building the stop word set
- Added unit tests in StandardReconConfigTests covering default, custom, case-insensitive, and empty preference scenarios
