### PR TITLE
Fixes #6852: format integral numbers as floating point

### DIFF
--- a/modules/grel/src/main/java/com/google/refine/expr/functions/ToString.java
+++ b/modules/grel/src/main/java/com/google/refine/expr/functions/ToString.java
@@ -60,6 +60,13 @@ public class ToString implements Function {
                     try {
                         return String.format((String) o2, o1);
                     } catch (IllegalFormatException e) {
+                        if (o1 instanceof Long || o1 instanceof Integer || o1 instanceof Short || o1 instanceof Byte) {
+                            try {
+                                return String.format((String) o2, ((Number) o1).doubleValue());
+                            } catch (IllegalFormatException e2) {
+                                return new EvalError(EvalErrorMessage.unknown_format_conversion(e2.getMessage()));
+                            }
+                        }
                         return new EvalError(EvalErrorMessage.unknown_format_conversion(e.getMessage()));
                     }
                 }

--- a/modules/grel/src/test/java/com/google/refine/expr/functions/ToStringTests.java
+++ b/modules/grel/src/test/java/com/google/refine/expr/functions/ToStringTests.java
@@ -47,6 +47,8 @@ public class ToStringTests extends GrelTestBase {
         assertEquals(invoke("toString", 100.0), "100.0");
         assertEquals(invoke("toString", 100.0, "%.0f"), "100");
         assertEquals(invoke("toString", 100.0, "%.1f"), String.format("%.1f", 100D));
+        assertEquals(invoke("toString", 1L, "%.4f"), "1.0000");
+        assertEquals(invoke("toString", 12L, "%2.2f"), "12.00");
 
         // test with other radix (2, 8, 10, 16)
         assertEquals(invoke("toString", 100L, "%x"), "64");
@@ -59,7 +61,6 @@ public class ToStringTests extends GrelTestBase {
         assertTrue(invoke("toString", 100L, "%") instanceof EvalError);
         assertTrue(invoke("toString", 100L, "%.") instanceof EvalError);
         assertTrue(invoke("toString", 100L, "%0") instanceof EvalError);
-        assertTrue(invoke("toString", 12L, "%2.2f") instanceof EvalError);
 
         // test with large number
         assertEquals(invoke("toString", 1000000000000000000L, "%d"), "1000000000000000000");


### PR DESCRIPTION
Fixes #6852.

### Summary
- Retry formatting integral values as double when the requested Java format rejects the integral type.
- Add regression coverage for %.4f and %2.2f applied to integral values.

### Testing
- Not run locally: compiling the project dependencies exceeded the available command time limit.