### PR TITLE
Fix choice editing after restoring a GREL facet expression

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/facet/facets.cy.js
@@ -99,6 +99,23 @@ describe(__filename, function () {
     cy.get('.dialog-container .dialog-header').contains(`Edit facet's Expression`);
   });
 
+  it('Re-enables choice edits when a GREL facet is restored to its default expression', function () {
+    cy.loadAndVisitProject('food.small');
+    cy.columnActionClick('Shrt_Desc', ['Facet', 'Custom text facet']);
+    cy.typeExpression('value.toUppercase()');
+    cy.confirmDialogPanel();
+    cy.get('body[ajax_in_progress="false"]');
+    cy.getFacetContainer('Shrt_Desc').find('.facet-choice-edit').should('not.exist');
+
+    cy.getFacetContainer('Shrt_Desc').find('a[bind="changeButton"]').click();
+    cy.typeExpression('value');
+    cy.get('.expression-preview-table-wrapper tbody > tr:nth-child(1) > td:nth-child(3)').should('have.text', 'value');
+    cy.confirmDialogPanel();
+    cy.get('body[ajax_in_progress="false"]');
+
+    cy.getFacetContainer('Shrt_Desc').find('.facet-choice-edit').should('exist');
+  });
+
   it('Test editing a facet / Preview', function () {
     cy.loadAndVisitProject('food.small');
     cy.columnActionClick('NDB_No', ['Facet', 'Text facet']);

--- a/main/webapp/modules/core/scripts/facets/list-facet.js
+++ b/main/webapp/modules/core/scripts/facets/list-facet.js
@@ -393,7 +393,8 @@ class ListFacet extends Facet {
       return temp.text(s).html();
     };
 
-    var renderEdit = this._config.expression === "value";
+    var renderEdit =
+      this._config.expression === "value" || this._config.expression === "grel:value";
     var renderChoice = function(index, choice, customLabel) {
       var label = customLabel || choice.v.l;
       var count = choice.c;


### PR DESCRIPTION
Fixes #7141

Changes proposed in this pull request:
- Restore per-choice edit links when a text facet is changed back to GREL's default `value` expression.
- Treat `grel:value` as equivalent to the legacy `value` form.
- Keep other custom expression languages unchanged, because their displayed facet values can differ from their source values.
- Add Cypress regression coverage for the GREL-only behavior.

Verification:
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./refine build`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./refine lint`
- `yarn run lint` in `main/tests/cypress`
- Focused Cypress regression: passing
- Full `facets.cy.js` spec: 22 passing; one pre-existing, unrelated actionability failure in `Test facet by choice count`

AI assistance:
This PR was developed with assistance from an AI coding agent. I reviewed the change and ran the verification listed above.