### PR TITLE
Apple Notarization followups

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -189,9 +189,28 @@ jobs:
         wc "$RUNNER_TEMP/notary_key.p8"
         openssl pkey -in "$RUNNER_TEMP/notary_key.p8" -noout \
           || { echo "::error::APPLE_BUILD_KEY is not a valid PKCS#8 private key"; exit 1; }
+
+        # Whitespace pasted into these two secrets is invisible in the web UI,
+        # but it changes the JWT and Apple rejects it as "401 Unauthenticated"
+        # with no indication of which value is at fault. Normalise and check
+        # them here, where the error names the culprit.
+        key_id="${APPLE_BUILD_KEY_ID//[[:space:]]/}"
+        issuer="${APPLE_ISSUER//[[:space:]]/}"
+        [ ${#key_id} -eq 10 ] \
+          || { echo "::error::APPLE_BUILD_KEY_ID is ${#key_id} characters after trimming, expected 10"; exit 1; }
+        [ ${#issuer} -eq 36 ] \
+          || { echo "::error::APPLE_ISSUER is ${#issuer} characters after trimming, expected a 36-character UUID"; exit 1; }
+        # Trimmed values are no longer identical to the stored secrets, so they
+        # are not covered by the automatic masking. Mask them explicitly.
+        echo "::add-mask::$key_id"
+        echo "::add-mask::$issuer"
+        echo "APPLE_BUILD_KEY_ID=$key_id" >> "$GITHUB_ENV"
+        echo "APPLE_ISSUER=$issuer" >> "$GITHUB_ENV"
       env:
         APPLE_BUILD_KEY: |
           ${{ secrets.APPLE_BUILD_KEY }}
+        APPLE_BUILD_KEY_ID: ${{ secrets.APPLE_BUILD_KEY_ID }}
+        APPLE_ISSUER: ${{ secrets.APPLE_ISSUER }}
 
     - name: Set up Java 21
       uses: actions/setup-java@v5.7.0
@@ -256,8 +275,6 @@ jobs:
         MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        APPLE_BUILD_KEY_ID: ${{ secrets.APPLE_BUILD_KEY_ID }}
-        APPLE_ISSUER: ${{ secrets.APPLE_ISSUER }}
 
     # Make sure key file is deleted even on error
     - name: Remove notarization API key

--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -267,14 +267,13 @@ jobs:
       run: |
         mvn -B deploy -DskipTests=true -Dmac.signing.identity="Code for Science and Society, Inc." -DrepositoryId=ossrh-staging-api \
           -Dapple.notarization.key.id="$APPLE_BUILD_KEY_ID" -Dapple.notarization.key="$RUNNER_TEMP/notary_key.p8" \
-          -Dapple.notarization.issuer="$APPLE_ISSUER" -Dapple.notarization.team.id="$APPLE_TEAM_ID" -Dgpg.signer=bc
+          -Dapple.notarization.issuer="$APPLE_ISSUER" -Dgpg.signer=bc
         rm -f $RUNNER_TEMP/notary_key.p8
       env:
         CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
         CENTRAL_PASS: ${{ secrets.CENTRAL_PASS }}
         MAVEN_GPG_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
     # Make sure key file is deleted even on error
     - name: Remove notarization API key

--- a/packaging/apple_certs/README
+++ b/packaging/apple_certs/README
@@ -1,7 +1,55 @@
-Apple distribution certificates
-===============================
+Apple code signing and notarization
+===================================
 
-Those certificates are used to code-sign OpenRefine binaries.
-They are decoded in the CI using the embedded GPG key.
+Certificates
+------------
 
+apple_cert.cer / apple_cert.p12 are the Developer ID Application certificate
+used to code-sign the macOS binaries. They are GPG encrypted to the release
+key and decrypted in CI by .github/workflows/release/add_apple_keys.sh.
 
+Decrypting them locally needs the GPG_PRIVATE_KEY repository secret imported
+into your keyring - the GPG_PASSPHRASE alone is not enough, since the files
+are encrypted to a public key rather than with a passphrase.
+
+The certificate is issued by, and can only be renewed by, the Account Holder
+of the Apple Developer team.
+
+Notarization
+------------
+
+Notarization authenticates with an App Store Connect API key, configured
+through four repository secrets:
+
+  APPLE_BUILD_KEY      contents of the AuthKey_XXXXXXXXXX.p8 file, verbatim,
+                       including the -----BEGIN/END PRIVATE KEY----- lines
+  APPLE_BUILD_KEY_ID   the 10 character key ID, which is also the XXXXXXXXXX
+                       portion of the .p8 filename
+  APPLE_ISSUER         the 36 character issuer UUID, from App Store Connect
+                       under Users and Access -> Integrations
+  APPLE_P12_PASSPHRASE passphrase for apple_cert.p12 (signing, not notarization)
+
+Take care pasting the first three. Whitespace and missing PEM header lines are
+invisible in the secrets UI, and Apple reports both as errors that name
+neither the value at fault nor the reason: a malformed key gives
+"Error: invalidP8" and a malformed ID gives "401 Unauthenticated". The
+workflow validates all three before building so such a failure is reported in
+seconds rather than after a full package run.
+
+Checking the credentials
+------------------------
+
+check_notarization_credentials.py validates a key, key ID and issuer ID
+against Apple's notary service without needing macOS, Xcode or a CI run:
+
+  pip install pyjwt cryptography
+  ./check_notarization_credentials.py AuthKey_XXXXXXXXXX.p8 <key-id> <issuer-id>
+
+HTTP 200 means the credentials are valid and hold notarization access, and the
+team's recent submission history is printed. HTTP 401 means the three values do
+not correspond to each other. HTTP 403 means they are valid but lack
+notarization access, which is a permissions question for the Account Holder.
+
+The submission history is team wide, so it also answers when notarization last
+succeeded - useful because a notarization failure does not necessarily fail the
+build in older revisions of the pipeline.

--- a/packaging/apple_certs/check_notarization_credentials.py
+++ b/packaging/apple_certs/check_notarization_credentials.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Validate an App Store Connect API key against Apple's notary service.
+
+The Linux equivalent of `xcrun notarytool history` - builds the same ES256 JWT
+notarytool builds, and calls the same endpoint. Useful for separating credential
+problems from build-pipeline problems without a Mac or a full CI run.
+
+Usage:
+    check_notarization_credentials.py <keyfile.p8> <key-id> <issuer-id>
+
+Prints status codes, Apple's error text, and recent submission history.
+Never prints the private key or the bearer token.
+"""
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+ENDPOINT = "https://appstoreconnect.apple.com/notary/v2/submissions"
+
+
+def main(argv):
+    if len(argv) != 4:
+        print(__doc__.strip())
+        return 2
+
+    key_path, key_id, issuer_id = argv[1], argv[2], argv[3]
+
+    try:
+        private_key = open(key_path).read()
+    except OSError as e:
+        print(f"cannot read key file: {e}")
+        return 1
+
+    # Surface the paste errors that cost us days: stray whitespace is invisible
+    # in a web form but changes the JWT and yields a bare 401 from Apple.
+    for label, value, expected in (("key id", key_id, 10), ("issuer id", issuer_id, 36)):
+        if value != value.strip():
+            print(f"WARNING: {label} has leading/trailing whitespace")
+        if len(value.strip()) != expected:
+            print(f"WARNING: {label} is {len(value.strip())} chars, expected {expected}")
+
+    try:
+        import jwt
+    except ImportError:
+        print("PyJWT is required:  pip install pyjwt cryptography")
+        return 1
+
+    now = int(time.time())
+    token = jwt.encode(
+        {"iss": issuer_id, "iat": now, "exp": now + 900, "aud": "appstoreconnect-v1"},
+        private_key,
+        algorithm="ES256",
+        headers={"kid": key_id},
+    )
+    print(f"JWT built: alg=ES256 kid={key_id} iss={issuer_id}")
+
+    req = urllib.request.Request(ENDPOINT, headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            data = json.loads(r.read().decode()).get("data", [])
+        print(f"HTTP {r.status} -- CREDENTIALS ACCEPTED ({len(data)} submissions visible)")
+        print("\nMost recent submissions:")
+        for s in data[:5]:
+            a = s.get("attributes", {})
+            print(f"  {a.get('createdDate','?'):26} {a.get('status','?'):10} {a.get('name','?')}")
+        return 0
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f"HTTP {e.code} -- REJECTED")
+        if e.code == 401:
+            print("  Unauthenticated: the JWT was rejected. The key, key id and")
+            print("  issuer id do not correspond, or one carries stray whitespace.")
+        elif e.code == 403:
+            print("  Forbidden: credentials are valid but lack notarization access.")
+        print(f"  Apple said: {body.strip()[:300]}")
+        return 1
+    except Exception as e:
+        print(f"request failed: {type(e).__name__}: {e}")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -155,8 +155,6 @@
                                     <arg value="${apple.notarization.key}"/>
                                     <arg value="--issuer"/>
                                     <arg value="${apple.notarization.issuer}"/>
-                                    <arg value="--team-id"/>
-                                    <arg value="${apple.notarization.team.id}"/>
                                     <arg value="--wait"/>
                                     <arg value="--timeout"/>
                                     <arg value="${apple.notarization.timeout}"/>


### PR DESCRIPTION
Follow-up to #7935 
Related to #7921

This PR was prepared by Claude (Opus-5) following a troubleshooting session to move the Apple credential account to use `APPLE_ISSUER` `APPLE_BUILD_KEY_ID` and `APPLE_BUILD_KEY`

Claude identified the following cleanup task; I asked it to prepare the PR since it already had the context and details. 

Below is verbatim from Claude 

----

**Validate the notarization ID secrets.** Whitespace pasted into APPLE_BUILD_KEY_ID or APPLE_ISSUER is invisible in the secrets UI but changes the signed JWT, and Apple rejects it as a bare "401 Unauthenticated" naming neither the value nor the reason. Both have fixed widths, so trim and check them next to the existing key parse check.

**Drop --team-id.** It belongs to notarytool's Apple ID authentication method; API key authentication implies the team from the issuer ID. Confirmed by authenticating against the notary API with only the key, key ID and issuer ID.

**Add check_notarization_credentials.py.** Credentials previously could only be tested by running the full macOS job. This builds the same ES256 JWT notarytool builds and validates the triple in a second from any machine with Python — no macOS, no Xcode, no CI run — distinguishing 401 (values do not correspond), 403 (valid but lacking access) and 200 (plus the team's submission history). That history is team-wide, so it also answers when notarization last succeeded, which build logs cannot: log retention is shorter than the five and a half months this went unnoticed.

The README now records what each secret holds, that only the Account Holder can renew the certificate, and that local decryption needs the private key rather than just the passphrase

----

I let the Core Dev Team decide what should get merged. 

I am also preparing an update under https://openrefine.org/docs/technical-reference/maintainer-guidelines to explain how the Apple notarization is configured. 