### PR TITLE
Update Mac appbundler. Fixes #7894

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -18,7 +18,7 @@
     <webapp.target>../main/target</webapp.target>
     <embedded.jre.version>${java.minversion}</embedded.jre.version>
 
-      <!-- Adoptium JREs x64 (undocumented x86_64 works too), aarch64; mvn os.arch x86_64, aarch64 -->
+    <!-- Adoptium JREs x64 (undocumented x86_64 works too), aarch64; mvn os.arch x86_64, aarch64 -->
     <mac.jre.path>${project.build.directory}/mac_jre</mac.jre.path>
     <mac.jre.url>https://api.adoptium.net/v3/binary/latest/${embedded.jre.version}/ga/mac/x64/jre/hotspot/normal/eclipse?project=jdk</mac.jre.url>
     <mac.build.directory>OpenRefine ${project.version}</mac.build.directory>
@@ -26,13 +26,12 @@
     <mac.icon.path>../graphics/icon/openrefine.icns</mac.icon.path>
     <mac.dmg.path>${project.build.directory}/${project.build.finalName}-mac-${project.version}.dmg</mac.dmg.path>
 
-<!--    <mac.signing.identity>Code for Science and Society, Inc.</mac.signing.identity>-->
+    <!-- The default value allows developers to use a self-signed cert locally. This is overridden for production releases -->
+    <!--    <mac.signing.identity>Code for Science and Society, Inc.</mac.signing.identity>-->
     <mac.signing.identity>OpenRefine Code Signing</mac.signing.identity>
-
     <!-- Apple Notarization settings -->
     <apple.notarization.timeout>15m</apple.notarization.timeout>
 
-    <windows.jre.path>${project.build.directory}/windows_jre</windows.jre.path>
     <windows.jre.url>https://api.adoptium.net/v3/binary/latest/${embedded.jre.version}/ga/windows/x64/jre/hotspot/normal/eclipse?project=jdk</windows.jre.url>
     <windows.copyright.line>Copyright (c) 2018 OpenRefine contributors, 2010 Google, Inc.</windows.copyright.line>
     <windows.fullversion>0.0.0.0</windows.fullversion>
@@ -50,8 +49,8 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>sh.tak.appbundler</groupId>
-            <artifactId>appbundle-maven-plugin</artifactId>
+            <groupId>de.perdian.maven.plugins</groupId>
+            <artifactId>macosappbundler-maven-plugin</artifactId>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -99,8 +98,8 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>sh.tak.appbundler</groupId>
-            <artifactId>appbundle-maven-plugin</artifactId>
+            <groupId>de.perdian.maven.plugins</groupId>
+            <artifactId>macosappbundler-maven-plugin</artifactId>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -110,7 +109,6 @@
                 <id>package-distributions</id>
                 <configuration>
                   <descriptors>
-                    <descriptor>windows-without-jre.xml</descriptor>
                     <descriptor>windows-with-jre.xml</descriptor>
                   </descriptors>
                   <attach>false</attach>
@@ -159,22 +157,21 @@
                                     <arg value="${apple.notarization.timeout}"/>
                                 </exec>
 
-                                <!-- Staple the notarization ticket to the DMG bundle -->
-                                <exec dir="${project.build.directory}" os="Mac OS X" executable="xcrun" failonerror="true">
-                                    <arg value="stapler"/>
-                                    <arg value="staple"/>
-                                    <arg value="${mac.dmg.path}"/>
-                                </exec>
+                              <!-- Staple the notarization ticket to the DMG bundle -->
+                              <exec dir="${project.build.directory}" os="Mac OS X" executable="xcrun" failonerror="true">
+                                <arg value="stapler"/>
+                                <arg value="staple"/>
+                                <arg value="${mac.dmg.path}"/>
+                              </exec>
                             </target>
                         </configuration>
                     </execution>
 
