### PR TITLE
Update build for Java 21 changes

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -360,11 +360,6 @@
             <configuration>
               <target name="generateDMG" description="Generate DMG">
 
-                <!-- Remove man pages from JRE as they are not accessible anyway, and prevent us from codesigning -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="rm">
-                    <arg line="-r"/>
-                    <arg line="&quot;${mac.build.directory}/OpenRefine.app/Contents/PlugIns/JRE/Contents/Home/jre/man&quot;"/>
-                </exec>
                 <!-- remove JRE licenses folder, cannot be signed -->
                 <exec dir="${project.build.directory}" os="Mac OS X" executable="rm">
                     <arg line="-r"/>
@@ -401,7 +396,7 @@
                     <arg value="--timestamp"/>
                     <arg value="--options"/>
                     <arg value="runtime"/>
-                    <arg value="${mac.build.directory}/OpenRefine.app/Contents/PlugIns/JRE/Contents/Home/jre/lib/jli/libjli.dylib" />
+                    <arg value="${mac.build.directory}/OpenRefine.app/Contents/PlugIns/JRE/Contents/Home/jre/lib/libjli.dylib" />
                 </exec>
 
                 <!-- Codesign jars with native code in them -->


### PR DESCRIPTION
Followup to #7691. 

Now that the build fails on errors, we need to fix all the errors

Changes proposed in this pull request:
- no man pages in the JRE, so we don't need to delete them (non-fatal, but adds logging noise)
- libjli has moved from lib/jli/libjli to just lib/libjli (fatal build killer)

