### PR TITLE
Fix modified clicks on reconciliation suggestions

### DIFF
--- a/main/tests/cypress/cypress/e2e/project/grid/column/reconcile/actions/cell-buttons.cy.js
+++ b/main/tests/cypress/cypress/e2e/project/grid/column/reconcile/actions/cell-buttons.cy.js
@@ -16,6 +16,82 @@ describe('In-cell reconciliation buttons', () => {
     cy.getCell(0, 'entity').find('.data-table-recon-visibility').should('to.contain', 'Search for match');
   });
 
+  it('Opens suggested entities with modified clicks without selecting them', () => {
+    const serviceUrl = 'https://wikidata.reconci.link/en/api';
+    const entityUrl = 'https://www.wikidata.org/wiki/Q42';
+    const service = {
+      name: 'Test reconciliation service',
+      identifierSpace: 'http://www.wikidata.org/entity/',
+      schemaSpace: 'http://www.wikidata.org/prop/direct/',
+      view: {
+        url: 'https://www.wikidata.org/wiki/{{id}}',
+      },
+      suggest: {
+        entity: {
+          service_url: '/reconciliation-test',
+          service_path: '/suggest/entity',
+        },
+      },
+      ui: {
+        access: 'json',
+      },
+      url: serviceUrl,
+    };
+
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: '/command/core/get-preference',
+        query: {
+          name: 'reconciliation.standardServices',
+        },
+      },
+      {
+        value: JSON.stringify([service]),
+      }
+    );
+    cy.intercept('GET', '/reconciliation-test/suggest/entity*', {
+      result: [
+        {
+          id: 'Q42',
+          name: 'Douglas Adams',
+        },
+      ],
+    }).as('suggestEntities');
+
+    cy.visitOpenRefine();
+    cy.navigateTo('Import project');
+    cy.get('#project-tar-file-input').selectFile('cypress/fixtures/reconciled-project-no-match.zip');
+    cy.get('#import-project-button').click();
+
+    cy.getCell(0, 'entity').find('.data-table-recon-visibility').contains('Search for match').click();
+    cy.wait('@suggestEntities');
+    cy.get('.fbs-pane:visible .fbs-item').should('have.length', 1).as('suggestion');
+    cy.window().then((win) => {
+      cy.stub(win, 'open').as('windowOpen');
+      cy.spy(win.Refine, 'postCoreProcess').as('postCoreProcess');
+    });
+
+    cy.get('@suggestion').trigger('mouseover');
+    cy.get('@suggestion').trigger('mousedown', { button: 1 });
+    cy.get('@suggestion').trigger('mouseup', { button: 1 });
+    cy.get('@suggestion').trigger('click', { button: 1 });
+    cy.get('@windowOpen').should('have.been.calledOnceWith', entityUrl, '_blank');
+    cy.get('@postCoreProcess').should('not.have.been.called');
+    cy.get('.dialog-frame').should('be.visible');
+
+    cy.get('@suggestion').click({ metaKey: true });
+    cy.get('@windowOpen').should('have.been.calledTwice');
+    cy.get('@windowOpen').should('have.been.calledWith', entityUrl, '_blank');
+    cy.get('@postCoreProcess').should('not.have.been.called');
+    cy.get('.dialog-frame').should('be.visible');
+
+    cy.get('@suggestion').click();
+    cy.get('@postCoreProcess').should('have.been.calledOnce');
+    cy.get('.dialog-frame').should('not.exist');
+    cy.getCell(0, 'entity').should('contain', 'Douglas Adams');
+  });
+
   it('Display see more / see less when there are candidates', () => {
     cy.visitOpenRefine();
     cy.navigateTo('Import project');

--- a/main/webapp/modules/core/externals/suggest/suggest-4_3a.js
+++ b/main/webapp/modules/core/externals/suggest/suggest-4_3a.js
@@ -202,6 +202,9 @@
       .on("click", function(e) {
         //console.log("pane click");
         e.stopPropagation();
+        if (e.button === 1 || (e.button === 0 && e.metaKey)) {
+          return;
+        }
         var s = self.get_selected();
         if (s) {
           self.onselect(s, true);
@@ -1301,14 +1304,13 @@
       }
 
       // If we know of a view URL for this suggest service,
-      // clicking with the middle button sends the user to
-      // the view page.
+      // middle-clicking or Command-clicking sends the user
+      // to the view page.
       if('view_url' in this.options && data.id) {
         var view_url = this.options.view_url.replace('{{id}}', data.id).replace('${id}', data.id);
         li.on('mousedown', function(e) {
-           if (e.which == 2) {
-              var win = window.open(view_url, '_blank');
-              win.focus();
+           if (e.button === 1 || (e.button === 0 && e.metaKey)) {
+              window.open(view_url, '_blank');
               e.preventDefault();
            }
         });

--- a/main/webapp/modules/core/scripts/util/custom-suggest.js
+++ b/main/webapp/modules/core/scripts/util/custom-suggest.js
@@ -38,6 +38,7 @@ function sanitizeSuggestOptions(options) {
     query_param_name: options.query_param_name,
     access: options.access,
     formatter_url: options.formatter_url,
+    view_url: options.view_url,
     service_url:options.service_url,
     service_path:options.service_path,
   };


### PR DESCRIPTION
Fixes #6697

Changes proposed in this pull request:
- Preserve reconciliation `view_url` when sanitizing suggest options.
- Open reconciliation suggestions in a new tab on middle-click or Cmd+click without selecting the candidate.
- Keep the existing normal-click selection behavior unchanged.
- Add Cypress end-to-end coverage for middle-click, Cmd+click, and normal click behavior.

Testing:
- Targeted Cypress spec: 4 passing
- `./refine lint`: BUILD SUCCESS
- `git diff --check`: passed

I also verified the behavior manually on macOS: both middle-click and Cmd+click open the corresponding Wikidata page in a new tab without selecting the reconciliation candidate.