-
-                </executions>
-              </plugin>
-            </plugins>
-          </build>
-      </profile>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>
@@ -188,7 +185,7 @@
           <connectTimeout>10000</connectTimeout>
           <cleanLicensesOutputDirectory>true</cleanLicensesOutputDirectory>
           <licensesConfigFile>${basedir}/manual_licenses.xml</licensesConfigFile>
-          <excludedArtifacts>oro</excludedArtifacts>  
+          <excludedArtifacts>oro</excludedArtifacts>
         </configuration>
         <executions>
           <execution>
@@ -199,23 +196,24 @@
           </execution>
         </executions>
       </plugin>
-      <plugin> <!-- we attach a dummy main artifact for the packaging project, 
+      <!-- TODO: Is all this machinery still necessary? Can we simplify it with our new bundler? -->
+      <plugin> <!-- we attach a dummy main artifact for the packaging project,
                 because Appbundle requires one -->
         <groupId>org.codehaus.gmaven</groupId>
         <artifactId>groovy-maven-plugin</artifactId>
         <version>2.1.1</version>
         <executions>
           <execution>
-          <id>set-main-artifact</id>
-          <phase>prepare-package</phase>
-          <goals> 
-            <goal>execute</goal>
-          </goals>
-          <configuration>
-            <source>
-            project.artifact.setFile(new File("./packaging/target/dummy_artifact.jar"))
-            </source>
-          </configuration>
+            <id>set-main-artifact</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <source>
+                project.artifact.setFile(new File("./packaging/target/dummy_artifact.jar"))
+              </source>
+            </configuration>
           </execution>
         </executions>
       </plugin>
@@ -234,69 +232,69 @@
                 <touch file="./target/dummy_artifact.jar" />
 
                 <mkdir dir="${mac.webapp.dir}" />
-                    
-                    <copy todir="${mac.webapp.dir}">
-                        <fileset dir="${webapp.dir}">
-                            <include name="**/*"/>
-                            <exclude name="node_modules/**"/>
-                            <exclude name="package.json"/>
-                            <exclude name="package-lock.json"/>
-                            <exclude name="dependencies.json"/>
-                            <exclude name="copy-dependencies.js"/>
-                            <exclude name="README.md"/>
-                            <exclude name="**/test-output/**"/>
-                            <exclude name="WEB-INF/classes/**"/>
-                            <exclude name="WEB-INF/lib-local/**"/>
-                            <exclude name="WEB-INF/lib-local-src/**"/>
-                            <exclude name="WEB-INF/lib/icu4j*.jar"/>
-                        </fileset>
-                    </copy>
-                    <copy todir="${mac.webapp.dir}">
-                        <fileset dir="${webapp.dir}">
-                            <include name="**/*.properties"/>
-                        </fileset>
-                    </copy>
-                    <copy todir="${mac.webapp.dir}/WEB-INF/lib/">
-                        <fileset dir="${webapp.target}">
-                            <include name="openrefine-main.jar" />
-                        </fileset>
-                    </copy>
-                    
-                    <copy todir="${mac.webapp.dir}/licenses/"> <!-- licenses for the backend -->
-                        <fileset dir="${project.build.directory}/generated-resources/">
-                            <include name="licenses.xml" />
-                            <include name="licenses/**/*" />
-                        </fileset>
-                    </copy>
 
