### PR TITLE
Make sure default profile is always active

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -42,7 +42,10 @@
     <profile>
       <id>default</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <!-- Always active unless explicitly disabled -->
+          <name>!skipDefaultProfile</name>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -42,10 +42,7 @@
     <profile>
       <id>default</id>
       <activation>
-        <property>
-          <!-- Always active unless explicitly disabled -->
-          <name>!skipDefaultProfile</name>
-        </property>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>


### PR DESCRIPTION
Refs #7886

Changes proposed in this pull request:
- Keep default profile active even if we are notarizing
