### PR TITLE
Localize the Actions column header in the preferences table

### DIFF
--- a/main/webapp/modules/core/langs/translation-en.json
+++ b/main/webapp/modules/core/langs/translation-en.json
@@ -21,6 +21,7 @@
     "core-index/preferences": "Preferences",
     "core-index/key": "Key",
     "core-index/value": "Value",
+    "core-index/actions": "Actions",
     "core-index/add-pref": "Add preference",
     "core-index/pref-key": "Preference key value:",
     "core-index/prefs-loading-failed": "Failed to load the preferences.",

--- a/main/webapp/modules/core/scripts/preferences.js
+++ b/main/webapp/modules/core/scripts/preferences.js
@@ -123,7 +123,7 @@ function populatePreferences(prefs) {
   var table = $('<table>')
   .addClass("list-table")
   .addClass("preferences")
-  .html('<tr><th>'+$.i18n('core-index/key')+'</th><th>'+$.i18n('core-index/value')+'</th><th>Actions</th></tr>')
+  .html('<tr><th>'+$.i18n('core-index/key')+'</th><th>'+$.i18n('core-index/value')+'</th><th>'+$.i18n('core-index/actions')+'</th></tr>')
   .appendTo(body)[0];
 
   for (var k in prefs) {


### PR DESCRIPTION
This is part of the remaining work on #1858: some UI text still bypasses the i18n library and stays hardcoded in English regardless of the user's locale.

In the preferences table (`main/webapp/modules/core/scripts/preferences.js`), the "Key" and "Value" column headers go through `$.i18n`, but the "Actions" header is a plain English string literal. That means it never gets translated even when the rest of the page is localized.

Added a `core-index/actions` key to `translation-en.json` and used it in `preferences.js` for the third header, following the same pattern already used for the other two.

## Testing

This is a small frontend-only change to a static JS file. I verified `translation-en.json` still parses as valid JSON and checked the diff is limited to this one header. I didn't build the full Java backend for this, since the change doesn't touch any server-side code, but I'm happy to run a fuller build if a maintainer wants me to.