-                    <copy todir="${mac.webapp.dir}/licenses/licenses/"> <!-- licenses for the frontend -->
-                        <fileset dir="${webapp.dir}/licenses/">
-                            <include name="**/*" />
-                        </fileset>
-                    </copy>
+                <copy todir="${mac.webapp.dir}">
+                  <fileset dir="${webapp.dir}">
+                    <include name="**/*"/>
+                    <exclude name="node_modules/**"/>
+                    <exclude name="package.json"/>
+                    <exclude name="package-lock.json"/>
+                    <exclude name="dependencies.json"/>
+                    <exclude name="copy-dependencies.js"/>
+                    <exclude name="README.md"/>
+                    <exclude name="**/test-output/**"/>
+                    <exclude name="WEB-INF/classes/**"/>
+                    <exclude name="WEB-INF/lib-local/**"/>
+                    <exclude name="WEB-INF/lib-local-src/**"/>
+                    <exclude name="WEB-INF/lib/icu4j*.jar"/>
+                  </fileset>
+                </copy>
+                <copy todir="${mac.webapp.dir}">
+                  <fileset dir="${webapp.dir}">
+                    <include name="**/*.properties"/>
+                  </fileset>
+                </copy>
+                <copy todir="${mac.webapp.dir}/WEB-INF/lib/">
+                  <fileset dir="${webapp.target}">
+                    <include name="openrefine-main.jar" />
+                  </fileset>
+                </copy>
 
-                    <copy todir="${mac.webapp.dir}/extensions">
-                        <fileset dir="../extensions">
-                            <include name="**/*"/>
-                            <exclude name="**/pom.xml"/>
-                            <exclude name="**/src/**"/>
-                            <exclude name="**/lib-local/**"/>
-                            <exclude name="**/lib-local-src/**"/>
-                            <exclude name="**/target/**" />
-                            <exclude name="**/tests/**" />
-                            <exclude name="**/*.java"/>
-                            <exclude name="**/.settings/**" />
-                            <exclude name="**/.project" />
-                        </fileset>
-                    </copy>
-                    
-                    <replace file="${mac.webapp.dir}/WEB-INF/web.xml">
-                        <replacefilter token="$VERSION" value="${project.version}"/>
-                    </replace>
+                <copy todir="${mac.webapp.dir}/licenses/"> <!-- licenses for the backend -->
+                  <fileset dir="${project.build.directory}/generated-resources/">
+                    <include name="licenses.xml" />
+                    <include name="licenses/**/*" />
+                  </fileset>
+                </copy>
 
-                    <replace file="${mac.webapp.dir}/WEB-INF/butterfly.properties">
-                        <replacefilter token="../../extensions" value="extensions"/>
-                    </replace>
+                <copy todir="${mac.webapp.dir}/licenses/licenses/"> <!-- licenses for the frontend -->
+                  <fileset dir="${webapp.dir}/licenses/">
+                    <include name="**/*" />
+                  </fileset>
+                </copy>
+
+                <copy todir="${mac.webapp.dir}/extensions">
+                  <fileset dir="../extensions">
+                    <include name="**/*"/>
+                    <exclude name="**/pom.xml"/>
+                    <exclude name="**/src/**"/>
+                    <exclude name="**/lib-local/**"/>
+                    <exclude name="**/lib-local-src/**"/>
+                    <exclude name="**/target/**" />
+                    <exclude name="**/tests/**" />
+                    <exclude name="**/*.java"/>
+                    <exclude name="**/.settings/**" />
+                    <exclude name="**/.project" />
+                  </fileset>
+                </copy>
+
+                <replace file="${mac.webapp.dir}/WEB-INF/web.xml">
+                  <replacefilter token="$VERSION" value="${project.version}"/>
+                </replace>
+
+                <replace file="${mac.webapp.dir}/WEB-INF/butterfly.properties">
+                  <replacefilter token="../../extensions" value="extensions"/>
+                </replace>
 
               </target>
 
@@ -326,6 +324,7 @@
 
                 <!-- Download JRE (Windows) -->
                 <exec dir="${project.build.directory}" executable="curl">
+                  <arg line="-S"/>
                   <arg line="-L"/>
                   <arg line="-C"/>
                   <arg line="-"/>
@@ -348,110 +347,6 @@
                 <unzip src="${project.build.directory}/windows_jre.zip" dest="${project.build.directory}/windows_jre">
                   <mapper type="regexp" from="^([^/]*)/(.*)$$" to="\2"/>
                 </unzip>
