### PR TITLE
Quote key value & tighten up key file handling

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -232,13 +232,22 @@ jobs:
       id: version_string_variable
       run: echo "output_value=$(mvn org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)" >> "$GITHUB_OUTPUT"
 
+    # Key is multiple lines, so wrap it in quotes
+    - name: Write notarization API key and validate it
+      run: |
+        install -m 600 /dev/null "$RUNNER_TEMP/notary_key.p8"
+        printf '%s\n' "$APPLE_BUILD_KEY" > "$RUNNER_TEMP/notary_key.p8"
+        openssl pkey -in "$RUNNER_TEMP/notary_key.p8" -noout \
+          || { echo "::error::APPLE_BUILD_KEY is not a valid PKCS#8 private key"; exit 1; }
+      env:
+        APPLE_BUILD_KEY: ${{ secrets.APPLE_BUILD_KEY }}
+
     - name: Package and upload to OSSRH
       run: |
-        echo ${APPLE_BUILD_KEY} > /tmp/openrefine-apple_build_key.p12
-        mvn -e -X -B deploy -DskipTests=true -Dmac.signing.identity="Code for Science and Society, Inc." -DrepositoryId=ossrh-staging-api -Dapple.notarization.key.id=$APPLE_BUILD_KEY_ID -Dapple.notarization.key=/tmp/openrefine-apple_build_key.p12 -Dapple.notarization.issuer=$APPLE_ISSUER -Dapple.notarization.team.id=$APPLE_TEAM_ID -Dgpg.signer=bc
-        rm /tmp/openrefine-apple_build_key.p12  
-        # The below POST is documented as being necessary, but it seems to work without it. Also not clear if it needs to be authenticated.
-        # curl -X POST https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/org.openrefine
+        mvn -B deploy -DskipTests=true -Dmac.signing.identity="Code for Science and Society, Inc." -DrepositoryId=ossrh-staging-api \
+          -Dapple.notarization.key.id="$APPLE_BUILD_KEY_ID" -Dapple.notarization.key="$RUNNER_TEMP/notary_key.p8" \
+          -Dapple.notarization.issuer="$APPLE_ISSUER" -Dapple.notarization.team.id="$APPLE_TEAM_ID" -Dgpg.signer=bc
+        rm -f $RUNNER_TEMP/notary_key.p8
       env:
         CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
         CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
@@ -246,8 +255,12 @@ jobs:
         MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         APPLE_BUILD_KEY_ID: ${{ secrets.APPLE_BUILD_KEY_ID }}
-        APPLE_BUILD_KEY: ${{ secrets.APPLE_BUILD_KEY }}
         APPLE_ISSUER: ${{ secrets.APPLE_ISSUER }}
+
+    # Make sure key file is deleted even on error
+    - name: Remove notarization API key
+      if: always()
+      run: rm -f "$RUNNER_TEMP/notary_key.p8"
 
     - name: Upload release asset for Windows (with Java)
       id: upload-release-asset-win-with-java


### PR DESCRIPTION
No issue.

Changes proposed in this pull request:
- quote key value when writing it to key file
- tighten permissions on key file & make sure it gets deleted even on error
- wrap long maven command line
- remove maven debug (optimistically) 

First two sourced from @magdmartin and Claude Opus 5

