### PR TITLE
Fix NPE when log4j initializes. Fixes #7902

### DIFF
--- a/extensions/database/tests/log4j-test.properties
+++ b/extensions/database/tests/log4j-test.properties
@@ -2,4 +2,4 @@ log4j.rootLogger=ERROR, console
 log4j.logger.com.google.refine.extension.database=DEBUG
 
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=com.google.refine.logging.IndentingLayout
+log4j.appender.console.layout=com.google.util.logging.IndentingLayout

--- a/extensions/jython/tests/src/tests.log4j.properties
+++ b/extensions/jython/tests/src/tests.log4j.properties
@@ -1,4 +1,4 @@
 log4j.rootLogger=ERROR, console
 
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=com.google.refine.logging.IndentingLayout
+log4j.appender.console.layout=com.google.util.logging.IndentingLayout

--- a/extensions/wikibase/tests/src/tests.log4j.properties
+++ b/extensions/wikibase/tests/src/tests.log4j.properties
@@ -1,4 +1,4 @@
 log4j.rootLogger=ERROR, console
 
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=com.google.refine.logging.IndentingLayout
+log4j.appender.console.layout=com.google.util.logging.IndentingLayout

--- a/main/tests/server/src/tests.log4j.properties
+++ b/main/tests/server/src/tests.log4j.properties
@@ -27,4 +27,4 @@
 log4j.rootLogger=ERROR, console
 
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=com.google.refine.logging.IndentingLayout
+log4j.appender.console.layout=com.google.util.logging.IndentingLayout

--- a/server/src/com/google/util/logging/IndentingLayout.java
+++ b/server/src/com/google/util/logging/IndentingLayout.java
@@ -38,7 +38,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Node;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
@@ -51,7 +50,7 @@ import org.apache.logging.log4j.core.layout.AbstractStringLayout;
  * accordingly. This is very useful to visually inspect a debug log and see what calls what. An example of logs are
  * "&gt; method()" and "&lt; method()" where &gt; and &lt; are used to indicate respectively "entering" and "exiting".
  */
-@Plugin(name = "IndentingLayout", elementType = Layout.ELEMENT_TYPE, category = Node.CATEGORY, printObject = true)
+@Plugin(name = "IndentingLayout", category = Node.CATEGORY, printObject = true)
 public class IndentingLayout extends AbstractStringLayout {
 
     protected IndentingLayout(Charset charset) {

--- a/server/src/com/google/util/logging/IndentingLayout.java
+++ b/server/src/com/google/util/logging/IndentingLayout.java
@@ -81,9 +81,7 @@ public class IndentingLayout extends AbstractStringLayout {
             return message;
         }
 
-        char leader = message.charAt(0);
-        char secondLeader = message.charAt(1);
-        if ((leader == '<') && (secondLeader == ' ') && (this.indentation > 0)) {
+        if (message.startsWith("< ") && (this.indentation > 0)) {
             this.indentation--;
         }
 
@@ -128,7 +126,7 @@ public class IndentingLayout extends AbstractStringLayout {
         buf.append(delta.toMillis());
         buf.append("ms)\n");
 
-        if ((leader == '>') && (secondLeader == ' ')) {
+        if (message.startsWith("> ")) {
             indentation++;
         }
 
@@ -140,9 +138,7 @@ public class IndentingLayout extends AbstractStringLayout {
     }
 
     private void pad(StringBuilder buffer, int pads, char padchar) {
-        for (int i = 0; i < pads; i++) {
-            buffer.append(padchar);
-        }
+        buffer.repeat(String.valueOf(padchar), Math.max(0, pads));
     }
 
 }

--- a/server/src/log4j2.properties
+++ b/server/src/log4j2.properties
@@ -1,6 +1,6 @@
 status = error
 name = Log4j2PropertiesConfig
-packages = com.google.refine.logging
+packages = com.google.util.logging
  
 appenders = console
  


### PR DESCRIPTION
Fixes #7902

Changes proposed in this pull request:
- Remove the elementType parameter from the `@Plugin` annotation to prevent NPE at startup
- Correct package name in the properties files

Either of the above changes will fix the NullPointerException, but we include both just for good measure.