-              </target>
-            </configuration>
-          </execution>
-          <execution>
-            <id>generate-dmg</id>
-            <phase>package</phase> 
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <target name="generateDMG" description="Generate DMG">
-
-                <!-- remove JRE licenses folder, cannot be signed -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="rm">
-                    <arg line="-r"/>
-                    <arg line="&quot;${mac.build.directory}/OpenRefine.app/Contents/PlugIns/JRE/Contents/Home/jre/legal&quot;"/>
-                </exec>
-                <!-- adapt file permissions, for https://github.com/OpenRefine/OpenRefine/issues/5160 -->
-                <exec dir="${project.build.directory}" executable="chmod">
-                    <arg line="-R" />
-                    <arg line="go+r" />
-                    <arg line="&quot;${mac.build.directory}/OpenRefine.app/Contents/Resources/webapp/WEB-INF/&quot;" />
-                </exec>
-
-                <!-- remove any existing DMG (hdiutil fails otherwise) -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="rm">
-                    <arg value="-f"/>
-                    <arg value="${mac.dmg.path}"/>
-                </exec>
-
-                <!-- Remove quarantine bit set recursively on JRE -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="xattr">
-                    <arg line="-rd"/>
-                    <arg line="com.apple.quarantine"/>
-                    <arg line="&quot;${mac.build.directory}/OpenRefine.app/Contents/PlugIns&quot;"/>
-                </exec>
-
-                <!-- Codesign JRE -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="codesign" failonerror="true">
-                    <arg value="--entitlements" />
-                    <arg value="../Entitlements.plist" />
-                    <arg value="--sign"/>
-                    <arg value="${mac.signing.identity}"/>
-                    <arg value="--deep"/>
-                    <arg value="--force"/>
-                    <arg value="--timestamp"/>
-                    <arg value="--options"/>
-                    <arg value="runtime"/>
-                    <arg value="${mac.build.directory}/OpenRefine.app/Contents/PlugIns/JRE/Contents/Home/jre/lib/libjli.dylib" />
-                </exec>
-
-                <!-- Codesign jars with native code in them -->
-                <exec executable="/bin/bash" os="Mac OS X" dir="${project.build.directory}/${mac.build.directory}"  failonerror="true">
-                    <arg value="${basedir}/apple_certs/codesign.sh" />
-                    <arg value="OpenRefine.app" />
-                    <arg value="${mac.signing.identity}" />
-                    <arg value="../../Entitlements.plist" />
-                </exec>
-
-                <!-- Codesign app -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="codesign" failonerror="true">
-                    <arg value="--entitlements" />
-                    <arg value="../Entitlements.plist" />
-                    <arg value="--sign"/>
-                    <arg value="${mac.signing.identity}"/>
-                    <arg value="--deep"/>
-                    <arg value="--force"/>
-                    <arg value="--timestamp"/>
-                    <arg value="--options"/>
-                    <arg value="runtime"/>
-                    <arg value="${mac.build.directory}/OpenRefine.app"/>
-                </exec>
-
-                <!-- Create DMG (Mac OS X) -->
-                <exec dir="${project.build.directory}" os="Mac OS X" executable="python3" failonerror="true">
-                    <arg value="-m"/>
-                    <arg value="dmgbuild"/>
-                    <arg value="-s"/>
-                    <arg value="../dmg_settings.py"/>
-                    <arg value="-D"/>
-                    <arg value="app=${mac.build.directory}/OpenRefine.app"/>
-                    <arg value="OpenRefine"/>
-                    <arg value="${mac.dmg.path}"/>
-                </exec>
-
-                <!-- Create DMG (Linux), only for testing -->
-                <exec dir="${project.build.directory}" os="Linux" executable="genisoimage">
-                    <arg value="-V"/>
-                    <arg value="OpenRefine"/>
-                    <arg value="-U"/>
-                    <arg value="-D"/>
-                    <arg value="-l"/>
-                    <arg value="-allow-multidot"/>
-                    <arg value="-max-iso9660-filenames"/>
-                    <arg value="-relaxed-filenames"/>
-                    <arg value="-no-iso-translate"/>
-                    <arg value="-r"/>
-                    <arg value="-o"/>
-                    <arg value="${mac.dmg.path}"/>
-                    <arg value="-root"/>
-                    <arg value="${mac.build.directory}"/>
-                    <arg value="${mac.build.directory}"/>
-                </exec>
-                  <!-- Notarization is done separately in the notarize profile -->
               </target>
             </configuration>
           </execution>
