### PR TITLE
Update formatter-maven-plugin to 2.29.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,6 @@ updates:
     interval: "weekly"
   open-pull-requests-limit: 15
   ignore:
-    - dependency-name: com.thoughtworks.xstream:xstream
-      versions:
-      - "> 1.4.12"
-      - "< 2"
     - dependency-name: "org.eclipse.jetty:jetty-*"
       versions:
         - ">= 10.0.0"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,6 @@ updates:
     - dependency-name: "org.eclipse.jetty:jetty-*"
       versions:
         - ">= 10.0.0"
-    - dependency-name: "formatter-maven-plugin"
   target-branch: "master"
    
 # For main webapp

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/editing/EditBatchProcessorTest.java
@@ -367,7 +367,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
                     Collections.emptyMap(),
                     Datamodel.makeStatementUpdate(Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
                     Collections.emptyList(), Collections.emptyList()), false, summary, tags))
-                            .thenReturn(new EditingResult(revId));
+                    .thenReturn(new EditingResult(revId));
             revId++;
         }
 
@@ -427,7 +427,7 @@ public class EditBatchProcessorTest extends WikidataRefineTest {
                     Collections.emptyList());
             when(editor.editEntityDocument(Datamodel.makeMediaInfoUpdate((MediaInfoIdValue) doc.getEntityId(),
                     doc.getRevisionId(), labelsUpdate, statementUpdate), false, summary, tags))
-                            .thenReturn(new EditingResult(revId));
+                    .thenReturn(new EditingResult(revId));
             revId++;
         }
 

--- a/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/MediaInfoEditTest.java
+++ b/extensions/wikibase/tests/src/org/openrefine/wikibase/updates/MediaInfoEditTest.java
@@ -158,7 +158,7 @@ public class MediaInfoEditTest {
                 .thenReturn(mid);
         when(mediaFileUtils.uploadRemoteFile(new URL(url), "Foo.png", "{{wikitext}}\n[[Category:Uploaded with OpenRefine]]", "summary",
                 Collections.emptyList(), false))
-                        .thenReturn(response);
+                .thenReturn(response);
         when(mediaFileUtils.checkIfPageNamesExist(anyList()))
                 .thenReturn(Collections.singleton("File:Foo.png"));
 
@@ -187,7 +187,7 @@ public class MediaInfoEditTest {
                 .thenReturn(mid);
         when(mediaFileUtils.uploadRemoteFile(new URL(url), "Foo.png", "{{wikitext}}\n[[Category:Uploaded with OpenRefine]]", "summary",
                 Collections.emptyList(), false))
-                        .thenReturn(response);
+                .thenReturn(response);
         when(mediaFileUtils.checkIfPageNamesExist(anyList()))
                 .thenReturn(Collections.emptySet())
                 .thenReturn(Collections.emptySet())

--- a/modules/core/src/main/java/com/google/refine/model/ColumnModel.java
+++ b/modules/core/src/main/java/com/google/refine/model/ColumnModel.java
@@ -277,7 +277,7 @@ public class ColumnModel {
             public int compare(ColumnGroup o1, ColumnGroup o2) {
                 int firstDiff = o1.startColumnIndex - o2.startColumnIndex;
                 return firstDiff != 0 ? firstDiff : // whichever group that starts first goes first
-                (o2.columnSpan - o1.columnSpan); // otherwise, the larger group goes first
+                        (o2.columnSpan - o1.columnSpan); // otherwise, the larger group goes first
             }
         });
 

--- a/pom.xml
+++ b/pom.xml
@@ -276,12 +276,14 @@
       <plugin>
         <groupId>net.revelc.code.formatter</groupId>
         <artifactId>formatter-maven-plugin</artifactId>
-        <version>2.17.1</version>
+        <version>2.29.0</version>
         <configuration>
           <configFile>${maven.multiModuleProjectDirectory}/IDEs/eclipse/Refine.style.xml</configFile>
           <excludes> <!-- file should not be linted because it was copied from a dependency (sigh) -->
             <exclude>**/Metaphone3.java</exclude>
           </excludes>
+          <!-- removeTrailingWhitespace changed default in 2.18 to true, but we'll leave it as false for now until we do a separate update to remove trailing whitespace -->
+          <removeTrailingWhitespace>false</removeTrailingWhitespace>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Replaces #5614

Changes proposed in this pull request:
- Update formatter-maven-plugin to 2.29.0
- Set `removeTrailingWhitespace` to `false`
- Fixup a handful of formatting changes
- remove formatter & xstream from dependabot ignores