@@ -557,74 +452,71 @@
               <phase>package</phase>
               <configuration>
                 <descriptors>
-                <!-- TBD -->
+                  <!-- TBD -->
                 </descriptors>
               </configuration>
             </execution>
           </executions>
         </plugin>
         <plugin>
-          <groupId>sh.tak.appbundler</groupId>
-          <artifactId>appbundle-maven-plugin</artifactId>
-          <version>1.2.0</version>
-          <dependencies>
-            <dependency>
-              <!-- dependency upgraded to >4.0 to fix runtime issues with some JRE versions:
-                   https://stackoverflow.com/questions/53696439/appbundle-maven-plugin-fails-on-mac-osx-with-java-10 -->
-              <groupId>org.codehaus.plexus</groupId>
-              <artifactId>plexus-archiver</artifactId>
-              <version>4.14.0</version>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.velocity</groupId>
-              <artifactId>velocity-tools</artifactId>
-              <version>2.0</version>
-            </dependency>
-          </dependencies>
+          <groupId>de.perdian.maven.plugins</groupId>
+          <artifactId>macosappbundler-maven-plugin</artifactId>
+          <version>1.21.2</version>
           <configuration>
-            <mainClass>com.google.refine.Refine</mainClass>
-            <bundleName>OpenRefine</bundleName>
-            <buildDirectory>${project.build.directory}/${mac.build.directory}</buildDirectory>
-            <iconFile>${mac.icon.path}</iconFile>
-            <generateDiskImageFile>false</generateDiskImageFile>
-              <!-- FIXME: This looks obsolete -->
-            <jvmVersion>1.8</jvmVersion>
-            <jrePath>${mac.jre.path}</jrePath>
-            <jvmOptions>
-              <param>-Xms512M</param>
-              <param>-Xmx2048M</param>
-              <param>-Drefine.version=${project.version}</param>
-              <param>-Drefine.webapp=$APP_ROOT/Contents/Resources/webapp</param>
-            </jvmOptions>
-            <additionalResources>
-              <fileSet>
-                <directory>target</directory>
-                <includes>
-                  <include>OpenRefine.app/Contents/Resources/webapp/**/**</include>
-                </includes>
-              </fileSet>
-            </additionalResources>
-            <additionalBundledClasspathResources>
-              <fileSet>
-                <directory>${rootdir}/server/target/lib/</directory>
-                <includes>
-                  <include>*.jar</include>
-                </includes>
-              </fileSet>
-              <fileSet>
-                <directory>${rootdir}/server/target</directory>
-                <includes>
-                  <include>openrefine-${project.version}-server.jar</include>
-                </includes>
-                <excludes>
-                  <exclude>**/lib/**</exclude>
-                  <exclude>**/org/**</exclude>
-                </excludes>
-              </fileSet>
-            </additionalBundledClasspathResources>
+            <plist>
+              <JVMMainClassName>com.google.refine.Refine</JVMMainClassName>
+              <CFBundleName>OpenRefine</CFBundleName>
+              <CFBundleIconFile>${mac.icon.path}</CFBundleIconFile>
+              <JVMVersion>${java.minversion}+</JVMVersion>
+              <JVMLogLevel>INFO</JVMLogLevel>
+              <JVMOptions>
+                <param>-Xms512M</param>
+                <param>-Xmx2048M</param>
+                <param>-Drefine.version=${project.version}</param>
+                <param>-Drefine.webapp=Contents/Resources/webapp</param>
+              </JVMOptions>
+            </plist>
+            <jdk>
+              <include>true</include>
+              <location>${mac.jre.path}</location>
+            </jdk>
+            <nativeBinary>X86_64</nativeBinary>
+            <dmg>
+              <generate>true</generate>
+              <additionalResources>
+                <fileSet>
+                  <directory>target</directory>
+                  <includes>
+                    <include>OpenRefine.app/Contents/Resources/webapp/**/**</include>
+                  </includes>
+                </fileSet>
+              </additionalResources>
+            </dmg>
+            <app>
+              <additionalResources>
+                <fileSet>
+                  <outputDirectory>Contents/Java/classpath</outputDirectory>
+                  <directory>${rootdir}/server/target/lib/</directory>
+                  <includes>
+                    <include>*.jar</include>
+                  </includes>
+                </fileSet>
+                <fileSet>
+                  <outputDirectory>Contents/Java/classpath</outputDirectory>
+                  <directory>${rootdir}/server/target</directory>
+                  <includes>
+                    <include>openrefine-${project.version}-server.jar</include>
+                  </includes>
+                </fileSet>
+              </additionalResources>
+            </app>
+            <codesign>
+              <identity>${mac.signing.identity}</identity>
+            </codesign>
           </configuration>
           <executions>
             <execution>
+              <id>bundle-x86</id>
               <phase>prepare-package</phase>
               <goals>
                 <goal>bundle</goal>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -409,36 +409,36 @@
       </plugin>
     </plugins>
     <pluginManagement>
-    	<plugins>
-    		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-    		<plugin>
-    			<groupId>org.eclipse.m2e</groupId>
-    			<artifactId>lifecycle-mapping</artifactId>
-    			<version>1.0.0</version>
-    			<configuration>
-    				<lifecycleMappingMetadata>
-    					<pluginExecutions>
-    						<pluginExecution>
-    							<pluginExecutionFilter>
-    								<groupId>
-    									org.apache.maven.plugins
-    								</groupId>
-    								<artifactId>
-    									maven-antrun-plugin
-    								</artifactId>
-    								<versionRange>[1.4,)</versionRange>
-    								<goals>
-    									<goal>run</goal>
-    								</goals>
-    							</pluginExecutionFilter>
-    							<action>
-    								<ignore></ignore>
-    							</action>
-    						</pluginExecution>
-    					</pluginExecutions>
-    				</lifecycleMappingMetadata>
-    			</configuration>
-    		</plugin>
+      <plugins>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <lifecycleMappingMetadata>
+              <pluginExecutions>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>
+                      org.apache.maven.plugins
+                    </groupId>
+                    <artifactId>
+                      maven-antrun-plugin
+                    </artifactId>
+                    <versionRange>[1.4,)</versionRange>
+                    <goals>
+                      <goal>run</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
+              </pluginExecutions>
+            </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
@@ -524,15 +524,15 @@
             </execution>
           </executions>
         </plugin>
-         <plugin>
-	   <groupId>org.apache.maven.plugins</groupId>
-	   <artifactId>maven-deploy-plugin</artifactId>
-	   <version>${maven-deploy-plugin.version}</version>
-	   <configuration>
-	    <skip>false</skip>
-	  </configuration>
-         </plugin>
-    	</plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>${maven-deploy-plugin.version}</version>
+          <configuration>
+            <skip>false</skip>
+          </configuration>
+        </plugin>
+      </plugins>
     </pluginManagement>
   </build>
   <dependencies>


### PR DESCRIPTION
Fixes #7894

Changes proposed in this pull request:
- Switches to e.perdian.maven.plugins:macosappbundler-maven-plugin which supports recent Javas
- Removes codesigning and a bunch of other stuff that's now built-in
- Preps for, but does not implement, aarch64 support (#6052)
- Detabifies and normalizes indentation (in a separate commit)